### PR TITLE
SQL Syntax Error when using DB2

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricVariableInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricVariableInstance.xml
@@ -86,7 +86,7 @@
   </select>
   
   <select id="selectHistoricVariableInstanceCountByQueryCriteria" parameterType="org.activiti.engine.impl.HistoricVariableInstanceQueryImpl" resultType="long">
-    select count(RES.*)
+    select count(*)
     <include refid="selectHistoricVariableInstanceByQueryCriteriaSql"/>
   </select>
   


### PR DESCRIPTION
My version of DB2 Express (v10.5.0.420) does not like the syntax "[...] count(RES.*) [...]" and gives me a syntax error (SQLCODE=-104, SQLSTATE=42601) when I try to open the reports tab. As soon as a take the prefix ("RES.") out of the statement, it works perfectly fine.

As far as I can see, the prefix is not necessary for the statement, so I would suggest to just drop it, provided that this does not cause problems when using other DBMS, which I cannot assess.

Please feel free to approach me with any questions concerning this matter and / or correct / drop this request if you have a better solution.

Thank you!
