### PR TITLE
Presumably missing "}" added

### DIFF
--- a/modules/activiti-webapp-explorer2/src/main/webapp/diagram-viewer/js/jstools.js
+++ b/modules/activiti-webapp-explorer2/src/main/webapp/diagram-viewer/js/jstools.js
@@ -19,4 +19,5 @@ if (!Object.isSVGElement) {
   Object.isSVGElement = function(vArg) {
   var str = Object.prototype.toString.call(vArg);
   return (str.indexOf("[object SVG") == 0);
-};
+  };
+}


### PR DESCRIPTION
Internet Explorer 8 complained about a missing "}" which prevented models to be displayed in process details view of activiti explorer. As far as I can see, IE is right concerning that missing "}", so I thought, I'd add it. Works for me now.
