### PR TITLE
Prevent clear the task owner

### DIFF
--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/listener/ChangeOwnershipListener.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/listener/ChangeOwnershipListener.java
@@ -63,6 +63,9 @@ public class ChangeOwnershipListener implements ClickListener {
       protected void submitted(SubmitEvent event) {
         // Update owner
         String selectedUser = involvePeoplePopupWindow.getSelectedUserId();
+        if (selectedUser == null) {
+        	return;
+        }
         task.setOwner(selectedUser);
         ProcessEngines.getDefaultProcessEngine().getTaskService().setOwner(task.getId(), selectedUser);
         


### PR DESCRIPTION
The owner is the one who take responsibility for the task. Once the task is claimed, the owner can transfer the ownership to others but cannot abandon the task.
