### PR TITLE
Correct the Description of Task InvolvedPage

### DIFF
--- a/userguide/src/en/chapters/ch12-Explorer.xml
+++ b/userguide/src/en/chapters/ch12-Explorer.xml
@@ -95,8 +95,9 @@
         </listitem>
          <listitem>
           <para>
-            <emphasis role="bold">Involved:</emphasis> shows the tasks where the logged in user is
-            involved with (i.e. not assignee or owner).
+            <emphasis role="bold">Involved:</emphasis> shows the tasks where the logged in user is one of 
+            the following: (1) the one who is involved with (i.e. candidate user or participant), (2) the 
+            assignee, and (3) the owner.
           </para>
         </listitem>
          <listitem>


### PR DESCRIPTION
After testing the behavior of Task InvolvedPage and tracing org.activiti.db.mapping.entity.Task.xml, I found the InvolvePage would show tasks if the login user is one of the following: (1) assignee, (2) owner, (3) participant (include candidate user and customer UserIdentityLink-ed user).
