### PR TITLE
Rework XML parsing of WSDLImporter using the J2SE standard way instead

### DIFF
--- a/modules/activiti-cxf/pom.xml
+++ b/modules/activiti-cxf/pom.xml
@@ -132,10 +132,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/WSDLImporter.java
+++ b/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/WSDLImporter.java
@@ -31,6 +31,9 @@ import javax.wsdl.extensions.soap.SOAPAddress;
 import javax.wsdl.factory.WSDLFactory;
 import javax.wsdl.xml.WSDLReader;
 import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.activiti.bpmn.model.Import;
 import org.activiti.engine.ActivitiException;
@@ -39,7 +42,6 @@ import org.activiti.engine.impl.bpmn.data.StructureDefinition;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.bpmn.parser.XMLImporter;
 import org.activiti.engine.impl.util.ReflectUtil;
-import org.apache.xerces.parsers.DOMParser;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
@@ -208,15 +210,16 @@ public class WSDLImporter implements XMLImporter {
 
   private Element getRootTypes() {
     try {
-      DOMParser parser = new DOMParser();
-      parser.parse(this.wsdlLocation);
-      Document doc = parser.getDocument();
+      DocumentBuilder docBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+      Document doc = docBuilder.parse(this.wsdlLocation);
       Element root = (Element) doc.getFirstChild();
       Element typesElement = (Element) root.getElementsByTagName("wsdl:types").item(0);
       return (Element) typesElement.getElementsByTagNameNS("http://www.w3.org/2001/XMLSchema", "schema").item(0);
     } catch (SAXException e) {
       throw new ActivitiException(e.getMessage(), e);
     } catch (IOException e) {
+      throw new ActivitiException(e.getMessage(), e);
+    } catch (ParserConfigurationException e) {
       throw new ActivitiException(e.getMessage(), e);
     }
   }


### PR DESCRIPTION
Rework XML parsing of WSDLImporter using the J2SE standard way instead of using directly Xerces classes. Now unit tests of the module activiti-cxf are runnable with Eclipse.

Caution: In one way, this commit remove the dependency on Xerces, the DOM parser of the J2SE will be used. In another way, WSDLImporter seems to be not used (The importer used by the engine seems to be CxfWSDLImporter). If Xerces is required, just re-add it as dependency in the POM.

As WSDLImporter is not used, I think no JIRA issue is required. If it is, just tell me and I will create one.
