### PR TITLE
Various reviewer/editor type changes to the user guide

### DIFF
--- a/userguide/src/en/chapters/ch03-Configuration.xml
+++ b/userguide/src/en/chapters/ch03-Configuration.xml
@@ -1109,7 +1109,7 @@ in your subclass, BPMN-event throwing can be prevented. The classes involved are
               </row>
               <row>
                 <entry>ACTIVITY_TIMOUT</entry>
-                <entry>An activity is interupted due to an interrupting timer boundary event.</entry>
+                <entry>An activity is interrupted due to an interrupting timer boundary event.</entry>
                 <entry><literal>org.activiti...ActivitiActivityEvent</literal></entry>
               </row>
               <row>
@@ -1231,7 +1231,7 @@ in your subclass, BPMN-event throwing can be prevented. The classes involved are
           they are running in the same JVM or not. 
         </para>
         <para>
-          Certain event-types (related to entities) expose the targetted entity. Depending on the type or event, these entities cannot be updated anymore (eg. when the entity is deleted). If possible, use the <literal>EngineServices</literal> exposed by the event to interact in a safe way with the engine. Even then, you need to 
+          Certain event-types (related to entities) expose the targeted entity. Depending on the type or event, these entities cannot be updated anymore (eg. when the entity is deleted). If possible, use the <literal>EngineServices</literal> exposed by the event to interact in a safe way with the engine. Even then, you need to
           be cautious with updates/operations on entities that are involved in the dispatched event.
         </para>
         <para>

--- a/userguide/src/en/chapters/ch04-API.xml
+++ b/userguide/src/en/chapters/ch04-API.xml
@@ -81,7 +81,7 @@ FormService formService = processEngine.getFormService();</programlisting>
     </para>
     
     <para>
