### PR TITLE
ACT-1963 Data Object support for Activiti Modeler

### DIFF
--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/ValuedDataObjectConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/ValuedDataObjectConverterTest.java
@@ -5,9 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Calendar;
+import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,13 +77,8 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
     assertEquals("DateTest", dataObj.getName());
     assertEquals("xsd:datetime", dataObj.getItemSubjectRef().getStructureRef());
     assertTrue(dataObj.getValue() instanceof Date);
-    GregorianCalendar dateCal = new GregorianCalendar();
-    dateCal.setTime((Date) dataObj.getValue());
-    assertEquals(2013, dateCal.get(Calendar.YEAR));
-    assertEquals(8, dateCal.get(Calendar.MONTH));
-    assertEquals(16, dateCal.get(Calendar.DAY_OF_MONTH));
-    assertEquals(11, dateCal.get(Calendar.HOUR_OF_DAY));
-    assertEquals(23, dateCal.get(Calendar.MINUTE));
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    assertEquals("2013-09-16T11:23:00", sdf.format(dataObj.getValue()));
     
     dataObj = objectMap.get("dObj4");
     assertEquals("dObj4", dataObj.getId());
@@ -161,11 +155,7 @@ public class ValuedDataObjectConverterTest extends AbstractConverterTest {
     assertEquals("DateSubTest", dataObj.getName());
     assertEquals("xsd:datetime", dataObj.getItemSubjectRef().getStructureRef());
     assertTrue(dataObj.getValue() instanceof Date);
-    dateCal = new GregorianCalendar();
-    dateCal.setTime((Date) dataObj.getValue());
-    assertEquals(2013, dateCal.get(Calendar.YEAR));
-    assertEquals(10, dateCal.get(Calendar.MONTH));
-    assertEquals(11, dateCal.get(Calendar.DAY_OF_MONTH));
+    assertEquals("2013-11-11T22:00:00", sdf.format(dataObj.getValue()));
       
     dataObj = objectMap.get("dObj10");
     assertEquals("dObj10", dataObj.getId());

--- a/modules/activiti-bpmn-converter/src/test/resources/valueddataobjectmodel.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/valueddataobjectmodel.bpmn
@@ -52,7 +52,7 @@
 	  </dataObject>
       <dataObject id="dObj9" name="DateSubTest" itemSubjectRef="xsd:datetime">
       <extensionElements>
-        <activiti:value>2013-11-11</activiti:value>
+        <activiti:value>2013-11-11T22:00:00</activiti:value>
       </extensionElements>
 	  </dataObject>
       <dataObject id="dObj10" name="DoubleSubTest" itemSubjectRef="xsd:double">

--- a/modules/activiti-json-converter/pom.xml
+++ b/modules/activiti-json-converter/pom.xml
@@ -105,7 +105,6 @@
     <dependency>
       <groupId>org.activiti</groupId>
       <artifactId>activiti-bpmn-converter</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
@@ -172,6 +172,12 @@ public interface StencilConstants {
   final String PROPERTY_FORM_FORM_VALUE_ID = "formproperty_formvalue_id";
   final String PROPERTY_FORM_FORM_VALUE_NAME = "formproperty_formvalue_name";
 
+  final String PROPERTY_DATA_PROPERTIES = "dataproperties";
+  final String PROPERTY_DATA_ID = "dataproperty_id";
+  final String PROPERTY_DATA_NAME = "dataproperty_name";
+  final String PROPERTY_DATA_TYPE = "dataproperty_type";
+  final String PROPERTY_DATA_VALUE = "dataproperty_value";
+
 	final String PROPERTY_SCRIPT_FORMAT = "scriptformat";
 	final String PROPERTY_SCRIPT_TEXT = "scripttext";
 	

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
@@ -12,12 +12,14 @@
  */
 package org.activiti.editor.language.json.converter;
 
+import java.util.List;
 import java.util.Map;
 
 import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.GraphicInfo;
 import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.ValuedDataObject;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -56,12 +58,29 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter {
     processor.processFlowElements(subProcess.getFlowElements(), model, subProcessShapesArrayNode, 
     		graphicInfo.getX(), graphicInfo.getY());
     flowElementNode.put("childShapes", subProcessShapesArrayNode);
+    
+    /*
+     * No point in copying the data conversion methods here. It would be helpful
+     * if BaseBpmnJsonConverter inherited from BpmnJsonConverter.
+     */
+    new BpmnJsonConverter().convertDataPropertiesToJson(subProcess.getDataObjects(), propertiesNode);
   }
   
   protected FlowElement convertJsonToElement(JsonNode elementNode, JsonNode modelNode, Map<String, JsonNode> shapeMap) {
     SubProcess subProcess = new SubProcess();
     JsonNode childShapesArray = elementNode.get(EDITOR_CHILD_SHAPES);
     processor.processJsonElements(childShapesArray, modelNode, subProcess, shapeMap);
+    
+    /*
+     * No point in copying the data conversion methods here. It would be helpful
+     * if BaseBpmnJsonConverter inherited from BpmnJsonConverter.
+     */
+    JsonNode processDataPropertiesNode = elementNode.get(EDITOR_SHAPE_PROPERTIES).get(PROPERTY_DATA_PROPERTIES);
+    if (processDataPropertiesNode != null) {
+      List<ValuedDataObject> dataObjects = new BpmnJsonConverter().convertJsonToDataProperties(processDataPropertiesNode, subProcess);
+      subProcess.setDataObjects(dataObjects);
+      subProcess.getFlowElements().addAll(dataObjects);
+    }
     return subProcess;
   }
 }

--- a/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/ValuedDataObjectConverterTest.java
+++ b/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/ValuedDataObjectConverterTest.java
@@ -1,0 +1,154 @@
+package org.activiti.editor.language;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import org.activiti.bpmn.model.BooleanDataObject;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.DateDataObject;
+import org.activiti.bpmn.model.DoubleDataObject;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.IntegerDataObject;
+import org.activiti.bpmn.model.LongDataObject;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.StringDataObject;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.ValuedDataObject;
+import org.junit.Test;
+
+public class ValuedDataObjectConverterTest extends AbstractConverterTest {
+
+  @Test
+  public void convertJsonToModel() throws Exception {
+    BpmnModel bpmnModel = readJsonFile();
+    validateModel(bpmnModel);
+  }
+  
+  @Test
+  public void doubleConversionValidation() throws Exception {
+    BpmnModel bpmnModel = readJsonFile();
+    bpmnModel = convertToJsonAndBack(bpmnModel);
+    validateModel(bpmnModel);
+  }
+  
+  protected String getResource() {
+    return "test.valueddataobjectmodel.json";
+  }
+  
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+    
+    // verify main process data objects
+    List<ValuedDataObject> dataObjects = model.getMainProcess().getDataObjects();
+    assertEquals(6, dataObjects.size());
+    for (ValuedDataObject dObj : dataObjects) {
+      if ("dObj1".equals(dObj.getId())) {
+        assertEquals(StringDataObject.class, dObj.getClass());
+        assertEquals("StringTest", dObj.getName());
+        assertTrue(dObj.getValue() instanceof String);
+        assertEquals("xsd:string", dObj.getItemSubjectRef().getStructureRef());
+        assertEquals("Testing123", dObj.getValue());
+      } else if ("dObj2".equals(dObj.getId())) {
+        assertEquals(BooleanDataObject.class, dObj.getClass());
+        assertEquals("BooleanTest", dObj.getName());
+        assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Boolean);
+        assertEquals(new Boolean(true), dObj.getValue());
+      } else if ("dObj3".equals(dObj.getId())) {
+        assertEquals(DateDataObject.class, dObj.getClass());
+        assertEquals("DateTest", dObj.getName());
+        assertEquals("xsd:datetime", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Date);
+        GregorianCalendar dateCal = new GregorianCalendar();
+        dateCal.setTime((Date) dObj.getValue());
+        assertEquals(2013, dateCal.get(Calendar.YEAR));
+        assertEquals(8, dateCal.get(Calendar.MONTH));
+        assertEquals(16, dateCal.get(Calendar.DAY_OF_MONTH));
+        assertEquals(11, dateCal.get(Calendar.HOUR_OF_DAY));
+        assertEquals(23, dateCal.get(Calendar.MINUTE));
+      } else if ("dObj4".equals(dObj.getId())) {
+        assertEquals(DoubleDataObject.class, dObj.getClass());
+        assertEquals("DoubleTest", dObj.getName());
+        assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Double);
+        assertEquals(new Double(123456789), dObj.getValue());
+      } else if ("dObj5".equals(dObj.getId())) {
+        assertEquals(IntegerDataObject.class, dObj.getClass());
+        assertEquals("IntegerTest", dObj.getName());
+        assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Integer);
+        assertEquals(new Integer(123), dObj.getValue());
+      } else if ("dObj6".equals(dObj.getId())) {
+        assertEquals(LongDataObject.class, dObj.getClass());
+        assertEquals("LongTest", dObj.getName());
+        assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Long);
+        assertEquals(new Long(-123456), dObj.getValue());
+      }
+    }
+    
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertEquals(11, subProcess.getFlowElements().size());
+
+    // verify subprocess data objects
+    dataObjects = ((SubProcess)flowElement).getDataObjects();
+    assertEquals(6, dataObjects.size());
+    for (ValuedDataObject dObj : dataObjects) {
+      if ("dObj1".equals(dObj.getId())) {
+        assertEquals(StringDataObject.class, dObj.getClass());
+        assertEquals("SubStringTest", dObj.getName());
+        assertTrue(dObj.getValue() instanceof String);
+        assertEquals("xsd:string", dObj.getItemSubjectRef().getStructureRef());
+        assertEquals("Testing456", dObj.getValue());
+      } else if ("dObj2".equals(dObj.getId())) {
+        assertEquals(BooleanDataObject.class, dObj.getClass());
+        assertEquals("SubBooleanTest", dObj.getName());
+        assertEquals("xsd:boolean", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Boolean);
+        assertEquals(new Boolean(false), dObj.getValue());
+      } else if ("dObj3".equals(dObj.getId())) {
+        assertEquals(DateDataObject.class, dObj.getClass());
+        assertEquals("SubDateTest", dObj.getName());
+        assertEquals("xsd:datetime", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Date);
+        GregorianCalendar dateCal = new GregorianCalendar();
+        dateCal.setTime((Date) dObj.getValue());
+        assertEquals(2013, dateCal.get(Calendar.YEAR));
+        assertEquals(10, dateCal.get(Calendar.MONTH));
+        assertEquals(11, dateCal.get(Calendar.DAY_OF_MONTH));
+      } else if ("dObj4".equals(dObj.getId())) {
+        assertEquals(DoubleDataObject.class, dObj.getClass());
+        assertEquals("SubDoubleTest", dObj.getName());
+        assertEquals("xsd:double", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Double);
+        assertEquals(new Double(678912345), dObj.getValue());
+      } else if ("dObj5".equals(dObj.getId())) {
+        assertEquals(IntegerDataObject.class, dObj.getClass());
+        assertEquals("SubIntegerTest", dObj.getName());
+        assertEquals("xsd:int", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Integer);
+        assertEquals(new Integer(45), dObj.getValue());
+      } else if ("dObj6".equals(dObj.getId())) {
+        assertEquals(LongDataObject.class, dObj.getClass());
+        assertEquals("SubLongTest", dObj.getName());
+        assertEquals("xsd:long", dObj.getItemSubjectRef().getStructureRef());
+        assertTrue(dObj.getValue() instanceof Long);
+        assertEquals(new Long(456123), dObj.getValue());
+        assertEquals(1, dObj.getExtensionElements().size());
+      }
+    }
+  }
+}

