### PR TITLE
Diagramgenerator draws Message Start / Intermediate / Boundaryevents

### DIFF
--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
@@ -454,6 +454,11 @@ public class DefaultProcessDiagramCanvas {
     drawCatchingEvent(graphicInfo, isInterrupting, MESSAGE_CATCH_IMAGE, "message", scaleFactor);
   }
 
+  public void drawCatchingMessageEvent(String name, GraphicInfo graphicInfo, boolean isInterrupting, double scaleFactor) {
+    drawCatchingEvent(graphicInfo, isInterrupting, MESSAGE_CATCH_IMAGE, "message", scaleFactor);
+    drawLabel(name, graphicInfo);
+  }
+  
   public void drawThrowingSignalEvent(GraphicInfo graphicInfo, double scaleFactor) {
     drawCatchingEvent(graphicInfo, true, SIGNAL_THROW_IMAGE, "signal", scaleFactor);
   }

--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
@@ -121,7 +121,7 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
           } else if (intermediateCatchEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition) {
             processDiagramCanvas.drawCatchingTimerEvent(flowNode.getName(), graphicInfo, true, scaleFactor);
           } else if (intermediateCatchEvent.getEventDefinitions().get(0) instanceof MessageEventDefinition) {
-            processDiagramCanvas.drawCatchingMessageEvent(graphicInfo, true, scaleFactor);  
+            processDiagramCanvas.drawCatchingMessageEvent(flowNode.getName(), graphicInfo, true, scaleFactor);  
           }
         }
       }
@@ -293,7 +293,7 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition) {
             processDiagramCanvas.drawCatchingSignalEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof MessageEventDefinition) {
-            processDiagramCanvas.drawCatchingMessageEvent(graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);  
+            processDiagramCanvas.drawCatchingMessageEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);  
           }
         }
         


### PR DESCRIPTION
This patch adds the previously missing drawing instructions for Message Events to the DefaultProcessDiagramGenerator, as described in http://jira.codehaus.org/browse/ACT-1745 and http://jira.codehaus.org/browse/ACT-1527. Also, the calculation of the icon position within the event node was improved.
