### PR TITLE
implemented mail multi-tenancy

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -14,11 +14,14 @@
 package org.activiti.engine;
 
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
 import org.activiti.engine.impl.asyncexecutor.AsyncExecutor;
 import org.activiti.engine.impl.cfg.BeansConfigurationHelper;
+import org.activiti.engine.impl.cfg.MailServerInfo;
 import org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration;
 import org.activiti.engine.impl.history.HistoryLevel;
@@ -104,14 +107,16 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected boolean asyncExecutorEnabled;
   protected boolean asyncExecutorActivate;
 
-  protected String mailServerHost = "localhost";
-  protected String mailServerUsername; // by default no name and password are provided, which 
-  protected String mailServerPassword; // means no authentication for mail server
-  protected int mailServerPort = 25;
-  protected boolean useSSL = false;
-  protected boolean useTLS = false;
-  protected String mailServerDefaultFrom = "activiti@localhost";
-  protected String mailSessionJndi;
+  //protected String mailServerHost = "localhost";
+  //protected String mailServerUsername; // by default no name and password are provided, which
+  //protected String mailServerPassword; // means no authentication for mail server
+  //protected int mailServerPort = 25;
+  //protected boolean useSSL = false;
+  //protected boolean useTLS = false;
+  //protected String mailServerDefaultFrom = "activiti@localhost";
+  protected Map<String,MailServerInfo> mailServers = new HashMap<String,MailServerInfo>();
+  //protected String mailSessionJndi;
+  protected Map<String, String> mailSessionsJndi = new HashMap<String, String>();
 
   protected String databaseType;
   protected String databaseSchemaUpdate = DB_SCHEMA_UPDATE_FALSE;
@@ -266,76 +271,101 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
     this.history = history;
     return this;
   }
