### PR TITLE
changed behavior on process-deploy: check only existing start-message-su...

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -324,9 +324,13 @@ public class BpmnDeployer implements Deployer {
                   .getDbSqlSession()
                   .pruneDeletedEntities(subscriptionsForSameMessageName);
                 
-          if(!subscriptionsForSameMessageName.isEmpty()) {
-            throw new ActivitiException("Cannot deploy process definition '" + processDefinition.getResourceName()
-                    + "': there already is a message event subscription for the message with name '" + eventDefinition.getEventName() + "'.");
+          for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsForSameMessageName) {
+            // throw exception only if there's already a subscription as start event
+            if(eventSubscriptionEntity.getProcessInstanceId() == null || eventSubscriptionEntity.getProcessInstanceId().isEmpty()) {
+              // the event subscription has no instance-id, so it's a message start event
+              throw new ActivitiException("Cannot deploy process definition '" + processDefinition.getResourceName()
+                      + "': there already is a message event subscription for the message with name '" + eventDefinition.getEventName() + "'.");
+            }
           }
           
           MessageEventSubscriptionEntity newSubscription = new MessageEventSubscriptionEntity();


### PR DESCRIPTION
fix for jira ACT-2151 (http://jira.codehaus.org/browse/ACT-2151):

added check if existing event subscription is start event while deploying new process definitions (instead of checking all subscriptions with the same message name)
