### PR TITLE
crystalball- replay event log implementation

### DIFF
--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/AbstractSimulationRun.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/AbstractSimulationRun.java
@@ -32,6 +32,7 @@ public abstract class AbstractSimulationRun implements SimulationRun, Simulation
 
   private static Logger log = LoggerFactory.getLogger(AbstractSimulationRun.class);
 
+  protected String id;
   /**
    * Map for eventType -> event handlers to execute events on simulation engine
    */

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/ReplaySimulationRun.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/ReplaySimulationRun.java
@@ -43,6 +43,7 @@ public class ReplaySimulationRun extends AbstractSimulationRun {
   protected void initSimulationRunContext(VariableScope execution) {
     SimulationRunContext.setEventCalendar(eventCalendar);
     SimulationRunContext.setProcessEngine(processEngine);
+    SimulationRunContext.setSimulationRunId(processEngine.getProcessEngineConfiguration().getIdGenerator().getNextId());
   }
 
   /**

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/SimulationRunContext.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/SimulationRunContext.java
@@ -41,6 +41,11 @@ public abstract class SimulationRunContext {
 	protected static ThreadLocal<Stack<EventCalendar>> eventCalendarThreadLocal = new ThreadLocal<Stack<EventCalendar>>();
 
   //
+  // Simulation run Id
+  //
+  protected static ThreadLocal<Stack<String>> simulationRunIdThreadLocal = new ThreadLocal<Stack<String>>();
+
+  //
   // Variable scope used for getting/setting variables to the simulationManager
   //
   protected static ThreadLocal<Stack<VariableScope>> executionThreadLocal = new ThreadLocal<Stack<VariableScope>>();
@@ -85,7 +90,19 @@ public abstract class SimulationRunContext {
 	  getStack(eventCalendarThreadLocal).push(eventCalendar);
 	}
 
-	public static void removeEventCalendar() {
+  public static String getSimulationRunId() {
+    Stack<String> stack = getStack(simulationRunIdThreadLocal);
+    if (stack.isEmpty()) {
+      return null;
+    }
+    return stack.peek();
+  }
+
+  public static void setSimulationRunId(String simulationRunId) {
+    getStack(simulationRunIdThreadLocal).push(simulationRunId);
+  }
+
+  public static void removeEventCalendar() {
 	  getStack(eventCalendarThreadLocal).pop();
 	}
 

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLog2SimulationEventFunction.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLog2SimulationEventFunction.java
@@ -1,0 +1,30 @@
+package org.activiti.crystalball.simulator.delegate.event.impl;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.crystalball.simulator.delegate.event.Function;
+import org.activiti.engine.event.EventLogEntry;
+
+/**
+ * This class provides abstract base for ActivitiEvent  -> SimulationEvent transformation
+ *
+ * @author martin.grofcik
+ */
+public abstract class EventLog2SimulationEventFunction implements Function<EventLogEntry, SimulationEvent> {
+  protected final String simulationEventType;
+
+  public EventLog2SimulationEventFunction(String simulationEventType) {this.simulationEventType = simulationEventType;}
+}

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogProcessInstanceCreateTransformer.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogProcessInstanceCreateTransformer.java
@@ -1,0 +1,74 @@
+package org.activiti.crystalball.simulator.delegate.event.impl;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.crystalball.simulator.CrystalballException;
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.engine.event.EventLogEntry;
+import org.activiti.engine.impl.event.logger.handler.Fields;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author martin.grofcik
+ */
+public class EventLogProcessInstanceCreateTransformer extends EventLog2SimulationEventFunction {
+
+  public static final String PROCESS_INSTANCE_ID = "processInstanceId";
+  private final String processDefinitionIdKey;
+  private final String businessKey;
+  private final String variablesKey;
+
+  public EventLogProcessInstanceCreateTransformer(String simulationEventType, String processDefinitionIdKey, String businessKey, String variablesKey) {
+    super(simulationEventType);
+    this.processDefinitionIdKey = processDefinitionIdKey;
+    this.businessKey = businessKey;
+    this.variablesKey = variablesKey;
+  }
+
+  @Override
+  public SimulationEvent apply(EventLogEntry event) {
+    if ("PROCESSINSTANCE_START".equals(event.getType())) {
+
+      ObjectMapper objectMapper = new ObjectMapper();
+      Map<String, Object> data;
+      try {
+        data = objectMapper.readValue(event.getData(), new TypeReference<HashMap<String, Object>>() {});
+      } catch (IOException e) {
+        throw new CrystalballException("unable to parse JSON string.", e);
+      }
+      String processDefinitionId = (String) data.get(Fields.PROCESS_DEFINITION_ID);
+//      Variables are missing
+      String businessKeyValue = (String) data.get(Fields.BUSINESS_KEY);
+      String processInstanceId= (String) data.get(Fields.PROCESS_INSTANCE_ID);
+
+      Map<String, Object> simEventProperties = new HashMap<String, Object>();
+      simEventProperties.put(processDefinitionIdKey, processDefinitionId);
+      simEventProperties.put(this.businessKey, businessKeyValue);
+      //simEventProperties.put(variablesKey, executionEntity.getVariables());
+      simEventProperties.put(PROCESS_INSTANCE_ID, processInstanceId);
+
+      return new SimulationEvent.Builder(simulationEventType).
+                  priority((int) event.getLogNumber()).
+                  properties(simEventProperties).
+                  build();
+    }
+    return null;
+  }
+}

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogTransformer.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogTransformer.java
@@ -1,0 +1,36 @@
+package org.activiti.crystalball.simulator.delegate.event.impl;
+
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.crystalball.simulator.delegate.event.Function;
+import org.activiti.engine.event.EventLogEntry;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * This class transforms event log events into simulation events
+ */
+public class EventLogTransformer {
+  protected List<Function<EventLogEntry, SimulationEvent>> transformers;
+
+  public EventLogTransformer(List<Function<EventLogEntry, SimulationEvent>> transformers) {this.transformers = transformers;}
+
+  public List<SimulationEvent> transform(List<EventLogEntry> eventLog) {
+    List<SimulationEvent> simulationEvents = new ArrayList<SimulationEvent>();
+    for (EventLogEntry logEntry : eventLog) {
+      simulationEvents.addAll(transformEntry(logEntry));
+    }
+    return simulationEvents;
+  }
+  protected Collection<SimulationEvent> transformEntry(EventLogEntry event) {
+    List<SimulationEvent> simEvents = new ArrayList<SimulationEvent>();
+    for (Function<EventLogEntry, SimulationEvent> t : transformers) {
+      SimulationEvent simEvent = t.apply(event);
+      if (simEvent != null)
+        simEvents.add(simEvent);
+    }
+    return simEvents;
+  }
+
+}

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogUserTaskCompleteTransformer.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/delegate/event/impl/EventLogUserTaskCompleteTransformer.java
@@ -1,0 +1,73 @@
+package org.activiti.crystalball.simulator.delegate.event.impl;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.crystalball.simulator.CrystalballException;
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.event.EventLogEntry;
+import org.activiti.engine.impl.event.logger.handler.Fields;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author martin.grofcik
+ */
+public class EventLogUserTaskCompleteTransformer extends EventLog2SimulationEventFunction {
+
+  public static final String PROCESS_INSTANCE_ID = "processInstanceId";
+  public static final String TASK_DEFINITION_KEY = "taskDefinitionKey";
+  public static final String TASK_VARIABLES = "taskVariables";
+
+  public EventLogUserTaskCompleteTransformer(String simulationEventType) {
+    super(simulationEventType);
+  }
+
+  @Override
+  public SimulationEvent apply(EventLogEntry event) {
+    if (ActivitiEventType.TASK_COMPLETED.toString().equals(event.getType())) {
+
+      ObjectMapper objectMapper = new ObjectMapper();
+      Map<String, Object> data;
+      try {
+        data = objectMapper.readValue(event.getData(), new TypeReference<HashMap<String, Object>>() {});
+      } catch (IOException e) {
+        throw new CrystalballException("unable to parse JSON string.", e);
+      }
+      String taskIdValue = (String) data.get(Fields.ACTIVITY_ID);
+//      Variables are missing
+      String taskDefinitionKeyValue = (String) data.get(Fields.TASK_DEFINITION_KEY);
+
+
+
+      Map<String, Object> properties = new HashMap<String, Object>();
+      properties.put("taskId", taskIdValue);
+      properties.put(TASK_DEFINITION_KEY, taskDefinitionKeyValue);
+      properties.put(PROCESS_INSTANCE_ID, event.getProcessInstanceId());
+//      properties.put(TASK_VARIABLES, task.getProcessVariables());
+      return
+          new SimulationEvent.Builder(this.simulationEventType).
+            priority((int) event.getLogNumber()).
+            properties(properties).
+            build();
+    }
+    return null;
+  }
+
+}

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/StartReplayLogEventHandler.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/StartReplayLogEventHandler.java
@@ -1,0 +1,73 @@
+package org.activiti.crystalball.simulator.impl;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.crystalball.simulator.SimulationEventHandler;
+import org.activiti.crystalball.simulator.SimulationRunContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class schedules replay start simulation event and takes care about process start and
+ * next event schedule
+ *
+ * @author martin.grofcik
+ */
+public class StartReplayLogEventHandler implements SimulationEventHandler {
+
+  private static Logger log = LoggerFactory.getLogger(StartReplayLogEventHandler.class.getName());
+
+  /** variable name where original process instance ID is stored - only for internal replay purposes */
+  public static final String PROCESS_INSTANCE_ID = "_replay.processInstanceId";
+  public static final String SIMULATION_RUN_ID = "_replay.simulationRunId";
+
+  private final String processInstanceId;
+  private final String processToStartIdKey;
+  private final String businessKey;
+  private final String variablesKey;
+
+  public StartReplayLogEventHandler(String processInstanceId, String processToStartIdKey, String businessKey, String variablesKey) {
+    this.processInstanceId = processInstanceId;
+    this.processToStartIdKey = processToStartIdKey;
+    this.businessKey = businessKey;
+    this.variablesKey = variablesKey;
+  }
+
+  @Override
+  public void init() {
+
+  }
+
+  @Override
+  public void handle(SimulationEvent event) {
+    // start process now
+    String processDefinitionId = (String) event.getProperty(processToStartIdKey);
+    String businessKey = (String) event.getProperty(this.businessKey);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> variables = new HashMap<String, Object>();
+    Map<String, Object> processVariables = (Map<String, Object>) event.getProperty(variablesKey);
+    if (processVariables != null)
+      variables.putAll(processVariables);
+    variables.put(PROCESS_INSTANCE_ID, processInstanceId);
+    variables.put(SIMULATION_RUN_ID, SimulationRunContext.getSimulationRunId());
+
+    log.debug("Starting new processDefId[{}] businessKey[{}] with variables[{}]", processDefinitionId, businessKey, variables);
+    SimulationRunContext.getRuntimeService().startProcessInstanceById(processDefinitionId, businessKey, variables);
+  }
+}

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/replay/ReplayUserTaskCompleteEventHandler.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/replay/ReplayUserTaskCompleteEventHandler.java
@@ -1,0 +1,63 @@
+package org.activiti.crystalball.simulator.impl.replay;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.activiti.crystalball.simulator.SimulationEvent;
+import org.activiti.crystalball.simulator.SimulationEventHandler;
+import org.activiti.crystalball.simulator.SimulationRunContext;
+import org.activiti.crystalball.simulator.delegate.event.impl.EventLogUserTaskCompleteTransformer;
+import org.activiti.crystalball.simulator.impl.StartReplayLogEventHandler;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * complete user task handler for replay purposes
+ *
+ * @author martin.grofcik
+ */
+public class ReplayUserTaskCompleteEventHandler implements SimulationEventHandler {
+
+	private static Logger log = LoggerFactory.getLogger(ReplayUserTaskCompleteEventHandler.class);
+
+	@Override
+	public void handle(SimulationEvent event) {
+    String taskDefinitionKey = (String) event.getProperty(EventLogUserTaskCompleteTransformer.TASK_DEFINITION_KEY);
+    String processInstanceId = (String) event.getProperty(EventLogUserTaskCompleteTransformer.PROCESS_INSTANCE_ID);
+    String simulationRunId = SimulationRunContext.getSimulationRunId();
+    ProcessInstance processInstance = SimulationRunContext.getRuntimeService().createProcessInstanceQuery().
+      variableValueEquals(StartReplayLogEventHandler.PROCESS_INSTANCE_ID, processInstanceId).
+      variableValueEquals(StartReplayLogEventHandler.SIMULATION_RUN_ID, simulationRunId).
+      singleResult();
+    Task task = SimulationRunContext.getTaskService().createTaskQuery().
+      processInstanceId(processInstance.getId()).
+      taskDefinitionKey(taskDefinitionKey).
+      singleResult();
+
+		@SuppressWarnings("unchecked")
+		Map<String, Object> variables = (Map<String, Object>) event.getProperty("variables");		
+
+		SimulationRunContext.getTaskService().complete( task.getId(), variables );
+		log.debug( "completed {}, {}, {}", task, task.getName(), variables);
+	}
+
+	@Override
+	public void init() {
+		
+	}
+}

--- a/modules/activiti-crystalball/src/test/java/org/activiti/crystalball/simulator/impl/replay/ReplayEventLogTest.java
+++ b/modules/activiti-crystalball/src/test/java/org/activiti/crystalball/simulator/impl/replay/ReplayEventLogTest.java
@@ -1,0 +1,150 @@
+package org.activiti.crystalball.simulator.impl.replay;
+
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import org.activiti.crystalball.simulator.*;
+import org.activiti.crystalball.simulator.delegate.event.Function;
+import org.activiti.crystalball.simulator.delegate.event.impl.EventLogProcessInstanceCreateTransformer;
+import org.activiti.crystalball.simulator.delegate.event.impl.EventLogTransformer;
+import org.activiti.crystalball.simulator.delegate.event.impl.EventLogUserTaskCompleteTransformer;
+import org.activiti.crystalball.simulator.impl.StartReplayLogEventHandler;
+import org.activiti.engine.ManagementService;
+import org.activiti.engine.ProcessEngines;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.event.EventLogEntry;
+import org.activiti.engine.impl.ProcessEngineImpl;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.el.NoExecutionVariableScope;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author martin.grofcik
+ */
+public class ReplayEventLogTest {
+
+  // Process instance start event
+  private static final String PROCESS_INSTANCE_START_EVENT_TYPE = "PROCESS_INSTANCE_START";
+  private static final String PROCESS_DEFINITION_ID_KEY = "processDefinitionId";
+  private static final String VARIABLES_KEY = "variables";
+  // User task completed event
+  private static final String USER_TASK_COMPLETED_EVENT_TYPE = "USER_TASK_COMPLETED";
+
+  private static final String USERTASK_PROCESS = "oneTaskProcess";
+  private static final String BUSINESS_KEY = "testBusinessKey";
+  private static final String TEST_VALUE = "TestValue";
+  private static final String TEST_VARIABLE = "testVariable";
+
+  private static final String THE_USERTASK_PROCESS = "org/activiti/crystalball/simulator/impl/playback/PlaybackProcessStartTest.testUserTask.bpmn20.xml";
+
+  @Test
+  public void testProcessInstanceStartEvents() throws Exception {
+    ProcessEngineImpl processEngine = initProcessEngine();
+
+    TaskService taskService = processEngine.getTaskService();
+    RuntimeService runtimeService = processEngine.getRuntimeService();
+    ManagementService managementService = processEngine.getManagementService();
+
+    // record events
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put(TEST_VARIABLE, TEST_VALUE);
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey(USERTASK_PROCESS, BUSINESS_KEY, variables);
+
+    Task task = taskService.createTaskQuery().taskDefinitionKey("userTask").singleResult();
+    TimeUnit.MILLISECONDS.sleep(50);
+    taskService.complete(task.getId());
+
+    // transform log events
+    List<EventLogEntry> eventLogEntries = managementService.getEventLogEntries(null, null);
+
+    EventLogTransformer transformer = new EventLogTransformer(getTransformers());
+
+    List<SimulationEvent> simulationEvents = transformer.transform(eventLogEntries);
+
+    SimpleEventCalendar eventCalendar = new SimpleEventCalendar(processEngine.getProcessEngineConfiguration().getClock(), new SimulationEventComparator());
+    eventCalendar.addEvents(simulationEvents);
+
+    // replay process instance run
+    final SimulationDebugger simRun = new ReplaySimulationRun(processEngine, eventCalendar, getReplayHandlers(processInstance.getId()));
+
+    simRun.init(new NoExecutionVariableScope());
+
+    // original process is finished - there should not be any running process instance/task
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
+    assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+
+    simRun.step();
+
+    // replay process was started
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
+    // there should be one task
+    assertEquals(1, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+
+    simRun.step();
+
+    // userTask was completed - replay process was finished
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey(USERTASK_PROCESS).count());
+    assertEquals(0, taskService.createTaskQuery().taskDefinitionKey("userTask").count());
+
+    // close simulation
+    simRun.close();
+    processEngine.close();
+    ProcessEngines.destroy();
+  }
+
+  private ProcessEngineImpl initProcessEngine() {
+    ProcessEngineConfigurationImpl configuration = getProcessEngineConfiguration();
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) configuration.buildProcessEngine();
+
+    processEngine.getRepositoryService().
+        createDeployment().
+        addClasspathResource(THE_USERTASK_PROCESS).
+        deploy();
+    return processEngine;
+  }
+
+  private ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+    ProcessEngineConfigurationImpl configuration = new org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration();
+    configuration.
+      setEnableDatabaseEventLogging(true).
+      setDatabaseSchemaUpdate("create-drop").
+      setJobExecutorActivate(false);
+    return configuration;
+  }
+
+  private static List<Function<EventLogEntry, SimulationEvent>> getTransformers() {
+    List<Function<EventLogEntry, SimulationEvent>> transformers = new ArrayList<Function<EventLogEntry, SimulationEvent>>();
+    transformers.add(new EventLogProcessInstanceCreateTransformer(PROCESS_INSTANCE_START_EVENT_TYPE, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
+    transformers.add(new EventLogUserTaskCompleteTransformer(USER_TASK_COMPLETED_EVENT_TYPE));
+    return transformers;
+  }
+
+  public static Map<String, SimulationEventHandler> getReplayHandlers(String processInstanceId) {
+    Map<String, SimulationEventHandler> handlers = new HashMap<String, SimulationEventHandler>();
+    handlers.put(PROCESS_INSTANCE_START_EVENT_TYPE, new StartReplayLogEventHandler(processInstanceId, PROCESS_DEFINITION_ID_KEY, BUSINESS_KEY, VARIABLES_KEY));
+    handlers.put(USER_TASK_COMPLETED_EVENT_TYPE, new ReplayUserTaskCompleteEventHandler());
+    return handlers;
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1965,8 +1965,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 		return enableDatabaseEventLogging;
 	}
 
-	public void setEnableDatabaseEventLogging(boolean enableDatabaseEventLogging) {
+	public ProcessEngineConfigurationImpl setEnableDatabaseEventLogging(boolean enableDatabaseEventLogging) {
 		this.enableDatabaseEventLogging = enableDatabaseEventLogging;
+    return this;
 	}
 	
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/Fields.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/Fields.java
@@ -24,6 +24,7 @@ public interface Fields {
   String OWNER = "owner";
   String PRIORITY = "priority";
   String PROCESS_DEFINITION_ID = "processDefinitionId";
+  String TASK_DEFINITION_KEY = "taskDefinitionKey";
   String PROCESS_INSTANCE_ID = "processInstanceId";
   String PROCESS_INSTANCE_NAME = "processInstanceName";
   String SOURCE_ACTIVITY_ID = "sourceActivityId";

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/logger/handler/TaskCompletedEventHandler.java
@@ -22,7 +22,8 @@ public class TaskCompletedEventHandler extends AbstractDatabaseEventLoggerEventH
 		Map<String, Object> data = new HashMap<String, Object>();
 		putInMapIfNotNull(data, Fields.ID, task.getId());
 		putInMapIfNotNull(data, Fields.NAME, task.getName());
-		putInMapIfNotNull(data, Fields.DESCRIPTION, task.getDescription());
+    putInMapIfNotNull(data, Fields.TASK_DEFINITION_KEY, task.getTaskDefinitionKey());
+    putInMapIfNotNull(data, Fields.DESCRIPTION, task.getDescription());
 		putInMapIfNotNull(data, Fields.ASSIGNEE, task.getAssignee());
 		putInMapIfNotNull(data, Fields.OWNER, task.getOwner());
 		putInMapIfNotNull(data, Fields.CATEGORY, task.getCategory());


### PR DESCRIPTION
Known issue:
Variables are not stored in the EventLog data field for process instance start event and task complete event.
 That's why replay is not able to simulate variables values.
