### PR TITLE
Add compensate handler.

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
@@ -29,6 +29,7 @@ import org.activiti.bpmn.model.Activity;
 import org.activiti.bpmn.model.Artifact;
 import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.CompensateEventDefinition;
 import org.activiti.bpmn.model.DataObject;
 import org.activiti.bpmn.model.ErrorEventDefinition;
 import org.activiti.bpmn.model.Event;
@@ -156,6 +157,9 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         if (activity.isNotExclusive()) {
           writeQualifiedAttribute(ATTRIBUTE_ACTIVITY_EXCLUSIVE, ATTRIBUTE_VALUE_FALSE, xtw);
         }
+      }
+      if (activity.isForCompensation()) {
+    	writeDefaultAttribute(ATTRIBUTE_ACTIVITY_ISFORCOMPENSATION, ATTRIBUTE_VALUE_TRUE, xtw);
       }
       if (StringUtils.isNotEmpty(activity.getDefaultFlow())) {
         FlowElement defaultFlowElement = model.getFlowElement(activity.getDefaultFlow());
@@ -388,6 +392,8 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
         writeErrorDefinition(parentEvent, (ErrorEventDefinition) eventDefinition, xtw);
       } else if (eventDefinition instanceof TerminateEventDefinition) {
         writeTerminateDefinition(parentEvent, (TerminateEventDefinition) eventDefinition, xtw);
+      } else if (eventDefinition instanceof CompensateEventDefinition) {
+        writeCompensateDefinition(parentEvent, (CompensateEventDefinition) eventDefinition, xtw);
       }
     }
   }
@@ -429,6 +435,16 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
     }
     xtw.writeEndElement();
   }
+  
+  protected void writeCompensateDefinition(Event parentEvent, CompensateEventDefinition compensateEventDefinition, XMLStreamWriter xtw) throws Exception {
+	    xtw.writeStartElement(ELEMENT_EVENT_COMPENSATEDEFINITION);
+	    writeDefaultAttribute(ATTRIBUTE_COMPENSATE_ACTIVITYREF, compensateEventDefinition.getActivityRef(), xtw);
+	    boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(compensateEventDefinition, false, xtw);
+	    if (didWriteExtensionStartElement) {
+	      xtw.writeEndElement();
+	    }
+	    xtw.writeEndElement();
+	  }
   
   protected void writeMessageDefinition(Event parentEvent, MessageEventDefinition messageDefinition, BpmnModel model, XMLStreamWriter xtw) throws Exception {
     xtw.writeStartElement(ELEMENT_EVENT_MESSAGEDEFINITION);


### PR DESCRIPTION
Problem: When using activiti designer to draw a activiti for compensate, the attribute will be removed.
Solution: Add the compensate handler. When the isForcompensate attribute is setted, keep it.
