### PR TITLE
Additional TaskQuery options

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -250,6 +250,9 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 	if (involvementType == null) {
 	  throw new ActivitiIllegalArgumentException("involvementType is null");
 	}
+	if ("owner".equals(involvementType) || "assignee".equals(involvementType)) {
+	  throw new ActivitiIllegalArgumentException("involvementType "+involvementType+" is not a valid option");
+	}
 	this.involvementType = involvementType;
 	return this;
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -565,7 +565,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
       candidateGroupList.add(candidateGroup);
       return candidateGroupList;
     } else if (candidateUser != null) {
-    	candidateGroups = getGroupsForCandidateUser(candidateUser); // cache candidate user groups
+    	if(candidateGroups == null)
+    	  candidateGroups = getGroupsForCandidateUser(candidateUser); // cache candidate user groups
       return candidateGroups;
     } else if(candidateGroups != null) {
       return candidateGroups;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -49,7 +49,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String involvedUser;
   protected String owner;
   protected String ownerLike;
-  protected boolean unassigned = false;
+  protected Boolean owned;
+  protected Boolean assigned;
   protected boolean noDelegationState = false;
   protected DelegationState delegationState;
   protected String candidateUser;
@@ -83,6 +84,10 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected boolean includeProcessVariables = false;
   protected String userIdForCandidateAndAssignee;
   protected boolean bothCandidateAndAssigned = false;
+  
+  protected String involvementType;
+  protected List<String> involvedGroups;
+  protected String involvedGroup;
 
   public TaskQueryImpl() {
   }
@@ -198,8 +203,13 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   }
 
   public TaskQuery taskUnassigned() {
-    this.unassigned = true;
+    this.assigned = false;
     return this;
+  }
+  
+  public TaskQuery taskAssigned() {
+	this.assigned = true;
+	return this;
   }
 
   public TaskQuery taskDelegationState(DelegationState delegationState) {
@@ -209,6 +219,49 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
       this.delegationState = delegationState;
     }
     return this;
+  }
+  
+  public TaskQuery taskInvolvedGroup(String involvedGroup) {
+	if (involvedGroup == null) {
+	  throw new ActivitiIllegalArgumentException("involvedGroup group is null");
+	}
+	if (involvedGroups != null) {
+	  throw new ActivitiIllegalArgumentException("Invalid query usage: cannot set both involvedGroup and involvedGroupIn");
+	}
+	this.involvedGroup = involvedGroup;
+	return this;
+  }
+
+  public TaskQuery taskInvolvedGroupIn(List<String> involvedGroups) {
+	if (involvedGroups == null) {
+	  throw new ActivitiIllegalArgumentException("involvedGroups list is null");
+	}
+	if (involvedGroups.size()== 0) {
+	  throw new ActivitiIllegalArgumentException("involvedGroups list is empty");
+	}
+	if (involvedGroup != null) {
+	  throw new ActivitiIllegalArgumentException("Invalid query usage: cannot set both involvedGroupIn and involvedGroup");
+	}
+	this.involvedGroups = involvedGroups;
+	return this;
+  }
+
+  public TaskQuery taskInvolvementType(String involvementType) {
+	if (involvementType == null) {
+	  throw new ActivitiIllegalArgumentException("involvementType is null");
+	}
+	this.involvementType = involvementType;
+	return this;
+  }
+
+  public TaskQuery taskOwned() {
+	this.owned = true;
+	return this;
+  }
+
+  public TaskQuery taskUnowned() {
+	this.owned = false;
+	return this;
   }
 
   public TaskQueryImpl taskCandidateUser(String candidateUser) {
@@ -509,7 +562,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
       candidateGroupList.add(candidateGroup);
       return candidateGroupList;
     } else if (candidateUser != null) {
-      return getGroupsForCandidateUser(candidateUser);
+    	candidateGroups = getGroupsForCandidateUser(candidateUser); // cache candidate user groups
+      return candidateGroups;
     } else if(candidateGroups != null) {
       return candidateGroups;
     }
@@ -623,8 +677,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   public String getAssignee() {
     return assignee;
   }
