### PR TITLE
ACT-1454 Support custom comment types

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
@@ -381,6 +381,9 @@ public interface TaskService {
   /** Add a comment to a task and/or process instance. */
   Comment addComment(String taskId, String processInstanceId, String message);
   
+  /** Add a comment to a task and/or process instance with a custom type. */
+  Comment addComment(String taskId, String processInstanceId, String type, String message);
+  
   /** 
    * Returns an individual comment with the given id. Returns null if no comment exists with the given id.
    */
@@ -397,6 +400,12 @@ public interface TaskService {
 
   /** The comments related to the given task. */
   List<Comment> getTaskComments(String taskId);
+  
+  /** The comments related to the given task of the given type. */
+  List<Comment> getTaskComments(String taskId, String type);
+  
+  /** All comments of a given type. */
+  List<Comment> getCommentsByType(String type);
 
   /** The all events related to the given task. */
   List<Event> getTaskEvents(String taskId);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
@@ -40,11 +40,13 @@ import org.activiti.engine.impl.cmd.GetProcessInstanceAttachmentsCmd;
 import org.activiti.engine.impl.cmd.GetProcessInstanceCommentsCmd;
 import org.activiti.engine.impl.cmd.GetSubTasksCmd;
 import org.activiti.engine.impl.cmd.GetTaskAttachmentsCmd;
+import org.activiti.engine.impl.cmd.GetTaskCommentsByTypeCmd;
 import org.activiti.engine.impl.cmd.GetTaskCommentsCmd;
 import org.activiti.engine.impl.cmd.GetTaskEventCmd;
 import org.activiti.engine.impl.cmd.GetTaskEventsCmd;
 import org.activiti.engine.impl.cmd.GetTaskVariableCmd;
 import org.activiti.engine.impl.cmd.GetTaskVariablesCmd;
+import org.activiti.engine.impl.cmd.GetTypeCommentsCmd;
 import org.activiti.engine.impl.cmd.HasTaskVariableCmd;
 import org.activiti.engine.impl.cmd.RemoveTaskVariablesCmd;
 import org.activiti.engine.impl.cmd.ResolveTaskCmd;
@@ -277,6 +279,10 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
     return commandExecutor.execute(new AddCommentCmd(taskId, processInstance, message));
   }
   
+  public Comment addComment(String taskId, String processInstance, String type, String message) {
+    return commandExecutor.execute(new AddCommentCmd(taskId, processInstance, type, message));
+  }
+  
   @Override
   public Comment getComment(String commentId) {
     return commandExecutor.execute(new GetCommentCmd(commentId));
@@ -289,6 +295,14 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
 
   public List<Comment> getTaskComments(String taskId) {
     return commandExecutor.execute(new GetTaskCommentsCmd(taskId));
+  }
+  
+  public List<Comment> getTaskComments(String taskId, String type) {
+    return commandExecutor.execute(new GetTaskCommentsByTypeCmd(taskId, type));
+  }
+  
+  public List<Comment> getCommentsByType(String type) {
+    return commandExecutor.execute(new GetTypeCommentsCmd(type));
   }
 
   public List<Event> getTaskEvents(String taskId) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AddCommentCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AddCommentCmd.java
@@ -36,11 +36,19 @@ public class AddCommentCmd implements Command<Comment>{
 
   protected String taskId;
   protected String processInstanceId;
+  protected String type;
   protected String message;
   
   public AddCommentCmd(String taskId, String processInstanceId, String message) {
     this.taskId = taskId;
     this.processInstanceId = processInstanceId;
+    this.message = message;
+  }
+  
+  public AddCommentCmd(String taskId, String processInstanceId, String type, String message) {
+    this.taskId = taskId;
+    this.processInstanceId = processInstanceId;
+    this.type = type;
     this.message = message;
   }
   
@@ -74,7 +82,7 @@ public class AddCommentCmd implements Command<Comment>{
     String userId = Authentication.getAuthenticatedUserId();
     CommentEntity comment = new CommentEntity();
     comment.setUserId(userId);
-    comment.setType(CommentEntity.TYPE_COMMENT);
+    comment.setType( (type == null)? CommentEntity.TYPE_COMMENT : type );
     comment.setTime(ClockUtil.getCurrentTime());
     comment.setTaskId(taskId);
     comment.setProcessInstanceId(processInstanceId);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskCommentsByTypeCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskCommentsByTypeCmd.java
@@ -1,0 +1,40 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.cmd;
+
+import java.util.List;
+
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.task.Comment;
+
+/**
+ * @author Sam Kim
+ */
+public class GetTaskCommentsByTypeCmd extends GetTaskCommentsCmd {
+
+  private static final long serialVersionUID = 1L;
+  protected String type;
+  
+  public GetTaskCommentsByTypeCmd(String taskId, String type) {
+    super(taskId);
+    this.type = type;
+  }
+  
+  public List<Comment> execute(CommandContext commandContext) {
+    return commandContext
+      .getCommentEntityManager()
+      .findCommentsByTaskIdAndType(taskId, type);
+  }
+
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTypeCommentsCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTypeCommentsCmd.java
@@ -1,0 +1,41 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.task.Comment;
+
+
+/**
+ * @author Sam Kim
+ */
+public class GetTypeCommentsCmd implements Command<List<Comment>>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String type;
+  
+  public GetTypeCommentsCmd(String type) {
+    this.type = type;
+  }
+
+  public List<Comment> execute(CommandContext commandContext) {
+    return commandContext
+      .getCommentEntityManager()
+      .findCommentsByType(type);
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/CommentEntityManager.java
@@ -13,7 +13,9 @@
 
 package org.activiti.engine.impl.persistence.entity;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.impl.db.PersistentObject;
@@ -41,6 +43,21 @@ public class CommentEntityManager extends AbstractManager {
   public List<Comment> findCommentsByTaskId(String taskId) {
     checkHistoryEnabled();
     return getDbSqlSession().selectList("selectCommentsByTaskId", taskId);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public List<Comment> findCommentsByTaskIdAndType(String taskId, String type) {
+    checkHistoryEnabled();
+    Map<String, Object> params = new HashMap<String, Object>();
+    params.put("taskId", taskId);
+    params.put("type", type);
+    return getDbSqlSession().selectListWithRawParameter("selectCommentsByTaskIdAndType", params, 0, Integer.MAX_VALUE);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public List<Comment> findCommentsByType(String type) {
+    checkHistoryEnabled();
+    return getDbSqlSession().selectList("selectCommentsByType", type);
   }
 
   @SuppressWarnings("unchecked")

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/Comment.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/Comment.java
@@ -39,6 +39,9 @@ public interface Comment {
 
   /** reference to the process instance on which this comment was made */ 
   String getProcessInstanceId();
+  
+  /** reference to the type given to the comment */
+  String getType();
 
   /** the full comment message the user had related to the task and/or process instance
    * @see TaskService#getTaskComments(String) */ 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Comment.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Comment.xml
@@ -114,6 +114,36 @@
       and TYPE_ = 'comment'
     order by TIME_ desc
   </select>
+  
+  <select id="selectCommentsByTaskIdAndType" parameterType="java.util.Map" resultMap="commentResultMap">
+  	select *
+  	from ${prefix}ACT_HI_COMMENT
+  	where TASK_ID_ = #{taskId,jdbcType=VARCHAR}
+  		and TYPE_ = #{type,jdbcType=VARCHAR}
+  	order by TIME_ desc
+  </select>
+  
+  <select id="selectCommentsByTaskIdAndType_postgres" parameterType="java.util.Map" resultMap="commentResultMap_postgres">
+  	select *
+  	from ${prefix}ACT_HI_COMMENT
+  	where TASK_ID_ = #{taskId,jdbcType=VARCHAR}
+  		and TYPE_ = #{type,jdbcType=VARCHAR}
+  	order by TIME_ desc
+  </select>
+  
+  <select id="selectCommentsByType" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap">
+  	select *
+  	from ${prefix}ACT_HI_COMMENT
+  	where TYPE_ = #{parameter,jdbcType=VARCHAR}
+  	order by TIME_ desc
+  </select>
+  
+  <select id="selectCommentsByType_postgres" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap_postgres">
+  	select *
+  	from ${prefix}ACT_HI_COMMENT
+  	where TYPE_ = #{parameter,jdbcType=VARCHAR}
+  	order by TIME_ desc
+  </select>
 
   <select id="selectEventsByTaskId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="commentResultMap">
     select * 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
@@ -32,6 +32,7 @@ import org.activiti.engine.identity.Group;
 import org.activiti.engine.identity.User;
 import org.activiti.engine.impl.TaskServiceImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.persistence.entity.CommentEntity;
 import org.activiti.engine.impl.persistence.entity.HistoricDetailVariableInstanceUpdateEntity;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -145,6 +146,50 @@ public class TaskServiceTest extends PluggableActivitiTestCase {
       assertNotNull(comment.getTime());
 
       // Finally, delete task
+      taskService.deleteTask(taskId, true);
+    }
+  }
+  
+  public void testCustomTaskComments() {
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+      Task task = taskService.newTask();
+      task.setOwner("johndoe");
+      taskService.saveTask(task);
+      String taskId = task.getId();
+      
+      identityService.setAuthenticatedUserId("johndoe");
+      String customType1 = "Type1";
+      String customType2 = "Type2";
+      
+      Comment comment = taskService.addComment(taskId, null, "This is a regular comment");
+      Comment customComment1 = taskService.addComment(taskId, null, customType1, "This is a custom comment of type Type1");
+      Comment customComment2 = taskService.addComment(taskId, null, customType1, "This is another Type1 comment");
+      Comment customComment3 = taskService.addComment(taskId, null, customType2, "This is another custom comment. Type2 this time!");
+      
+      assertEquals(CommentEntity.TYPE_COMMENT, comment.getType());
+      assertEquals(customType1, customComment1.getType());
+      assertEquals(customType2, customComment3.getType());
+      
+      assertNotNull(taskService.getComment(comment.getId()));
+      assertNotNull(taskService.getComment(customComment1.getId()));
+      
+      List<Comment> regularComments = taskService.getTaskComments(taskId);
+      assertEquals(1, regularComments.size());
+      assertEquals("This is a regular comment", regularComments.get(0).getFullMessage());
+      
+      List<Event> allComments = taskService.getTaskEvents(taskId);
+      assertEquals(4, allComments.size());
+      
+      List<Comment> type2Comments = taskService.getCommentsByType(customType2);
+      assertEquals(1, type2Comments.size());
+      assertEquals("This is another custom comment. Type2 this time!", type2Comments.get(0).getFullMessage());
+      
+      List<Comment> taskTypeComments = taskService.getTaskComments(taskId, customType1);
+      assertEquals(2, taskTypeComments.size());
+      assertEquals("This is another Type1 comment", taskTypeComments.get(0).getFullMessage());
+      assertEquals("This is a custom comment of type Type1", taskTypeComments.get(1).getFullMessage());
+      
+      // Clean up
       taskService.deleteTask(taskId, true);
     }
   }


### PR DESCRIPTION
https://jira.codehaus.org/browse/ACT-1454

Added interface methods to allow for optional comment type field. Functionality of existing interface methods remain unchanged (most notably, getTaskComments(taskId) only grabs comments of type "comment"). 
