### PR TITLE
Add a time property to the Attachment entity and corresponding column on ACT_HI_ATTACHMENT

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CreateAttachmentCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CreateAttachmentCmd.java
@@ -70,6 +70,7 @@ public class CreateAttachmentCmd implements Command<Attachment> {
     attachment.setProcessInstanceId(processInstanceId);
     attachment.setUrl(url);
     attachment.setUserId(Authentication.getAuthenticatedUserId());
+    attachment.setTime(commandContext.getProcessEngineConfiguration().getClock().getCurrentTime());
     
     DbSqlSession dbSqlSession = commandContext.getDbSqlSession();
     dbSqlSession.insert(attachment);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntity.java
@@ -14,6 +14,7 @@
 package org.activiti.engine.impl.persistence.entity;
 
 import java.io.Serializable;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,6 +41,7 @@ public class AttachmentEntity implements Attachment, PersistentObject, HasRevisi
   protected String contentId;
   protected ByteArrayEntity content;
   protected String userId;
+  protected Date time;
 
   public Object getPersistentState() {
     Map<String, Object> persistentState = new HashMap<String, Object>();
@@ -155,6 +157,14 @@ public class AttachmentEntity implements Attachment, PersistentObject, HasRevisi
   
   public String getUserId() {
 	return userId;
+  }
+  
+  public Date getTime() {
+    return time;
+  }
+  
+  public void setTime(Date time) {
+    this.time = time;
   }
   
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/Attachment.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/Attachment.java
@@ -13,6 +13,8 @@
 
 package org.activiti.engine.task;
 
+import java.util.Date;
+
 import org.activiti.engine.TaskService;
 
 
@@ -55,4 +57,11 @@ public interface Attachment {
   
   /** reference to the user who created this attachment. */
   String getUserId();
+
+  /** timestamp when this attachment was created */
+  Date getTime();
+  
+  /** timestamp when this attachment was created */
+  void setTime(Date time);
+
 }

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.history.sql
@@ -122,6 +122,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ varchar(64),
     URL_ varchar(4000),
     CONTENT_ID_ varchar(64),
+    TIME_ timestamp,
     primary key (ID_)
 );
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.h2.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.h2.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ varchar(64),
     URL_ varchar(4000),
     CONTENT_ID_ varchar(64),
+    TIME_ timestamp,
     primary key (ID_)
 );
 create table ACT_HI_IDENTITYLINK (

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mssql.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mssql.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ nvarchar(64),
     URL_ nvarchar(4000),
     CONTENT_ID_ nvarchar(64),
+    TIME_ datetime,
     primary key (ID_)
 );
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ varchar(64),
     URL_ varchar(4000),
     CONTENT_ID_ varchar(64),
+    TIME_ datetime(3),
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql55.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql55.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ varchar(64),
     URL_ varchar(4000),
     CONTENT_ID_ varchar(64),
+    TIME_ datetime,
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.oracle.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.oracle.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ NVARCHAR2(64),
     URL_ NVARCHAR2(2000),
     CONTENT_ID_ NVARCHAR2(64),
+    TIME_ TIMESTAMP(6),
     primary key (ID_)
 );
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.postgres.create.history.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.postgres.create.history.sql
@@ -120,6 +120,7 @@ create table ACT_HI_ATTACHMENT (
     PROC_INST_ID_ varchar(64),
     URL_ varchar(4000),
     CONTENT_ID_ varchar(64),
+    TIME_ timestamp,
     primary key (ID_)
 );
 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Attachment.xml
@@ -21,7 +21,7 @@
   <!-- ATTACHMENT INSERT -->
 
   <insert id="insertAttachment" parameterType="org.activiti.engine.impl.persistence.entity.AttachmentEntity">
-    insert into ${prefix}ACT_HI_ATTACHMENT (ID_, REV_, USER_ID_, NAME_, DESCRIPTION_, TYPE_, TASK_ID_, PROC_INST_ID_, URL_, CONTENT_ID_)
+    insert into ${prefix}ACT_HI_ATTACHMENT (ID_, REV_, USER_ID_, NAME_, DESCRIPTION_, TYPE_, TASK_ID_, PROC_INST_ID_, URL_, CONTENT_ID_, TIME_)
     values (
       #{id ,jdbcType=VARCHAR},
       1,
@@ -32,7 +32,8 @@
       #{taskId ,jdbcType=VARCHAR},
       #{processInstanceId ,jdbcType=VARCHAR},
       #{url ,jdbcType=VARCHAR},
-      #{contentId ,jdbcType=VARCHAR}
+      #{contentId ,jdbcType=VARCHAR},
+      #{time ,jdbcType=TIMESTAMP}
     )
   </insert>
 
@@ -68,20 +69,29 @@
     <result property="url" column="URL_" jdbcType="VARCHAR" />
     <result property="contentId" column="CONTENT_ID_" jdbcType="VARCHAR" />
     <result property="userId" column="USER_ID_" jdbcType="VARCHAR" />
+    <result property="time" column="TIME_" jdbcType="TIMESTAMP" />
   </resultMap>
   
   <!-- ATTACHMENT SELECT -->
 
   <select id="selectAttachment" parameterType="string" resultMap="attachmentResultMap">
