### PR TITLE
ACT-1186: ActivitiRule services not initialized when using SpringJUnit4C...

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
@@ -139,6 +139,7 @@ public class ActivitiRule extends TestWatchman {
   
   public void setProcessEngine(ProcessEngine processEngine) {
     this.processEngine = processEngine;
+	initializeServices();
   }
   
   public RepositoryService getRepositoryService() {

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/junit4/SpringJunit4Test.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/junit4/SpringJunit4Test.java
@@ -14,6 +14,7 @@
 package org.activiti.spring.test.junit4;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.RuntimeService;
@@ -62,6 +63,9 @@ public class SpringJunit4Test {
     runtimeService.startProcessInstanceByKey("simpleProcess");
     Task task = taskService.createTaskQuery().singleResult();
     assertEquals("My Task", task.getName());
+	
+	// ACT-1186: ActivitiRule services not initialized when using SpringJUnit4ClassRunner together with @ContextConfiguration
+	assertNotNull(activitiSpringRule.getRuntimeService());
   
     taskService.complete(task.getId());
     assertEquals(0, runtimeService.createProcessInstanceQuery().count());


### PR DESCRIPTION
...lassRunner together with @ContextConfiguration

Work done at Hackergarten Vienna together with Siegfried Goeschl siegfried.goeschl@it20one.at
