### PR TITLE
Reference userId in Attachment

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CreateAttachmentCmd.java
@@ -21,6 +21,7 @@ import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.db.DbSqlSession;
+import org.activiti.engine.impl.identity.Authentication;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.AttachmentEntity;
@@ -69,6 +70,7 @@ public class CreateAttachmentCmd implements Command<Attachment> {
     attachment.setTaskId(taskId);
     attachment.setProcessInstanceId(processInstanceId);
     attachment.setUrl(url);
+    attachment.setUserId(Authentication.getAuthenticatedUserId());
     
     DbSqlSession dbSqlSession = commandContext.getDbSqlSession();
     dbSqlSession.insert(attachment);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
@@ -39,6 +39,7 @@ public class AttachmentEntity implements Attachment, PersistentObject, HasRevisi
   protected String url;
   protected String contentId;
   protected ByteArrayEntity content;
+  protected String userId;
 
   public Object getPersistentState() {
     Map<String, Object> persistentState = new HashMap<String, Object>();
@@ -147,4 +148,13 @@ public class AttachmentEntity implements Attachment, PersistentObject, HasRevisi
   public void setContent(ByteArrayEntity content) {
     this.content = content;
   }
+  
+  public void setUserId(String userId) {
+	this.userId = userId;
+  }
+  
+  public String getUserId() {
+	return userId;
+  }
+  
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/Attachment.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/Attachment.java
@@ -52,4 +52,7 @@ public interface Attachment {
    * {@link TaskService#createAttachment(String, String, String, String, String, java.io.InputStream) uploaded with an input stream}, 
    * then this method returns null and the content can be fetched with {@link TaskService#getAttachmentContent(String)}. */
   String getUrl();
+  
+  /** reference to the user who created this attachment. */
+  String getUserId();
 }

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
@@ -21,10 +21,11 @@
   <!-- ATTACHMENT INSERT -->
 
   <insert id="insertAttachment" parameterType="org.activiti.engine.impl.persistence.entity.AttachmentEntity">
-    insert into ${prefix}ACT_HI_ATTACHMENT (ID_, REV_, NAME_, DESCRIPTION_, TYPE_, TASK_ID_, PROC_INST_ID_, URL_, CONTENT_ID_)
+    insert into ${prefix}ACT_HI_ATTACHMENT (ID_, REV_, USER_ID_, NAME_, DESCRIPTION_, TYPE_, TASK_ID_, PROC_INST_ID_, URL_, CONTENT_ID_)
     values (
       #{id ,jdbcType=VARCHAR},
       1,
+      #{userId ,jdbcType=VARCHAR},
       #{name ,jdbcType=VARCHAR},
       #{description ,jdbcType=VARCHAR},
       #{type ,jdbcType=VARCHAR},


### PR DESCRIPTION
Adds a userId reference to Attachment as discussed in forum

http://forums.activiti.org/content/user-id-acthiattachment-always-null
