### PR TITLE
Activity cancelled event for process delete API call

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManager.java
@@ -52,7 +52,7 @@ public class TaskEntityManager extends AbstractManager {
       if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
         commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
           ActivitiEventBuilder.createActivityCancelledEvent(
-            task.getId(),
+            task.getExecution().getActivityId(),
             task.getName(),
             task.getExecutionId(),
             task.getProcessInstanceId(),

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -247,6 +247,7 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     assertEquals("ActivitiEventType.ACTIVITY_CANCELLED was expected 1 time.", 1, taskCancelledEvents.size());
     ActivitiActivityCancelledEvent activityCancelledEvent = (ActivitiActivityCancelledEvent) taskCancelledEvents.get(0);
     assertTrue("The cause has to be the same as deleteProcessInstance method call", ActivitiActivityCancelledEvent.class.isAssignableFrom(activityCancelledEvent.getClass()));
+    assertEquals("The activity id has to be the same as processInstance activity", processInstance.getActivityId(), activityCancelledEvent.getActivityId());
     assertEquals("The process instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), activityCancelledEvent.getProcessInstanceId());
     assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), activityCancelledEvent.getExecutionId());
     assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());


### PR DESCRIPTION
Similar to PROCESS_CANCELLED for tasks.
