### PR TITLE
Generalise abstract layers

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/IProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/IProcessEngineConfiguration.java
@@ -1,0 +1,95 @@
+package org.activiti.engine;
+
+import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
+import org.activiti.engine.impl.calendar.BusinessCalendarManager;
+import org.activiti.engine.impl.cfg.IdGenerator;
+import org.activiti.engine.impl.el.ExpressionManager;
+import org.activiti.engine.impl.event.EventHandler;
+import org.activiti.engine.impl.form.FormTypes;
+import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.interceptor.CommandExecutor;
+import org.activiti.engine.impl.interceptor.DelegateInterceptor;
+import org.activiti.engine.impl.jobexecutor.JobExecutor;
+import org.activiti.engine.impl.jobexecutor.JobHandler;
+import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
+import org.activiti.engine.impl.scripting.ScriptingEngines;
+import org.activiti.engine.impl.variable.VariableTypes;
+import org.activiti.engine.runtime.Clock;
+import org.activiti.image.ProcessDiagramGenerator;
+import org.activiti.validation.ProcessValidator;
+import java.util.Map;
+
+/**
+ * Interface for a Process Engine configurator.
+ *
+ */
+public interface IProcessEngineConfiguration extends EngineServices {
+
+    ActivitiEventDispatcher getEventDispatcher();
+
+    HistoryLevel getHistoryLevel();
+
+    boolean isDbIdentityUsed();
+
+    String getDatabaseSchemaUpdate();
+
+    Clock getClock();
+
+    CommandExecutor getCommandExecutor();
+
+    VariableTypes getVariableTypes();
+
+    DeploymentManager getDeploymentManager();
+
+    DelegateInterceptor getDelegateInterceptor();
+
+    EventHandler getEventHandler(String eventType);
+
+    JobExecutor getJobExecutor();
+
+    Map<String, JobHandler> getJobHandlers();
+
+    boolean isCreateDiagramOnDeploy();
+
+    ProcessDiagramGenerator getProcessDiagramGenerator();
+
+    String getActivityFontName();
+
+    String getLabelFontName();
+
+    ClassLoader getClassLoader();
+
+    BusinessCalendarManager getBusinessCalendarManager();
+
+    boolean isEnableSafeBpmnXml();
+
+    String getXmlEncoding();
+
+    ProcessValidator getProcessValidator();
+
+    String getMailServerDefaultFrom();
+
+    String getMailSesionJndi();
+
+    String getMailServerHost();
+
+    int getMailServerPort();
+
+    boolean getMailServerUseSSL();
+
+    boolean getMailServerUseTLS();
+
+    String getMailServerUsername();
+
+    String getMailServerPassword();
+
+    ExpressionManager getExpressionManager();
+
+    ScriptingEngines getScriptingEngines();
+
+    IdGenerator getIdGenerator();
+
+    FormTypes getFormTypes();
+
+    Map<Object, Object> getBeans();
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/RepositoryService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/RepositoryService.java
@@ -15,16 +15,7 @@ package org.activiti.engine;
 
 import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.model.BpmnModel;
-import org.activiti.engine.repository.DeploymentBuilder;
-import org.activiti.engine.repository.DeploymentQuery;
-import org.activiti.engine.repository.DiagramLayout;
-import org.activiti.engine.repository.Model;
-import org.activiti.engine.repository.ModelQuery;
-import org.activiti.engine.repository.NativeDeploymentQuery;
-import org.activiti.engine.repository.NativeModelQuery;
-import org.activiti.engine.repository.NativeProcessDefinitionQuery;
-import org.activiti.engine.repository.ProcessDefinition;
-import org.activiti.engine.repository.ProcessDefinitionQuery;
+import org.activiti.engine.repository.*;
 import org.activiti.engine.task.IdentityLink;
 import org.activiti.validation.ValidationError;
 
@@ -57,7 +48,14 @@ public interface RepositoryService {
    * instances or jobs. 
    */
   void deleteDeployment(String deploymentId);
-  
+
+    /**
+     *
+     * @param deploymentBuilder
+     * @return
+     */
+  Deployment deploy(DeploymentBuilder deploymentBuilder);
+
   /**
    * Deletes the given deployment and cascade deletion to process instances, 
    * history process instances and jobs.

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RepositoryServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RepositoryServiceImpl.java
@@ -74,7 +74,8 @@ public class RepositoryServiceImpl extends ServiceImpl implements RepositoryServ
     return new DeploymentBuilderImpl(this);
   }
 
-  public Deployment deploy(DeploymentBuilderImpl deploymentBuilder) {
+  @Override
+  public Deployment deploy(DeploymentBuilder deploymentBuilder) {
     return commandExecutor.execute(new DeployCmd<Deployment>(deploymentBuilder));
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -17,6 +17,7 @@ import javax.naming.NamingException;
 
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -186,7 +187,7 @@ public class MailActivityBehavior extends AbstractBpmnActivityBehavior {
   }
 
   protected void setMailServerProperties(Email email) {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    IProcessEngineConfiguration processEngineConfiguration = Context.getProcessEngineConfiguration();
 
     String mailSessionJndi = processEngineConfiguration.getMailSesionJndi();
     if (mailSessionJndi != null) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.delegate.event.ActivitiEventType;
@@ -76,7 +77,7 @@ public class BpmnDeployer implements Deployer {
     List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
     Map<String, ResourceEntity> resources = deployment.getResources();
 
-    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    final IProcessEngineConfiguration processEngineConfiguration = Context.getProcessEngineConfiguration();
     for (String resourceName : resources.keySet()) {
 
       LOG.info("Processing resource {}", resourceName);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
@@ -38,6 +38,7 @@ import org.activiti.bpmn.model.SequenceFlow;
 import org.activiti.bpmn.model.SubProcess;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.impl.bpmn.data.ClassStructureDefinition;
 import org.activiti.engine.impl.bpmn.data.ItemDefinition;
 import org.activiti.engine.impl.bpmn.data.ItemKind;
@@ -171,7 +172,7 @@ public class BpmnParse implements BpmnXMLConstants {
   public BpmnParse execute() {
     try {
 
-    	ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    	IProcessEngineConfiguration processEngineConfiguration = Context.getProcessEngineConfiguration();
       BpmnXMLConverter converter = new BpmnXMLConverter();
       
       boolean enableSafeBpmnXml = false;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -34,16 +34,7 @@ import java.util.Set;
 import javax.naming.InitialContext;
 import javax.sql.DataSource;
 
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.FormService;
-import org.activiti.engine.HistoryService;
-import org.activiti.engine.IdentityService;
-import org.activiti.engine.ManagementService;
-import org.activiti.engine.ProcessEngine;
-import org.activiti.engine.ProcessEngineConfiguration;
-import org.activiti.engine.RepositoryService;
-import org.activiti.engine.RuntimeService;
-import org.activiti.engine.TaskService;
+import org.activiti.engine.*;
 import org.activiti.engine.cfg.ProcessEngineConfigurator;
 import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
 import org.activiti.engine.delegate.event.ActivitiEventListener;
@@ -231,7 +222,7 @@ import org.slf4j.LoggerFactory;
  * @author Tom Baeyens
  * @author Joram Barrez
  */
-public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration {  
+public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfiguration implements IProcessEngineConfiguration {
 
   private static Logger log = LoggerFactory.getLogger(ProcessEngineConfigurationImpl.class);
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
@@ -29,6 +29,7 @@ import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.activiti.engine.impl.persistence.entity.ResourceEntity;
 import org.activiti.engine.impl.repository.DeploymentBuilderImpl;
 import org.activiti.engine.repository.Deployment;
+import org.activiti.engine.repository.DeploymentBuilder;
 
 /**
  * @author Tom Baeyens
@@ -37,9 +38,9 @@ import org.activiti.engine.repository.Deployment;
 public class DeployCmd<T> implements Command<Deployment>, Serializable {
 
   private static final long serialVersionUID = 1L;
-  protected DeploymentBuilderImpl deploymentBuilder;
+  protected DeploymentBuilder deploymentBuilder;
 
-  public DeployCmd(DeploymentBuilderImpl deploymentBuilder) {
+  public DeployCmd(DeploymentBuilder deploymentBuilder) {
     this.deploymentBuilder = deploymentBuilder;
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/context/Context.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/context/Context.java
@@ -15,6 +15,8 @@ package org.activiti.engine.impl.context;
 
 import java.util.Stack;
 
+import org.activiti.engine.IProcessEngineConfiguration;
+import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.jobexecutor.JobExecutorContext;
@@ -28,7 +30,7 @@ import org.activiti.engine.impl.pvm.runtime.InterpretableExecution;
 public class Context {
 
   protected static ThreadLocal<Stack<CommandContext>> commandContextThreadLocal = new ThreadLocal<Stack<CommandContext>>();
-  protected static ThreadLocal<Stack<ProcessEngineConfigurationImpl>> processEngineConfigurationStackThreadLocal = new ThreadLocal<Stack<ProcessEngineConfigurationImpl>>();
+  protected static ThreadLocal<Stack<IProcessEngineConfiguration>> processEngineConfigurationStackThreadLocal = new ThreadLocal<Stack<IProcessEngineConfiguration>>();
   protected static ThreadLocal<Stack<ExecutionContext>> executionContextStackThreadLocal = new ThreadLocal<Stack<ExecutionContext>>();
   protected static ThreadLocal<JobExecutorContext> jobExecutorContextThreadLocal = new ThreadLocal<JobExecutorContext>();
 
@@ -48,15 +50,15 @@ public class Context {
     getStack(commandContextThreadLocal).pop();
   }
 
-  public static ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
-    Stack<ProcessEngineConfigurationImpl> stack = getStack(processEngineConfigurationStackThreadLocal);
+  public static IProcessEngineConfiguration getProcessEngineConfiguration() {
+    Stack<IProcessEngineConfiguration> stack = getStack(processEngineConfigurationStackThreadLocal);
     if (stack.isEmpty()) {
       return null;
     }
     return stack.peek();
   }
 
-  public static void setProcessEngineConfiguration(ProcessEngineConfigurationImpl processEngineConfiguration) {
+  public static void setProcessEngineConfiguration(IProcessEngineConfiguration processEngineConfiguration) {
     getStack(processEngineConfigurationStackThreadLocal).push(processEngineConfiguration);
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -31,11 +31,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.ActivitiOptimisticLockingException;
-import org.activiti.engine.ActivitiWrongDbException;
-import org.activiti.engine.ProcessEngine;
-import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.*;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.ActivitiVariableEvent;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
@@ -914,7 +910,7 @@ public class DbSqlSession implements Session {
   }
 
   public void dbSchemaCreate() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    IProcessEngineConfiguration processEngineConfiguration = Context.getProcessEngineConfiguration();
     
     if (isEngineTablePresent()) {
       String dbVersion = getDbVersion();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContextInterceptor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContextInterceptor.java
@@ -13,6 +13,7 @@
 
 package org.activiti.engine.impl.interceptor;
 
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
 import org.slf4j.Logger;
@@ -25,12 +26,12 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
   private static final Logger log = LoggerFactory.getLogger(CommandContextInterceptor.class);
 
   protected CommandContextFactory commandContextFactory;
-  protected ProcessEngineConfigurationImpl processEngineConfiguration;
+  protected IProcessEngineConfiguration processEngineConfiguration;
 
   public CommandContextInterceptor() {
   }
 
-  public CommandContextInterceptor(CommandContextFactory commandContextFactory, ProcessEngineConfigurationImpl processEngineConfiguration) {
+  public CommandContextInterceptor(CommandContextFactory commandContextFactory, IProcessEngineConfiguration processEngineConfiguration) {
     this.commandContextFactory = commandContextFactory;
     this.processEngineConfiguration = processEngineConfiguration;
   }
@@ -83,11 +84,11 @@ public class CommandContextInterceptor extends AbstractCommandInterceptor {
     this.commandContextFactory = commandContextFactory;
   }
 
-  public ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+  public IProcessEngineConfiguration getProcessEngineConfiguration() {
     return processEngineConfiguration;
   }
 
-  public void setProcessEngineContext(ProcessEngineConfigurationImpl processEngineContext) {
+  public void setProcessEngineContext(IProcessEngineConfiguration processEngineContext) {
     this.processEngineConfiguration = processEngineContext;
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/AbstractManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/AbstractManager.java
@@ -13,6 +13,7 @@
 
 package org.activiti.engine.impl.persistence;
 
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.db.DbSqlSession;
@@ -152,7 +153,7 @@ public abstract class AbstractManager implements Session {
     return getSession(HistoryManager.class);
   }
   
-  protected ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+  protected IProcessEngineConfiguration getProcessEngineConfiguration() {
   	return Context.getProcessEngineConfiguration();
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -16,7 +16,7 @@ import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
-import org.activiti.engine.impl.RepositoryServiceImpl;
+import org.activiti.engine.RepositoryService;
 import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
 import org.activiti.engine.impl.persistence.entity.ResourceEntity;
 import org.activiti.engine.impl.util.IoUtil;
@@ -40,14 +40,14 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   private static final long serialVersionUID = 1L;
   protected static final String DEFAULT_ENCODING = "UTF-8";
 
-  protected transient RepositoryServiceImpl repositoryService;
+  protected transient RepositoryService repositoryService;
   protected DeploymentEntity deployment = new DeploymentEntity();
   protected boolean isBpmn20XsdValidationEnabled = true;
   protected boolean isProcessValidationEnabled = true;
   protected boolean isDuplicateFilterEnabled = false;
   protected Date processDefinitionsActivationDate;
 
-  public DeploymentBuilderImpl(RepositoryServiceImpl repositoryService) {
+  public DeploymentBuilderImpl(RepositoryService repositoryService) {
     this.repositoryService = repositoryService;
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 
 import org.activiti.engine.ActivitiClassLoadingException;
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.IProcessEngineConfiguration;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
 import org.slf4j.Logger;
@@ -269,7 +270,7 @@ public abstract class ReflectUtil {
   }
   
   private static ClassLoader getCustomClassLoader() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    IProcessEngineConfiguration processEngineConfiguration = Context.getProcessEngineConfiguration();
     if(processEngineConfiguration != null) {
       final ClassLoader classLoader = processEngineConfiguration.getClassLoader();
       if(classLoader != null) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentBuilder.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentBuilder.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.zip.ZipInputStream;
 
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
 
 /**
  * Builder for creating new deployments.
@@ -88,5 +89,14 @@ public interface DeploymentBuilder {
    * Deploys all provided sources to the Activiti engine.
    */
   Deployment deploy();
-  
+
+    DeploymentEntity getDeployment();
+
+    boolean isDuplicateFilterEnabled();
+
+    boolean isBpmn20XsdValidationEnabled();
+
+    boolean isProcessValidationEnabled();
+
+    Date getProcessDefinitionsActivationDate();
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstance.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstance.java
@@ -25,7 +25,8 @@ import org.activiti.engine.repository.ProcessDefinition;
  * @author Daniel Meyer
  */
 public interface ProcessInstance extends Execution {
-  
+
+
   /**
    * The id of the process definition of the process instance.
    */

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/ProcessEngineFactoryBean.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/ProcessEngineFactoryBean.java
@@ -14,7 +14,6 @@
 package org.activiti.spring;
 
 import org.activiti.engine.ProcessEngine;
-import org.activiti.engine.impl.ProcessEngineImpl;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.cfg.SpringBeanFactoryProxyMap;
 import org.springframework.beans.BeansException;
@@ -33,7 +32,7 @@ public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, Dis
 
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected ApplicationContext applicationContext;
-  protected ProcessEngineImpl processEngine;
+  protected ProcessEngine processEngine;
   
   public void destroy() throws Exception {
     if (processEngine != null) {
@@ -53,7 +52,7 @@ public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, Dis
       processEngineConfiguration.setBeans(new SpringBeanFactoryProxyMap(applicationContext));
     }
     
-    processEngine = (ProcessEngineImpl) processEngineConfiguration.buildProcessEngine();
+    processEngine = processEngineConfiguration.buildProcessEngine();
 
     return processEngine;
   }


### PR DESCRIPTION
Within this changeset we extracted new interface for ProjectEngineConfiguration. Now, all the abstract layers are communicated through an interface, but not by calling a particular class.

There is no new functionality within this pull-request. Thus, we didn't touch behaviour of the whole code at all. This changeset allows us to implement our own Process Engine Configurator and use our own persistance layer.  We require this feature in order to continue work on [our fork of activiti-neo4j](https://github.com/p-i/activiti-neo4j).