### PR TITLE
Added option to specify deploymentMode for SpringProcessEngineConfiguration

### DIFF
--- a/modules/activiti-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
@@ -13,138 +13,107 @@
 
 package org.activiti.spring;
 
-import java.io.IOException;
-import java.util.zip.ZipInputStream;
+import java.util.ArrayList;
+import java.util.Collection;
 
 import javax.sql.DataSource;
 
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.ProcessEngineConfiguration;
-import org.activiti.engine.RepositoryService;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 import org.activiti.engine.impl.interceptor.CommandConfig;
 import org.activiti.engine.impl.interceptor.CommandInterceptor;
 import org.activiti.engine.impl.variable.EntityManagerSession;
-import org.activiti.engine.repository.DeploymentBuilder;
+import org.activiti.spring.autodeployment.AutoDeploymentStrategy;
+import org.activiti.spring.autodeployment.DefaultAutoDeploymentStrategy;
+import org.activiti.spring.autodeployment.ResourceParentFolderAutoDeploymentStrategy;
+import org.activiti.spring.autodeployment.SingleResourceAutoDeploymentStrategy;
 import org.springframework.beans.BeansException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.ContextResource;
 import org.springframework.core.io.Resource;
 import org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy;
 import org.springframework.transaction.PlatformTransactionManager;
