### PR TITLE
set MultiInstanceActivityBehavior when executing service tasks (inheriti...

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -74,6 +74,11 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
         ClassDelegate.applyFieldDeclaration(fieldDeclarations, delegate);
 
         if (delegate instanceof ActivityBehavior) {
+
+          if(delegate instanceof AbstractBpmnActivityBehavior){
+            ((AbstractBpmnActivityBehavior) delegate).setMultiInstanceActivityBehavior(getMultiInstanceActivityBehavior());
+          }
+
           Context.getProcessEngineConfiguration().getDelegateInterceptor()
                   .handleInvocation(new ActivityBehaviorInvocation((ActivityBehavior) delegate, execution));
 


### PR DESCRIPTION
fix for jira ACT-2159 (https://jira.codehaus.org/browse/ACT-2159)

when executing a service task (which inherits from AbstractBpmnActivityBehavior) as delegate expression with multi instance, then the MultiInstanceActivityBehavior property was not set in the service task instance which results in an infinite loop (when setting parallel execution in multi instance)
