### PR TITLE
Fix missing StartNodeEvent and optimizing text displayed in workflow boxes 

### DIFF
--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
@@ -788,8 +788,12 @@ public class DefaultProcessDiagramCanvas {
   
 
   protected String fitTextToWidth(String original, int width, boolean forceAdd) {
+    if (fontMetrics.stringWidth(original) <= width && !forceAdd) {
+      // if it fits already and we don't need to add "...", return original
+      return original;
+    }
+    
     String text = original;
-
     // remove length for "..."
     int maxWidth = width - 10;
 
@@ -797,7 +801,7 @@ public class DefaultProcessDiagramCanvas {
       text = text.substring(0, text.length() - 1);
     }
 
-    if (!text.equals(original)) {
+    if (!text.equals(original) || forceAdd) {
       text = text + "...";
     }
 

--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
@@ -674,7 +674,7 @@ public class DefaultProcessDiagramCanvas {
       Font theDerivedFont = currentFont.deriveFont(transformation);
       g.setFont(theDerivedFont);
       
-      String truncated = fitTextToWidth(name, availableTextSpace);
+      String truncated = fitTextToWidth(name, availableTextSpace, false);
       int realWidth = fontMetrics.stringWidth(truncated);
       
       g.drawString(truncated, x + 2 + fontMetrics.getHeight(), 3 + y + availableTextSpace - (availableTextSpace - realWidth) / 2);
@@ -714,7 +714,7 @@ public class DefaultProcessDiagramCanvas {
     // text
     if (name != null && name.length() > 0) {
       int boxWidth = width - (2 * TEXT_PADDING);
-      int boxHeight = height - 16 - ICON_PADDING - ICON_PADDING - MARKER_WIDTH - 2 - 2;
+      int boxHeight = height - ICON_PADDING - ICON_PADDING - MARKER_WIDTH - 2 - 2;
       int boxX = x + width/2 - boxWidth/2;
       int boxY = y + height/2 - boxHeight/2 + ICON_PADDING + ICON_PADDING - 2 - 2;
       
@@ -760,10 +760,7 @@ public class DefaultProcessDiagramCanvas {
         // to indicate more text is truncated
         if (!layouts.isEmpty()) {
           layouts.remove(layouts.size() - 1);
-          
-          if(lastLine.length() >= 4) {
-            lastLine = lastLine.substring(0, lastLine.length() - 4) + "...";
-          }
+          lastLine = fitTextToWidth(lastLine, boxWidth, true);
           layouts.add(new TextLayout(lastLine, g.getFont(), g.getFontRenderContext()));
         }
       } else {
@@ -790,7 +787,7 @@ public class DefaultProcessDiagramCanvas {
   }
   
 
-  protected String fitTextToWidth(String original, int width) {
+  protected String fitTextToWidth(String original, int width, boolean forceAdd) {
     String text = original;
 
     // remove length for "..."
@@ -863,7 +860,7 @@ public class DefaultProcessDiagramCanvas {
     }
 
     if (scaleFactor == 1.0 && name != null && !name.isEmpty()) {
-      String text = fitTextToWidth(name, (int) graphicInfo.getWidth());
+      String text = fitTextToWidth(name, (int) graphicInfo.getWidth(), false);
       g.drawString(text, (int) graphicInfo.getX() + 10, (int) graphicInfo.getY() + 15);
     }
   }

--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
@@ -101,6 +101,8 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
             processDiagramCanvas.drawSignalStartEvent(graphicInfo, scaleFactor);
           } else if (eventDefinition instanceof MessageEventDefinition) {
             processDiagramCanvas.drawMessageStartEvent(graphicInfo, scaleFactor);
+          } else {
+            processDiagramCanvas.drawNoneStartEvent(graphicInfo);
           }
         } else {
           processDiagramCanvas.drawNoneStartEvent(graphicInfo);
@@ -114,8 +116,7 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
       public void draw(DefaultProcessDiagramCanvas processDiagramCanvas, BpmnModel bpmnModel, FlowNode flowNode) {
         GraphicInfo graphicInfo = bpmnModel.getGraphicInfo(flowNode.getId());
         IntermediateCatchEvent intermediateCatchEvent = (IntermediateCatchEvent) flowNode;
-        if (intermediateCatchEvent.getEventDefinitions() != null && !intermediateCatchEvent.getEventDefinitions()
-                                                                                           .isEmpty()) {
+        if (intermediateCatchEvent.getEventDefinitions() != null && !intermediateCatchEvent.getEventDefinitions().isEmpty()) {
           if (intermediateCatchEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition) {
             processDiagramCanvas.drawCatchingSignalEvent(flowNode.getName(), graphicInfo, true, scaleFactor);
           } else if (intermediateCatchEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition) {
@@ -287,20 +288,15 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
         BoundaryEvent boundaryEvent = (BoundaryEvent) flowNode;
         if (boundaryEvent.getEventDefinitions() != null && !boundaryEvent.getEventDefinitions().isEmpty()) {
           if (boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition) {
-            
             processDiagramCanvas.drawCatchingTimerEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
-            
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof ErrorEventDefinition) {
-            
             processDiagramCanvas.drawCatchingErrorEvent(graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
-            
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof SignalEventDefinition) {
             processDiagramCanvas.drawCatchingSignalEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);
           } else if (boundaryEvent.getEventDefinitions().get(0) instanceof MessageEventDefinition) {
             processDiagramCanvas.drawCatchingMessageEvent(flowNode.getName(), graphicInfo, boundaryEvent.isCancelActivity(), scaleFactor);  
           }
         }
-        
       }
     });
 


### PR DESCRIPTION
Missing default case for start event node in if / else if statements
Computed BoxHeight for text is too small (height - 16 - 5 - 5 - 12 - 2 - 2) ==> deleting -16 to allow one more line to be drawn
On multilined text, use fixTextToWidth when text couldn't be fully displayed
On line text : use original if it already fits in original width (without -10 pixels for "..." statement).