### PR TITLE
ACT-2083

### DIFF
--- a/modules/activiti-bpmn-layout/pom.xml
+++ b/modules/activiti-bpmn-layout/pom.xml
@@ -98,6 +98,15 @@
       <artifactId>jgraphx</artifactId>
       <version>1.10.4.1</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+    	<groupId>org.activiti</groupId>
+    	<artifactId>activiti-bpmn-converter</artifactId>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/modules/activiti-bpmn-layout/src/main/java/org/activiti/bpmn/BpmnAutoLayout.java
+++ b/modules/activiti-bpmn-layout/src/main/java/org/activiti/bpmn/BpmnAutoLayout.java
@@ -26,6 +26,7 @@ import javax.swing.SwingConstants;
 import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.CallActivity;
+import org.activiti.bpmn.model.DataObject;
 import org.activiti.bpmn.model.Event;
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.FlowElementsContainer;
@@ -299,7 +300,7 @@ public class BpmnAutoLayout {
               graphicInfo.setX(graphicInfo.getX() + translationX);
               graphicInfo.setY(graphicInfo.getY() + translationY);
             }
-          } else {
+          } else if (subProcessElement instanceof DataObject == false) {
             GraphicInfo graphicInfo = bpmnModel.getLocationMap().get(subProcessElement.getId());
             graphicInfo.setX(graphicInfo.getX() + translationX);
             graphicInfo.setY(graphicInfo.getY() + translationY);

--- a/modules/activiti-bpmn-layout/src/test/java/org/activiti/bpmn/SubProcessConverterAutoLayoutTest.java
+++ b/modules/activiti-bpmn-layout/src/test/java/org/activiti/bpmn/SubProcessConverterAutoLayoutTest.java
@@ -1,0 +1,73 @@
+package org.activiti.bpmn;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.UserTask;
+import org.activiti.bpmn.model.ValuedDataObject;
+import org.activiti.editor.language.xml.AbstractConverterTest;
+import org.junit.Test;
+
+public class SubProcessConverterAutoLayoutTest extends AbstractConverterTest {
+
+  @Test
+  public void convertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+  
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    
+    // Add DI information to bpmn model
+    BpmnAutoLayout bpmnAutoLayout = new BpmnAutoLayout(bpmnModel);
+    bpmnAutoLayout.execute();
+    
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+  
+  protected String getResource() {
+    return "subprocessmodel_autolayout.bpmn";
+  }
+  
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+    
+    flowElement = model.getMainProcess().getFlowElement("userTask1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof UserTask);
+    assertEquals("userTask1", flowElement.getId());
+    UserTask userTask = (UserTask) flowElement;
+    assertTrue(userTask.getCandidateUsers().size() == 1);
+    assertTrue(userTask.getCandidateGroups().size() == 1);
+    
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertTrue(subProcess.getFlowElements().size() == 6);
+    
+    List<ValuedDataObject> dataObjects = ((SubProcess)flowElement).getDataObjects();
+    assertTrue(dataObjects.size() == 1);
+
+    ValuedDataObject dataObj = dataObjects.get(0);
+    assertEquals("SubTest", dataObj.getName());
+    assertEquals("xsd:string", dataObj.getItemSubjectRef().getStructureRef());
+    assertTrue(dataObj.getValue() instanceof String);
+    assertEquals("Testing", dataObj.getValue());
+  }
+}

--- a/modules/activiti-bpmn-layout/src/test/resources/subprocessmodel_autolayout.bpmn
+++ b/modules/activiti-bpmn-layout/src/test/resources/subprocessmodel_autolayout.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:sas="http://www.sas.com/bpmn" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <subProcess id="subprocess1" name="subProcess">
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <userTask id="subUserTask1" name="User task 2"></userTask>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+      <dataObject id="sid-AA1205FD-63BD-47BA-9FB3-AA9F7C1E31F0" name="SubTest" itemSubjectRef="xsd:string">
+        <extensionElements>
+          <activiti:value>Testing</activiti:value>
+        </extensionElements>
+      </dataObject>
+    </subProcess>
+    <startEvent id="start1"></startEvent>
+    <sequenceFlow id="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" activiti:async="true" activiti:exclusive="false" activiti:candidateUsers="kermit" activiti:candidateGroups="management"></userTask>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+        <omgdc:Bounds height="160.0" width="348.0" x="345.0" y="125.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="585.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="365.0" y="189.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="440.0" y="164.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="105.0" y="190.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
+        <omgdc:Bounds height="35.0" width="35.0" x="738.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="180.0" y="165.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
+        <omgdi:waypoint x="140.0" y="207.0"></omgdi:waypoint>
+        <omgdi:waypoint x="180.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
+        <omgdi:waypoint x="540.0" y="204.0"></omgdi:waypoint>
+        <omgdi:waypoint x="585.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="400.0" y="206.0"></omgdi:waypoint>
+        <omgdi:waypoint x="440.0" y="204.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" id="BPMNEdge_sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2">
+        <omgdi:waypoint x="693.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="738.0" y="208.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" id="BPMNEdge_sid-287D861F-4498-4A5C-8EC8-E07F79265E90">
+        <omgdi:waypoint x="280.0" y="205.0"></omgdi:waypoint>
+        <omgdi:waypoint x="345.0" y="205.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Autolayout fails with subprocess data objects

Added dependency on converter module so I could add a conversion unit test that generates the BPMNDI values to a template with only the BPMN model information.
