### PR TITLE
attachment result map include userId now

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
@@ -67,6 +67,7 @@
     <result property="processInstanceId" column="PROC_INST_ID_" jdbcType="VARCHAR" />
     <result property="url" column="URL_" jdbcType="VARCHAR" />
     <result property="contentId" column="CONTENT_ID_" jdbcType="VARCHAR" />
+    <result property="userId" column="USER_ID_" jdbcType="VARCHAR" />
   </resultMap>
   
   <!-- ATTACHMENT SELECT -->


### PR DESCRIPTION
Attachment.getUserId() always return null before since missing userId in resultMap