-  
-  public String getMailServerHost() {
-    return mailServerHost;
+
+  public MailServerInfo getMailServer() {
+    if (mailServers.get("") == null) {
+      mailServers.put("",new MailServerInfo());
+    }
+    return mailServers.get("");
   }
-  
+
+  public MailServerInfo getMailServer(String tenantId) {
+    return mailServers.get(tenantId);
+  }
+
+  public ProcessEngineConfiguration setMailServers(Map<String, MailServerInfo> mailServers) {
+    this.mailServers.putAll(mailServers);
+    return this;
+  }
+
+  public String getMailServerHost() {
+    return mailServers.get(null) == null ? null : mailServers.get(null).getMailServerHost();
+  }
+
   public ProcessEngineConfiguration setMailServerHost(String mailServerHost) {
-    this.mailServerHost = mailServerHost;
+    getMailServer().setMailServerHost(mailServerHost);
     return this;
   }
   
   public String getMailServerUsername() {
-    return mailServerUsername;
+    return mailServers.get(null) == null ? null : mailServers.get(null).getMailServerUsername();
   }
-  
+
   public ProcessEngineConfiguration setMailServerUsername(String mailServerUsername) {
-    this.mailServerUsername = mailServerUsername;
+    getMailServer(null).setMailServerUsername(mailServerUsername);
     return this;
   }
   
   public String getMailServerPassword() {
-    return mailServerPassword;
+    return getMailServer().getMailServerPassword();
   }
-  
+
   public ProcessEngineConfiguration setMailServerPassword(String mailServerPassword) {
-    this.mailServerPassword = mailServerPassword;
+    getMailServer().setMailServerPassword(mailServerPassword);
     return this;
   }
 
   public String getMailSesionJndi() {
-    return mailSessionJndi;
+    return getMailSessionJndi(null);
   }
-  
+
+  public String getMailSessionJndi(String tenantId) {
+    return mailSessionsJndi.get(tenantId);
+  }
+
   public ProcessEngineConfiguration setMailSessionJndi(String mailSessionJndi) {
-    this.mailSessionJndi = mailSessionJndi;
+    mailSessionsJndi.put(null, mailSessionJndi);
+    return this;
+  }
+
+  public ProcessEngineConfiguration setMailSessionJndi(String mailSessionJndi, String tenantId) {
+    mailSessionsJndi.put(tenantId, mailSessionJndi);
     return this;
   }
 
   public int getMailServerPort() {
-    return mailServerPort;
+    return getMailServer().getMailServerPort();
   }
   
   public ProcessEngineConfiguration setMailServerPort(int mailServerPort) {
-    this.mailServerPort = mailServerPort;
+    getMailServer().setMailServerPort(mailServerPort);
     return this;
   }
   
   public boolean getMailServerUseSSL() {
-	  return useSSL;
+	  return getMailServer().getMailServerUseSSL();
   }
   
   public ProcessEngineConfiguration setMailServerUseSSL(boolean useSSL) {
-	  this.useSSL = useSSL;
+	  getMailServer().setMailServerUseSSL(useSSL);
 	  return this;
   }
   
   public boolean getMailServerUseTLS() {
-    return useTLS;
+    return getMailServer().getMailServerUseTLS();
   }
   
   public ProcessEngineConfiguration setMailServerUseTLS(boolean useTLS) {
-    this.useTLS = useTLS;
+    getMailServer().setMailServerUseTLS(useTLS);
     return this;
   }
   
   public String getMailServerDefaultFrom() {
-    return mailServerDefaultFrom;
+    return getMailServer().getMailServerDefaultFrom();
   }
   
   public ProcessEngineConfiguration setMailServerDefaultFrom(String mailServerDefaultFrom) {
-    this.mailServerDefaultFrom = mailServerDefaultFrom;
+    getMailServer().setMailServerDefaultFrom(mailServerDefaultFrom);
     return this;
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -37,6 +37,7 @@ import org.activiti.engine.task.IdentityLinkType;
  * @author Tom Baeyens
  * @author Joram Barrez
  * @author Daniel Meyer
+ * @author Tim Stephenson
  */
 public interface RuntimeService {
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -64,7 +64,7 @@ import org.activiti.engine.task.IdentityLinkType;
  * @author Daniel Meyer
  */
 public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
-  
+
   public ProcessInstance startProcessInstanceByKey(String processDefinitionKey) {
     return commandExecutor.execute(new StartProcessInstanceCmd<ProcessInstance>(processDefinitionKey, null, null, null));
   }
@@ -294,7 +294,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   public ProcessInstance startProcessInstanceByMessageAndTenantId(String messageName, String tenantId) {
   	return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, null, null, tenantId));
   }
-  
+
   public ProcessInstance startProcessInstanceByMessage(String messageName, String businessKey) {
     return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, businessKey, null, null));
   }
@@ -302,7 +302,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   public ProcessInstance startProcessInstanceByMessageAndTenantId(String messageName, String businessKey, String tenantId) {
     return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, businessKey, null, tenantId));
   }
-  
+
   public ProcessInstance startProcessInstanceByMessage(String messageName, Map<String, Object> processVariables) {
     return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, null, processVariables, null));
   }
@@ -310,7 +310,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   public ProcessInstance startProcessInstanceByMessageAndTenantId(String messageName, Map<String, Object> processVariables, String tenantId) {
   	return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, null, processVariables, tenantId));
   }
