### PR TITLE
Update userguide/src/en/chapters/ch07b-BPMN-Constructs.xml

### DIFF
--- a/userguide/src/en/chapters/ch07b-BPMN-Constructs.xml
+++ b/userguide/src/en/chapters/ch07b-BPMN-Constructs.xml
@@ -5628,7 +5628,7 @@ public class MyTaskCreateListener implements TaskListener {
    ...
  </programlisting> 
 In the above xml excerpt user(user3) refers directly to user user3 and group(group3) to group group3. No indicator will default to a group type.
-It is also possible to use attributes of the &lt;process&gt; tag, namely &lt;activiti:candidateStarterUsers&gt; and &lt;activiti:candidateStarterUsers&gt;. Here is an example:
+It is also possible to use attributes of the &lt;process&gt; tag, namely &lt;activiti:candidateStarterUsers&gt; and &lt;activiti:candidateStarterGroups&gt;. Here is an example:
 
   <programlisting>
       &lt;process id="potentialStarter" activiti:candidateStarterUsers="user1, user2"  


### PR DESCRIPTION
fixed typo in user guide, Should be activiti:candidateStarterGroups instead of  activiti:candidateStarterUsers