-
 
 /**
  * @author Tom Baeyens
  * @author David Syer
  * @author Joram Barrez
+ * @author Tiese Barrell
  */
 public class SpringProcessEngineConfiguration extends ProcessEngineConfigurationImpl implements ApplicationContextAware {
 
   protected PlatformTransactionManager transactionManager;
   protected String deploymentName = "SpringAutoDeployment";
   protected Resource[] deploymentResources = new Resource[0];
+  protected String deploymentMode = "default";
   protected ApplicationContext applicationContext;
   protected Integer transactionSynchronizationAdapterOrder = null;
-  
-  
+  private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
+
   public SpringProcessEngineConfiguration() {
     this.transactionsExternallyManaged = true;
+    deploymentStrategies.add(new DefaultAutoDeploymentStrategy());
+    deploymentStrategies.add(new SingleResourceAutoDeploymentStrategy());
+    deploymentStrategies.add(new ResourceParentFolderAutoDeploymentStrategy());
   }
-  
+
   @Override
   public ProcessEngine buildProcessEngine() {
     ProcessEngine processEngine = super.buildProcessEngine();
     autoDeployResources(processEngine);
     return processEngine;
   }
-  
+
   public void setTransactionSynchronizationAdapterOrder(Integer transactionSynchronizationAdapterOrder) {
     this.transactionSynchronizationAdapterOrder = transactionSynchronizationAdapterOrder;
   }
 
   @Override
   protected void initDefaultCommandConfig() {
-    if (defaultCommandConfig==null) {
+    if (defaultCommandConfig == null) {
       defaultCommandConfig = new CommandConfig().setContextReusePossible(true);
     }
   }
 
   @Override
   protected CommandInterceptor createTransactionInterceptor() {
-    if (transactionManager==null) {
-      throw new ActivitiException("transactionManager is required property for SpringProcessEngineConfiguration, use "+StandaloneProcessEngineConfiguration.class.getName()+" otherwise");
+    if (transactionManager == null) {
+      throw new ActivitiException("transactionManager is required property for SpringProcessEngineConfiguration, use "
+              + StandaloneProcessEngineConfiguration.class.getName() + " otherwise");
     }
-    
+
     return new SpringTransactionInterceptor(transactionManager);
   }
 
   @Override
   protected void initTransactionContextFactory() {
-    if(transactionContextFactory == null && transactionManager != null) {
+    if (transactionContextFactory == null && transactionManager != null) {
       transactionContextFactory = new SpringTransactionContextFactory(transactionManager, transactionSynchronizationAdapterOrder);
     }
   }
-  
+
   @Override
   protected void initJpa() {
     super.initJpa();
     if (jpaEntityManagerFactory != null) {
-      sessionFactories.put(EntityManagerSession.class, 
-              new SpringEntityManagerSessionFactory(jpaEntityManagerFactory, jpaHandleTransaction, jpaCloseEntityManager));
+      sessionFactories.put(EntityManagerSession.class, new SpringEntityManagerSessionFactory(jpaEntityManagerFactory, jpaHandleTransaction,
+              jpaCloseEntityManager));
     }
   }
 
   protected void autoDeployResources(ProcessEngine processEngine) {
-    if (deploymentResources!=null && deploymentResources.length>0) {
-      RepositoryService repositoryService = processEngine.getRepositoryService();
-      
-      DeploymentBuilder deploymentBuilder = repositoryService
-        .createDeployment()
-        .enableDuplicateFiltering()
-        .name(deploymentName);
-      
-      for (Resource resource : deploymentResources) {
-        String resourceName = null;
-        
-        if (resource instanceof ContextResource) {
-          resourceName = ((ContextResource) resource).getPathWithinContext();
-          
-        } else if (resource instanceof ByteArrayResource) {
-          resourceName = resource.getDescription();
-          
-        } else {
-          try {
-            resourceName = resource.getFile().getAbsolutePath();
-          } catch (IOException e) {
-            resourceName = resource.getFilename();
-          }
-        }
-        
-        try {
-          if ( resourceName.endsWith(".bar")
-               || resourceName.endsWith(".zip")
-               || resourceName.endsWith(".jar") ) {
-            deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
-          } else {
-            deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
-          }
-        } catch (IOException e) {
-          throw new ActivitiException("couldn't auto deploy resource '"+resource+"': "+e.getMessage(), e);
-        }
-      }
-      
-      deploymentBuilder.deploy();
+    if (deploymentResources != null && deploymentResources.length > 0) {
+      final AutoDeploymentStrategy strategy = getAutoDeploymentStrategy(deploymentMode);
+      strategy.deployResources(deploymentName, deploymentResources, processEngine.getRepositoryService());
     }
   }
-  
+
   @Override
   public ProcessEngineConfiguration setDataSource(DataSource dataSource) {
-    if(dataSource instanceof TransactionAwareDataSourceProxy) {
+    if (dataSource instanceof TransactionAwareDataSourceProxy) {
       return super.setDataSource(dataSource);
     } else {
       // Wrap datasource in Transaction-aware proxy
@@ -152,11 +121,11 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
       return super.setDataSource(proxiedDataSource);
     }
   }
-  
+
   public PlatformTransactionManager getTransactionManager() {
     return transactionManager;
   }
-  
+
   public void setTransactionManager(PlatformTransactionManager transactionManager) {
     this.transactionManager = transactionManager;
   }
@@ -164,15 +133,15 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
   public String getDeploymentName() {
     return deploymentName;
   }
-  
+
   public void setDeploymentName(String deploymentName) {
     this.deploymentName = deploymentName;
   }
-  
+
   public Resource[] getDeploymentResources() {
     return deploymentResources;
   }
-  
+
   public void setDeploymentResources(Resource[] deploymentResources) {
     this.deploymentResources = deploymentResources;
   }
@@ -185,4 +154,34 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
   public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
     this.applicationContext = applicationContext;
   }
+
+  public String getDeploymentMode() {
+    return deploymentMode;
+  }
+
+  public void setDeploymentMode(String deploymentMode) {
+    this.deploymentMode = deploymentMode;
+  }
+
+  /**
+   * Gets the {@link AutoDeploymentStrategy} for the provided mode. This method
+   * may be overridden to implement custom deployment strategies if required,
+   * but implementors should take care not to return <code>null</code>.
+   * 
+   * @param mode
+   *          the mode to get the strategy for
+   * @return the deployment strategy to use for the mode. Never
+   *         <code>null</code>
+   */
+  protected AutoDeploymentStrategy getAutoDeploymentStrategy(final String mode) {
+    AutoDeploymentStrategy result = new DefaultAutoDeploymentStrategy();
+    for (final AutoDeploymentStrategy strategy : deploymentStrategies) {
+      if (strategy.handlesMode(mode)) {
+        result = strategy;
+        break;
+      }
+    }
+    return result;
+  }
+
 }

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/AbstractAutoDeploymentStrategy.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/AbstractAutoDeploymentStrategy.java
@@ -1,0 +1,56 @@
+package org.activiti.spring.autodeployment;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ContextResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * Abstract base class for implementations of {@link AutoDeploymentStrategy}.
+ * 
+ * @author Tiese Barrell
+ * 
+ */
+public abstract class AbstractAutoDeploymentStrategy implements AutoDeploymentStrategy {
+
+  /**
+   * Gets the deployment mode this strategy handles.
+   * 
+   * @return the name of the deployment mode
+   */
+  protected abstract String getDeploymentMode();
+
+  @Override
+  public boolean handlesMode(final String mode) {
+    return StringUtils.equalsIgnoreCase(mode, getDeploymentMode());
+  }
+
+  /**
+   * Determines the name to be used for the provided resource.
+   * 
+   * @param resource
+   *          the resource to get the name for
+   * @return the name of the resource
+   */
+  protected String determineResourceName(final Resource resource) {
+    String resourceName = null;
+
+    if (resource instanceof ContextResource) {
+      resourceName = ((ContextResource) resource).getPathWithinContext();
+
+    } else if (resource instanceof ByteArrayResource) {
+      resourceName = resource.getDescription();
+
+    } else {
+      try {
+        resourceName = resource.getFile().getAbsolutePath();
+      } catch (IOException e) {
+        resourceName = resource.getFilename();
+      }
+    }
+    return resourceName;
+  }
+
+}

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/AutoDeploymentStrategy.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/AutoDeploymentStrategy.java
@@ -1,0 +1,43 @@
+package org.activiti.spring.autodeployment;
+
+import org.activiti.engine.RepositoryService;
+import org.springframework.core.io.Resource;
+
+/**
+ * Strategy interface for implementations of automatically deploying resources.
+ * A strategy may perform any amount of deployments for the {@link Resource}s it
+ * is provided with.
+ * 
+ * <p>
+ * A strategy is capable of handling deployments corresponding to a certain
+ * indicated deployment mode. This applicability is verified using the
+ * {@link #handlesMode(String)} method.
+ * 
+ * @author Tiese Barrell
+ */
+public interface AutoDeploymentStrategy {
+
+  /**
+   * Determines whether the strategy handles deployments for the provided
+   * deployment mode.
+   * 
+   * @param mode
+   *          the mode to determine handling for
+   * @return true if the strategy handles the mode; false otherwise
+   */
+  boolean handlesMode(final String mode);
+
+  /**
+   * Performs deployment for the provided resources, using the provided name as
+   * a hint and the provided {@link RepositoryService} to perform deployment(s).
+   * 
+   * @param deploymentName
+   *          the hint for the name of deployment(s) performed
+   * @param resources
+   *          the resources to be deployed
+   * @param repositoryService
+   *          the repository service to use for deployment(s)
+   */
+  void deployResources(final String deploymentNameHint, final Resource[] resources, final RepositoryService repositoryService);
+
+}

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -1,0 +1,56 @@
+package org.activiti.spring.autodeployment;
+
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.DeploymentBuilder;
+import org.springframework.core.io.Resource;
+
+/**
+ * Default implementation of {@link AutoDeploymentStrategy} that groups all
+ * {@link Resource}s into a single deployment. This implementation is equivalent
+ * to the previously used implementation.
+ * 
+ * @author Tiese Barrell
+ * 
+ */
+public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrategy {
+
+  /**
+   * The deployment mode this strategy handles.
+   */
+  public static final String DEPLOYMENT_MODE = "default";
+
+  @Override
+  protected String getDeploymentMode() {
+    return DEPLOYMENT_MODE;
+  }
+
+  @Override
+  public void deployResources(final String deploymentNameHint, final Resource[] resources, final RepositoryService repositoryService) {
+
+    // Create a single deployment for all resources using the name hint as the
+    // literal name
+    final DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(deploymentNameHint);
+
+    for (final Resource resource : resources) {
+      final String resourceName = determineResourceName(resource);
+
+      try {
+        if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
+          deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
+        } else {
+          deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+        }
+      } catch (IOException e) {
+        throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
+      }
+    }
+
+    deploymentBuilder.deploy();
+
+  }
+
+}

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
@@ -1,0 +1,103 @@
+package org.activiti.spring.autodeployment;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.DeploymentBuilder;
+import org.springframework.core.io.Resource;
+
+/**
+ * Implementation of {@link AutoDeploymentStrategy} that performs a separate
+ * deployment for each set of {@link Resource}s that share the same parent
+ * folder. The namehint is used to prefix the names of deployments. If the
+ * parent folder for a {@link Resource} cannot be determined, the resource's
+ * name is used.
+ * 
+ * @author Tiese Barrell
+ * 
+ */
+public class ResourceParentFolderAutoDeploymentStrategy extends AbstractAutoDeploymentStrategy {
+
+  /**
+   * The deployment mode this strategy handles.
+   */
+  public static final String DEPLOYMENT_MODE = "resource-parent-folder";
+
+  private static final String DEPLOYMENT_NAME_PATTERN = "%s.%s";
+
+  @Override
+  protected String getDeploymentMode() {
+    return DEPLOYMENT_MODE;
+  }
+
+  @Override
+  public void deployResources(final String deploymentNameHint, final Resource[] resources, final RepositoryService repositoryService) {
+
+    // Create a deployment for each distinct parent folder using the name hint
+    // as a prefix
+    final Map<String, Set<Resource>> resourcesMap = createMap(resources);
+
+    for (final Entry<String, Set<Resource>> group : resourcesMap.entrySet()) {
+
+      final String deploymentName = determineDeploymentName(deploymentNameHint, group.getKey());
+
+      final DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(deploymentName);
+
+      for (final Resource resource : group.getValue()) {
+        final String resourceName = determineResourceName(resource);
+
+        try {
+          if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
+            deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
+          } else {
+            deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+          }
+        } catch (IOException e) {
+          throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
+        }
+      }
+      deploymentBuilder.deploy();
+    }
+
+  }
+
+  private Map<String, Set<Resource>> createMap(final Resource[] resources) {
+    final Map<String, Set<Resource>> resourcesMap = new HashMap<String, Set<Resource>>();
+
+    for (final Resource resource : resources) {
+      final String parentFolderName = determineGroupName(resource);
+      if (resourcesMap.get(parentFolderName) == null) {
+        resourcesMap.put(parentFolderName, new HashSet<Resource>());
+      }
+      resourcesMap.get(parentFolderName).add(resource);
+    }
+    return resourcesMap;
+  }
+
+  private String determineGroupName(final Resource resource) {
+    String result = determineResourceName(resource);
+    try {
+      if (resourceParentIsDirectory(resource)) {
+        result = resource.getFile().getParentFile().getName();
+      }
+    } catch (IOException e) {
+      // no-op, fallback to resource name
+    }
+    return result;
+  }
+
+  private boolean resourceParentIsDirectory(final Resource resource) throws IOException {
+    return resource.getFile() != null && resource.getFile().getParentFile() != null && resource.getFile().getParentFile().isDirectory();
+  }
+
+  private String determineDeploymentName(final String deploymentNameHint, final String groupName) {
+    return String.format(DEPLOYMENT_NAME_PATTERN, deploymentNameHint, groupName);
+  }
+}

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/SingleResourceAutoDeploymentStrategy.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/autodeployment/SingleResourceAutoDeploymentStrategy.java
@@ -1,0 +1,54 @@
+package org.activiti.spring.autodeployment;
+
+import java.io.IOException;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.DeploymentBuilder;
+import org.springframework.core.io.Resource;
+
+/**
+ * Implementation of {@link AutoDeploymentStrategy} that performs a separate
+ * deployment for each resource by name.
+ * 
+ * @author Tiese Barrell
+ * 
+ */
+public class SingleResourceAutoDeploymentStrategy extends AbstractAutoDeploymentStrategy {
+
+  /**
+   * The deployment mode this strategy handles.
+   */
+  public static final String DEPLOYMENT_MODE = "single-resource";
+
+  @Override
+  protected String getDeploymentMode() {
+    return DEPLOYMENT_MODE;
+  }
+
+  @Override
+  public void deployResources(final String deploymentNameHint, final Resource[] resources, final RepositoryService repositoryService) {
+
+    // Create a separate deployment for each resource using the resource name
+
+    for (final Resource resource : resources) {
+
+      final String resourceName = determineResourceName(resource);
+      final DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(resourceName);
+
+      try {
+        if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
+          deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
+        } else {
+          deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
+        }
+      } catch (IOException e) {
+        throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
+      }
+
+      deploymentBuilder.deploy();
+    }
+  }
+
+}

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -1,0 +1,117 @@
+package org.activiti.spring.test.autodeployment;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.InputStream;
+
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.Deployment;
+import org.activiti.engine.repository.DeploymentBuilder;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.ContextResource;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Tiese Barrell
+ */
+public class AbstractAutoDeploymentStrategyTest {
+
+  @Mock
+  protected RepositoryService repositoryServiceMock;
+
+  @Mock
+  protected DeploymentBuilder deploymentBuilderMock;
+
+  @Mock
+  protected ContextResource resourceMock1;
+
+  @Mock
+  protected ByteArrayResource resourceMock2;
+
+  @Mock
+  protected Resource resourceMock3;
+
+  @Mock
+  protected Resource resourceMock4;
+
+  @Mock
+  protected Resource resourceMock5;
+
+  @Mock
+  protected File fileMock1;
+
+  @Mock
+  protected File fileMock2;
+
+  @Mock
+  protected File fileMock3;
+
+  @Mock
+  protected File fileMock4;
+
+  @Mock
+  protected File fileMock5;
+
+  @Mock
+  private InputStream inputStreamMock;
+
+  @Mock
+  private Deployment deploymentMock;
+
+  protected final String deploymentNameHint = "nameHint";
+
+  protected final String resourceName1 = "resourceName1.bpmn";
+  protected final String resourceName2 = "resourceName2.bpmn";
+  protected final String resourceName3 = "/opt/processes/resourceName3.bar";
+  protected final String resourceName4 = "/opt/processes/resourceName4.zip";
+  protected final String resourceName5 = "/opt/processes/resourceName5.jar";
+
+  @Before
+  public void before() throws Exception {
+
+    when(resourceMock1.getPathWithinContext()).thenReturn(resourceName1);
+    when(resourceMock1.getFile()).thenReturn(fileMock1);
+
+    when(resourceMock2.getDescription()).thenReturn(resourceName2);
+    when(resourceMock2.getFile()).thenReturn(fileMock2);
+
+    when(resourceMock3.getFile()).thenReturn(fileMock3);
+    when(fileMock3.getAbsolutePath()).thenReturn(resourceName3);
+
+    when(resourceMock4.getFile()).thenReturn(fileMock4);
+    when(fileMock4.getAbsolutePath()).thenReturn(resourceName4);
+
+    when(resourceMock5.getFile()).thenReturn(fileMock5);
+    when(fileMock5.getAbsolutePath()).thenReturn(resourceName5);
+
+    when(resourceMock1.getInputStream()).thenReturn(inputStreamMock);
+    when(resourceMock2.getInputStream()).thenReturn(inputStreamMock);
+    when(resourceMock3.getInputStream()).thenReturn(inputStreamMock);
+    when(resourceMock4.getInputStream()).thenReturn(inputStreamMock);
+    when(resourceMock5.getInputStream()).thenReturn(inputStreamMock);
+
+    when(repositoryServiceMock.createDeployment()).thenReturn(deploymentBuilderMock);
+    when(deploymentBuilderMock.enableDuplicateFiltering()).thenReturn(deploymentBuilderMock);
+    when(deploymentBuilderMock.name(isA(String.class))).thenReturn(deploymentBuilderMock);
+
+    when(deploymentBuilderMock.deploy()).thenReturn(deploymentMock);
+  }
+
+}

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -1,0 +1,108 @@
+package org.activiti.spring.test.autodeployment;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.spring.autodeployment.DefaultAutoDeploymentStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Tiese Barrell
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
+
+  private DefaultAutoDeploymentStrategy classUnderTest;
+
+  @Before
+  public void before() throws Exception {
+    super.before();
+    classUnderTest = new DefaultAutoDeploymentStrategy();
+    assertNotNull(classUnderTest);
+  }
+
+  @Test
+  public void testHandlesMode() {
+    assertTrue(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
+    assertFalse(classUnderTest.handlesMode("other-mode"));
+    assertFalse(classUnderTest.handlesMode(null));
+  }
+
+  @Test
+  public void testDeployResources() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(1)).createDeployment();
+    verify(deploymentBuilderMock, times(1)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(3)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(1)).deploy();
+  }
+
+  @Test
+  public void testDeployResourcesNoResources() {
+    final Resource[] resources = new Resource[] {};
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(1)).createDeployment();
+    verify(deploymentBuilderMock, times(1)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint);
+    verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(1)).deploy();
+  }
+
+  @Test(expected = ActivitiException.class)
+  public void testDeployResourcesIOExceptionYieldsActivitiException() throws Exception {
+    when(resourceMock3.getInputStream()).thenThrow(new IOException());
+
+    final Resource[] resources = new Resource[] { resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    fail("Expected exception for IOException");
+  }
+
+  @Test
+  public void testDetermineResourceNameWithExceptionFailsGracefully() throws Exception {
+    when(resourceMock3.getFile()).thenThrow(new IOException());
+    when(resourceMock3.getFilename()).thenReturn(resourceName3);
+
+    final Resource[] resources = new Resource[] { resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+  }
+
+}

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -1,0 +1,211 @@
+package org.activiti.spring.test.autodeployment;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.spring.autodeployment.ResourceParentFolderAutoDeploymentStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Tiese Barrell
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
+
+  private ResourceParentFolderAutoDeploymentStrategy classUnderTest;
+
+  @Mock
+  private File parentFile1Mock;
+
+  @Mock
+  private File parentFile2Mock;
+
+  private final String parentFilename1 = "parentFilename1";
+  private final String parentFilename2 = "parentFilename2";
+
+  @Before
+  public void before() throws Exception {
+    super.before();
+    classUnderTest = new ResourceParentFolderAutoDeploymentStrategy();
+    assertNotNull(classUnderTest);
+
+    when(parentFile1Mock.getName()).thenReturn(parentFilename1);
+    when(parentFile1Mock.isDirectory()).thenReturn(true);
+    when(parentFile2Mock.getName()).thenReturn(parentFilename2);
+    when(parentFile2Mock.isDirectory()).thenReturn(true);
+  }
+
+  @Test
+  public void testHandlesMode() {
+    assertTrue(classUnderTest.handlesMode(ResourceParentFolderAutoDeploymentStrategy.DEPLOYMENT_MODE));
+    assertFalse(classUnderTest.handlesMode("other-mode"));
+    assertFalse(classUnderTest.handlesMode(null));
+  }
+
+  @Test
+  public void testDeployResources_Separate() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2 };
+
+    when(fileMock1.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
+
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(2)).createDeployment();
+    verify(deploymentBuilderMock, times(2)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename1);
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename2);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(2)).deploy();
+  }
+
+  @Test
+  public void testDeployResources_Joined() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2 };
+
+    when(fileMock1.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock2.getParentFile()).thenReturn(parentFile1Mock);
+
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(1)).createDeployment();
+    verify(deploymentBuilderMock, times(1)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename1);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).deploy();
+  }
+
+  @Test
+  public void testDeployResources_AllInOne() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5 };
+
+    when(fileMock1.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock2.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock3.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock4.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock5.getParentFile()).thenReturn(parentFile1Mock);
+
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(1)).createDeployment();
+    verify(deploymentBuilderMock, times(1)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename1);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(3)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(1)).deploy();
+  }
+
+  @Test
+  public void testDeployResources_Mixed() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
+
+    when(fileMock1.getParentFile()).thenReturn(parentFile1Mock);
+    when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
+    when(fileMock3.getParentFile()).thenReturn(parentFile1Mock);
+
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(2)).createDeployment();
+    verify(deploymentBuilderMock, times(2)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename1);
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + parentFilename2);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(2)).deploy();
+  }
+
+  @Test
+  public void testDeployResources_NoParent() {
+
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    when(fileMock1.getParentFile()).thenReturn(null);
+    when(fileMock2.getParentFile()).thenReturn(parentFile2Mock);
+    when(parentFile2Mock.isDirectory()).thenReturn(false);
+    when(fileMock3.getParentFile()).thenReturn(null);
+
+    verify(repositoryServiceMock, times(3)).createDeployment();
+    verify(deploymentBuilderMock, times(3)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + resourceName1);
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + resourceName2);
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + resourceName3);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(3)).deploy();
+  }
+
+  @Test
+  public void testDeployResourcesNoResources() {
+    final Resource[] resources = new Resource[] {};
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, never()).createDeployment();
+    verify(deploymentBuilderMock, never()).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, never()).name(deploymentNameHint);
+    verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, never()).deploy();
+  }
+
+  @Test
+  public void testDeployResourcesIOExceptionWhenCreatingMapFallsBackToResourceName() throws Exception {
+    when(resourceMock3.getFile()).thenThrow(new IOException());
+    when(resourceMock3.getFilename()).thenReturn(resourceName3);
+
+    final Resource[] resources = new Resource[] { resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(1)).createDeployment();
+    verify(deploymentBuilderMock, times(1)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(deploymentNameHint + "." + resourceName3);
+    verify(deploymentBuilderMock, times(1)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(1)).deploy();
+  }
+
+  @Test(expected = ActivitiException.class)
+  public void testDeployResourcesIOExceptionYieldsActivitiException() throws Exception {
+    when(resourceMock3.getInputStream()).thenThrow(new IOException());
+
+    final Resource[] resources = new Resource[] { resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+  }
+
+}

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -1,0 +1,100 @@
+package org.activiti.spring.test.autodeployment;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.spring.autodeployment.SingleResourceAutoDeploymentStrategy;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.core.io.Resource;
+
+/**
+ * @author Tiese Barrell
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
+
+  private SingleResourceAutoDeploymentStrategy classUnderTest;
+
+  @Before
+  public void before() throws Exception {
+    super.before();
+    classUnderTest = new SingleResourceAutoDeploymentStrategy();
+    assertNotNull(classUnderTest);
+  }
+
+  @Test
+  public void testHandlesMode() {
+    assertTrue(classUnderTest.handlesMode(SingleResourceAutoDeploymentStrategy.DEPLOYMENT_MODE));
+    assertFalse(classUnderTest.handlesMode("other-mode"));
+    assertFalse(classUnderTest.handlesMode(null));
+  }
+
+  @Test
+  public void testDeployResources() {
+    final Resource[] resources = new Resource[] { resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, times(5)).createDeployment();
+    verify(deploymentBuilderMock, times(5)).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, times(1)).name(resourceName1);
+    verify(deploymentBuilderMock, times(1)).name(resourceName2);
+    verify(deploymentBuilderMock, times(1)).name(resourceName3);
+    verify(deploymentBuilderMock, times(1)).name(resourceName4);
+    verify(deploymentBuilderMock, times(1)).name(resourceName5);
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName1), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(1)).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, times(3)).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, times(5)).deploy();
+  }
+
+  @Test
+  public void testDeployResourcesNoResources() {
+    final Resource[] resources = new Resource[] {};
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+
+    verify(repositoryServiceMock, never()).createDeployment();
+    verify(deploymentBuilderMock, never()).enableDuplicateFiltering();
+    verify(deploymentBuilderMock, never()).name(deploymentNameHint);
+    verify(deploymentBuilderMock, never()).addInputStream(isA(String.class), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addInputStream(eq(resourceName2), isA(InputStream.class));
+    verify(deploymentBuilderMock, never()).addZipInputStream(isA(ZipInputStream.class));
+    verify(deploymentBuilderMock, never()).deploy();
+  }
+
+  @Test(expected = ActivitiException.class)
+  public void testDeployResourcesIOExceptionYieldsActivitiException() throws Exception {
+    when(resourceMock3.getInputStream()).thenThrow(new IOException());
+
+    final Resource[] resources = new Resource[] { resourceMock3 };
+    classUnderTest.deployResources(deploymentNameHint, resources, repositoryServiceMock);
+  }
+
+}

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SpringAutoDeployTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SpringAutoDeployTest.java
@@ -29,84 +29,85 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.AbstractXmlApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-
 /**
  * @author Tom Baeyens
  * @author Joram Barrez
  */
 public class SpringAutoDeployTest extends PvmTestCase {
-  
-  protected static final String CTX_PATH 
-    = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-context.xml";
-  protected static final String CTX_NO_DROP_PATH 
-    = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-no-drop-context.xml";
-  protected static final String CTX_CREATE_DROP_CLEAN_DB 
-    = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-create-drop-clean-db-context.xml";
-  
+
+  protected static final String CTX_PATH = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-context.xml";
+  protected static final String CTX_NO_DROP_PATH = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-no-drop-context.xml";
+  protected static final String CTX_CREATE_DROP_CLEAN_DB = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-create-drop-clean-db-context.xml";
+  protected static final String CTX_DEPLOYMENT_MODE_DEFAULT = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-default-context.xml";
+  protected static final String CTX_DEPLOYMENT_MODE_SINGLE_RESOURCE = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-single-resource-context.xml";
+  protected static final String CTX_DEPLOYMENT_MODE_RESOURCE_PARENT_FOLDER = "org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-resource-parent-folder-context.xml";
+
   protected ApplicationContext applicationContext;
   protected RepositoryService repositoryService;
-  
+
   protected void createAppContext(String path) {
     this.applicationContext = new ClassPathXmlApplicationContext(path);
     this.repositoryService = applicationContext.getBean(RepositoryService.class);
   }
-  
+
   protected void tearDown() throws Exception {
     removeAllDeployments();
     this.applicationContext = null;
     this.repositoryService = null;
     super.tearDown();
   }
-  
+
   public void testBasicActivitiSpringIntegration() {
     createAppContext("org/activiti/spring/test/autodeployment/SpringAutoDeployTest-context.xml");
-    List<ProcessDefinition> processDefinitions = repositoryService
-      .createProcessDefinitionQuery()
-      .list();
-    
+    List<ProcessDefinition> processDefinitions = repositoryService.createProcessDefinitionQuery().list();
+
     Set<String> processDefinitionKeys = new HashSet<String>();
-    for (ProcessDefinition processDefinition: processDefinitions) {
+    for (ProcessDefinition processDefinition : processDefinitions) {
       processDefinitionKeys.add(processDefinition.getKey());
     }
-    
+
     Set<String> expectedProcessDefinitionKeys = new HashSet<String>();
     expectedProcessDefinitionKeys.add("a");
     expectedProcessDefinitionKeys.add("b");
     expectedProcessDefinitionKeys.add("c");
-    
+
     assertEquals(expectedProcessDefinitionKeys, processDefinitionKeys);
   }
-  
+
   public void testNoRedeploymentForSpringContainerRestart() throws Exception {
     createAppContext(CTX_PATH);
     DeploymentQuery deploymentQuery = repositoryService.createDeploymentQuery();
     assertEquals(1, deploymentQuery.count());
     ProcessDefinitionQuery processDefinitionQuery = repositoryService.createProcessDefinitionQuery();
     assertEquals(3, processDefinitionQuery.count());
-    
-    // Creating a new app context with same resources doesn't lead to more deployments
+
+    // Creating a new app context with same resources doesn't lead to more
+    // deployments
     new ClassPathXmlApplicationContext(CTX_NO_DROP_PATH);
     assertEquals(1, deploymentQuery.count());
     assertEquals(3, processDefinitionQuery.count());
   }
-  
-  // Updating the bpmn20 file should lead to a new deployment when restarting the Spring container
+
+  // Updating the bpmn20 file should lead to a new deployment when restarting
+  // the Spring container
   public void testResourceRedeploymentAfterProcessDefinitionChange() throws Exception {
     createAppContext(CTX_PATH);
     assertEquals(1, repositoryService.createDeploymentQuery().count());
-    ((AbstractXmlApplicationContext)applicationContext).destroy();
-    
+    ((AbstractXmlApplicationContext) applicationContext).destroy();
+
     String filePath = "org/activiti/spring/test/autodeployment/autodeploy.a.bpmn20.xml";
     String originalBpmnFileContent = IoUtil.readFileAsString(filePath);
     String updatedBpmnFileContent = originalBpmnFileContent.replace("flow1", "fromStartToEndFlow");
     assertTrue(updatedBpmnFileContent.length() > originalBpmnFileContent.length());
     IoUtil.writeStringToFile(updatedBpmnFileContent, filePath);
-    
+
     // Classic produced/consumer problem here:
-    // The file is already written in Java, but not yet completely persisted by the OS
-    // Constructing the new app context reads the same file which is sometimes not yet fully written to disk
+    // The file is already written in Java, but not yet completely persisted by
+    // the OS
+    // Constructing the new app context reads the same file which is sometimes
+    // not yet fully written to disk
     waitUntilFileIsWritten(filePath, updatedBpmnFileContent.length());
-    
+
     try {
       applicationContext = new ClassPathXmlApplicationContext(CTX_NO_DROP_PATH);
       repositoryService = (RepositoryService) applicationContext.getBean("repositoryService");
@@ -114,26 +115,45 @@ public class SpringAutoDeployTest extends PvmTestCase {
       // Reset file content such that future test are not seeing something funny
       IoUtil.writeStringToFile(originalBpmnFileContent, filePath);
     }
-   
-    // Assertions come AFTER the file write! Otherwise the process file is messed up if the assertions fail.
+
+    // Assertions come AFTER the file write! Otherwise the process file is
+    // messed up if the assertions fail.
     assertEquals(2, repositoryService.createDeploymentQuery().count());
     assertEquals(6, repositoryService.createProcessDefinitionQuery().count());
   }
-  
+
   public void testAutoDeployWithCreateDropOnCleanDb() {
     createAppContext(CTX_CREATE_DROP_CLEAN_DB);
     assertEquals(1, repositoryService.createDeploymentQuery().count());
     assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
   }
-  
+
+  public void testAutoDeployWithDeploymentModeDefault() {
+    createAppContext(CTX_DEPLOYMENT_MODE_DEFAULT);
+    assertEquals(1, repositoryService.createDeploymentQuery().count());
+    assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
+  }
+
+  public void testAutoDeployWithDeploymentModeSingleResource() {
+    createAppContext(CTX_DEPLOYMENT_MODE_SINGLE_RESOURCE);
+    assertEquals(3, repositoryService.createDeploymentQuery().count());
+    assertEquals(3, repositoryService.createProcessDefinitionQuery().count());
+  }
+
+  public void testAutoDeployWithDeploymentModeResourceParentFolder() {
+    createAppContext(CTX_DEPLOYMENT_MODE_RESOURCE_PARENT_FOLDER);
+    assertEquals(2, repositoryService.createDeploymentQuery().count());
+    assertEquals(4, repositoryService.createProcessDefinitionQuery().count());
+  }
+
   // --Helper methods ----------------------------------------------------------
-  
+
   private void removeAllDeployments() {
     for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
       repositoryService.deleteDeployment(deployment.getId(), true);
     }
   }
-  
+
   private boolean waitUntilFileIsWritten(String filePath, int expectedBytes) throws URISyntaxException {
     while (IoUtil.getFile(filePath).length() != (long) expectedBytes) {
       try {
@@ -144,5 +164,5 @@ public class SpringAutoDeployTest extends PvmTestCase {
     }
     return true;
   }
-  
+
 }

--- a/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-default-context.xml
+++ b/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-default-context.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/tx      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.activiti.spring.SpringProcessEngineConfiguration">
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <property name="deploymentMode" value="default" />
+    <property name="deploymentResources" value="classpath*:/org/activiti/spring/test/autodeployment/autodeploy.*.bpmn20.xml" /> 
+  </bean>
+  
+  <bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+</beans>

--- a/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-resource-parent-folder-context.xml
+++ b/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-resource-parent-folder-context.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/tx      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.activiti.spring.SpringProcessEngineConfiguration">
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <property name="deploymentMode" value="resource-parent-folder" />
+    <property name="deploymentResources" value="classpath*:/org/activiti/spring/test/autodeployment/**/autodeploy.*.bpmn20.xml" /> 
+  </bean>
+  
+  <bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+</beans>

--- a/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-single-resource-context.xml
+++ b/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/SpringAutoDeployTest-deploymentmode-single-resource-context.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans" 
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:tx="http://www.springframework.org/schema/tx"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd
+                           http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-2.5.xsd
+                           http://www.springframework.org/schema/tx      http://www.springframework.org/schema/tx/spring-tx-3.0.xsd">
+
+  <bean id="dataSource" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="org.h2.Driver" />
+    <property name="url" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
+    <property name="username" value="sa" />
+    <property name="password" value="" />
+  </bean>
+
+  <bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+    <property name="dataSource" ref="dataSource" />
+  </bean>
+  
+  <bean id="processEngineConfiguration" class="org.activiti.spring.SpringProcessEngineConfiguration">
+    <property name="dataSource" ref="dataSource" />
+    <property name="transactionManager" ref="transactionManager" />
+    <property name="databaseSchemaUpdate" value="true" />
+    <property name="jobExecutorActivate" value="false" />
+    <property name="deploymentMode" value="single-resource" />
+    <property name="deploymentResources" value="classpath*:/org/activiti/spring/test/autodeployment/autodeploy.*.bpmn20.xml" /> 
+  </bean>
+  
+  <bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean">
+    <property name="processEngineConfiguration" ref="processEngineConfiguration" />
+  </bean>
+
+  <bean id="repositoryService" factory-bean="processEngine" factory-method="getRepositoryService" />
+  <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService" />
+  <bean id="taskService" factory-bean="processEngine" factory-method="getTaskService" />
+  <bean id="historyService" factory-bean="processEngine" factory-method="getHistoryService" />
+  <bean id="managementService" factory-bean="processEngine" factory-method="getManagementService" />
+
+</beans>

--- a/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/subdirectory/autodeploy.d.bpmn20.xml
+++ b/modules/activiti-spring/src/test/resources/org/activiti/spring/test/autodeployment/subdirectory/autodeploy.d.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  
+  <process id="d">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    
+    <endEvent id="end" />
+    
+  </process>
+  
+    <bpmndi:BPMNDiagram id="BPMNDiagram_MyProcess">
+    <bpmndi:BPMNPlane bpmnElement="d" id="BPMNPlane_MyProcess">
+      <bpmndi:BPMNShape bpmnElement="start" id="BPMNShape_start">
+        <omgdc:Bounds height="35" width="35" x="130" y="180"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="end" id="BPMNShape_end">
+        <omgdc:Bounds height="35" width="35" x="250" y="180"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="165" y="197"></omgdi:waypoint>
+        <omgdi:waypoint x="250" y="197"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+
+</definitions>

--- a/userguide/src/en/chapters/ch05-Spring.xml
+++ b/userguide/src/en/chapters/ch05-Spring.xml
@@ -222,6 +222,51 @@ userBean.hello();</programlisting>
 &lt;bean id=&quot;processEngine&quot; class=&quot;org.activiti.spring.ProcessEngineFactoryBean&quot;&gt;
   &lt;property name=&quot;processEngineConfiguration&quot; ref=&quot;processEngineConfiguration&quot; /&gt;
 &lt;/bean&gt;</programlisting>
+
+	<para>
+		By default, the configuration above will group all of the resources matching the filtering into a single deployment to the Activiti engine. The duplicate filtering to prevent re-deployment of unchanged 
+		resources applies to the whole deployment. In some cases, this may not be what you want. For instance, if you deploy a set of process resources this way and only a single 
+		process definition in those resources has changed, the deployment as a whole will be considered new and all of the process definitions in that deployment will be re-deployed, resulting in new 
+		versions of each of the process definitions, even though only one was actually changed.
+	</para>
+	
+	<para>
+		To be able to customize the way deployments are determined, you can specify an additional property in the <literal>SpringProcessEngineConfiguration</literal>, <literal>deploymentMode</literal>. This 
+		property defines the way deployments will be determined from the set of resources that match the filter. There are 3 values that are supported by default for this property:
+	</para>
+	
+	<itemizedlist>
+		<listitem>
+			<code>default</code>: Group all resources into a single deployment and apply duplicate filtering to that deployment. 
+				This is the default value and it will be used if you don&apos;t specify a value.
+		</listitem>
+		<listitem>
+			<code>single-resource</code>: Create a separate deployment for each individual resource and apply duplicate filtering to that deployment. This is the 
+				value you would use to have each process definition be deployed separately and only create a new process definition version if it has changed. 
+		</listitem>
+		<listitem>
+			<code>resource-parent-folder</code>: Create a separate deployment for resources that share the same parent folder and apply duplicate filtering to that 
+				deployment. This value can be used to create separate deployments for most resources, but still be able to group some by placing them in a shared folder.
+		</listitem>
+	</itemizedlist>
+	
+	<para>
+		Here&apos;s an example of how to specify the <code>single-resource</code> configuration for <code>deploymentMode</code>:
+	</para>
+	
+	<programlisting>
+&lt;bean id=&quot;processEngineConfiguration&quot; class=&quot;org.activiti.spring.SpringProcessEngineConfiguration&quot;&gt;
+  ...
+  <emphasis>&lt;property name=&quot;deploymentResources&quot; value=&quot;classpath*:/activiti/*.bpmn&quot; /&gt;</emphasis>
+  <emphasis role="bold">&lt;property name=&quot;deploymentMode&quot; value=&quot;single-resource&quot; /&gt;</emphasis>
+&lt;/bean&gt;</programlisting>
+	
+	<para>
+		In addition to using the values listed above for <code>deploymentMode</code>, you may require customized behavior towards determining deployments. If so, 
+		you can create a subclass of <code>SpringProcessEngineConfiguration</code> and override the <code>getAutoDeploymentStrategy(String deploymentMode)</code> method. 
+		This method determines which deployment strategy is used for a certain value of the <code>deploymentMode</code> configuration.
+	</para>
+
   </section>
   
   <section id="springUnitTest">


### PR DESCRIPTION
Added option to specify deployment mode of
SpringProcessEngineConfiguration when auto deployment resources are
specified.
- There is a new optional property deploymentMode in
  SpringProcessEngineConfiguration;
- Default behavior is the same as currently implemented: all resources
  are grouped in a single deployment;
- New options are single-resource (each resource in a separate
  deployment) and resource-parent-folder (group resources into deployments
  for each parent folder);
- Updated existing testcases and added some new resources to cover
  various scenarios;
- Updated documentation in Userguide;
