### PR TITLE
Camel body and headers to Activiti variables

### DIFF
--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiEndpoint.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiEndpoint.java
@@ -39,6 +39,10 @@ public class ActivitiEndpoint extends DefaultEndpoint {
   
   private boolean copyVariablesFromProperties;
 
+  private boolean copyVariablesFromHeader;
+  
+  private boolean copyCamelBodyToBodyAsString;
+
   public ActivitiEndpoint(String uri, CamelContext camelContext, RuntimeService runtimeService) {
     super();
     setCamelContext(camelContext);
@@ -104,8 +108,25 @@ public class ActivitiEndpoint extends DefaultEndpoint {
     this.copyVariablesFromProperties = copyVariablesFromProperties;
   }
 
+  public boolean isCopyVariablesFromHeader() {
+    return this.copyVariablesFromHeader;
+  }
+
+  public void setCopyVariablesFromHeader(boolean copyVariablesFromHeader) {
+    this.copyVariablesFromHeader = copyVariablesFromHeader;
+  }
+  
+  public boolean isCopyCamelBodyToBodyAsString() {
+    return copyCamelBodyToBodyAsString;
+  }
+  
+  public void setCopyCamelBodyToBodyAsString(boolean copyCamelBodyToBodyAsString) {
+    this.copyCamelBodyToBodyAsString = copyCamelBodyToBodyAsString;
+  }
+  
   @Override
   public boolean isLenientProperties() {
     return true;
   }
+
 }

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
@@ -122,7 +122,7 @@ public abstract class CamelBehavior extends BpmnActivityBehavior implements Acti
   }
   
   protected void copyVariablesToBody(Map<String, Object> variables, Exchange exchange) {
-    Object camelBody = variables.get("camelBody");
+    Object camelBody = variables.get(ExchangeUtils.CAMELBODY);
     if(camelBody != null) {
       exchange.getIn().setBody(camelBody);
     }

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ExchangeUtils.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ExchangeUtils.java
@@ -24,16 +24,23 @@ import org.apache.camel.Exchange;
  */
 public class ExchangeUtils {
 
+  public static final String CAMELBODY = "camelBody";
+	
   /**
    * Copies variables from Camel into Activiti.
    * 
-   * This method will conditionally copy the Camel body to the "camelBody" variable if it is of type java.lang.String, OR it will copy the Camel body to
-   * individual variables within Activiti if it is of type Map<String,Object>.
-   * If the copyVariablesFromProperties parameter is set on the endpoint, the properties are copied instead
+   * This method will copy the Camel body to the "camelBody" variable. It will copy the Camel body to individual variables within Activiti if it is of type 
+   * Map&lt;String, Object&gt; or it will copy the Object as it comes.
+   * <ul>
+   * <li>If the copyVariablesFromProperties parameter is set on the endpoint, the properties are copied instead</li>
+   * <li>If the copyCamelBodyToBodyAsString parameter is set on the endpoint, the camelBody is converted to java.lang.String and added as a camelBody variable,
+   * unless it is a Map&lt;String, Object&gt;</li>
+   * <li>If the copyVariablesFromHeader parameter is set on the endpoint, each Camel Header will be copied to an individual variable within Activiti.</li>
+   * </ul>
    * 
    * @param exchange The Camel Exchange object
    * @param activitiEndpoint The ActivitiEndpoint implementation
-   * @return A Map<String,Object> containing all of the variables to be used in Activiti
+   * @return A Map&lt;String, Object&gt; containing all of the variables to be used in Activiti
    */
   
   public static Map<String, Object> prepareVariables(Exchange exchange, ActivitiEndpoint activitiEndpoint) {
@@ -45,15 +52,24 @@ public class ExchangeUtils {
     } else {
       camelVarMap = new HashMap<String, Object>();
       Object camelBody = exchange.getIn().getBody();
-      if(camelBody instanceof String) {
-        camelVarMap.put("camelBody", camelBody);
-      }
-      else if(camelBody instanceof Map<?,?>) {
+      
+      if(camelBody instanceof Map<?,?>) {
         Map<?,?> camelBodyMap = (Map<?,?>)camelBody;
         for (@SuppressWarnings("rawtypes") Map.Entry e : camelBodyMap.entrySet()) {
           if (e.getKey() instanceof String) {
             camelVarMap.put((String) e.getKey(), e.getValue());
           }
+        }
+      } else {
+        if(activitiEndpoint.isCopyCamelBodyToBodyAsString() && !(camelBody instanceof String)) {
+          camelBody = exchange.getContext().getTypeConverter().convertTo(String.class, exchange, camelBody);
+        }
+        camelVarMap.put(CAMELBODY, camelBody);
+      }
+
+      if(activitiEndpoint.isCopyVariablesFromHeader()) {
+        for(Map.Entry<String, Object> header : exchange.getIn().getHeaders().entrySet()) {
+    	  camelVarMap.put(header.getKey(), header.getValue());
         }
       }
     }

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/EmptyProcessTest.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/EmptyProcessTest.java
@@ -1,0 +1,65 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.camel;
+
+import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.test.Deployment;
+import org.activiti.spring.impl.test.SpringActivitiTestCase;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration("classpath:camel-activiti-context.xml")
+public class EmptyProcessTest extends SpringActivitiTestCase {
+
+  @Deployment(resources = {"process/empty.bpmn20.xml"})
+  public void testRunProcessWithHeader() throws Exception {
+    CamelContext ctx = applicationContext.getBean(CamelContext.class);
+    ProducerTemplate tpl = ctx.createProducerTemplate();
+    String body = "body text";
+    String instanceId = (String) tpl.requestBody("direct:startEmptyWithHeader", body);
+    assertProcessEnded(instanceId);
+    HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
+    assertNotNull(var);
+    assertEquals(body, var.getValue());
+    var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("MyVar").singleResult();
+    assertNotNull(var);
+    assertEquals("Foo", var.getValue());
+  }
+  
+  @Deployment(resources = {"process/empty.bpmn20.xml"})
+  public void testObjectAsVariable() throws Exception {
+    CamelContext ctx = applicationContext.getBean(CamelContext.class);
+    ProducerTemplate tpl = ctx.createProducerTemplate();
+    Object expectedObj = new Long(99);
+    String instanceId = (String) tpl.requestBody("direct:startEmpty", expectedObj);
+    assertProcessEnded(instanceId);
+    HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
+    assertNotNull(var);
+    assertEquals(expectedObj, var.getValue());
+  }
+  
+  @Deployment(resources = {"process/empty.bpmn20.xml"})
+  public void testObjectAsStringVariable() throws Exception {
+    CamelContext ctx = applicationContext.getBean(CamelContext.class);
+    ProducerTemplate tpl = ctx.createProducerTemplate();
+    Object expectedObj = new Long(99);
+
+    String instanceId = (String) tpl.requestBody("direct:startEmptyBodyAsString", expectedObj);
+    assertProcessEnded(instanceId);
+    HistoricVariableInstance var = processEngine.getHistoryService().createHistoricVariableInstanceQuery().variableName("camelBody").singleResult();
+    assertNotNull(var);
+    assertEquals(expectedObj.toString(), var.getValue());
+  }
+}

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/SimpleProcessTest.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/SimpleProcessTest.java
@@ -52,7 +52,7 @@ public class SimpleProcessTest extends SpringActivitiTestCase {
     assertProcessEnded(instanceId);
 
     service1.assertIsSatisfied();
-    Map m = service2.getExchanges().get(0).getIn().getBody(Map.class);
+    Map<?, ?> m = service2.getExchanges().get(0).getIn().getBody(Map.class);
     assertEquals("ala", m.get("var1"));
     assertEquals("var2", m.get("var2"));
 

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/SimpleSpringProcessTest.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/SimpleSpringProcessTest.java
@@ -53,7 +53,7 @@ public class SimpleSpringProcessTest extends SpringActivitiTestCase {
     assertProcessEnded(instanceId);
 
     service1.assertIsSatisfied();
-    Map m = service2.getExchanges().get(0).getIn().getBody(Map.class);
+    Map<?, ?> m = service2.getExchanges().get(0).getIn().getBody(Map.class);
     assertEquals("ala", m.get("var1"));
     assertEquals("var2", m.get("var2"));
 

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/route/EmptyCamelRoute.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/route/EmptyCamelRoute.java
@@ -1,0 +1,26 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.camel.route;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class EmptyCamelRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+      from("direct:startEmpty").to("activiti:emptyProcess");
+      from("direct:startEmptyWithHeader").setHeader("MyVar", constant("Foo")).to("activiti:emptyProcess?copyVariablesFromHeader=true");
+      from("direct:startEmptyBodyAsString").to("activiti:emptyProcess?copyBodyToCamelBodyAsString=true");
+    }
+}

--- a/modules/activiti-camel/src/test/resources/process/empty.bpmn20.xml
+++ b/modules/activiti-camel/src/test/resources/process/empty.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+             http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+
+
+    <process id="emptyProcess">
+
+        <startEvent id="start"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="end"/>
+        <endEvent id="end"/>
+
+    </process>
+
+</definitions>


### PR DESCRIPTION
Added more functionality to ActivitiCamel component.
- Property copyVariablesFromHeader: Allows Activiti Producer to read all the Camel headers as variables. It is useful for some endpoints such as Email, HTTP or JMS.
- Property copyCamelBodyToBodyAsString: Allows passing the Camel body as a String, using CamelContext's type converters from Activiti Producer
- When the Camel Body is not a Map&lt;String, Object&gt; the object contained is added as _camelBody_ variable
