### PR TITLE
Added ExecuteJobsRunnable exception handling

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/ExecuteJobsRunnable.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/ExecuteJobsRunnable.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExecuteJobsRunnable implements Runnable
 {
-    private static Logger log = LoggerFactory.getLogger(AcquireJobsRunnable.class);
+    private static Logger log = LoggerFactory.getLogger(ExecuteJobsRunnable.class);
 
     private final List<String> jobIds;
     private final JobExecutor jobExecutor;


### PR DESCRIPTION
I surrounded the `commandExecutor.execute` method call with a try/catch. This will allow other locked exclusive jobs that were acquired to continue executing after an exception was thrown by one.  Without this, if more than one job was acquired, and one of them throws an exception, the others will not continue to execute, and will not be tried again until the job's `lockExpirationTime` is reached.
