### PR TITLE
HouseKeeping: remove unused and unneeded import statements

### DIFF
--- a/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/impl/el/ElTest.java
+++ b/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/impl/el/ElTest.java
@@ -16,7 +16,6 @@ import static org.junit.Assert.assertEquals;
 
 import org.activiti.cdi.test.CdiActivitiTestCase;
 import org.activiti.cdi.test.impl.beans.MessageBean;
-import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.test.Deployment;
 import org.junit.Test;
 

--- a/modules/activiti-crystalball/src/test/java/org/activiti/crystalball/simulator/impl/ScriptEventHandlerTest.java
+++ b/modules/activiti-crystalball/src/test/java/org/activiti/crystalball/simulator/impl/ScriptEventHandlerTest.java
@@ -1,9 +1,6 @@
 package org.activiti.crystalball.simulator.impl;
 
-import org.activiti.crystalball.examples.tutorial.step01.Counter;
-import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
-import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.test.Deployment;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/mock/MockResolverFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/mock/MockResolverFactory.java
@@ -16,7 +16,6 @@ package org.activiti.engine.test.mock;
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.scripting.Resolver;
 import org.activiti.engine.impl.scripting.ResolverFactory;
-import org.activiti.engine.test.mock.Mocks;
 
 /**
  * This is a bridge resolver, making available any objects registered through

--- a/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LdapGroupCacheTest.java
+++ b/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LdapGroupCacheTest.java
@@ -19,7 +19,6 @@ import org.activiti.engine.test.Deployment;
 import org.activiti.ldap.LDAPGroupCache;
 import org.activiti.ldap.LDAPGroupCache.LDAPGroupCacheListener;
 import org.activiti.ldap.LDAPGroupManagerFactory;
-import org.activiti.spring.impl.test.SpringActivitiTestCase;
 import org.springframework.test.context.ContextConfiguration;
 
 @ContextConfiguration("classpath:activiti-context-ldap-group-cache.xml")

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/api/jpa/JpaRestTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/api/jpa/JpaRestTest.java
@@ -10,7 +10,6 @@ import org.activiti.rest.service.api.RestUrls;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.HttpGet;
-import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/history/HistoricActivityInstanceCollectionResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/history/HistoricActivityInstanceCollectionResourceTest.java
@@ -30,7 +30,6 @@ import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.junit.Assert;
-import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/history/HistoricProcessInstanceCommentResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/history/HistoricProcessInstanceCommentResourceTest.java
@@ -20,7 +20,6 @@ import org.activiti.engine.task.Comment;
 import org.activiti.engine.test.Deployment;
 import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.api.RestUrls;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/identity/UserResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/identity/UserResourceTest.java
@@ -16,7 +16,6 @@ package org.activiti.rest.service.api.identity;
 import org.activiti.engine.identity.User;
 import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.api.RestUrls;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/management/JobExceptionStacktraceResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/management/JobExceptionStacktraceResourceTest.java
@@ -1,6 +1,5 @@
 package org.activiti.rest.service.api.management;
 
-import java.io.InputStream;
 import java.util.Calendar;
 import java.util.Collections;
 

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/repository/DeploymentResourceResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/repository/DeploymentResourceResourceTest.java
@@ -8,7 +8,6 @@ import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.api.RestUrls;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/ExecutionResourceTest.java
@@ -19,7 +19,6 @@ import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.test.Deployment;
 import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.api.RestUrls;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskIdentityLinkResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskIdentityLinkResourceTest.java
@@ -20,7 +20,6 @@ import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
 import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.api.RestUrls;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/TaskVariablesCollectionResourceTest.java
@@ -28,7 +28,6 @@ import org.activiti.engine.test.Deployment;
 import org.activiti.rest.service.BaseSpringRestTestCase;
 import org.activiti.rest.service.HttpMultipartHelper;
 import org.activiti.rest.service.api.RestUrls;
-import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpDelete;

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-actuator/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-actuator/src/main/java/activiti/Application.java
@@ -3,7 +3,6 @@ package activiti;
 
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
-import org.activiti.engine.task.Task;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/EndpointAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/EndpointAutoConfiguration.java
@@ -7,7 +7,6 @@ import org.activiti.spring.boot.actuate.endpoint.ProcessEngineMvcEndpoint;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.endpoint.AbstractEndpoint;
 
 /**
  * The idea behind this module is that Spring Security could

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -26,8 +26,6 @@ import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 /**

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -28,8 +28,6 @@ import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 /**

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -26,8 +26,6 @@ import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
 import static org.junit.Assert.*;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.*;
 
 /**

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/jpa/JpaTest.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/jpa/JpaTest.java
@@ -4,7 +4,6 @@ import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.spring.impl.test.SpringActivitiTestCase;
-import org.junit.Test;
 import org.springframework.test.context.ContextConfiguration;
 
 import java.util.HashMap;


### PR DESCRIPTION
Removed unused and unneeded import statements; run "mvn -Pcheck clean install" and all is fine.  
