### PR TITLE
Add text flow when generating diagram

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -129,6 +129,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String defaultCamelContext = "camelContext";
   
   protected String activityFontName = "Arial";
+  protected String labelFontName = "Arial";
   
   protected ClassLoader classLoader;
   protected ProcessEngineLifecycleListener processEngineLifecycleListener;
@@ -539,5 +540,13 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   
   public ProcessEngineLifecycleListener getProcessEngineLifecycleListener() {
     return processEngineLifecycleListener;
+  }
+
+  public String getLabelFontName() {
+    return labelFontName;
+  }
+
+  public void setLabelFontName(String labelFontName) {
+    this.labelFontName = labelFontName;
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramCanvas.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramCanvas.java
@@ -84,7 +84,7 @@ public class ProcessDiagramCanvas {
   protected static Color LABEL_COLOR = new Color(112, 146, 190);
   
   // Fonts
-  protected static Font LABEL_FONT = new Font("Arial", Font.ITALIC, 10);
+  protected static Font LABEL_FONT = null;
 
   // Strokes
   protected static Stroke THICK_TASK_BORDER_STROKE = new BasicStroke(3.0f);
@@ -140,6 +140,7 @@ public class ProcessDiagramCanvas {
   protected FontMetrics fontMetrics;
   protected boolean closed;
   protected String activityFontName = "Arial";
+  protected String labelFontName = "Arial";
 
   /**
    * Creates an empty canvas with given width and height.
@@ -151,6 +152,10 @@ public class ProcessDiagramCanvas {
     if (Context.getProcessEngineConfiguration() != null) {
       this.activityFontName = Context.getProcessEngineConfiguration().getActivityFontName();
     }
+
+    if (Context.getProcessEngineConfiguration() != null) {
+      this.labelFontName = Context.getProcessEngineConfiguration().getLabelFontName();
+    }
     
     this.processDiagram = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
     this.g = processDiagram.createGraphics();
@@ -160,6 +165,8 @@ public class ProcessDiagramCanvas {
     Font font = new Font(activityFontName, Font.BOLD, FONT_SIZE);
     g.setFont(font);
     this.fontMetrics = g.getFontMetrics();
+
+    LABEL_FONT = new Font(labelFontName, Font.ITALIC, 10);
   }
 
   /**

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramGenerator.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/diagram/ProcessDiagramGenerator.java
@@ -408,6 +408,7 @@ public class ProcessDiagramGenerator {
     // Outgoing transitions of activity
     for (SequenceFlow sequenceFlow : flowNode.getOutgoingFlows()) {
       List<GraphicInfo> graphicInfoList = bpmnModel.getFlowLocationGraphicInfo(sequenceFlow.getId());
+      boolean drawedLabel = false;
       for (int i=1; i<graphicInfoList.size(); i++) {
         
         GraphicInfo graphicInfo = graphicInfoList.get(i);
@@ -422,6 +423,17 @@ public class ProcessDiagramGenerator {
         } else {
           processDiagramCanvas.drawSequenceflow((int) previousGraphicInfo.getX(), (int) previousGraphicInfo.getY(), 
                   (int) graphicInfo.getX(), (int) graphicInfo.getY(), drawConditionalIndicator, highLighted);
+          if (!drawedLabel) {
+            GraphicInfo labelGraphicInfo = bpmnModel.getLabelGraphicInfo(sequenceFlow.getId());
+            if (labelGraphicInfo != null) {
+              int middleX = (int) (((previousGraphicInfo.getX() + labelGraphicInfo.getX()) + (graphicInfo.getX()+ labelGraphicInfo.getX())) / 2);
+              int middleY = (int) (((previousGraphicInfo.getY() + labelGraphicInfo.getY()) + (graphicInfo.getY()+ labelGraphicInfo.getY())) / 2);
+              middleX += 15;
+              processDiagramCanvas.drawLabel(sequenceFlow.getName(), middleX, middleY,
+                      (int) labelGraphicInfo.getWidth(), (int) labelGraphicInfo.getHeight());
+              drawedLabel = true;
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
If you not using default fontName (activity and label) and generate diagram manual outer engine (Spring MVC or Struts2 eg.),

``` java
InputStream imageStream = ProcessDiagramGenerator.generateDiagram(bpmnModel, "png", activeActivityIds);
```

please use codes bellow ( use spring engine ):

``` java
@Autowired
ProcessEngineFactoryBean processEngine;

Context.setProcessEngineConfiguration(processEngine.getProcessEngineConfiguration());
```

or standalone:

``` java
ProcessEngineImpl defaultProcessEngine = (ProcessEngineImpl) ProcessEngines.getDefaultProcessEngine();
Context.setProcessEngineConfiguration(defaultProcessEngine.getProcessEngineConfiguration());
```
