### PR TITLE
fix executionListeners in subProcesses

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/ExtensionElementsParser.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/ExtensionElementsParser.java
@@ -44,7 +44,7 @@ public class ExtensionElementsParser implements BpmnXMLConstants {
       xtr.next();
       if (xtr.isStartElement()) {
         if (ELEMENT_EXECUTION_LISTENER.equals(xtr.getLocalName())) {
-          new ExecutionListenerParser().parseChildElement(xtr, activeProcess, model);
+          new ExecutionListenerParser().parseChildElement(xtr, parentElement, model);
         } else {
           ExtensionElement extensionElement = BpmnXMLUtil.parseExtensionElement(xtr);
           parentElement.addExtensionElement(extensionElement);

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessConverterTest.java
@@ -60,6 +60,12 @@ public class SubProcessConverterTest extends AbstractConverterTest {
     assertEquals("${assignee == \"\"}", subProcess.getLoopCharacteristics().getCompletionCondition());
     assertTrue(subProcess.getFlowElements().size() == 5);
     
+    assertEquals(1, subProcess.getExecutionListeners().size());
+    ActivitiListener listenerSubProcess = subProcess.getExecutionListeners().get(0);
+    assertEquals("SubProcessTestClass", listenerSubProcess.getImplementation());
+    assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listenerSubProcess.getImplementationType());
+    assertEquals("start", listenerSubProcess.getEvent());    
+    
     flowElement = model.getMainProcess().getFlowElement("boundaryEvent1");
     assertNotNull(flowElement);
     assertTrue(flowElement instanceof BoundaryEvent);
@@ -71,9 +77,9 @@ public class SubProcessConverterTest extends AbstractConverterTest {
     assertTrue(boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
     
     assertEquals(1, model.getMainProcess().getExecutionListeners().size());
-    ActivitiListener listener = model.getMainProcess().getExecutionListeners().get(0);
-    assertEquals("TestClass", listener.getImplementation());
-    assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listener.getImplementationType());
-    assertEquals("start", listener.getEvent());
+    ActivitiListener listenerMainProcess = model.getMainProcess().getExecutionListeners().get(0);
+    assertEquals("TestClass", listenerMainProcess.getImplementation());
+    assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listenerMainProcess.getImplementationType());
+    assertEquals("start", listenerMainProcess.getEvent());
   }
 }

--- a/modules/activiti-bpmn-converter/src/test/resources/subprocessmodel.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/subprocessmodel.bpmn
@@ -2,11 +2,14 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
   <process id="process" name="process1" isExecutable="true">
     <extensionElements>
-      <activiti:executionListener class="TestClass" event="start" />
+      <activiti:executionListener event="start" class="TestClass"></activiti:executionListener>
     </extensionElements>
     <sequenceFlow id="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" sourceRef="boundaryEvent1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
     <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
     <subProcess id="subprocess1" name="subProcess">
+      <extensionElements>
+        <activiti:executionListener event="start" class="SubProcessTestClass"></activiti:executionListener>
+      </extensionElements>
       <multiInstanceLoopCharacteristics isSequential="true">
         <loopCardinality>10</loopCardinality>
         <completionCondition>${assignee == ""}</completionCondition>
@@ -36,54 +39,54 @@
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_process">
     <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
-      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
-        <omgdc:Bounds height="28.0" width="28.0" x="585.0" y="190.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
-        <omgdc:Bounds height="30.0" width="30.0" x="365.0" y="189.0"></omgdc:Bounds>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1" isExpanded="false">
         <omgdc:Bounds height="160.0" width="348.0" x="345.0" y="125.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
-        <omgdc:Bounds height="30.0" width="30.0" x="105.0" y="190.0"></omgdc:Bounds>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="585.0" y="190.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape bpmnElement="boundaryEvent1" id="BPMNShape_boundaryEvent1">
-        <omgdc:Bounds height="30.0" width="30.0" x="492.56652542110646" y="270.03432205225494"></omgdc:Bounds>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="365.0" y="189.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
         <omgdc:Bounds height="80.0" width="100.0" x="440.0" y="164.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryEvent1" id="BPMNShape_boundaryEvent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="492.0" y="270.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="105.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
-        <omgdc:Bounds height="28.0" width="28.0" x="738.0" y="191.0"></omgdc:Bounds>
+        <omgdc:Bounds height="35.0" width="35.0" x="738.0" y="191.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
         <omgdc:Bounds height="80.0" width="100.0" x="180.0" y="165.0"></omgdc:Bounds>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge bpmnElement="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" id="BPMNEdge_sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1">
-        <omgdi:waypoint x="521.9873953195935" y="289.16209522563923"></omgdi:waypoint>
+        <omgdi:waypoint x="507.0" y="300.0"></omgdi:waypoint>
         <omgdi:waypoint x="752.0" y="355.0"></omgdi:waypoint>
-        <omgdi:waypoint x="752.0" y="219.0"></omgdi:waypoint>
+        <omgdi:waypoint x="755.0" y="226.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
-        <omgdi:waypoint x="135.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="140.0" y="207.0"></omgdi:waypoint>
         <omgdi:waypoint x="180.0" y="205.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
         <omgdi:waypoint x="540.0" y="204.0"></omgdi:waypoint>
-        <omgdi:waypoint x="585.0" y="204.0"></omgdi:waypoint>
+        <omgdi:waypoint x="585.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="400.0" y="206.0"></omgdi:waypoint>
+        <omgdi:waypoint x="440.0" y="204.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" id="BPMNEdge_sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2">
         <omgdi:waypoint x="693.0" y="205.0"></omgdi:waypoint>
-        <omgdi:waypoint x="738.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="208.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge bpmnElement="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" id="BPMNEdge_sid-287D861F-4498-4A5C-8EC8-E07F79265E90">
         <omgdi:waypoint x="280.0" y="205.0"></omgdi:waypoint>
         <omgdi:waypoint x="345.0" y="205.0"></omgdi:waypoint>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
-        <omgdi:waypoint x="395.0" y="204.0"></omgdi:waypoint>
-        <omgdi:waypoint x="440.0" y="204.0"></omgdi:waypoint>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
execution listeners on sub process were moved to the main process when
parsing the bpmn model. this commit provides a fix and also extends then
test case for parsing sub processes.
