### PR TITLE
ACT-1698: Activiti fails to build when default charset is Windows-1252

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/standalone/parsing/ChineseConverterTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/standalone/parsing/ChineseConverterTest.java
@@ -3,6 +3,7 @@ package org.activiti.standalone.parsing;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.UnsupportedEncodingException;
 
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -42,10 +43,11 @@ public class ChineseConverterTest extends PluggableActivitiTestCase {
     return parsedModel;
   }
   
-  protected void deployProcess(BpmnModel bpmnModel)  {
+  protected void deployProcess(BpmnModel bpmnModel) throws UnsupportedEncodingException  {
     byte[] xml = new BpmnXMLConverter().convertToXML(bpmnModel);
     try {
-      Deployment deployment = processEngine.getRepositoryService().createDeployment().name("test").addString("test.bpmn20.xml", new String(xml)).deploy();
+      final String bpXml = new String(xml, "UTF-8");
+      Deployment deployment = processEngine.getRepositoryService().createDeployment().name("test").addString("test.bpmn20.xml", bpXml).deploy();
       processEngine.getRepositoryService().deleteDeployment(deployment.getId());
     } finally {
       processEngine.close();


### PR DESCRIPTION
Hi,
I encountered a minor issue when building activiti on my new windows box. This patch fixes it. I'll have a look and see if I can spot any similar issues using the String(byte[]) in the rest of the code base.
NB this issue affects both 5.12.1 and trunk but as it's pretty minor I'm not sure if it's worth fixing 5.12.*. I guess it depends how long you're planning to run with that branch.
Regards,
Rob
