### PR TITLE
Fix ACT-1794 LDAP group lookups with user DN containing special chars

### DIFF
--- a/modules/activiti-ldap/src/main/java/org/activiti/ldap/LDAPQueryBuilder.java
+++ b/modules/activiti-ldap/src/main/java/org/activiti/ldap/LDAPQueryBuilder.java
@@ -19,6 +19,7 @@ import javax.naming.NamingException;
 import javax.naming.directory.InitialDirContext;
 import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
+import javax.naming.ldap.Rdn;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.slf4j.Logger;
@@ -73,7 +74,7 @@ public class LDAPQueryBuilder {
         
       });
       
-      searchExpression = MessageFormat.format(ldapConfigurator.getQueryGroupsForUser(), userDn);
+      searchExpression = MessageFormat.format(ldapConfigurator.getQueryGroupsForUser(), Rdn.escapeValue(userDn));
       
     } else {
       searchExpression = userId;

--- a/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LdapIntegrationTest.java
+++ b/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LdapIntegrationTest.java
@@ -23,6 +23,7 @@ public class LdapIntegrationTest extends LDAPTestCase {
   
   public void testAuthenticationThroughLdap() {
     assertTrue(identityService.checkPassword("kermit", "pass"));
+    assertTrue(identityService.checkPassword("bunsen", "pass"));
     assertFalse(identityService.checkPassword("kermit", "blah"));
   }
   
@@ -34,7 +35,10 @@ public class LdapIntegrationTest extends LDAPTestCase {
 
     // Pepe is a member of the candidate group and should be able to find the task
     assertEquals(1, taskService.createTaskQuery().taskCandidateUser("pepe").count());
-    
+
+    // Dr. Bunsen is also a member of the candidate group and should be able to find the task
+    assertEquals(1, taskService.createTaskQuery().taskCandidateUser("bunsen").count());
+
     // Kermit is a candidate user and should be able to find the task
     assertEquals(1, taskService.createTaskQuery().taskCandidateUser("kermit").count());
   }
@@ -74,8 +78,8 @@ public class LdapIntegrationTest extends LDAPTestCase {
     assertEquals("The Frog", user.getLastName());
     
     users = identityService.createUserQuery().userFullNameLike("e").list();
-    assertEquals(4, users.size());
-    assertEquals(4, identityService.createUserQuery().userFullNameLike("e").count());
+    assertEquals(5, users.size());
+    assertEquals(5, identityService.createUserQuery().userFullNameLike("e").count());
     
     users = identityService.createUserQuery().userFullNameLike("The").list();
     assertEquals(3, users.size());

--- a/modules/activiti-ldap/src/test/resources/users.ldif
+++ b/modules/activiti-ldap/src/test/resources/users.ldif
@@ -35,6 +35,7 @@ uniqueMember: uid=kermit, ou=users,o=activiti
 uniqueMember: uid=pepe, ou=users,o=activiti
 uniqueMember: uid=gonzo, ou=users,o=activiti
 uniqueMember: uid=fozzie, ou=users,o=activiti
+uniqueMember: cn=Dr\, Bunsen,ou=users,o=activiti
 
 dn: cn=Admin,ou=groups,o=activiti
 objectClass: groupOfUniqueNames
@@ -51,6 +52,7 @@ cn: Sales
 uid : sales
 uniqueMember: uid=pepe, ou=users,o=activiti
 uniqueMember: uid=gonzo, ou=users,o=activiti
+uniqueMember: cn=Dr\, Bunsen,ou=users,o=activiti
 
 # Actual users
 
@@ -102,4 +104,14 @@ objectClass: top
 cn: Gonzo
 sn: The Great
 uid: gonzo
+userPassword:: cGFzcw==
+
+dn: cn=Dr\, Bunsen,ou=users,o=activiti
+objectClass: organizationalPerson
+objectClass: person
+objectClass: inetOrgPerson
+objectClass: top
+cn: Dr\, Bunsen
+sn: Honeydew
+uid: bunsen
 userPassword:: cGFzcw==


### PR DESCRIPTION
LDAP Group lookups fail if user distinguishedName attribute contains special characters. This can occur if CN attribute in AD is in the format "Lastname,Firstname". I ran into this problem when integrating with AD and noticed that there is an open Jira ticket for this issue. 