-        While the <literal>RepositoryService</literal> is rather about static information (ie. data that doesn't change, or at least not a lot),
+        While the <literal>RepositoryService</literal> is rather about static information (i.e. data that doesn't change, or at least not a lot),
         the <emphasis role="bold">RuntimeService</emphasis> is quite the opposite. It deals with starting new process instances of process definitions.
         As said above, a <literal>process definition</literal> defines the structure and behaviour of the different steps in a process.
         A process instance is one execution of such a process definition. For each process definition there typically are many 
@@ -121,7 +121,7 @@ FormService formService = processEngine.getFormService();</programlisting>
         The <emphasis role="bold">IdentityService</emphasis> is pretty simple. It allows the management (creation, update, deletion, querying, ...)
         of groups and users. It is important to understand that Activiti actually doesn't do any checking on users at runtime.
         For example, a task could be assigned to any user, but the engine does not verify if that user is known to the system.
-        This is because the Activiti engine can also used in conjunction with services such as ldap, active directory, etc.
+        This is because the Activiti engine can also used in conjunction with services such as LDAP, Active Directory, etc.
     </para>
     
     <para>
@@ -169,7 +169,7 @@ FormService formService = processEngine.getFormService();</programlisting>
     In the example above, when an id is passed for which no task exists, an exception will be thrown. Also, since the javadoc <emphasis role="bold">explicitly states that taskId cannot be null, an <literal>ActivitiIllegalArgumentException</literal> will be thrown when <literal>null</literal> is passed</emphasis>.
     </para>
     <para>
-      Even though we want to avoid a big exception hierarchy, the following subclasses were added which are thrown in specific cases. All other errors that occur during process-execution or API-invokation that don't fit into the
+      Even though we want to avoid a big exception hierarchy, the following subclasses were added which are thrown in specific cases. All other errors that occur during process-execution or API-invocation that don't fit into the
       possible exceptions below, are throw as regular <literal>ActivitiExceptions</literal>s.
       <itemizedlist>
         <listitem>
@@ -189,7 +189,7 @@ FormService formService = processEngine.getFormService();</programlisting>
           </listitem>
           <listitem>
             <para>
-             <literal>ActivitiObjectNotFoundException: </literal> Thrown when an object that is requested or actioned on does not exist.
+             <literal>ActivitiObjectNotFoundException: </literal> Thrown when an object that is requested or action on does not exist.
             </para>
           </listitem>
           <listitem>
@@ -211,7 +211,7 @@ FormService formService = processEngine.getFormService();</programlisting>
     <para>
         As described above, the way to interact with the Activiti engine is through the services exposed by 
         an instance of the <literal>org.activiti.engine.ProcessEngine</literal> class. The following 
-        code snippets assume you have a working Activiti environment, ie. you have access
+        code snippets assume you have a working Activiti environment, i.e. you have access
         to a valid <literal>org.activiti.engine.ProcessEngine</literal>. If you simply want to try
         out the code below, you can download or clone the 
         <ulink url="https://github.com/Activiti/activiti-unit-test-template">Activiti unit test template</ulink>,
@@ -235,7 +235,7 @@ FormService formService = processEngine.getFormService();</programlisting>
             Create a new xml file <literal>VacationRequest.bpmn20.xml</literal> in the <literal>src/test/resources/org/activiti/test</literal>
             resource folder (or anywhere else if you're not using the unit test template) with the 
             following content. Note that this section won't explain the xml constructs being used in the example above. 
-            Please read <link linkend="bpmn20">the bpmn 2.0 chapter</link> to become familiar
+            Please read <link linkend="bpmn20">the BPMN 2.0 chapter</link> to become familiar
             with these constructs first if needed.
             <programlisting>
 &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot; ?&gt;

--- a/userguide/src/en/chapters/ch07b-BPMN-Constructs.xml
+++ b/userguide/src/en/chapters/ch07b-BPMN-Constructs.xml
@@ -424,7 +424,7 @@ ProcessInstance startProcessInstanceByMessage(String messageName, String busines
 	        </para>
 	        <para>
 	        	If the message needs to be received by an existing process instance, you first have to correlate the message to 
-	        	a specific process instance (see next section) and then trigger the continuation of the wating execution.
+	        	a specific process instance (see next section) and then trigger the continuation of the waiting execution.
 	        	The runtime service offers the following methods for triggering an execution based on a message event subscription:
 	        	 	<programlisting>
 void messageEventReceived(String messageName, String executionId);
@@ -1215,7 +1215,7 @@ ProcessInstance startProcessInstanceByMessage(String messageName, String busines
         </para>        
 
         <para>
-          Since BPMn 2.0 there is the difference between the interrupting and non interrupting timer event. The 
+          Since BPMN 2.0 there is the difference between the interrupting and non interrupting timer event. The
           interrupting is the default. The non-interrupting leads to the original activity is <emphasis role="bold">not</emphasis>
           interrupted but the activity stays there. Instead an additional executions is created and send over the
           outgoing transition of the event. In the XML representation, the <emphasis>cancelActivity</emphasis> attribute
@@ -1961,7 +1961,7 @@ ProcessInstance startProcessInstanceByMessage(String messageName, String busines
 		   			</listitem>
 		   			<listitem>
 		   				<para>
-					   		If compensation is thrown for the current scope, all activities withing the current scope are compensated, 
+					   		If compensation is thrown for the current scope, all activities within the current scope are compensated,
 					   		which includes activities on concurrent branches.  
 					   	</para>
 		   			</listitem>
@@ -1971,7 +1971,7 @@ ProcessInstance startProcessInstanceByMessage(String messageName, String busines
 							triggered for all activities contained in the subprocess. If the subprocess has nested activities, compensation 
 							is thrown recursively. However, compensation is not propagated to the "upper levels" of the process: if compensation 
 							is triggered within a subprocess, it is not propagated to activities outside of the subprocess scope. 
-							The bpmn specification states that compensation is triggered for activities at "the same level of subprocess". 
+							The BPMN specification states that compensation is triggered for activities at "the same level of subprocess".
 						</para>
 		   			</listitem>
 		   			<listitem>
@@ -5857,7 +5857,7 @@ public class MyTaskCreateListener implements TaskListener {
 		   		<itemizedlist>
 		   			<listitem>
 		   				<para>
-		   					The bpmn specification requires that the process engine reacts to events issued by the underlying transaction protocol 
+		   					The PBMN specification requires that the process engine reacts to events issued by the underlying transaction protocol
 		   					and for instance that a transaction is cancelled, if a cancel event occurs in the underlying protocol.
 		   					As an embeddable engine, Activiti does currently not support this. (For some ramifications of this, see paragraph on consistency below.)		   					
 		   				</para>
@@ -6118,7 +6118,7 @@ public class MyTaskCreateListener implements TaskListener {
         <programlisting>
 &lt;serviceTask id=&quot;service1&quot; name=&quot;Generate Invoice&quot; activiti:class=&quot;my.custom.Delegate&quot; activiti:async=&quot;true&quot; /&gt; 
         </programlisting>
-        activiti:async ca be specified on the following bpmn task types:
+        activiti:async can be specified on the following BPMN task types:
         task, serviceTask, scriptTask, businessRuleTask, sendTask, receiveTask, userTask, subProcess, callActivity
     </para>
     

--- a/userguide/src/en/chapters/ch08-Forms.xml
+++ b/userguide/src/en/chapters/ch08-Forms.xml
@@ -153,7 +153,7 @@
     <para> 
       The hidden 
 	    fields provide extra information to the Activiti Explorer client application.
-	    So the Javascript in the browser will use the hidden fields and enhance the corresponding 
+	    So the JavaScript in the browser will use the hidden fields and enhance the corresponding
 	    input fields.  For example, it's possible to specify that a certain text field is a date 
 	    and Activiti Explorer will add a date picker.
       <itemizedlist>

--- a/userguide/src/en/chapters/ch11-Designer.xml
+++ b/userguide/src/en/chapters/ch11-Designer.xml
@@ -12,7 +12,7 @@
     <title>Installation</title>
     <para>
     	The following installation instructions are verified on <ulink
-        url="http://www.eclipse.org/downloads/">Eclipse Indigo</ulink>. Note that Eclipse Helio is <emphasis role="bold">NOT</emphasis> supported.
+        url="http://www.eclipse.org/downloads/">Eclipse Indigo</ulink>. Note that Eclipse Helios is <emphasis role="bold">NOT</emphasis> supported.
     </para>
     <para>
     	Go to <emphasis role="bold">Help -> Install New Software</emphasis>. In the following

--- a/userguide/src/en/chapters/ch12-Explorer.xml
+++ b/userguide/src/en/chapters/ch12-Explorer.xml
@@ -8,7 +8,7 @@
   <para>
     Activiti Explorer is a web application that is included when you download Activiti from the
     Activiti website. The purpose of Explorer is not a finished, end-user ready application, but 
-    rather to excersise and show the functionality of Activiti. As such, Explorer is meant as a demo,
+    rather to excercise and show the functionality of Activiti. As such, Explorer is meant as a demo,
     or maybe inspiration for people using Activiti in there own applications. Out of the box, Explorer 
     uses an in-memory database, but it is easy to switch to your own database (see the applicationContext files in the WEB-INF folder).
   </para>
@@ -52,12 +52,12 @@
     <title>Process diagram</title>
     
     <para>
-      The Explorer includes functionality to dynamically generate an overview of a process definition using the <ulink url="http://raphaeljs.com/">Raphaël</ulink> Javascript framework.
+      The Explorer includes functionality to dynamically generate an overview of a process definition using the <ulink url="http://raphaeljs.com/">Raphaël</ulink> JavaScript framework.
       This process image can only be generated when the process definition XML contains BPMN DI information. When there's no BPMN DI information in the process definition XML and the deployment contains a process definition image, that image will be shown.
       <mediaobject><imageobject><imagedata align="center" fileref="images/explorer.process.definition.image.png"/></imageobject></mediaobject>
     </para>
     <para>
-      When you don't want to use the Javascript process definition overview you can disable it in the ui.properties file
+      When you don't want to use the JavaScript process definition overview you can disable it in the ui.properties file
       <programlisting>activiti.ui.jsdiagram = false</programlisting>
     </para>
     <para>
@@ -257,7 +257,7 @@
       to be seen in the list of known reports in Explorer. A 'report process' can be as simple or as complex as wanted.
       The only requirement to actually be able to see the report, is that the process produces a variable
       called <emphasis role="bold">reportData</emphasis> is created. This variable must be a byte array representation
-      of a json object. This variable is stored in the history tables of Activiti
+      of a JSON object. This variable is stored in the history tables of Activiti
       (hence the requirement that history must be enabled for the engine) so it can be retrieved later 
       when the report is saved. 
       <mediaobject><imageobject><imagedata align="center" fileref="images/explorer.reporting.explained.png"/></imageobject></mediaobject>
@@ -269,7 +269,7 @@
         
         <para>
           A report process must generate a variable <emphasis>reportData</emphasis> that is a JSON representation
-          of the data that must be displayed to the user. The json should look as follows:
+          of the data that must be displayed to the user. The JSON should look as follows:
           <programlisting>
 {
   &quot;title&quot;: &quot;My Report&quot;,
@@ -290,8 +290,8 @@
   ]
 }          
           </programlisting>
-          This json will be fetched at runtime in Explorer and will be used to generate 
-          charts or lists. The elements in the json are:
+          This JSON will be fetched at runtime in Explorer and will be used to generate
+          charts or lists. The elements in the JSON are:
           <itemizedlist>
             <listitem>
                 <para><emphasis role="bold">title</emphasis>: this is the general title for the whole report</para>
@@ -314,7 +314,7 @@
                 Optional parameter that determines the name of the axes of the chart</para>
             </listitem>
             <listitem>
-                <para><emphasis role="bold">data</emphasis>: this is the actual data. The data is a json 
+                <para><emphasis role="bold">data</emphasis>: this is the actual data. The data is a JSON
                 object with key-value elements.</para>
             </listitem>
           </itemizedlist>
@@ -328,14 +328,14 @@
         
         <para>
             The following example shows a 'process instance overview' report. The process itself is very easy and
-            contains only a script task (besides start and end) that generates the json dataset using javascript. Although all of the 
+            contains only a script task (besides start and end) that generates the JSON dataset using JavaScript. Although all of the
             examples in Explorer use scripting, this can very well be done using Java service tasks. The end result of
             running the process should just be the <emphasis>reportData</emphasis> variable that contains the data.
         </para>
         
         <para>
             <emphasis role="bold">Important note:</emphasis> The following example only works on JDK 7+.
-            The reason for this is that the javascript engine (<emphasis>Rhino</emphasis>) that is shipped
+            The reason for this is that the JavaScript engine (<emphasis>Rhino</emphasis>) that is shipped
             with older JDK versions isn't advanced enough to cope with some constructs needed to write
             scripts like the one below. See below for a JDK 6+ compliant example.
         </para>
@@ -394,7 +394,7 @@
        </para>
        
        <para>    
-            Besides the typical XML linea at the top of the process xml, the main difference is that the 
+            Besides the typical XML line at the top of the process xml, the main difference is that the
             <emphasis>targetNamespace</emphasis> is set to <emphasis role="bold">activiti-report</emphasis>,
             adding the category with the same name to the deployed process definition.
         </para>
@@ -403,21 +403,21 @@
             The first lines of the script are just some imports to avoid having to type the package names
             all the time. The first line of interest is where the <emphasis>ReportingUtil</emphasis> is used
             to query the Activiti database. The result of that call is a regular <emphasis>JDBC Resultset</emphasis>.
-            In the lines following the query, the javascript capabilities to easily create json is used. 
-            The json that is produced matches <link linkend="explorer.reporting.json">the requirements</link>.
+            In the lines following the query, the JavaScript capabilities to easily create JSON is used.
+            The JSON that is produced matches <link linkend="explorer.reporting.json">the requirements</link>.
         </para>
         
         <para>
             The last line of the script may seem a bit odd. The first thing we need to do is to convert
-            the json object to a string by using the javascript function <emphasis>JSON.stringify()</emphasis>.
+            the JSON object to a string by using the JavaScript function <emphasis>JSON.stringify()</emphasis>.
             This string then needs to be stored as a byte array variable. The reason for this is technical:
-            a byte array is unlimited in size while the string is not. That is why the javascript string
+            a byte array is unlimited in size while the string is not. That is why the JavaScript string
             must be converted to a Java string which has the capability to get the byte representation.
         </para>
         
         <para>
             The same process which is compatible with JDK 6 (and higher) looks a bit different. The native
-            json capabilities cannot be used, hence some helper classes (<emphasis>ReportData</emphasis> and <emphasis>Dataset</emphasis>)
+            JSON capabilities cannot be used, hence some helper classes (<emphasis>ReportData</emphasis> and <emphasis>Dataset</emphasis>)
             are provided:
             <programlisting>
 &lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;

--- a/userguide/src/en/chapters/ch13-Modeler.xml
+++ b/userguide/src/en/chapters/ch13-Modeler.xml
@@ -46,7 +46,7 @@
   
    <section>
   
-    <title>Convert deployed definitions to a editeable model</title>
+    <title>Convert deployed definitions to a editable model</title>
     
     <para>
       Deployed process definition can be converted into models that can be edited by the Activiti Modeler.

--- a/userguide/src/en/chapters/ch14-REST.xml
+++ b/userguide/src/en/chapters/ch14-REST.xml
@@ -831,7 +831,7 @@
       </itemizedlist>
     </para>
     <para>
-      <emphasis>The dataUrl property in the resulting json for a single resource contains the actual URL to use for retrieving the binary resource.</emphasis>
+      <emphasis>The dataUrl property in the resulting JSON for a single resource contains the actual URL to use for retrieving the binary resource.</emphasis>
     </para>
   </section>
   <section>
@@ -5273,7 +5273,7 @@ In case the variable is a binary variable or serializable, the <literal>valueUrl
         </para>
         <para>
           All supported JSON parameter fields allowed are exactly the same as the parameters found for <link linkend="restTasksGet">getting a collection of tasks</link> (except for candidateGroupIn which is only available in this POST task query REST service), but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows
-          for filtering based on task and process variables. The <literal>taskVariables</literal> and <literal>processInstanceVariables</literal> are both json-arrays containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
+          for filtering based on task and process variables. The <literal>taskVariables</literal> and <literal>processInstanceVariables</literal> are both JSON-arrays containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
         </para>
         <para>
           <table>
@@ -6358,7 +6358,7 @@ GET runtime/tasks/{taskId}/identitylinks/groups</programlisting>
                   <entry>family</entry>
                   <entry>Yes</entry>
                   <entry>String</entry>
-                  <entry>Either <literal>groups</literal> or <literal>users</literal>, depending on what kind of identity is targetted.</entry>
+                  <entry>Either <literal>groups</literal> or <literal>users</literal>, depending on what kind of identity is targeted.</entry>
                 </row>
                 <row>
                   <entry>identityId</entry>
@@ -6519,7 +6519,7 @@ GET runtime/tasks/{taskId}/identitylinks/groups</programlisting>
                   <entry>family</entry>
                   <entry>Yes</entry>
                   <entry>String</entry>
-                  <entry>Either <literal>groups</literal> or <literal>users</literal>, depending on what kind of identity is targetted.</entry>
+                  <entry>Either <literal>groups</literal> or <literal>users</literal>, depending on what kind of identity is targeted.</entry>
                 </row>
                 <row>
                   <entry>identityId</entry>
@@ -7702,7 +7702,7 @@ Only the attachment name is required to create a new attachment.
       </para>
       <para>
         All supported JSON parameter fields allowed are exactly the same as the parameters found for <link linkend="restHistoricProcessInstancesGet">getting a collection of historic process instances</link>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows
-        for filtering based on process variables. The <literal>variables</literal> property is a json-array containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
+        for filtering based on process variables. The <literal>variables</literal> property is a JSON-array containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
       </para>
       <para>
         <table>
@@ -8581,7 +8581,7 @@ Only the attachment name is required to create a new attachment.
       </para>
       <para>
         All supported JSON parameter fields allowed are exactly the same as the parameters found for <link linkend="restHistoricTaskInstancesGet">getting a collection of historic task instances</link>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows
-        for filtering based on process variables. The <literal>taskVariables</literal> and <literal>processVariables</literal> properties are json-arrays containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
+        for filtering based on process variables. The <literal>taskVariables</literal> and <literal>processVariables</literal> properties are JSON-arrays containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
       </para>
       <para>
         <table>
@@ -9114,7 +9114,7 @@ Only the attachment name is required to create a new attachment.
       </para>
       <para>
         All supported JSON parameter fields allowed are exactly the same as the parameters found for <link linkend="restHistoricVariableInstancesGet">getting a collection of historic process instances</link>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows
-        for filtering based on process variables. The <literal>variables</literal> property is a json-array containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
+        for filtering based on process variables. The <literal>variables</literal> property is a JSON-array containing objects with the format <link linkend="restQueryVariable"> as described here.</link>
       </para>
       <para>
         <table>
@@ -10042,7 +10042,7 @@ Only the attachment name is required to create a new attachment.
                 <tbody>
                   <row>
                     <entry>200</entry>
-                    <entry>Indicated signal has been processed and no errors occured.</entry>
+                    <entry>Indicated signal has been processed and no errors occurred.</entry>
                   </row>
                   <row>
                     <entry>202</entry>

--- a/userguide/src/en/chapters/ch16-Ldap.xml
+++ b/userguide/src/en/chapters/ch16-Ldap.xml
@@ -51,7 +51,7 @@
                 <listitem>
                     <para>
                         Fetching the groups of a user. This is important when for example querying tasks
-                        to see which tasks a certain user can see (ie. tasks with a candidate group).
+                        to see which tasks a certain user can see (i.e. tasks with a candidate group).
                     </para>
                 </listitem>
             </itemizedlist>
@@ -361,7 +361,7 @@
                             <entry>Sets the expiration time of the group cache in milliseconds.
                             When groups for a specific user are fetched, and if the group cache exists,
                             the groups will be stored in this cache for the time set in this property.
-                            ie. when the groups were fetched at 00:00 and the expiration time is 30 mins,
+                            I.e. when the groups were fetched at 00:00 and the expiration time is 30 minutes,
                             any fetch of the groups for that user after 00:30 will not come from the cache, but do
                             a fetch again from the LDAP system. Likewise, everything group fetch for that user done
                             between 00:00 - 00:30 will come from the cache.</entry>

--- a/userguide/src/en/chapters/ch17-Advanced.xml
+++ b/userguide/src/en/chapters/ch17-Advanced.xml
@@ -14,7 +14,7 @@
 	   <title>Hooking into process parsing</title>
 	
 	   <para>
-	       A bpmn 2.0 xml needs to be parsed to the Activiti internal model to be executed on the Activiti engine. This parsing
+	       A BPMN 2.0 xml needs to be parsed to the Activiti internal model to be executed on the Activiti engine. This parsing
 	       happens during a deployment of the process or when a process is not found in memory, and the
 	       xml is fetched from the database. 
 	   </para>
@@ -227,7 +227,7 @@ public class CustomUserTaskBpmnParseHandler extends ServiceTaskParseHandler {
             <listitem>
                <para>
                     Firing a signal throw event (in the process itself or through the API) can be done whilst providing a tenant identifier.
-                    The signal will only be executed in the tenant context: ie. if there are multiple signal catch events with the same name,
+                    The signal will only be executed in the tenant context: i.e. if there are multiple signal catch events with the same name,
                     only the one with the correct tenant identifier will actually be called.
                </para>
             </listitem>
@@ -245,7 +245,7 @@ public class CustomUserTaskBpmnParseHandler extends ServiceTaskParseHandler {
             </listitem>
             <listitem>
                <para>
-                    As a side note, models can have a tenant identifier too (models are used eg. by the Activiti Modeler to store bpmn 2.0 models) .           
+                    As a side note, models can have a tenant identifier too (models are used eg. by the Activiti Modeler to store BPMN 2.0 models).
                </para>
             </listitem>
 	      </itemizedlist>
@@ -656,7 +656,7 @@ runtimeService.addEventListener(databaseEventLogger);</programlisting>
 	   <para>
 	       It is easy to see how this table data can now be used to feed the JSON into a big data NoSQL store such as MongDb, Elastic Search, etc.
 	       It is also easy to see that the classes used here (org.activiti.engine.impl.event.logger.EventLogger/EventFlusher and many EventHandler classes)
-	       are pluggable and can be tweaked to your own use case (eg not storing the JSON in the database, but firing it straight onto a queueu or big data store).
+	       are pluggable and can be tweaked to your own use case (eg not storing the JSON in the database, but firing it straight onto a queue or big data store).
 	   </para>
 	   
 	   <para>

--- a/userguide/src/en/chapters/ch18-Simulation.xml
+++ b/userguide/src/en/chapters/ch18-Simulation.xml
@@ -81,7 +81,7 @@
         One of the usecases where simulation can be used is analysis of the history.
         The production environment does not give any chance to repeat and debug bugs. That's why it is almost
         impossible to get process engine into the state which is the same as it was on the production environment
-        on the time when bug occured.
+        on the time when bug occurred.
         The problem is not the hardware but
         <itemizedlist>
           <listitem>
@@ -144,7 +144,7 @@
         and it is crystalball's advantage.
         </para>
         <para>
-          The best way to understand how playback works is to explain step by step an example based on jUnit test
+          The best way to understand how playback works is to explain step by step an example based on JUnit test
           org.activiti.crystalball.simulator.delegate.event.PlaybackRunTest. The process on which simulation
           is tested is the simplest one:
 <programlisting id="crb-playbackDeploy">


### PR DESCRIPTION
Various reviewer/editor type changes to the user guide.  The changes include

correcting some spelling and grammar mistakes.  Other changes include standardizing
on a single form of a word. Examples include i.e., BPMN, LDAP, JUnit, JSON, and JavaScript.
I either selected the common industry usage or the most prevalent usage in the
document.  Thus 'i.e.' was selected over 'ie.'.  In other cases where the usage was
large and split almost evenly I left them alone.  Such an example is 'eg.' vs. 'e.g.'.
