### PR TITLE
writes multiinstance_sequential:'Yes' in JSON output

### DIFF
--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -141,6 +141,9 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
           if (loopDef.isSequential() == false) {
             propertiesNode.put(PROPERTY_MULTIINSTANCE_SEQUENTIAL, PROPERTY_VALUE_NO);
           }
+          else {
+              propertiesNode.put(PROPERTY_MULTIINSTANCE_SEQUENTIAL, PROPERTY_VALUE_YES);
+          }
           if (StringUtils.isNotEmpty(loopDef.getLoopCardinality())) {
             propertiesNode.put(PROPERTY_MULTIINSTANCE_CARDINALITY, loopDef.getLoopCardinality());
           }


### PR DESCRIPTION
the old BaseBpmnJsonConverter.convertToJson() does not write 'multiinstance_sequential' property when the value is 'true', which causes JsonConverterUtil.getPropertyValueAsBoolean(PROPERTY_MULTIINSTANCE_SEQUENTIAL, elementNode) returns default value 'false' in BaseBpmnJsonConverter.convertToBpmnModel() method:

```
  public static boolean getPropertyValueAsBoolean(String name, JsonNode objectNode, boolean defaultValue) {
    boolean result = defaultValue;
    String stringValue = getPropertyValueAsString(name, objectNode);

    if (PROPERTY_VALUE_YES.equalsIgnoreCase(stringValue)) {
      result = true;
    } else if (PROPERTY_VALUE_NO.equalsIgnoreCase(stringValue)) {
      result = false;
    }

    return result;
  }
```
