### PR TITLE
ACT-1739: added message boundary event support to diagram viewer

### DIFF
--- a/modules/activiti-webapp-explorer2/src/main/webapp/diagram-viewer/js/ProcessDiagramGenerator.js
+++ b/modules/activiti-webapp-explorer2/src/main/webapp/diagram-viewer/js/ProcessDiagramGenerator.js
@@ -404,6 +404,20 @@ var ProcessDiagramGenerator = {
       if (label)
         processDiagramCanvas.drawLabel(label.text, label.x, label.y, label.width, label.height);
 		};
+
+        // Boundary message event
+        this.activityDrawInstructions["boundaryMessage"] = function(){
+            var activityImpl = this.activity;
+            var processDiagramCanvas = this.processDiagramCanvas;
+            processDiagramCanvas.setConextObject(activityImpl);
+
+            var isInterrupting = activityImpl.getProperty("isInterrupting");
+            processDiagramCanvas.drawCatchingMessageEvent(activityImpl.getX(), activityImpl.getY(), activityImpl.getWidth(), activityImpl.getHeight(), isInterrupting, null);
+
+            var label = ProcessDiagramGenerator.getActivitiLabel(activityImpl);
+            if (label)
+                processDiagramCanvas.drawLabel(label.text, label.x, label.y, label.width, label.height);
+        };
 		
 		// timer catch event
 		this.activityDrawInstructions["intermediateTimer"] = function(){


### PR DESCRIPTION
This adds support for message boundary events to the diagram viewer. The explorers rest endpoint already sends the right nodes, so no changes on that end.
