### PR TITLE
Add wildcards to osgi import with resolution:=optional

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -148,8 +148,8 @@
       org.activiti.db.mapping.entity
     </activiti.osgi.export.additional>
     <activiti.osgi.import.additional>
-      junit;resolution:=optional,
-      org.junit;resolution:=optional,
+      junit.*;resolution:=optional,
+      org.junit.*;resolution:=optional,
       com.sun;resolution:=optional,
       javax.persistence;resolution:=optional,
       org.apache.commons.mail;resolution:=optional,
@@ -158,8 +158,8 @@
       org.activiti.camel;resolution:=optional,
       org.activiti.camel.impl;resolution:=optional,
       org.springframework;resolution:=optional,
-      org.drools;resolution:=optional,
-      com.fasterxml;resolution:=optional,
+      org.drools.*;resolution:=optional,
+      com.fasterxml.*;resolution:=optional,
     </activiti.osgi.import.additional>
   </properties>
 


### PR DESCRIPTION
The manifest generation will only apply the optional resolution to the exact package defined (e.g. com.fasterxml;resolution:=optional will apply resolution:=optional to com.fastexml but not to com.fasterxml.uuid). When deploying activiti-engine, karaf complains about missing bundles (junit, drools, com.fasterxml.uuid) that are supposed to be optional.
