### PR TITLE
Updated potentialStarter test which covers now also the extensionElement

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/authorization/StartAuthorizationTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/authorization/StartAuthorizationTest.java
@@ -218,6 +218,19 @@ public class StartAuthorizationTest extends PluggableActivitiTestCase {
 	    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("potentialStarter");
 	    assertProcessEnded(processInstance.getId());
 	    assertTrue(processInstance.isEnded());
+	        
+	    //check extensionElements with : <formalExpression>group2, group(group3), user(user3)</formalExpression>
+	    ProcessDefinition potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("user1").latestVersion().singleResult();
+	    assertNotNull(potentialStarter);
+	    
+	    potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("user3").latestVersion().singleResult();
+	    assertNotNull(potentialStarter);
+	    
+	    potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup2").latestVersion().singleResult();
+	    assertNotNull(potentialStarter);
+	    
+	    potentialStarter = repositoryService.createProcessDefinitionQuery().processDefinitionKey("potentialStarter").startableByUser("userInGroup3").latestVersion().singleResult();
+	    assertNotNull(potentialStarter);
     } finally {
 
       tearDownUsersAndGroups();


### PR DESCRIPTION
Test was updated in order to cover:

```
 <extensionElements>
            <activiti:potentialStarter>
                <resourceAssignmentExpression>
                    <formalExpression>group2, group(group3), user(user3)</formalExpression>
                </resourceAssignmentExpression>
            </activiti:potentialStarter>
     </extensionElements>
</xml>
```

More details : http://forums.activiti.org/content/process-initiation-authorization?page=0 
