### PR TITLE
ACT-1941: prevent internal UserEntity class leaking though API

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SaveUserCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SaveUserCmd.java
@@ -51,9 +51,23 @@ public class SaveUserCmd implements Command<Void>, Serializable {
       throw new ActivitiIllegalArgumentException("user is null");
     }
     if (user.getRevision()==0) {
-      commandContext
-        .getUserIdentityManager()
-        .insertUser(user);
+      try { 
+        commandContext
+          .getUserIdentityManager()
+          .insertUser(user);
+      } catch (Exception e) { 
+        // This occurs when the received User instance was not a 
+        // UserEntity at construction time AND the user record 
+        // does already exist. 
+        UserEntity user = (UserEntity) commandContext.getProcessEngineConfiguration().getIdentityService().createUserQuery().userId(this.user.getId()).singleResult();
+        user.setFirstName(this.user.getFirstName());
+        user.setLastName(this.user.getLastName());
+        user.setEmail(this.user.getEmail());
+        user.setPassword(this.user.getPassword());
+        commandContext
+          .getUserIdentityManager()
+          .updateUser(user);
+      }   
     } else {
       commandContext
         .getUserIdentityManager()


### PR DESCRIPTION
Simply test if the received User interface is castable to UserEntity and if not create a new one copying the fields over. 