-  public boolean getUnassigned() {
-    return unassigned;
+  public Boolean getAssigned() {
+    return assigned;
   }
   public DelegationState getDelegationState() {
     return delegationState;
@@ -700,5 +754,12 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
 	}
   public String getUserIdForCandidateAndAssignee() {
     return userIdForCandidateAndAssignee;
+  }
+  public List<String> getInvolvedGroups() {
+	if(involvedGroup != null && involvedGroups == null){
+	  involvedGroups = new ArrayList<String>();
+	  involvedGroups.add(involvedGroup);
+	}
+	return involvedGroups;
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskQuery.java
@@ -112,7 +112,11 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   TaskQuery taskInvolvedGroupIn(List<String> involvedGroups);
   
   /** Only select tasks which have an {@link IdentityLink} of given involvementType, whether {@link IdentityLink} was for a user or a group.
-   Use with taskInvolvedUser, taskInvolvedGroup, taskInvolvedGroupIn methods to limit results to specific user or group or group list*/
+   * Use with taskInvolvedUser, taskInvolvedGroup, taskInvolvedGroupIn methods to limit results to specific user or group or group list
+   *
+   * @throws ActivitiIllegalArgumentException 
+   *   When involvementType value is null or 'owner' or 'assignee' 
+   */
   TaskQuery taskInvolvementType(String involvementType);
 
   /** Only select tasks for which users in the given group are candidates. */

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskQuery.java
@@ -77,8 +77,17 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
    */
   TaskQuery taskOwnerLike(String ownerLike);
   
+  /** Only select tasks which have an owner. */
+  TaskQuery taskOwned();
+  
+  /** Only select tasks which don't have an owner. */
+  TaskQuery taskUnowned();
+  
   /** Only select tasks which don't have an assignee. */
   TaskQuery taskUnassigned();
+  
+  /** Only select tasks which have an assignee. */
+  TaskQuery taskAssigned();
   
   /** @see {@link #taskUnassigned} */
   @Deprecated
@@ -93,6 +102,18 @@ public interface TaskQuery extends Query<TaskQuery, Task>{
   /** Only select tasks for which there exist an {@link IdentityLink} with the given user, including tasks which have been 
    * assigned to the given user (assignee) or owned by the given user (owner). */
   TaskQuery taskInvolvedUser(String involvedUser);
+  
+  /** Only select tasks for which users in the given group are involved. */
+  TaskQuery taskInvolvedGroup(String involvedGroup);
+  
+  /** 
+   * Only select tasks for which the 'involvedGroups' is one of the given groups involved in the task.
+   */
+  TaskQuery taskInvolvedGroupIn(List<String> involvedGroups);
+  
+  /** Only select tasks which have an {@link IdentityLink} of given involvementType, whether {@link IdentityLink} was for a user or a group.
+   Use with taskInvolvedUser, taskInvolvedGroup, taskInvolvedGroupIn methods to limit results to specific user or group or group list*/
+  TaskQuery taskInvolvementType(String involvementType);
 
   /** Only select tasks for which users in the given group are candidates. */
   TaskQuery taskCandidateGroup(String candidateGroup);

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -279,7 +279,7 @@
   </sql>
   
   <sql id="commonSelectTaskByQueryCriteriaSql">
-    <if test="candidateUser != null || candidateGroups != null || bothCandidateAndAssigned">
+    <if test="involvementType!=null || involvedUser !=null || involvedGroups != null || candidateUser != null || candidateGroups != null || bothCandidateAndAssigned">
       <if test="bothCandidateAndAssigned">left</if>
       <if test="!bothCandidateAndAssigned">inner</if>
       join ${prefix}ACT_RU_IDENTITYLINK I on I.TASK_ID_ = RES.ID_
@@ -337,8 +337,21 @@
       <if test="ownerLike != null">
         and RES.OWNER_ like #{ownerLike}
       </if>
-      <if test="unassigned">
-        and RES.ASSIGNEE_ IS NULL
+      <if test="owned != null">
+        <if test="owned == false">
+          and RES.OWNER_ IS NULL
+        </if>
+        <if test="owned == true">
+          and RES.OWNER_ IS NOT NULL
+        </if>
+      </if>
+      <if test="assigned != null">
+        <if test="assigned == false">
+          and RES.ASSIGNEE_ IS NULL
+        </if>
+        <if test="assigned == true">
+          and RES.ASSIGNEE_ IS NOT NULL
+        </if>
       </if>
       <if test="noDelegationState">
         and RES.DELEGATION_ IS NULL
@@ -429,12 +442,66 @@
           </if>
         )
       </if>
-      <if test="involvedUser != null">
-        and (
-          exists(select LINK.USER_ID_ from ${prefix}ACT_RU_IDENTITYLINK LINK where USER_ID_ = #{involvedUser} and LINK.TASK_ID_ = RES.ID_)
-          or RES.ASSIGNEE_ = #{involvedUser}
+      <if test="involvementType!=null || involvedUser != null || involvedGroups != null">
+	  <if test="!bothCandidateAndAssigned">
+      	<if test="involvementType != null">
+       	 and I.TYPE_ = #{involvementType}
+		</if> 
+		<if test="involvedUser != null || involvedGroups != null">
+		and (
+		  <if test="involvementType == null">
+		   <if test="involvedUser != null">
+          RES.ASSIGNEE_ = #{involvedUser}
           or RES.OWNER_ = #{involvedUser}
+		  or
+		  </if>
+		</if> 
+          <if test="involvedUser != null">
+            I.USER_ID_ = #{involvedUser}          
+          </if>
+          <if test="involvedUser != null &amp;&amp; involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+            or
+          </if>
+          <if test="involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+            I.GROUP_ID_ IN
+            <foreach item="group" index="index" collection="involvedGroups" 
+                     open="(" separator="," close=")">
+              #{group}
+            </foreach>
+          </if>
+        )
+        </if>
+	</if>
+    <if test="bothCandidateAndAssigned">
+        and (
+      <if test="involvedUser != null &amp;&amp; involvementType==null">
+          RES.ASSIGNEE_ = #{involvedUser}
+          or RES.OWNER_ = #{involvedUser}
+		  or 
+		</if> 
+          exists(select LINK.USER_ID_ from ${prefix}ACT_RU_IDENTITYLINK LINK where LINK.TASK_ID_ = RES.ID_
+          <if test="involvementType != null">
+       	 and LINK.TYPE_ = #{involvementType}
+		</if> 
+		<if test="involvedUser != null || involvedGroups != null">
+		and (
+          <if test="involvedUser != null">
+            LINK.USER_ID_ = #{involvedUser}          
+          </if>
+          <if test="involvedUser != null &amp;&amp; involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+            or
+          </if>
+          <if test="involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+            LINK.GROUP_ID_ IN
+            <foreach item="group" index="index" collection="involvedGroups" 
+                     open="(" separator="," close=")">
+              #{group}
+            </foreach>
+          </if>
           )
+          </if>
+		))
+      </if>
       </if>
       <foreach item="var" collection="queryVariableValues" index="index">
         <if test="!var.local">

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -343,6 +343,19 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
 	assertEquals(11, taskService.createTaskQuery().taskInvolvementType("candidate").count());
 	assertEquals(6, taskService.createTaskQuery().taskInvolvedUser("kermit").taskInvolvementType("candidate").count());
 	assertEquals(3, taskService.createTaskQuery().taskInvolvedGroup("management").taskInvolvementType("candidate").count());
+	
+	try {
+	  taskService.createTaskQuery().taskInvolvementType("owner");
+	  fail("expected exception");
+	  } catch (ActivitiException e) {
+	    // OK
+	  }
+	try {
+	  taskService.createTaskQuery().taskInvolvementType("assignee");
+	  fail("expected exception");
+	  } catch (ActivitiException e) {
+	    // OK
+	  }
   }
   
   public void testQueryByNullAssignee() {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -257,11 +257,15 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
       adhocTask.setOwner("fozzie");
       taskService.saveTask(adhocTask);
       taskService.addUserIdentityLink(adhocTask.getId(), "gonzo", "customType");
+      taskService.addCandidateUser(adhocTask.getId(), "kermit");
+      taskService.addUserIdentityLink(adhocTask.getId(), "gonzo", "anotherCustomType");
       
-      assertEquals(3, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+      assertEquals(5, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
       
       assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").count());
-      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("kermit").count());
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").taskInvolvementType("customType").count());
+      assertEquals(1, taskService.createTaskQuery().taskInvolvedUser("gonzo").taskInvolvementType("customType").taskCandidateOrAssigned("kermit").count());
+      assertEquals(0, taskService.createTaskQuery().taskInvolvedUser("gonzo").taskInvolvementType("noSuchType").taskCandidateOrAssigned("kermit").count());
       assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("fozzie").count());
       
     } finally {
@@ -275,6 +279,70 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
         }
       }
     }
+  }
+  
+  public void testQueryByInvolvedGroup() {
+    try {
+      Task adhocTask = taskService.newTask();
+      adhocTask.setAssignee("kermit");
+      adhocTask.setOwner("fozzie");
+      taskService.saveTask(adhocTask);
+      taskService.addGroupIdentityLink(adhocTask.getId(), "sales", "customType");
+      taskService.addGroupIdentityLink(adhocTask.getId(), "management", "customType");
+      
+      assertEquals(4, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+      
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedGroup("sales").count());
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedGroup("management").taskInvolvementType("customType").count());
+      
+    } finally {
+      List<Task> allTasks = taskService.createTaskQuery().list();
+      for(Task task : allTasks) {
+        if(task.getExecutionId() == null) {
+          taskService.deleteTask(task.getId());
+          if(processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+            historyService.deleteHistoricTaskInstance(task.getId());
+          }
+        }
+      }
+    }
+  }
+  
+  public void testQueryByInvolvedUserAndGroup() {
+    try {
+      Task adhocTask = taskService.newTask();
+      adhocTask.setAssignee("kermit");
+      adhocTask.setOwner("fozzie");
+      taskService.saveTask(adhocTask);
+      taskService.addGroupIdentityLink(adhocTask.getId(), "sales", "customType");
+      taskService.addGroupIdentityLink(adhocTask.getId(), "management", "anotherCustomType");
+      taskService.addUserIdentityLink(adhocTask.getId(), "gonzo", "anotherCustomType");
+      
+      assertEquals(5, taskService.getIdentityLinksForTask(adhocTask.getId()).size());
+      
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").taskInvolvedGroup("sales").count());
+      assertEquals(0, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").taskInvolvedGroup("management").taskInvolvementType("customType").count());
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvedUser("gonzo").taskInvolvedGroup("management").taskInvolvementType("anotherCustomType").count());
+      assertEquals(1, taskService.createTaskQuery().taskId(adhocTask.getId()).taskInvolvementType("anotherCustomType").count());
+      
+    } finally {
+      List<Task> allTasks = taskService.createTaskQuery().list();
+      for(Task task : allTasks) {
+        if(task.getExecutionId() == null) {
+          taskService.deleteTask(task.getId());
+          if(processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+            historyService.deleteHistoricTaskInstance(task.getId());
+          }
+        }
+      }
+    }
+  }
+  
+  public void testQueryByInvolvementType() {
+	assertEquals(0, taskService.createTaskQuery().taskInvolvementType("noSuchType").count());
+	assertEquals(11, taskService.createTaskQuery().taskInvolvementType("candidate").count());
+	assertEquals(6, taskService.createTaskQuery().taskInvolvedUser("kermit").taskInvolvementType("candidate").count());
+	assertEquals(3, taskService.createTaskQuery().taskInvolvedGroup("management").taskInvolvementType("candidate").count());
   }
   
   public void testQueryByNullAssignee() {
@@ -291,6 +359,24 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
     assertEquals(11, query.count());
     assertEquals(11, query.list().size());
   }
+  
+  public void testQueryByAssigned() {
+	TaskQuery query = taskService.createTaskQuery().taskAssigned();
+	assertEquals(1, query.count());
+	assertEquals(1, query.list().size());
+  }
+
+  public void testQueryByUnowned() {
+	TaskQuery query = taskService.createTaskQuery().taskUnowned();
+	assertEquals(12, query.count());
+	assertEquals(12, query.list().size());
+  }
+	  
+  public void testQueryByOwned() {
+	TaskQuery query = taskService.createTaskQuery().taskOwned();
+	assertEquals(0, query.count());
+	assertEquals(0, query.list().size());
+ }
   
   public void testQueryByCandidateUser() {
     TaskQuery query = taskService.createTaskQuery().taskCandidateUser("kermit");


### PR DESCRIPTION
Added the following with test methods
taskAssigned() to select tasks that are assigned
taskOwned() and taskUnowned() to select tasks have or don't have an owner 
taskInvolvedGroup() and taskInvolvedGroupIn() to select tasks that a group or groups are involved in
taskInvolvementType() to select tasks based on identityLink type

cache candidate user groups