### PR TITLE
Added feature that allows Camel header to set Process initiator

### DIFF
--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiComponent.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiComponent.java
@@ -14,6 +14,7 @@ package org.activiti.camel;
 
 import java.util.Map;
 
+import org.activiti.engine.IdentityService;
 import org.activiti.engine.RuntimeService;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Endpoint;
@@ -25,10 +26,12 @@ import org.apache.camel.impl.DefaultComponent;
  * or you can choose to create your own. Please reference the comments for the "CamelBehavior" class for more information on the 
  * out-of-the-box implementation class options. 
  * 
- * @author Ryan Johnston (@rjfsu), Tijs Rademakers
+ * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Arnold Schrijver
  */
 public class ActivitiComponent extends DefaultComponent {
 
+  private IdentityService identityService;
+    
   private RuntimeService runtimeService;
   
   private boolean copyVariablesToProperties;
@@ -42,6 +45,7 @@ public class ActivitiComponent extends DefaultComponent {
   @Override
   public void setCamelContext(CamelContext context) {
     super.setCamelContext(context);
+    identityService = getByType(context, IdentityService.class);
     runtimeService = getByType(context, RuntimeService.class);
   }
 
@@ -57,6 +61,7 @@ public class ActivitiComponent extends DefaultComponent {
   @Override
   protected Endpoint createEndpoint(String s, String s1, Map<String, Object> stringObjectMap) throws Exception {
     ActivitiEndpoint ae = new ActivitiEndpoint(s, getCamelContext(), runtimeService);
+    ae.setIdentityService(identityService);
     ae.setCopyVariablesToProperties(this.copyVariablesToProperties);
     ae.setCopyVariablesToBodyAsMap(this.copyVariablesToBodyAsMap);
     ae.setCopyCamelBodyToBody(this.copyCamelBodyToBody);

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiEndpoint.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiEndpoint.java
@@ -13,6 +13,7 @@
 
 package org.activiti.camel;
 
+import org.activiti.engine.IdentityService;
 import org.activiti.engine.RuntimeService;
 import org.apache.camel.CamelContext;
 import org.apache.camel.Consumer;
@@ -20,6 +21,7 @@ import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.impl.DefaultEndpoint;
+import org.springframework.util.StringUtils;
 
 /**
  * This class has been modified to be consistent with the changes to CamelBehavior and its implementations. The set of changes
@@ -27,10 +29,11 @@ import org.apache.camel.impl.DefaultEndpoint;
  * or you can choose to create your own. Please reference the comments for the "CamelBehavior" class for more information on the 
  * out-of-the-box implementation class options.  
  * 
- * @author Ryan Johnston (@rjfsu), Tijs Rademakers
+ * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Arnold Schrijver
  */
 public class ActivitiEndpoint extends DefaultEndpoint {
 
+  private IdentityService identityService;
 
   private RuntimeService runtimeService;
 
@@ -48,6 +51,8 @@ public class ActivitiEndpoint extends DefaultEndpoint {
   
   private boolean copyCamelBodyToBodyAsString;
   
+  private String processInitiatorHeaderName;
+  
   private long timeout = 5000;
   
   private int timeResolution = 100;
@@ -59,9 +64,13 @@ public class ActivitiEndpoint extends DefaultEndpoint {
     this.runtimeService = runtimeService;
   }
 
+  public void setIdentityService(IdentityService identityService) {
+      this.identityService = identityService;
+  }
+  
   void addConsumer(ActivitiConsumer consumer) {
     if (activitiConsumer != null) {
-      throw new RuntimeException("Activit consumer already defined for " + getEndpointUri() + "!");
+      throw new RuntimeException("Activiti consumer already defined for " + getEndpointUri() + "!");
     }
     activitiConsumer = consumer;
   }
@@ -78,7 +87,11 @@ public class ActivitiEndpoint extends DefaultEndpoint {
   }
 
   public Producer createProducer() throws Exception {
-    return new ActivitiProducer(this, runtimeService, getTimeout(), getTimeResolution());
+    ActivitiProducer producer = new ActivitiProducer(this, runtimeService, getTimeout(), getTimeResolution());
+    if (isSetProcessInitiator()) {
+        producer.setIdentityService(identityService);
+    }
+    return producer;
   }
 
   public Consumer createConsumer(Processor processor) throws Exception {
@@ -135,6 +148,18 @@ public class ActivitiEndpoint extends DefaultEndpoint {
   
   public void setCopyCamelBodyToBodyAsString(boolean copyCamelBodyToBodyAsString) {
     this.copyCamelBodyToBodyAsString = copyCamelBodyToBodyAsString;
+  }
+  
+  public boolean isSetProcessInitiator() {
+      return StringUtils.hasText(getProcessInitiatorHeaderName());
+  }
+  
+  public String getProcessInitiatorHeaderName() {
+      return processInitiatorHeaderName;
+  }
+  
+  public void setProcessInitiatorHeaderName(String processInitiatorHeaderName) {
+      this.processInitiatorHeaderName = processInitiatorHeaderName;
   }
   
   @Override

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ExchangeUtils.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ExchangeUtils.java
@@ -15,12 +15,15 @@ package org.activiti.camel;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.activiti.engine.ActivitiException;
 import org.apache.camel.Exchange;
+import org.apache.camel.TypeConversionException;
+import org.springframework.util.StringUtils;
 
 /**
  * This class contains one method - prepareVariables - that is used to copy variables from Camel into Activiti.
  * 
- * @author Ryan Johnston (@rjfsu), Tijs Rademakers
+ * @author Ryan Johnston (@rjfsu), Tijs Rademakers, Arnold Schrijver
  */
 public class ExchangeUtils {
 
@@ -83,12 +86,45 @@ public class ExchangeUtils {
       }
 
       if(activitiEndpoint.isCopyVariablesFromHeader()) {
+        boolean isSetProcessInitiator = activitiEndpoint.isSetProcessInitiator();
         for(Map.Entry<String, Object> header : exchange.getIn().getHeaders().entrySet()) {
+          // Don't pass the process initiator header as a variable.
+          if (isSetProcessInitiator && activitiEndpoint.getProcessInitiatorHeaderName().equals(header.getKey())) {
+              continue;
+          }
     	  camelVarMap.put(header.getKey(), header.getValue());
         }
       }
     }
     
     return camelVarMap;
+  }
+  
+  /**
+   * Gets the value of the Camel header that contains the userId to be set as the process initiator.
+   * Returns null if no header name was specified on the Camel route.
+   * 
+   * @param exchange The Camel Exchange object
+   * @param activitiEndpoint The ActivitiEndpoint implementation
+   * @return The userId of the user to be set as the process initiator
+   */
+  public static String prepareInitiator(Exchange exchange, ActivitiEndpoint activitiEndpoint) {
+     
+      String initiator = null;
+      if (activitiEndpoint.isSetProcessInitiator()) {
+          try {
+              initiator = exchange.getIn().getHeader(activitiEndpoint.getProcessInitiatorHeaderName(), String.class);
+          }
+          catch (TypeConversionException e) {
+              throw new ActivitiException("Initiator header '" + 
+                      activitiEndpoint.getProcessInitiatorHeaderName() + "': Value must be of type String.", e);
+          }
+          
+          if (!StringUtils.hasText(initiator)) {
+              throw new RuntimeException("Initiator header '" + 
+                      activitiEndpoint.getProcessInitiatorHeaderName() + "': Value must be provided");
+          }
+      }
+      return initiator;
   }
 }

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallRoute.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallRoute.java
@@ -1,0 +1,27 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.camel.examples.initiatorCamelCall;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class InitiatorCamelCallRoute extends RouteBuilder {
+
+  @Override
+  public void configure() throws Exception {
+
+      from("direct:startWithInitiatorHeader")
+          .setHeader("CamelProcessInitiatorHeader", constant("kermit"))
+          .to("activiti:InitiatorCamelCallProcess?processInitiatorHeaderName=CamelProcessInitiatorHeader");
+  }
+}

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallTest.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallTest.java
@@ -1,0 +1,39 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.camel.examples.initiatorCamelCall;
+
+import org.activiti.engine.test.Deployment;
+import org.activiti.spring.impl.test.SpringActivitiTestCase;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration("classpath:camel-activiti-context.xml")
+public class InitiatorCamelCallTest extends SpringActivitiTestCase {
+   
+  @Deployment
+  public void testInitiatorCamelCall() throws Exception {
+    CamelContext ctx = applicationContext.getBean(CamelContext.class);
+    ProducerTemplate tpl = ctx.createProducerTemplate();
+    String body = "body text";
+    String instanceId = (String) tpl.requestBody("direct:startWithInitiatorHeader", body);
+
+    String initiator = (String) runtimeService.getVariable(instanceId, "initiator");
+    assertEquals("kermit", initiator);
+    
+    Object camelInitiatorHeader = runtimeService.getVariable(instanceId, "CamelProcessInitiatorHeader");
+    assertNull(camelInitiatorHeader);
+  }
+
+}

--- a/modules/activiti-camel/src/test/resources/camel-activiti-context.xml
+++ b/modules/activiti-camel/src/test/resources/camel-activiti-context.xml
@@ -34,6 +34,8 @@
         <property name="processEngineConfiguration" ref="processEngineConfiguration"/>
     </bean>
 
+    <bean id="identityService" factory-bean="processEngine" factory-method="getIdentityService"/>
+
     <bean id="runtimeService" factory-bean="processEngine" factory-method="getRuntimeService"/>
     
     <camelContext id="camelContext" xmlns="http://camel.apache.org/schema/spring">

--- a/modules/activiti-camel/src/test/resources/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallTest.testInitiatorCamelCall.bpmn20.xml
+++ b/modules/activiti-camel/src/test/resources/org/activiti/camel/examples/initiatorCamelCall/InitiatorCamelCallTest.testInitiatorCamelCall.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="
+             http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/2.0/20100501/BPMN20.xsd">
+
+
+    <process id="InitiatorCamelCallProcess">
+        <startEvent id="start" activiti:initiator="initiator"/>
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="simpleTask"/>
+        <userTask id="simpleTask" name="Simple Task" activiti:assignee="kermit"/>
+        <sequenceFlow id="flow2" sourceRef="simpleTask" targetRef="end"/>       
+        <endEvent id="end"/>
+    </process>
+
+</definitions>


### PR DESCRIPTION
I added some code to the activiti-camel project that allows a Camel header to be specified, whose value will be used when setting the Initiator on the workflow instance.

So with this you can have a Camel route like below:

``` java
      from("direct:startWithInitiatorHeader")
          .setHeader("CamelProcessInitiatorHeader", constant("kermit"))
          .to("activiti:InitiatorCamelCallProcess?processInitiatorHeaderName=CamelProcessInitiatorHeader");
```

and "kermit" will be set as the initiator of the workflow instance.
