### PR TITLE
Removed System.out.println message.

### DIFF
--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/HistoricTaskDetailPanel.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/HistoricTaskDetailPanel.java
@@ -312,7 +312,6 @@ public class HistoricTaskDetailPanel extends DetailPanel {
     List<Attachment> attachments = new ArrayList<Attachment>();
     attachments.addAll(taskService.getTaskAttachments(historicTask.getId()));
     if (historicTask.getProcessInstanceId() != null) {
-      System.out.println("BIEP : " + taskService.getProcessInstanceAttachments(historicTask.getProcessInstanceId()).size());
       attachments.addAll(taskService.getProcessInstanceAttachments(historicTask.getProcessInstanceId()));
     }
     


### PR DESCRIPTION
This message is continuously being logged to the console while Activiti Explorer is running and tasks are being browsed. It looks like a debug message that was left over from development, listing the number of attachments a certain task has. I have removed it and not replaced it by logging since it seems to have no real value as far as logging is concerned and the rest of the class also doesn't appear to do any logging of its own.