-  
+
   public ProcessInstance startProcessInstanceByMessage(String messageName, String businessKey, Map<String, Object> processVariables) {
     return commandExecutor.execute(new StartProcessInstanceByMessageCmd(messageName, businessKey, processVariables, null));
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/MailServerInfo.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/MailServerInfo.java
@@ -16,15 +16,18 @@ package org.activiti.engine.impl.cfg;
 
 /**
  * @author Tom Baeyens
+ * @author Tim Stephenson
  */
 public class MailServerInfo {
 
-  protected String mailServerDefaultFrom;
-  protected String mailServerHost;
-  protected int mailServerPort;
+  protected String mailServerDefaultFrom = "activiti@localhost";
+  protected String mailServerHost = "localhost";
+  protected int mailServerPort = 25;
   protected String mailServerUsername;
   protected String mailServerPassword;
-  
+  protected boolean mailServerUseSSL = false;
+  protected boolean mailServerUseTLS = false;
+
   public String getMailServerDefaultFrom() {
     return mailServerDefaultFrom;
   }
@@ -63,5 +66,21 @@ public class MailServerInfo {
   
   public void setMailServerPassword(String mailServerPassword) {
     this.mailServerPassword = mailServerPassword;
+  }
+
+  public boolean getMailServerUseSSL() {
+    return mailServerUseSSL;
+  }
+
+  public void setMailServerUseSSL(boolean mailServerUseSSL) {
+    this.mailServerUseSSL = mailServerUseSSL;
+  }
+
+  public boolean getMailServerUseTLS() {
+    return mailServerUseTLS;
+  }
+
+  public void setMailServerUseTLS(boolean mailServerUseTLS) {
+    this.mailServerUseTLS = mailServerUseTLS;
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
@@ -36,9 +36,9 @@ import org.activiti.engine.runtime.ProcessInstance;
 public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance> {
 
   protected final String messageName;
+  protected final String tenantId;
   protected final String businessKey;
   protected final Map<String, Object> processVariables;
-  protected final String tenantId;
 
   public StartProcessInstanceByMessageCmd(String messageName, String businessKey, Map<String, Object> processVariables, String tenantId) {
     this.messageName = messageName;
@@ -46,7 +46,6 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
     this.processVariables = processVariables;
     this.tenantId = tenantId;
   }
-
   public ProcessInstance execute(CommandContext commandContext) {
     
     if(messageName == null) {
@@ -76,6 +75,10 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
   
     ActivityImpl startActivity = processDefinition.findActivity(messageEventSubscription.getActivityId());
     ExecutionEntity processInstance = processDefinition.createProcessInstance(businessKey, startActivity);
+
+    if (tenantId != null) {
+      processInstance.setTenantId(tenantId);
+    }
 
     if (processVariables != null) {
       processInstance.setVariables(processVariables);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -366,7 +366,7 @@ public class ExecutionImpl implements
   public String getProcessInstanceId() {
     return getProcessInstance().getId();
   }
-  
+
   public String getBusinessKey() {
     return getProcessInstance().getBusinessKey();
   }
@@ -374,7 +374,7 @@ public class ExecutionImpl implements
   public String getProcessBusinessKey() {
     return getProcessInstance().getBusinessKey();
   }
-  
+
   /** for setting the process instance, this setter must be used as subclasses can override */  
   public void setProcessInstance(InterpretableExecution processInstance) {
     this.processInstance = (ExecutionImpl) processInstance;
@@ -891,6 +891,6 @@ public class ExecutionImpl implements
   }
   
   public String getTenantId() {
-    return null; // Not implemented
+    return getProcessInstance().getTenantId();
   }
 }

--- a/modules/activiti-engine/src/test/resources/activiti.cfg.xml
+++ b/modules/activiti-engine/src/test/resources/activiti.cfg.xml
@@ -22,6 +22,24 @@
 
     <!-- mail server configurations -->
     <property name="mailServerPort" value="5025" />
+
+    <property name="mailServers">
+      <map>
+          <entry key="myTenant">
+              <bean class="org.activiti.engine.impl.cfg.MailServerInfo">
+                  <property name="mailServerHost" value="localhost" />
+                  <property name="mailServerPort" value="5025" />
+                  <property name="mailServerUseSSL" value="false" />
+                  <property name="mailServerUseTLS" value="false" />
+                  <property name="mailServerDefaultFrom" value="activiti@myTenant.com" />
+                  <property name="mailServerUsername" value="activiti@myTenant.com" />
+                  <property name="mailServerPassword" value="password" />
+              </bean>
+          </entry>
+      </map>
+    </property>
+
+
     <property name="history" value="full" />
   </bean>
 


### PR DESCRIPTION
Sometimes in a multi-tenant environment it is desirable to send each tenants' mail through a different server. Activiti has sent all mail through the single configured server up until now.

This patch allows multiple mail servers to be configured keyed by a tenant id as well as an unnamed (empty string) tenant configured to be compatible with existing configurations. 
