### PR TITLE
Pull Request for REST Endpoint POST runtime/process-instances

### DIFF
--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
@@ -32,7 +32,16 @@ import org.restlet.resource.Post;
 
 
 /**
+ * Modified the "createProcessInstance" method to conditionally call a 
+ *   "createProcessInstanceResponse" method with a different signature, which
+ *   will conditionally return the process variables that exist when the process
+ *   instance either enters its first wait state or completes. In this case,
+ *   the different method is always called with a flag of true, which means
+ *   that it will always return those variables. If variables are not to be 
+ *   returned, the original method is called, which doesn't return the variables.
+ * 
  * @author Frederik Heremans
+ * @author Ryan Johnston (@rjfsu)
  */
 public class ProcessInstanceCollectionResource extends BaseProcessInstanceResource {
 
@@ -166,7 +175,16 @@ public class ProcessInstanceCollectionResource extends BaseProcessInstanceResour
       }
       
       setStatus(Status.SUCCESS_CREATED);
-      return factory.createProcessInstanceResponse(this, instance);
+      
+      //Added by Ryan Johnston
+      if(request.getReturnVariables())
+    	  return factory.createProcessInstanceResponse(this, instance, true);
+      else
+    	  return factory.createProcessInstanceResponse(this, instance);
+      //End Added by Ryan Johnston
+      
+      //Removed by Ryan Johnston (obsolete given the above).
+      //return factory.createProcessInstanceResponse(this, instance);
     } catch(ActivitiObjectNotFoundException aonfe) {
       throw new ActivitiIllegalArgumentException(aonfe.getMessage(), aonfe);
     }

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceCreateRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceCreateRequest.java
@@ -24,7 +24,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 
 /**
+ * Modified to add a "returnVariables" flag, which determines whether the variables
+ *   that exist within the process instance when the first wait state is encountered
+ *   (or when the process instance completes) should be returned or not.
+ * 
  * @author Frederik Heremans
+ * @author Ryan Johnston (@rjfsu)
  */
 public class ProcessInstanceCreateRequest {
 
@@ -34,6 +39,9 @@ public class ProcessInstanceCreateRequest {
   private String businessKey;
   private List<RestVariable> variables;
   private String tenantId;
+  
+  //Added by Ryan Johnston
+  private boolean returnVariables;
   
   public String getProcessDefinitionId() {
     return processDefinitionId;
@@ -85,5 +93,15 @@ public class ProcessInstanceCreateRequest {
   @JsonIgnore
   public boolean isCustomTenantSet() {
   	return tenantId != null && !StringUtils.isEmpty(tenantId);
+  }
+  
+  //Added by Ryan Johnston
+  public boolean getReturnVariables() {
+	  return returnVariables;
+  }
+  
+  //Added by Ryan Johnston
+  public void setReturnVariables(boolean returnVariables) {
+	  this.returnVariables = returnVariables;
   }
 }

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceResponse.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceResponse.java
@@ -19,7 +19,12 @@ import java.util.List;
 import org.activiti.rest.service.api.engine.variable.RestVariable;
 
 /**
+ * Modified to add a "completed" flag, which lets the caller know if the process instance
+ *   has run to completion without encountering a wait state or experiencing an error/
+ *   exception.
+ * 
  * @author Frederik Heremans
+ * @author Ryan Johnston (@rjfsu)
  */
 public class ProcessInstanceResponse {
   protected String id;
@@ -32,6 +37,9 @@ public class ProcessInstanceResponse {
   protected String activityId;
   protected List<RestVariable> variables = new ArrayList<RestVariable>();
   protected String tenantId;
+  
+  //Added by Ryan Johnston
+  protected boolean completed;
   
   public String getId() {
     return id;
@@ -115,5 +123,15 @@ public class ProcessInstanceResponse {
   
   public String getTenantId() {
 	  return tenantId;
+  }
+  
+  //Added by Ryan Johnston
+  public boolean isCompleted() {
+	  return completed;
+  }
+  
+  //Added by Ryan Johnston
+  public void setCompleted(boolean completed) {
+	  this.completed = completed;
   }
 }


### PR DESCRIPTION
I modified the following four files from within the "activiti-rest" module to support the retrieval of process variables that exist within any started process instances when each enters a wait state or is completed:

(1) org/activiti/rest/service/api/RestResponseFactory.java
(2) org/activiti/rest/service/api/runtime/process/ProcessInstanceCollectionResource.java
(3) org/activiti/rest/service/api/runtime/process/ProcessInstanceCreateRequest.java
(4) org/activiti/rest/service/api/runtime/process/ProcessInstanceResponse.java

The flag that should be specified to request variable retrieval within the JSON request is "returnVariables". If that flag is not specified or if it's set to false, the variables will not be returned.

One additional change that is included is the population of a "completed" boolean in the JSON result that indicates whether the process instance ran through to completion without encountering a wait state. This flag is populated whether "returnVariables" is set to true or not.

-Ryan Johnston (@rjfsu)
