### PR TITLE
Added fields injection for the delegate instance loaded when handling si...

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -52,6 +52,7 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
   public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
     Object delegate = expression.getValue(execution);
     if( delegate instanceof SignallableActivityBehavior){
+      ClassDelegate.applyFieldDeclaration(fieldDeclarations, delegate);
       ((SignallableActivityBehavior) delegate).signal( execution , signalName , signalData);
     }
   }


### PR DESCRIPTION
The delegate instance used when handling a signal could be different than the one used when the execution has been handled (like a new instance), so there is the need to re-inject fields expressions otherwise they could be not accessible by the instance handling the signal
