### PR TITLE
fix for missing osgi package exports

### DIFF
--- a/modules/activiti-json-converter/pom.xml
+++ b/modules/activiti-json-converter/pom.xml
@@ -18,6 +18,9 @@
     <activiti.artifact>
       org.activiti.json.converter
     </activiti.artifact>
+    <activiti.osgi.export.additional>
+      org.activiti.editor*
+    </activiti.osgi.export.additional>
   </properties>
 
   <build>

--- a/modules/activiti-simple-workflow/pom.xml
+++ b/modules/activiti-simple-workflow/pom.xml
@@ -18,6 +18,9 @@
     <activiti.artifact>
       org.activiti.simple.workflow
     </activiti.artifact>
+    <activiti.osgi.export.additional>
+      org.activiti.workflow*
+    </activiti.osgi.export.additional>
   </properties>
 
   <build>


### PR DESCRIPTION
2 modules: activiti-json-converter and activiti-simple-workflow have missing Export-Package clause, what prevents their usage in osgi container. Following fix solves this issue. This is needed for deploying activiti-rest using plain osgi http service without full war deployment.
