### PR TITLE
ACT-2065: add Cobertura coverage reports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -560,12 +560,17 @@
         <artifactId>jtds</artifactId>
         <version>1.3.0</version>
       </dependency>
-        <dependency>
-            <groupId>com.googlecode.catch-exception</groupId>
-            <artifactId>catch-exception</artifactId>
-            <version>1.2.0</version>
-            <scope>test</scope>
-        </dependency>
+      <dependency>
+         <groupId>com.googlecode.catch-exception</groupId>
+         <artifactId>catch-exception</artifactId>
+         <version>1.2.0</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>xml-apis</groupId>
+         <artifactId>xml-apis</artifactId>
+         <version>1.4.01</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -604,6 +609,31 @@
           <runOrder>alphabetical</runOrder>
           <argLine>-Duser.language=en</argLine>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.5.2</version>
+        <configuration>
+          <maxmem>256m</maxmem>
+          <aggregate>true</aggregate>
+          <formats>
+            <format>html</format>
+          </formats>
+          <instrumentation>
+            <excludes>
+              <exclude>**/*TestCase.*</exclude>
+              <exclude>**/*Test.*</exclude>
+            </excludes>
+          </instrumentation>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.felix</groupId>
@@ -941,6 +971,16 @@
       </build>
     </profile>
   </profiles>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.5.2</version>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <!-- Various information, not used by the build -->
 


### PR DESCRIPTION
(1) The changes to lines 563-568 are just to line up the <dependency> block with everything else.
(2) This pull request is not using the latest version of the Cobertura plugin (version 2.6) but is using 2.5.2 because there were issues generating the aggregated report using 2.6 and I could never get it to work.
