### PR TITLE
Added support for compensation event definitions by using 'org/activiti/...

### DIFF
--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
@@ -123,6 +123,8 @@ public class DefaultProcessDiagramCanvas {
   protected static BufferedImage CAMEL_TASK_IMAGE;
   
   protected static BufferedImage TIMER_IMAGE;
+  protected static BufferedImage COMPENSATE_THROW_IMAGE;
+  protected static BufferedImage COMPENSATE_CATCH_IMAGE;
   protected static BufferedImage ERROR_THROW_IMAGE;
   protected static BufferedImage ERROR_CATCH_IMAGE;
   protected static BufferedImage MESSAGE_THROW_IMAGE;
@@ -227,6 +229,8 @@ public class DefaultProcessDiagramCanvas {
       MULE_TASK_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/muleTask.png", customClassLoader));
       
       TIMER_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/timer.png", customClassLoader));
+      COMPENSATE_THROW_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/compensate-throw.png", customClassLoader));
+      COMPENSATE_CATCH_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/compensate.png", customClassLoader));
       ERROR_THROW_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/error-throw.png", customClassLoader));
       ERROR_CATCH_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/error.png", customClassLoader));
       MESSAGE_THROW_IMAGE = ImageIO.read(ReflectUtil.getResourceAsStream("org/activiti/icons/message-throw.png", customClassLoader));
@@ -416,6 +420,15 @@ public class DefaultProcessDiagramCanvas {
     }
   }
 
+  public void drawCatchingCompensateEvent(String name, GraphicInfo graphicInfo, boolean isInterrupting, double scaleFactor) {
+    drawCatchingCompensateEvent(graphicInfo, isInterrupting, scaleFactor);
+    drawLabel(name, graphicInfo);
+  }
+
+  public void drawCatchingCompensateEvent(GraphicInfo graphicInfo, boolean isInterrupting, double scaleFactor) {
+    drawCatchingEvent(graphicInfo, isInterrupting, COMPENSATE_CATCH_IMAGE, "compensate", scaleFactor);
+  }
+
   public void drawCatchingTimerEvent(String name, GraphicInfo graphicInfo, boolean isInterrupting, double scaleFactor) {
     drawCatchingTimerEvent(graphicInfo, isInterrupting, scaleFactor);
     drawLabel(name, graphicInfo);
@@ -441,6 +454,10 @@ public class DefaultProcessDiagramCanvas {
 
   public void drawCatchingSignalEvent(GraphicInfo graphicInfo, boolean isInterrupting, double scaleFactor) {
     drawCatchingEvent(graphicInfo, isInterrupting, SIGNAL_CATCH_IMAGE, "signal", scaleFactor);
+  }
+
+  public void drawThrowingCompensateEvent(GraphicInfo graphicInfo, double scaleFactor) {
+    drawCatchingEvent(graphicInfo, true, COMPENSATE_THROW_IMAGE, "compensate", scaleFactor);
   }
 
   public void drawThrowingSignalEvent(GraphicInfo graphicInfo, double scaleFactor) {

--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
@@ -30,6 +30,7 @@ import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.BusinessRuleTask;
 import org.activiti.bpmn.model.CallActivity;
+import org.activiti.bpmn.model.CompensateEventDefinition;
 import org.activiti.bpmn.model.EndEvent;
 import org.activiti.bpmn.model.ErrorEventDefinition;
 import org.activiti.bpmn.model.Event;
@@ -131,6 +132,8 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
         if (throwEvent.getEventDefinitions() != null && !throwEvent.getEventDefinitions().isEmpty()) {
           if (throwEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition) {
             processDiagramCanvas.drawThrowingSignalEvent(graphicInfo, scaleFactor);
+          } else if (throwEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition) {
+            processDiagramCanvas.drawThrowingCompensateEvent(graphicInfo, scaleFactor);
           }
         } else {
           processDiagramCanvas.drawThrowingNoneEvent(graphicInfo, scaleFactor);
@@ -287,6 +290,8 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
             
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition) {
             processDiagramCanvas.drawCatchingSignalEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
+          } else if (boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition) {
+            processDiagramCanvas.drawCatchingCompensateEvent(graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
           }
         }
         


### PR DESCRIPTION
Added support for compensation event definitions in diagrams by using 'org/activiti/icons/compensate-throw.png' and 'org/activiti/icons/compensate.png'. After running 'ant clean distro', deployed activiti-explorer.war to Tomcat and upload a process definition that has both throw and catch compensation event definitions. You can check the result:
![](https://cloud.githubusercontent.com/assets/3234929/5021412/b3968f8e-6add-11e4-8f01-82655296f4ae.GIF).
