### PR TITLE
BaseStepDefinitionConverter form values not populated

### DIFF
--- a/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/converter/step/BaseStepDefinitionConverter.java
+++ b/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/converter/step/BaseStepDefinitionConverter.java
@@ -161,6 +161,7 @@ public abstract class BaseStepDefinitionConverter<U extends StepDefinition, T> i
             formValue.setName(entry.getName());
             formValues.add(formValue);
           }
+          formProperty.setFormValues(formValues);
         }
       } else {
       	// Fallback to simple text

--- a/modules/activiti-simple-workflow/src/test/java/org/activiti/workflow/simple/converter/step/BaseStepDefinitionConverterTest.java
+++ b/modules/activiti-simple-workflow/src/test/java/org/activiti/workflow/simple/converter/step/BaseStepDefinitionConverterTest.java
@@ -1,0 +1,97 @@
+package org.activiti.workflow.simple.converter.step;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.activiti.bpmn.model.FormProperty;
+import org.activiti.bpmn.model.FormValue;
+import org.activiti.bpmn.model.UserTask;
+import org.activiti.workflow.simple.converter.WorkflowDefinitionConversion;
+import org.activiti.workflow.simple.definition.HumanStepDefinition;
+import org.activiti.workflow.simple.definition.form.FormDefinition;
+import org.activiti.workflow.simple.definition.form.ListPropertyDefinition;
+import org.activiti.workflow.simple.definition.form.ListPropertyEntry;
+import org.activiti.workflow.simple.definition.form.TextPropertyDefinition;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link BaseStepDefinitionConverter}. Since {@link BaseStepDefinitionConverter} is abstract, this test
+ * uses a simple inner class to test basic functionality.
+ * 
+ */
+public class BaseStepDefinitionConverterTest {
+
+    @Test
+    public void testCovertFormPropertiesWithListValues() {
+
+        TestStepDefinitionConverter converter = new TestStepDefinitionConverter();
+
+        // Create a form with two properties, one of which is a ListProperty
+
+        FormDefinition formDefinition = new FormDefinition();
+
+        ListPropertyDefinition approveEnum = new ListPropertyDefinition();
+        approveEnum.setName("Approval");
+        approveEnum.setType("enum");
+        approveEnum.addEntry(new ListPropertyEntry("true", "Approve"));
+        approveEnum.addEntry(new ListPropertyEntry("false", "Reject"));
+        formDefinition.addFormProperty(approveEnum);
+
+        TextPropertyDefinition reason = new TextPropertyDefinition();
+        reason.setName("Reason");
+        reason.setType("string");
+        formDefinition.addFormProperty(reason);
+
+        List<FormProperty> properties = converter.convertProperties(formDefinition);
+        assertTrue(properties.size() == 2);
+
+        FormProperty firstProperty = properties.get(0);
+        assertNotNull(firstProperty);
+        assertEquals("Approval", firstProperty.getName());
+        assertEquals("enum", firstProperty.getType());
+
+        // Assert the values are set
+        List<FormValue> values = firstProperty.getFormValues();
+        assertTrue(values.size() == 2);
+
+        FormValue firstValue = values.get(0);
+        assertEquals("Approve", firstValue.getName());
+        assertEquals("true", firstValue.getId());
+
+        FormValue secondValue = values.get(1);
+        assertEquals("Reject", secondValue.getName());
+        assertEquals("false", secondValue.getId());
+
+        // Now confirm the second property, a non list property, is well formed as well.
+        FormProperty secondProperty = properties.get(1);
+        assertNotNull(secondProperty);
+        assertTrue(secondProperty.getFormValues().isEmpty());
+        assertEquals("Reason", secondProperty.getName());
+        assertEquals("string", secondProperty.getType());
+    }
+
+    /**
+     * Simple inner class to expose abstract functionality to the unit test.
+     * 
+     */
+    private class TestStepDefinitionConverter extends BaseStepDefinitionConverter<HumanStepDefinition, UserTask> {
+
+        @Override
+        public Class getHandledClass() {
+            // Does nothing for this unit test
+            return null;
+        }
+
+        @Override
+        protected UserTask createProcessArtifact(HumanStepDefinition stepDefinition,
+                WorkflowDefinitionConversion conversion) {
+            // Does nothing for this unit test
+            return null;
+        }
+
+    }
+
+}


### PR DESCRIPTION
Sorry about the previous pull request, I moved this change to its own branch.  Also thanks for the feedback on the parallel gateway change.  I will refactor locally to be more consistent with the code standards of changing the model.  I didn't see an obvious way to get the matching join gateway for a parallel gateway, even at the workflow definition conversion layer, but I will try harder!

> > > > > Fixed a minor bug in BaseStepDefinitionConverter in which the FormValues were being populated to a list, but never set back on the Property.
> > > > > Therefore Form Properties, like lists/enums were not well formed, with
> > > > > their corresponding values, in the resulting BPMN model.

Added unit test for the same.
