### PR TITLE
Process documentation (aka description) was lost when deploying from mod...

### DIFF
--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BpmnJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BpmnJsonConverter.java
@@ -311,7 +311,7 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
       }
       
       JsonNode processDocumentationNode = modelNode.get(EDITOR_SHAPE_PROPERTIES).get(PROPERTY_DOCUMENTATION);
-      if (processDocumentationNode !- null && StringUtils.isNotEmpty(processDocumentationNode.asText())) {
+      if (processDocumentationNode != null && StringUtils.isNotEmpty(processDocumentationNode.asText())) {
         process.setDocumentation(processDocumentationNode.asText());
       }
       


### PR DESCRIPTION
...el

Json converter not read process documentation from model node while creating bpmn object. Therefore there was no description in process definition after deploying model
