### PR TITLE
OSGi: optional import-package in activiti-engine for the packages of activiti-camel

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -164,6 +164,8 @@
       org.apache.commons.mail;resolution:=optional,
       org.apache.tools.ant*;resolution:=optional,
       org.apache.xerces*;resolution:=optional,
+      org.activiti.camel;resolution:=optional,
+      org.activiti.camel.impl;resolution:=optional,
       org.activiti.osgi*;resolution:=optional,
       org.springframework*;resolution:=optional,
       org.drools*;resolution:=optional,


### PR DESCRIPTION
Added optional import of packages from bundle activiti-camel in the manifest of the bundle activiti-engine.

Check thread in forum (http://forums.activiti.org/content/activiti-camel-osgi-problem-imported-packages) for details on the problem
