### PR TITLE
Exclude commons-logging from batik-transcoder to fix classes conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,12 @@
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>batik-transcoder</artifactId>
         <version>${batik.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
We’re using `jcl-over-slf4j`, so it’s not needed and should not be there.