-    select * from ${prefix}ACT_HI_ATTACHMENT where ID_ = #{id,jdbcType=VARCHAR}
+    select *
+    from ${prefix}ACT_HI_ATTACHMENT
+    where ID_ = #{id,jdbcType=VARCHAR}
   </select>
   
   <select id="selectAttachmentsByTaskId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="attachmentResultMap">
-    select * from ${prefix}ACT_HI_ATTACHMENT where TASK_ID_ = #{parameter,jdbcType=VARCHAR}
+    select *
+    from ${prefix}ACT_HI_ATTACHMENT
+    where TASK_ID_ = #{parameter,jdbcType=VARCHAR}
+    order by TIME_ desc
   </select>
   
   <select id="selectAttachmentsByProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="attachmentResultMap">
-    select * from ${prefix}ACT_HI_ATTACHMENT where PROC_INST_ID_ = #{parameter,jdbcType=VARCHAR}
+    select *
+    from ${prefix}ACT_HI_ATTACHMENT
+    where PROC_INST_ID_ = #{parameter,jdbcType=VARCHAR}
+    order by TIME_ desc
   </select>
 
 </mapper>

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ timestamp

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ timestamp

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ datetime

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ datetime(3)

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql55.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql55.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ datetime

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ TIMESTAMP(6)

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.51630.to.51640.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.51630.to.51640.engine.sql
@@ -1,3 +1,5 @@
 update ACT_GE_PROPERTY set VALUE_ = '5.16.4.0' where NAME_ = 'schema.version';
 
 create index ACT_IDX_HI_PROCVAR_TASK_ID on ACT_HI_VARINST(TASK_ID_);
+
+alter table ACT_HI_ATTACHMENT add TIME_ timestamp

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/RestResponseFactory.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/RestResponseFactory.java
@@ -415,6 +415,7 @@ public class RestResponseFactory {
     result.setId(attachment.getId());
     result.setName(attachment.getName());
     result.setDescription(attachment.getDescription());
+    result.setTime(attachment.getTime());
     result.setType(attachment.getType());
     result.setUserId(attachment.getUserId());
     

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/engine/AttachmentResponse.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/engine/AttachmentResponse.java
@@ -13,6 +13,12 @@
 
 package org.activiti.rest.service.api.engine;
 
+import java.util.Date;
+
+import org.activiti.rest.common.util.DateToStringSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 
 /**
  * @author Frederik Heremans
@@ -29,6 +35,8 @@ public class AttachmentResponse {
   private String processInstanceUrl;
   private String externalUrl;
   private String contentUrl;
+  @JsonSerialize(using = DateToStringSerializer.class, as=Date.class)
+  private Date time;
   
   public String getId() {
     return id;
@@ -108,5 +116,13 @@ public class AttachmentResponse {
   
   public void setContentUrl(String contentUrl) {
     this.contentUrl = contentUrl;
+  }
+
+  public Date getTime() {
+    return time;
+  }
+
+  public void setTime(Date time) {
+    this.time = time;
   }
 }

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskAttachmentResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskAttachmentResourceTest.java
@@ -134,6 +134,7 @@ public class TaskAttachmentResourceTest extends BaseRestTestCase {
 
       assertTrue(responseNode.get("contentUrl").isNull());
       assertTrue(responseNode.get("processInstanceUrl").isNull());
+      assertFalse(responseNode.get("time").isNull());
       
       
       // Get binary attachment
@@ -155,6 +156,7 @@ public class TaskAttachmentResourceTest extends BaseRestTestCase {
 
       assertTrue(responseNode.get("externalUrl").isNull());
       assertTrue(responseNode.get("processInstanceUrl").isNull());
+      assertFalse(responseNode.get("time").isNull());
     } finally {
       // Clean adhoc-tasks even if test fails
       List<Task> tasks = taskService.createTaskQuery().list();
@@ -358,6 +360,7 @@ public class TaskAttachmentResourceTest extends BaseRestTestCase {
 
       assertTrue(responseNode.get("contentUrl").isNull());
       assertTrue(responseNode.get("processInstanceUrl").isNull());
+      assertFalse(responseNode.get("time").isNull());
       
       
     } finally {
@@ -417,6 +420,7 @@ public class TaskAttachmentResourceTest extends BaseRestTestCase {
 
       assertTrue(responseNode.get("externalUrl").isNull());
       assertTrue(responseNode.get("processInstanceUrl").isNull());
+      assertFalse(responseNode.get("time").isNull());
       
     
     } finally {
@@ -545,6 +549,7 @@ public class TaskAttachmentResourceTest extends BaseRestTestCase {
 
       assertTrue(responseNode.get("contentUrl").isNull());
       assertTrue(responseNode.get("processInstanceUrl").isNull());
+      assertFalse(responseNode.get("time").isNull());
       
       
       // Get binary attachment


### PR DESCRIPTION
This patch adds a time property to attachments. Pretty much the same as is done for comments.

It's needed to correctly sort them between other activities.

Comments apreciated.