--- a/modules/activiti-json-converter/src/test/resources/test.valueddataobjectmodel.json
+++ b/modules/activiti-json-converter/src/test/resources/test.valueddataobjectmodel.json
@@ -1,0 +1,435 @@
+{ "bounds" : { "lowerRight" : { "x" : 1485,
+          "y" : 1050
+        },
+      "upperLeft" : { "x" : 0,
+          "y" : 0
+        }
+    },
+  "childShapes" : [ { "bounds" : { "lowerRight" : { "x" : 135,
+                "y" : 220
+              },
+            "upperLeft" : { "x" : 105,
+                "y" : 190
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [  ],
+        "outgoing" : [ { "resourceId" : "sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" } ],
+        "properties" : { "documentation" : "",
+            "executionlisteners" : "",
+            "formproperties" : "",
+            "initiator" : "",
+            "name" : ""
+          },
+        "resourceId" : "start1",
+        "stencil" : { "id" : "StartNoneEvent" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 280,
+                "y" : 245
+              },
+            "upperLeft" : { "x" : 180,
+                "y" : 165
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [  ],
+        "outgoing" : [ { "resourceId" : "sid-287D861F-4498-4A5C-8EC8-E07F79265E90" } ],
+        "properties" : { "asynchronousdefinition" : "Yes",
+            "documentation" : "",
+            "duedatedefinition" : "",
+            "exclusivedefinition" : "No",
+            "executionlisteners" : "",
+            "formkeydefinition" : "",
+            "formproperties" : { "items" : [ { "formproperty_expression" : "",
+                      "formproperty_id" : "test",
+                      "formproperty_name" : "Test",
+                      "formproperty_type" : "string",
+                      "formproperty_variable" : ""
+                    },
+                    { "formproperty_expression" : "",
+                      "formproperty_id" : "test2",
+                      "formproperty_name" : "Test 2",
+                      "formproperty_type" : "string",
+                      "formproperty_variable" : ""
+                    }
+                  ],
+                "totalCount" : 2
+              },
+            "isforcompensation" : "false",
+            "looptype" : "None",
+            "name" : "User task 1",
+            "prioritydefinition" : "",
+            "tasklisteners" : "{\"totalCount\": 1, \"items\": [{\"task_listener_event_type\": \"create\", \"task_listener_class\": \"test\", \"task_listener_expression\": \"\", \"task_listener_delegate_expression\": \"\", \"task_listener_fields\": \"{\\\"totalCount\\\": 1, \\\"items\\\": [{\\\"task_listener_field_name\\\": \\\"test\\\", \\\"task_listener_field_value\\\": \\\"hello\\\", \\\"task_listener_field_expression\\\": \\\"\\\"}]}\"}]}",
+            "usertaskassignment" : { "items" : [ { "assignment_type" : "candidateUsers",
+                      "resourceassignmentexpr" : "kermit"
+                    },
+                    { "assignment_type" : "candidateGroups",
+                      "resourceassignmentexpr" : "management"
+                    }
+                  ],
+                "totalCount" : 2
+              }
+          },
+        "resourceId" : "userTask1",
+        "stencil" : { "id" : "UserTask" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 179.15625,
+                "y" : 205
+              },
+            "upperLeft" : { "x" : 135.609375,
+                "y" : 205
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 15,
+              "y" : 15
+            },
+            { "x" : 50,
+              "y" : 40
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "userTask1" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "userTask1" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 693,
+                "y" : 285
+              },
+            "upperLeft" : { "x" : 345,
+                "y" : 125
+              }
+          },
+        "childShapes" : [ { "bounds" : { "lowerRight" : { "x" : 50,
+                      "y" : 94
+                    },
+                  "upperLeft" : { "x" : 20,
+                      "y" : 64
+                    }
+                },
+              "childShapes" : [  ],
+              "dockers" : [  ],
+              "outgoing" : [ { "resourceId" : "subFlowId1" } ],
+              "properties" : { "documentation" : "",
+                  "executionlisteners" : "",
+                  "formproperties" : "",
+                  "initiator" : "",
+                  "name" : ""
+                },
+              "resourceId" : "subStartEvent",
+              "stencil" : { "id" : "StartNoneEvent" }
+            },
+            { "bounds" : { "lowerRight" : { "x" : 195,
+                      "y" : 119
+                    },
+                  "upperLeft" : { "x" : 95,
+                      "y" : 39
+                    }
+                },
+              "childShapes" : [  ],
+              "dockers" : [  ],
+              "outgoing" : [ { "resourceId" : "sid-C7145ECA-31A2-4A91-B20A-023CF0764155" } ],
+              "properties" : { "asynchronousdefinition" : "No",
+                  "documentation" : "",
+                  "duedatedefinition" : "",
+                  "exclusivedefinition" : "Yes",
+                  "executionlisteners" : "",
+                  "formkeydefinition" : "",
+                  "formproperties" : "",
+                  "isforcompensation" : "false",
+                  "looptype" : "None",
+                  "name" : "User task 2",
+                  "prioritydefinition" : "",
+                  "tasklisteners" : "",
+                  "usertaskassignment" : ""
+                },
+              "resourceId" : "subUserTask1",
+              "stencil" : { "id" : "UserTask" }
+            },
+            { "bounds" : { "lowerRight" : { "x" : 268,
+                      "y" : 93
+                    },
+                  "upperLeft" : { "x" : 240,
+                      "y" : 65
+                    }
+                },
+              "childShapes" : [  ],
+              "dockers" : [  ],
+              "outgoing" : [  ],
+              "properties" : { "documentation" : "",
+                  "executionlisteners" : "",
+                  "name" : ""
+                },
+              "resourceId" : "sid-565296D1-FCF9-4B31-9048-528B10A27C46",
+              "stencil" : { "id" : "EndNoneEvent" }
+            }
+          ],
+        "dockers" : [  ],
+        "outgoing" : [ { "resourceId" : "sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" },
+            { "resourceId" : "boundaryEvent1" }
+          ],
+        "properties" : { "documentation" : "",
+            "name" : "",
+            "dataproperties" : { "items" : [ { "dataproperty_id" : "dObj7",
+                                  "dataproperty_name" : "SubStringTest",
+                                  "dataproperty_type" : "string",
+                                  "dataproperty_value" : "Testing456"
+                                },
+                                { "dataproperty_id" : "dObj8",
+                                  "dataproperty_name" : "SubBooleanTest",
+                                  "dataproperty_type" : "boolean",
+                                  "dataproperty_value" : "false"
+                                },
+                                { "dataproperty_id" : "dObj9",
+                                  "dataproperty_name" : "SubDateTest",
+                                  "dataproperty_type" : "datetime",
+                                  "dataproperty_value" : "2013-11-11"
+                                },
+                                { "dataproperty_id" : "dObj10",
+                                  "dataproperty_name" : "SubDoubleTest",
+                                  "dataproperty_type" : "double",
+                                  "dataproperty_value" : "678912345"
+                                },
+                                { "dataproperty_id" : "dObj11",
+                                  "dataproperty_name" : "SubIntegerTest",
+                                  "dataproperty_type" : "int",
+                                  "dataproperty_value" : "45"
+                                },
+                                { "dataproperty_id" : "dObj12",
+                                  "dataproperty_name" : "SubLongTest",
+                                  "dataproperty_type" : "long",
+                                  "dataproperty_value" : "456123"
+                                }
+                              ],
+                           "totalCount" : 6
+                          }
+          },
+        "resourceId" : "subprocess1",
+        "stencil" : { "id" : "SubProcess" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 344.1484375,
+                "y" : 205
+              },
+            "upperLeft" : { "x" : 280.671875,
+                "y" : 205
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 50,
+              "y" : 40
+            },
+            { "x" : 174,
+              "y" : 80
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "subprocess1" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-287D861F-4498-4A5C-8EC8-E07F79265E90",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "subprocess1" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 439.15625,
+                "y" : 204
+              },
+            "upperLeft" : { "x" : 395.609375,
+                "y" : 204
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 15,
+              "y" : 15
+            },
+            { "x" : 50,
+              "y" : 40
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "subUserTask1" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "subFlowId1",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "subUserTask1" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 584.375,
+                "y" : 204
+              },
+            "upperLeft" : { "x" : 540.390625,
+                "y" : 204
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 50,
+              "y" : 40
+            },
+            { "x" : 14,
+              "y" : 14
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "sid-565296D1-FCF9-4B31-9048-528B10A27C46" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-C7145ECA-31A2-4A91-B20A-023CF0764155",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "sid-565296D1-FCF9-4B31-9048-528B10A27C46" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 766,
+                "y" : 219
+              },
+            "upperLeft" : { "x" : 738,
+                "y" : 191
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [  ],
+        "outgoing" : [  ],
+        "properties" : { "documentation" : "",
+            "executionlisteners" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-194696BA-1A7D-47D7-95A9-A77390D25048",
+        "stencil" : { "id" : "EndNoneEvent" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 737.34765625,
+                "y" : 205
+              },
+            "upperLeft" : { "x" : 693.83984375,
+                "y" : 205
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 174,
+              "y" : 80
+            },
+            { "x" : 14,
+              "y" : 14
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "sid-194696BA-1A7D-47D7-95A9-A77390D25048" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "sid-194696BA-1A7D-47D7-95A9-A77390D25048" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 522.5665254211065,
+                "y" : 300.03432205225494
+              },
+            "upperLeft" : { "x" : 492.56652542110646,
+                "y" : 270.03432205225494
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 163,
+              "y" : 157
+            } ],
+        "outgoing" : [ { "resourceId" : "sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" } ],
+        "properties" : { "documentation" : "",
+            "name" : "",
+            "timercycledefinition" : "",
+            "timerdatedefinition" : "",
+            "timerdurationdefinition" : "PT5M"
+          },
+        "resourceId" : "boundaryEvent1",
+        "stencil" : { "id" : "BoundaryTimerEvent" }
+      },
+      { "bounds" : { "lowerRight" : { "x" : 752,
+                "y" : 355
+              },
+            "upperLeft" : { "x" : 522.8501906487794,
+                "y" : 219.4765625
+              }
+          },
+        "childShapes" : [  ],
+        "dockers" : [ { "x" : 15,
+              "y" : 15
+            },
+            { "x" : 752,
+              "y" : 355
+            },
+            { "x" : 14,
+              "y" : 14
+            }
+          ],
+        "outgoing" : [ { "resourceId" : "sid-194696BA-1A7D-47D7-95A9-A77390D25048" } ],
+        "properties" : { "conditionalflow" : "None",
+            "conditionsequenceflow" : "",
+            "defaultflow" : "None",
+            "documentation" : "",
+            "name" : ""
+          },
+        "resourceId" : "sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1",
+        "stencil" : { "id" : "SequenceFlow" },
+        "target" : { "resourceId" : "sid-194696BA-1A7D-47D7-95A9-A77390D25048" }
+      }
+    ],
+  "properties" : { "documentation" : "",
+      "executionlisteners" : "",
+      "dataproperties" : { "items" : [ { "dataproperty_id" : "dObj1",
+                            "dataproperty_name" : "StringTest",
+                            "dataproperty_type" : "string",
+                            "dataproperty_value" : "Testing123"
+                          },
+                          { "dataproperty_id" : "dObj2",
+                            "dataproperty_name" : "BooleanTest",
+                            "dataproperty_type" : "boolean",
+                            "dataproperty_value" : "true"
+                          },
+                          { "dataproperty_id" : "dObj3",
+                            "dataproperty_name" : "DateTest",
+                            "dataproperty_type" : "datetime",
+                            "dataproperty_value" : "2013-09-16T11:23:00"
+                          },
+                          { "dataproperty_id" : "dObj4",
+                            "dataproperty_name" : "DoubleTest",
+                            "dataproperty_type" : "double",
+                            "dataproperty_value" : "123456789"
+                          },
+                          { "dataproperty_id" : "dObj5",
+                            "dataproperty_name" : "IntegerTest",
+                            "dataproperty_type" : "int",
+                            "dataproperty_value" : "123"
+                          },
+                          { "dataproperty_id" : "dObj6",
+                            "dataproperty_name" : "LongTest",
+                            "dataproperty_type" : "long",
+                            "dataproperty_value" : "-123456"
+                          }
+                        ],
+                      "totalCount" : 6
+                    },
+      "name" : "",
+      "process_author" : "",
+      "process_id" : "process",
+      "process_namespace" : "http://www.activiti.org/processdef",
+      "process_version" : ""
+    },
+  "resourceId" : "canvas",
+  "ssextensions" : [  ],
+  "stencil" : { "id" : "BPMNDiagram" },
+  "stencilset" : { "namespace" : "http://b3mn.org/stencilset/bpmn2.0#",
+      "url" : "../stencilsets/bpmn2.0/bpmn2.0.json"
+    }
+}

--- a/modules/activiti-webapp-explorer2/src/main/resources/stencilset.json
+++ b/modules/activiti-webapp-explorer2/src/main/resources/stencilset.json
@@ -1110,6 +1110,79 @@
       } ]
     } ]
   }, {
+    "name" : "datadefinition",
+    "properties" : [ {
+      "id" : "dataproperties",
+      "type" : "Complex",
+      "title" : "Data properties",
+      "value" : "",
+      "description" : "Definition of the data object properties",
+      "popular" : true,
+      "complexItems" : [ {
+        "id" : "dataproperty_id",
+        "name" : "Id",
+        "type" : "String",
+        "description" : "This defines the id for the data object.",
+        "value" : "",
+        "width" : 150,
+        "popular" : true,
+      }, {
+        "id" : "dataproperty_name",
+        "name" : "Name",
+        "type" : "String",
+        "description" : "This defines the name for the data object.",
+        "value" : "",
+        "width" : 150,
+        "popular" : true,
+      }, {
+        "id" : "dataproperty_type",
+        "name" : "Type",
+        "type" : "Choice",
+        "value" : "",
+        "width" : 100,
+        "popular" : true,
+        "items" : [ {
+          "id" : "Boolean",
+          "title" : "Boolean",
+          "value" : "boolean",
+          "refToView" : ""
+        }, {
+          "id" : "Date",
+          "title" : "Date",
+          "value" : "datetime",
+          "refToView" : ""
+        }, {
+          "id" : "Double",
+          "title" : "Double",
+          "value" : "double",
+          "refToView" : ""
+        }, {
+          "id" : "Integer",
+          "title" : "Integer",
+          "value" : "int",
+          "refToView" : ""
+        }, {
+          "id" : "Long",
+          "title" : "Long",
+          "value" : "long",
+          "refToView" : ""
+        }, {
+          "id" : "String",
+          "title" : "String",
+          "value" : "string",
+          "refToView" : ""
+        } ]
+      }, {
+        "id" : "dataproperty_value",
+        "name" : "Value",
+        "type" : "String",
+        "description" : "This defines the value for the data object.",
+        "value" : "",
+        "width" : 200,
+        "popular" : true,
+      } ]
+    } ]
+  }, {
     "name" : "activity",
     "properties" : [ {
       "id" : "multiinstance_sequential",
@@ -1175,7 +1248,7 @@
     "groups" : [ "Diagram" ],
     "mayBeRoot" : true,
     "hide" : true,
-    "propertyPackages" : [ "baseattributes", "processbase", "executionlistenersbase", "eventListener" ],
+    "propertyPackages" : [ "baseattributes", "processbase", "executionlistenersbase", "eventListener", "datadefinition" ],
     "roles" : [ ]
   }, {
     "type" : "node",
@@ -1295,7 +1368,7 @@
     "view" : "activity/subprocess.expanded.svg",
     "icon" : "activity/expanded.subprocess.png",
     "groups" : [ "Structural" ],
-    "propertyPackages" : [ "elementbase", "baseattributes", "asynchronousbase", "executionlistenersbase", "loopcharacteristics" ],
+    "propertyPackages" : [ "elementbase", "baseattributes", "asynchronousbase", "executionlistenersbase", "loopcharacteristics", "datadefinition" ],
     "roles" : [ "sequence_start", "Activity", "sequence_end", "all" ]
   }, {
     "type" : "node",


### PR DESCRIPTION
Removed the joda dependency for XML and JSON conversion and used default
SimpleDateFormat similar to the runtime due date values.

Updated the xml conversion code and tests to use the same formats
simplified the test comparison (got rid of Calendar code).

Fixed NPE when data objects have no value - similar issue to ACT-2005
for Designer code.

Change Id: 6b6768fea020d4bf6907866652f4262f8bb0fee1
