### PR TITLE
ACT-1801: fix JSON-Serialisation of process with lanes

### DIFF
--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/Lane.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/Lane.java
@@ -12,6 +12,8 @@
  */
 package org.activiti.bpmn.model;
 
+import org.codehaus.jackson.annotate.JsonBackReference;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -32,6 +34,7 @@ public class Lane extends BaseElement {
     this.name = name;
   }
 
+  @JsonBackReference
   public Process getParentProcess() {
     return parentProcess;
   }


### PR DESCRIPTION
backreference to process in lanes leads to endless recursion and finally heap-space errors when marshalling a model to json.
Adding @JsonBackreference fixes this.

Thanks to Christian Huff for spotting this and coming up with a solution.
