### PR TITLE
Register rollback listener before executing the job

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
@@ -23,7 +23,6 @@ import org.activiti.engine.impl.cfg.TransactionState;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
-import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.jobexecutor.FailedJobListener;
 import org.activiti.engine.impl.jobexecutor.JobExecutorContext;
 import org.activiti.engine.impl.persistence.entity.JobEntity;
@@ -76,8 +75,15 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
     if (jobExecutorContext != null) { // if null, then we are not called by the job executor     
       jobExecutorContext.setCurrentJob(job);
     }
-    
+    FailedJobListener failedJobListener = null;
     try {
+      // When transaction is rolled back, decrement retries
+      failedJobListener = new FailedJobListener(commandContext.getProcessEngineConfiguration().getCommandExecutor(), jobId);
+      commandContext.getTransactionContext().addTransactionListener(
+              TransactionState.ROLLED_BACK,
+              failedJobListener
+              );
+
       job.execute(commandContext);
       
       if (commandContext.getEventDispatcher().isEnabled()) {
@@ -86,14 +92,7 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
       }
       
     } catch (Throwable exception) {
-      // When transaction is rolled back, decrement retries
-      CommandExecutor commandExecutor = Context
-        .getProcessEngineConfiguration()
-        .getCommandExecutor();
-      
-      commandContext.getTransactionContext().addTransactionListener(
-        TransactionState.ROLLED_BACK, 
-        new FailedJobListener(commandExecutor, jobId, exception));
+      failedJobListener.setException(exception);
       
       // Dispatch an event, indicating job execution failed in a try-catch block, to prevent the original
       // exception to be swallowed

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/FailedJobListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/FailedJobListener.java
@@ -33,10 +33,13 @@ public class FailedJobListener implements TransactionListener {
   protected String jobId;
   protected Throwable exception;
 
-  public FailedJobListener(CommandExecutor commandExecutor, String jobId, Throwable exception) {
+  public void setException(Throwable exception) {
+    this.exception = exception;
+  }
+  
+  public FailedJobListener(CommandExecutor commandExecutor, String jobId) {
     this.commandExecutor = commandExecutor;
     this.jobId = jobId;
-    this.exception = exception;
   }
   
   public void execute(CommandContext commandContext) {


### PR DESCRIPTION
We 've noticed that the failed job listener was registered to the transactional context after the job.execute() has failed. (see ExecuteJobsCmd @ try-catch block). This is kind of strange if the transaction is intercepted by JtaTransactionInterceptor as the transaction were already rolled back _before_ adding the failed job listener.
