### PR TITLE
HouseKeeping: Remove redundant initialization of fields to null, false, or 0

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/IndentingXMLStreamWriter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/IndentingXMLStreamWriter.java
@@ -30,7 +30,7 @@ public class IndentingXMLStreamWriter extends DelegatingXMLStreamWriter {
   private Stack<Object> stateStack = new Stack<Object>();
 
   private String indentStep = "  ";
-  private int depth = 0;
+  private int depth;
 
   public IndentingXMLStreamWriter(XMLStreamWriter writer) {
     super(writer);

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/ValuedDataObjectXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/ValuedDataObjectXMLConverter.java
@@ -29,7 +29,7 @@ public class ValuedDataObjectXMLConverter extends BaseBpmnXMLConverter {
   
   private final Pattern xmlChars = Pattern.compile("[<>&]");
   private SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-  protected boolean didWriteExtensionStartElement = false;
+  protected boolean didWriteExtensionStartElement;
   
   public Class<? extends BaseElement> getBpmnElementType() {
     return ValuedDataObject.class;

--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ScriptTask.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ScriptTask.java
@@ -22,7 +22,7 @@ public class ScriptTask extends Task {
   protected String scriptFormat;
   protected String script;
   protected String resultVariable;
-  protected boolean autoStoreVariables = false; // see http://jira.codehaus.org/browse/ACT-1626
+  protected boolean autoStoreVariables; // see http://jira.codehaus.org/browse/ACT-1626
 
   public String getScriptFormat() {
     return scriptFormat;

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiProducer.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/ActivitiProducer.java
@@ -46,9 +46,9 @@ public class ActivitiProducer extends DefaultProducer {
 
   private final long timeResolution;
   
-  private String processKey = null;
+  private String processKey;
 
-  private String activity = null;
+  private String activity;
 
   public ActivitiProducer(ActivitiEndpoint endpoint, long timeout, long timeResolution) {
     super(endpoint);

--- a/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
@@ -71,7 +71,7 @@ public abstract class CamelBehavior extends AbstractBpmnActivityBehavior impleme
         BODY_AS_MAP, BODY, PROPERTIES
       }  
 
-  protected TargetType toTargetType=null;
+  protected TargetType toTargetType;
   
   protected void updateTargetVariables(ActivitiEndpoint endpoint) {
     toTargetType = null;

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/exception/tools/ExceptionServiceMock.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/exception/tools/ExceptionServiceMock.java
@@ -5,7 +5,7 @@ import org.activiti.engine.delegate.JavaDelegate;
 
 
 public class ExceptionServiceMock implements JavaDelegate {
-  static boolean isCalled = false;
+  static boolean isCalled;
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {

--- a/modules/activiti-camel/src/test/java/org/activiti/camel/exception/tools/NoExceptionServiceMock.java
+++ b/modules/activiti-camel/src/test/java/org/activiti/camel/exception/tools/NoExceptionServiceMock.java
@@ -6,7 +6,7 @@ import org.activiti.engine.delegate.JavaDelegate;
 
 public class NoExceptionServiceMock implements JavaDelegate {
 
-  static boolean isCalled = false;
+  static boolean isCalled;
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {

--- a/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/CdiActivitiTestCase.java
+++ b/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/CdiActivitiTestCase.java
@@ -173,7 +173,7 @@ public abstract class CdiActivitiTestCase {
   }
   
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
     public InteruptTask(Thread thread) {
       this.thread = thread;

--- a/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/impl/event/TestEventListener.java
+++ b/modules/activiti-cdi/src/test/java/org/activiti/cdi/test/impl/event/TestEventListener.java
@@ -78,20 +78,20 @@ public class TestEventListener {
   
   // ---------------------------------------------------------
   
-  private int startActivityService1 = 0;
-  private int endActivityService1 = 0;
-  private int startActivityService2 = 0;
-  private int endActivityService2 = 0;
-  private int takeTransitiont1 = 0;
-  private int takeTransitiont2 = 0;
-  private int takeTransitiont3 = 0;
-  private int assignTask1 = 0;
-  private int completeTask1 = 0;
-  private int completeTask2 = 0;
-  private int completeTask3 = 0;
-  private int createTask1 = 0;
-  private int createTask2 = 0;
-  private int deleteTask3 = 0;
+  private int startActivityService1;
+  private int endActivityService1;
+  private int startActivityService2;
+  private int endActivityService2;
+  private int takeTransitiont1;
+  private int takeTransitiont2;
+  private int takeTransitiont3;
+  private int assignTask1;
+  private int completeTask1;
+  private int completeTask2;
+  private int completeTask3;
+  private int createTask1;
+  private int createTask2;
+  private int deleteTask3;
     
   public void onStartActivityService1(@Observes @StartActivity("service1") BusinessProcessEvent businessProcessEvent) {    
     startActivityService1 += 1;

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/SimpleSimulationRun.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/SimpleSimulationRun.java
@@ -34,7 +34,7 @@ public class SimpleSimulationRun extends AbstractSimulationRun {
 
   /** simulation start date*/
   protected Date simulationStartDate = new Date(0);
-  protected Date dueDate = null;
+  protected Date dueDate;
 
   protected SimpleSimulationRun(Builder builder) {
     super(builder.eventHandlers);

--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/AcquireJobNotificationEventHandler.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/AcquireJobNotificationEventHandler.java
@@ -34,7 +34,7 @@ public class AcquireJobNotificationEventHandler implements
 
 	private static Logger log = LoggerFactory.getLogger(AcquireJobNotificationEventHandler.class);
 
-	JobExecutor jobExecutor = null;
+	JobExecutor jobExecutor;
 	
 	public AcquireJobNotificationEventHandler(JobExecutor jobExecutor) {
 		this.jobExecutor = jobExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -111,8 +111,8 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String mailServerUsername; // by default no name and password are provided, which 
   protected String mailServerPassword; // means no authentication for mail server
   protected int mailServerPort = 25;
-  protected boolean useSSL = false;
-  protected boolean useTLS = false;
+  protected boolean useSSL;
+  protected boolean useTLS;
   protected String mailServerDefaultFrom = "activiti@localhost";
   protected String mailSessionJndi;
   protected Map<String,MailServerInfo> mailServers = new HashMap<String,MailServerInfo>();
@@ -124,7 +124,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String jdbcUrl = "jdbc:h2:tcp://localhost/~/activiti";
   protected String jdbcUsername = "sa";
   protected String jdbcPassword = "";
-  protected String dataSourceJndiName = null;
+  protected String dataSourceJndiName;
   protected boolean isDbIdentityUsed = true;
   protected boolean isDbHistoryUsed = true;
   protected HistoryLevel historyLevel;
@@ -132,12 +132,12 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected int jdbcMaxIdleConnections;
   protected int jdbcMaxCheckoutTime;
   protected int jdbcMaxWaitTime;
-  protected boolean jdbcPingEnabled = false;
-  protected String jdbcPingQuery = null;
+  protected boolean jdbcPingEnabled;
+  protected String jdbcPingQuery;
   protected int jdbcPingConnectionNotUsedFor;
   protected int jdbcDefaultTransactionIsolationLevel;
   protected DataSource dataSource;
-  protected boolean transactionsExternallyManaged = false;
+  protected boolean transactionsExternallyManaged;
   
   protected String jpaPersistenceUnitName;
   protected Object jpaEntityManagerFactory;
@@ -186,7 +186,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
    * doesn't return that correctly, see https://jira.codehaus.org/browse/ACT-1220,
    * https://jira.codehaus.org/browse/ACT-1062
    */
-  protected String databaseSchema = null;
+  protected String databaseSchema;
   
   /**
    * Set to true in case the defined databaseTablePrefix is a schema-name, instead of an actual table name
@@ -195,7 +195,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
    * 
    *  @since 5.15
    */
-  protected boolean tablePrefixIsSchema = false;
+  protected boolean tablePrefixIsSchema;
   
   protected boolean isCreateDiagramOnDeploy = true;
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -64,7 +64,7 @@ public abstract class ProcessEngines {
   
   public static final String NAME_DEFAULT = "default";
   
-  protected static boolean isInitialized = false; 
+  protected static boolean isInitialized;
   protected static Map<String, ProcessEngine> processEngines = new HashMap<String, ProcessEngine>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByName = new HashMap<String, ProcessEngineInfo>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByResourceUrl = new HashMap<String, ProcessEngineInfo>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/cfg/MailServerInfo.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/cfg/MailServerInfo.java
@@ -24,8 +24,8 @@ public class MailServerInfo {
   protected int mailServerPort;
   protected String mailServerUsername;
   protected String mailServerPassword;
-  protected boolean mailServerUseSSL = false;
-  protected boolean mailServerUseTLS = false;
+  protected boolean mailServerUseSSL;
+  protected boolean mailServerUseTLS;
   
   public String getMailServerDefaultFrom() {
     return mailServerDefaultFrom;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/BaseEntityEventListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/BaseEntityEventListener.java
@@ -25,7 +25,7 @@ package org.activiti.engine.delegate.event;
  */
 public class BaseEntityEventListener implements ActivitiEventListener {
 
-	protected boolean failOnException = false;
+	protected boolean failOnException;
 	protected Class<?> entityClass;
 
 	/**

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -44,7 +44,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery< ? , ? >, U> imp
   protected transient CommandContext commandContext;
 
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected ResultType resultType;
 
   private Map<String, Object> parameters = new HashMap<String, Object>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
@@ -40,7 +40,7 @@ public class HistoricDetailQueryImpl extends AbstractQuery<HistoricDetailQuery, 
   protected String activityId;
   protected String activityInstanceId;
   protected String type;
-  protected boolean excludeTaskRelated = false;
+  protected boolean excludeTaskRelated;
 
   public HistoricDetailQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -39,10 +39,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String businessKey;
   protected String deploymentId;
   protected List<String> deploymentIds;
-  protected boolean finished = false;
-  protected boolean unfinished = false;
-  protected boolean deleted = false;
-  protected boolean notDeleted = false;
+  protected boolean finished;
+  protected boolean unfinished;
+  protected boolean deleted;
+  protected boolean notDeleted;
   protected String startedBy;
   protected String superProcessInstanceId;
   protected boolean excludeSubprocesses;
@@ -62,7 +62,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String nameLike;
   protected String nameLikeIgnoreCase;
   protected HistoricProcessInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
   
   public HistoricProcessInstanceQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -83,7 +83,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected Date dueDate;
   protected Date dueAfter;
   protected Date dueBefore;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected Date creationDate;
   protected Date creationAfterDate;
   protected Date creationBeforeDate;
@@ -94,10 +94,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected String tenantId;
   protected String tenantIdLike;
   protected boolean withoutTenantId;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected HistoricTaskInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
 
   public HistoricTaskInstanceQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -40,8 +40,8 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   protected String activityInstanceId;
   protected String variableName;
   protected String variableNameLike;
-  protected boolean excludeTaskRelated = false;
-  protected boolean excludeVariableInitialization = false;
+  protected boolean excludeTaskRelated;
+  protected boolean excludeVariableInitialization;
   protected QueryVariableValue queryVariableValue;
 
   public HistoricVariableInstanceQueryImpl() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -49,7 +49,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   protected String resourceName;
   protected String resourceNameLike;
   protected Integer version;
-  protected boolean latest = false;
+  protected boolean latest;
   protected SuspensionState suspensionState;
   protected String authorizationUserId;
   protected String procDefId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -61,7 +61,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean withoutTenantId;
   
   protected ProcessInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
   
   // Unused, see dynamic query
   protected String activityId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -57,8 +57,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String owner;
   protected String ownerLike;
   protected String ownerLikeIgnoreCase;
-  protected boolean unassigned = false;
-  protected boolean noDelegationState = false;
+  protected boolean unassigned;
+  protected boolean noDelegationState;
   protected DelegationState delegationState;
   protected String candidateUser;
   protected String candidateGroup;
@@ -90,13 +90,13 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected Date dueDate;
   protected Date dueBefore;
   protected Date dueAfter;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected SuspensionState suspensionState;
-  protected boolean excludeSubtasks = false;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean excludeSubtasks;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected String userIdForCandidateAndAssignee;
-  protected boolean bothCandidateAndAssigned = false;
+  protected boolean bothCandidateAndAssigned;
   protected boolean orActive;
   protected TaskQueryImpl orQueryObject;
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
@@ -30,11 +30,11 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
 
   protected final AsyncExecutor asyncExecutor;
 
-  protected volatile boolean isInterrupted = false;
+  protected volatile boolean isInterrupted;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
   
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireAsyncJobsDueRunnable(AsyncExecutor asyncExecutor) {
     this.asyncExecutor = asyncExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
@@ -31,11 +31,11 @@ public class AcquireTimerJobsRunnable implements Runnable {
 
   protected final AsyncExecutor asyncExecutor;
 
-  protected volatile boolean isInterrupted = false;
+  protected volatile boolean isInterrupted;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
   
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireTimerJobsRunnable(AsyncExecutor asyncExecutor) {
     this.asyncExecutor = asyncExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -53,8 +53,8 @@ private static Logger log = LoggerFactory.getLogger(DefaultAsyncJobExecutor.clas
   protected AcquireTimerJobsRunnable timerJobRunnable;
   protected AcquireAsyncJobsDueRunnable asyncJobsDueRunnable;
   
-  protected boolean isAutoActivate = false;
-  protected boolean isActive = false;
+  protected boolean isAutoActivate;
+  protected boolean isActive;
   
   protected int maxTimerJobsPerAcquisition = 1;
   protected int maxAsyncJobsDuePerAcquisition = 1;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
@@ -36,7 +36,7 @@ public class BusinessRuleTaskActivityBehavior extends TaskActivityBehavior {
   
   protected Set<Expression> variablesInputExpressions = new HashSet<Expression>();
   protected Set<Expression> rulesExpressions = new HashSet<Expression>();
-  protected boolean exclude = false;
+  protected boolean exclude;
   protected String resultVariable;
 
   public BusinessRuleTaskActivityBehavior() {}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ScriptTaskActivityBehavior.java
@@ -40,7 +40,7 @@ public class ScriptTaskActivityBehavior extends TaskActivityBehavior {
   protected String script;
   protected String language;
   protected String resultVariable;
-  protected boolean storeScriptVariables = false; // see http://jira.codehaus.org/browse/ACT-1626
+  protected boolean storeScriptVariables; // see http://jira.codehaus.org/browse/ACT-1626
 
   public ScriptTaskActivityBehavior(String script, String language, String resultVariable) {
     this.script = script;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
@@ -25,9 +25,9 @@ public class ScriptExecutionListener implements ExecutionListener {
 
   private Expression script;
 
-	private Expression language = null;
+	private Expression language;
 
-	private Expression resultVariable = null;
+	private Expression resultVariable;
 
 	@Override
   public void notify(DelegateExecution execution) throws Exception {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
@@ -29,9 +29,9 @@ public class ScriptTaskListener implements TaskListener {
 
   protected Expression script;
 
-  protected Expression language = null;
+  protected Expression language;
 
-  protected Expression resultVariable = null;
+  protected Expression resultVariable;
   
   protected boolean autoStoreVariables;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/CronExpression.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/CronExpression.java
@@ -240,8 +240,8 @@ public class CronExpression implements Serializable, Cloneable {
     dayMap.put("SAT", Integer.valueOf(7));
   }
 
-  private String cronExpression = null;
-  private TimeZone timeZone = null;
+  private String cronExpression;
+  private TimeZone timeZone;
   protected transient TreeSet<Integer> seconds;
   protected transient TreeSet<Integer> minutes;
   protected transient TreeSet<Integer> hours;
@@ -250,12 +250,12 @@ public class CronExpression implements Serializable, Cloneable {
   protected transient TreeSet<Integer> daysOfWeek;
   protected transient TreeSet<Integer> years;
 
-  protected transient boolean lastdayOfWeek = false;
-  protected transient int nthdayOfWeek = 0;
-  protected transient boolean lastdayOfMonth = false;
-  protected transient boolean nearestWeekday = false;
-  protected transient int lastdayOffset = 0;
-  protected transient boolean expressionParsed = false;
+  protected transient boolean lastdayOfWeek;
+  protected transient int nthdayOfWeek;
+  protected transient boolean lastdayOfMonth;
+  protected transient boolean nearestWeekday;
+  protected transient int lastdayOffset;
+  protected transient boolean expressionParsed;
 
   public static final int MAX_YEAR = Calendar.getInstance().get(Calendar.YEAR) + 100;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -375,7 +375,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * hence the reason why it is disabled by default. If your platform allows 
    * the use of StaxSource during XML parsing, do enable it.
    */
-  protected boolean enableSafeBpmnXml = false;
+  protected boolean enableSafeBpmnXml;
   
   /**
    * The following settings will determine the amount of entities loaded at once when the engine 
@@ -403,7 +403,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected Map<String, List<ActivitiEventListener>> typedEventListeners;
   
   // Event logging to database
-  protected boolean enableDatabaseEventLogging = false;
+  protected boolean enableDatabaseEventLogging;
   
   
   // buildProcessEngine ///////////////////////////////////////////////////////

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -34,7 +34,7 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
   private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
   protected CommandContext commandContext;
-  protected Map<TransactionState,List<TransactionListener>> stateTransactionListeners = null;
+  protected Map<TransactionState,List<TransactionListener>> stateTransactionListeners;
   
   public StandaloneMybatisTransactionContext(CommandContext commandContext) {
     this.commandContext = commandContext;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -44,7 +44,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
   protected String processDefinitionId;
   protected String processDefinitionKey;
   protected ProcessDefinitionEntity processDefinitionEntity;
-  protected boolean includeProcessInstances = false;
+  protected boolean includeProcessInstances;
   protected Date executionDate;
   protected String tenantId;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
@@ -11,9 +11,9 @@ import org.activiti.engine.impl.interceptor.CommandContext;
  */
 public class GetEventLogEntriesCmd implements Command<List<EventLogEntry>> {
 	
-  protected String processInstanceId = null;
-	protected Long startLogNr = null;
-	protected Long pageSize = null;
+  protected String processInstanceId;
+	protected Long startLogNr;
+	protected Long pageSize;
 	
 	public GetEventLogEntriesCmd() {
 		

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
@@ -25,7 +25,7 @@ import org.activiti.engine.impl.interceptor.CommandExecutor;
 public class DbIdGenerator implements IdGenerator {
 
   protected int idBlockSize;
-  protected long nextId = 0;
+  protected long nextId;
   protected long lastId = -1;
   
   protected CommandExecutor commandExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
@@ -20,7 +20,7 @@ package org.activiti.engine.impl.db;
 public class ListQueryParameterObject {
   
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected Object parameter;
   protected String databaseType;
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -74,7 +74,7 @@ public class CommandContext {
   protected TransactionContext transactionContext;
   protected Map<Class< ? >, SessionFactory> sessionFactories;
   protected Map<Class< ? >, Session> sessions = new HashMap<Class< ? >, Session>();
-  protected Throwable exception = null;
+  protected Throwable exception;
   protected LinkedList<AtomicOperation> nextOperations = new LinkedList<AtomicOperation>();
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected FailedJobCommandFactory failedJobCommandFactory;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
@@ -194,7 +194,7 @@ public class BeanELResolver extends ELResolver {
 				return Collections.<FeatureDescriptor> emptyList().iterator();
 			}
 			return new Iterator<FeatureDescriptor>() {
-				int next = 0;
+				int next;
 
 				public boolean hasNext() {
 					return properties != null && next < properties.length;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AcquireJobsRunnableImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AcquireJobsRunnableImpl.java
@@ -30,12 +30,12 @@ public class AcquireJobsRunnableImpl implements AcquireJobsRunnable {
 
   protected final JobExecutor jobExecutor;
 
-  protected volatile boolean isInterrupted = false;
-  protected volatile boolean isJobAdded = false;
+  protected volatile boolean isInterrupted;
+  protected volatile boolean isJobAdded;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
   
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireJobsRunnableImpl(JobExecutor jobExecutor) {
     this.jobExecutor = jobExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/DefaultJobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/DefaultJobExecutor.java
@@ -43,7 +43,7 @@ public class DefaultJobExecutor extends JobExecutor {
   protected int queueSize = 3;
   protected int corePoolSize = 3;
   protected int maxPoolSize = 10;
-  protected long keepAliveTime = 0L;
+  protected long keepAliveTime;
 
   protected BlockingQueue<Runnable> threadPoolQueue;
   protected ThreadPoolExecutor threadPoolExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/JobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/JobExecutor.java
@@ -51,8 +51,8 @@ public abstract class JobExecutor {
   protected RejectedJobsHandler rejectedJobsHandler;
   protected Thread jobAcquisitionThread;
   
-  protected boolean isAutoActivate = false;
-  protected boolean isActive = false;
+  protected boolean isAutoActivate;
+  protected boolean isActive;
 
   /**
    * To avoid deadlocks, the default for this is one.

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -37,7 +37,7 @@ public class TimerDeclarationImpl implements Serializable {
   protected TimerDeclarationType type;
 
   protected String jobHandlerType;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerConfiguration;
   protected String repeat;
   protected boolean exclusive = TimerEntity.DEFAULT_EXCLUSIVE;
   protected int retries = TimerEntity.DEFAULT_RETRIES;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
@@ -24,7 +24,7 @@ public final class ByteArrayRef implements Serializable {
   private String id;
   private String name;
   private ByteArrayEntity entity;
-  protected boolean deleted = false;
+  protected boolean deleted;
 
   public ByteArrayRef() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -89,10 +89,10 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
   protected ActivityImpl activity;
   
   /** current transition.  is null when there is no transition being taken. */
-  protected TransitionImpl transition = null;
+  protected TransitionImpl transition;
   
   /** transition that will be taken.  is null when there is no transition being taken. */
-  protected TransitionImpl transitionBeingTaken = null;
+  protected TransitionImpl transitionBeingTaken;
 
   /** the process instance.  this is the root of the execution tree.  
    * the processInstance of a process instance is a self reference. */
@@ -130,15 +130,15 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
    * </ul>*/ 
   protected boolean isActive = true;
   protected boolean isScope = true;
-  protected boolean isConcurrent = false;
-  protected boolean isEnded = false;
-  protected boolean isEventScope = false;
+  protected boolean isConcurrent;
+  protected boolean isEnded;
+  protected boolean isEventScope;
   
   // events ///////////////////////////////////////////////////////////////////
   
   protected String eventName;
   protected PvmProcessElement eventSource;
-  protected int executionListenerIndex = 0;
+  protected int executionListenerIndex;
   
   // associated entities /////////////////////////////////////////////////////
   
@@ -169,7 +169,7 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
    * @see AtomicOperation
    * @see #performOperation(AtomicOperation) */
   protected AtomicOperation nextOperation;
-  protected boolean isOperating = false;
+  protected boolean isOperating;
 
   protected int revision = 1;
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
@@ -53,19 +53,19 @@ public abstract class JobEntity implements Job, PersistentObject, HasRevision, B
 
   protected Date duedate;
 
-  protected String lockOwner = null;
-  protected Date lockExpirationTime = null;
+  protected String lockOwner;
+  protected Date lockExpirationTime;
 
-  protected String executionId = null;
-  protected String processInstanceId = null;
-  protected String processDefinitionId = null;
+  protected String executionId;
+  protected String processInstanceId;
+  protected String processDefinitionId;
 
   protected boolean isExclusive = DEFAULT_EXCLUSIVE;
 
   protected int retries = DEFAULT_RETRIES;
 
-  protected String jobHandlerType = null;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerType;
+  protected String jobHandlerConfiguration;
   
   protected final ByteArrayRef exceptionByteArrayRef = new ByteArrayRef();
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/MessageEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/MessageEntity.java
@@ -22,7 +22,7 @@ public class MessageEntity extends JobEntity {
 
   private static final long serialVersionUID = 1L;
 
-  private String repeat = null;
+  private String repeat;
   
   @Override
   public void execute(CommandContext commandContext) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -61,7 +61,7 @@ public class ProcessDefinitionEntity extends ProcessDefinitionImpl implements Pr
   protected Map<String, Object> variables;
   protected boolean hasStartFormKey;
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> definitionIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
   protected Set<Expression> candidateStarterUserIdExpressions = new HashSet<Expression>();
   protected Set<Expression> candidateStarterGroupIdExpressions = new HashSet<Expression>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
@@ -29,7 +29,7 @@ public class ResourceEntity implements PersistentObject, Serializable {
   protected String name;
   protected byte[] bytes;
   protected String deploymentId;
-  protected boolean generated = false;
+  protected boolean generated;
   
   public String getId() {
     return id;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
@@ -76,7 +76,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
   protected String category;
   
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> taskIdentityLinkEntities = new ArrayList<IdentityLinkEntity>(); 
   
   protected String executionId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -50,7 +50,7 @@ public class VariableInstanceEntity implements ValueFields, PersistentObject, Ha
 
   protected Object cachedValue;
   protected boolean forcedUpdate;
-  protected boolean deleted = false;
+  protected boolean deleted;
   
   // Default constructor for SQL mapping
   protected VariableInstanceEntity() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -42,12 +42,12 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
   
   private static final long serialVersionUID = 1L;
   
-  protected Map<String, VariableInstanceEntity> variableInstances = null;
+  protected Map<String, VariableInstanceEntity> variableInstances;
   
   
   protected ELContext cachedElContext;
 
-  protected String id = null;
+  protected String id;
 
   protected abstract List<VariableInstanceEntity> loadVariableInstances();
   protected abstract VariableScopeImpl getParentVariableScope();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/pvm/runtime/ExecutionImpl.java
@@ -63,7 +63,7 @@ public class ExecutionImpl implements
   protected ActivityImpl activity;
   
   /** current transition.  is null when there is no transition being taken. */
-  protected TransitionImpl transition = null;
+  protected TransitionImpl transition;
 
   /** the process instance.  this is the root of the execution tree.  
    * the processInstance of a process instance is a self reference. */
@@ -96,17 +96,17 @@ public class ExecutionImpl implements
    * </ul>*/ 
   protected boolean isActive = true;
   protected boolean isScope = true;
-  protected boolean isConcurrent = false;
-  protected boolean isEnded = false;
-  protected boolean isEventScope = false;
+  protected boolean isConcurrent;
+  protected boolean isEnded;
+  protected boolean isEventScope;
   
-  protected Map<String, Object> variables = null;
+  protected Map<String, Object> variables;
   
   // events ///////////////////////////////////////////////////////////////////
   
   protected String eventName;
   protected PvmProcessElement eventSource;
-  protected int executionListenerIndex = 0;
+  protected int executionListenerIndex;
     
   // cascade deletion ////////////////////////////////////////////////////////
   
@@ -128,7 +128,7 @@ public class ExecutionImpl implements
    * @see AtomicOperation
    * @see #performOperation(AtomicOperation) */
   protected AtomicOperation nextOperation;
-  protected boolean isOperating = false;
+  protected boolean isOperating;
 
   /* Default constructor for ibatis/jpa/etc. */
   public ExecutionImpl() {    

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -44,7 +44,7 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   protected DeploymentEntity deployment = new DeploymentEntity();
   protected boolean isBpmn20XsdValidationEnabled = true;
   protected boolean isProcessValidationEnabled = true;
-  protected boolean isDuplicateFilterEnabled = false;
+  protected boolean isDuplicateFilterEnabled;
   protected Date processDefinitionsActivationDate;
 
   public DeploymentBuilderImpl(RepositoryServiceImpl repositoryService) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/AbstractActivitiTestCase.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/AbstractActivitiTestCase.java
@@ -428,7 +428,7 @@ public abstract class AbstractActivitiTestCase extends PvmTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
     public InteruptTask(Thread thread) {
       this.thread = thread;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
@@ -328,7 +328,7 @@ public abstract class TestHelper {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
     public InteruptTask(Thread thread) {
       this.thread = thread;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/DefaultClockImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/DefaultClockImpl.java
@@ -22,7 +22,7 @@ import java.util.TimeZone;
  */
 public class DefaultClockImpl implements org.activiti.engine.runtime.Clock {
   
-  private static volatile Calendar CURRENT_TIME = null;
+  private static volatile Calendar CURRENT_TIME;
 
   @Override
   public void setCurrentTime(Date currentTime) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
  */
 public class EntityMetaData {
 
-  private boolean isJPAEntity = false;
+  private boolean isJPAEntity;
   private Class< ? > entityClass;
   private Method idMethod;
   private Field idField;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
@@ -26,7 +26,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
   
   protected JPAEntityMappings mappings;
   
-  protected boolean forceCachedValue = false;
+  protected boolean forceCachedValue;
   
   public JPAEntityListVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
@@ -29,7 +29,7 @@ public class JPAEntityVariableType implements VariableType, CacheableVariable {
   
   private JPAEntityMappings mappings;
   
-  private boolean forceCacheable = false;
+  private boolean forceCacheable;
   
   public JPAEntityVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
@@ -17,7 +17,7 @@ public class LogMDC {
   public static final String LOG_MDC_BUSINESS_KEY = "mdcBusinessKey";
   public static final String LOG_MDC_TASK_ID = "mdcTaskId";
 
-  static boolean enabled = false;
+  static boolean enabled;
 
   public static boolean isMDCEnabled() {
     return enabled;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramEdgeWaypoint.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramEdgeWaypoint.java
@@ -25,8 +25,8 @@ public class DiagramEdgeWaypoint implements Serializable {
 
   private static final long serialVersionUID = 1L;
   
-  private Double x = null;
-  private Double y = null;
+  private Double x;
+  private Double y;
   
   public Double getX() {
     return x;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
@@ -24,7 +24,7 @@ abstract public class DiagramElement implements Serializable {
 
   private static final long serialVersionUID = 1L;
   
-  protected String id = null;
+  protected String id;
 
   public DiagramElement() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
@@ -22,10 +22,10 @@ public class DiagramNode extends DiagramElement {
 
   private static final long serialVersionUID = 1L;
 
-  private Double x = null;
-  private Double y = null;
-  private Double width = null;
-  private Double height = null;
+  private Double x;
+  private Double y;
+  private Double width;
+  private Double height;
 
   public DiagramNode() {
     super();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
@@ -86,7 +86,7 @@ import org.junit.runners.model.Statement;
 public class ActivitiRule implements TestRule {
 
 	protected String configurationResource = "activiti.cfg.xml";
-	protected String deploymentId = null;
+	protected String deploymentId;
 
   protected ProcessEngineConfiguration processEngineConfiguration;
 	protected ProcessEngine processEngine;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiTestCase.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiTestCase.java
@@ -54,7 +54,7 @@ import org.activiti.engine.test.mock.ActivitiMockSupport;
 public abstract class ActivitiTestCase extends TestCase {
 
   protected String configurationResource = "activiti.cfg.xml";
-  protected String deploymentId = null;
+  protected String deploymentId;
 
   protected ProcessEngineConfiguration processEngineConfiguration;
   protected ProcessEngine processEngine;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestBaseEntityEventListener.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestBaseEntityEventListener.java
@@ -17,11 +17,11 @@ import org.activiti.engine.delegate.event.BaseEntityEventListener;
 
 public class TestBaseEntityEventListener extends BaseEntityEventListener {
 
-	private boolean updateReceived = false;
-	private boolean createReceived = false;
-	private boolean deleteReceived = false;
-	private boolean initializeReceived = false;
-	private boolean customReceived = false;
+	private boolean updateReceived;
+	private boolean createReceived;
+	private boolean deleteReceived;
+	private boolean initializeReceived;
+	private boolean customReceived;
 
 	public TestBaseEntityEventListener() {
 		super();

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/DeployInvalidXmlTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/DeployInvalidXmlTest.java
@@ -112,7 +112,7 @@ public class DeployInvalidXmlTest extends PluggableActivitiTestCase {
   
   static class MyRunnable implements Runnable {
     
-    public boolean finished = false;
+    public boolean finished;
     
     protected RepositoryService repositoryService;
     

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/IntermediateNoneEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/IntermediateNoneEventTest.java
@@ -20,7 +20,7 @@ import org.activiti.engine.test.Deployment;
 
 public class IntermediateNoneEventTest extends PluggableActivitiTestCase {
   
-  private static boolean listenerExcecuted = false;
+  private static boolean listenerExcecuted;
   
   public static class MyExecutionListener implements ExecutionListener {
     public void notify(DelegateExecution execution) throws Exception {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/compensate/helper/SetVariablesDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/compensate/helper/SetVariablesDelegate.java
@@ -28,7 +28,7 @@ public class SetVariablesDelegate implements JavaDelegate {
   public static Map<Object, Integer> variablesMap = new HashMap<Object, Integer>(); 
   
   // activiti creates a single instance of the delegate
-  protected int lastInt = 0;
+  protected int lastInt;
 
   public void execute(DelegateExecution execution) throws Exception {
     Object nrOfCompletedInstances = execution.getVariableLocal("nrOfCompletedInstances");    

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/EndEventTestJavaDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/EndEventTestJavaDelegate.java
@@ -20,7 +20,7 @@ import org.activiti.engine.delegate.JavaDelegate;
  */
 public class EndEventTestJavaDelegate implements JavaDelegate {
   
-  public static int timesCalled = 0;
+  public static int timesCalled;
   
   public void execute(DelegateExecution execution) throws Exception {
     timesCalled++;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -26,7 +26,7 @@ import org.activiti.engine.test.Deployment;
  */
 public class TerminateEndEventTest extends PluggableActivitiTestCase {
 
-  public static int serviceTaskInvokedCount = 0;
+  public static int serviceTaskInvokedCount;
 
   public static class CountDelegate implements JavaDelegate {
     
@@ -38,7 +38,7 @@ public class TerminateEndEventTest extends PluggableActivitiTestCase {
     }
   }
   
-  public static int serviceTaskInvokedCount2 = 0;
+  public static int serviceTaskInvokedCount2;
 
   public static class CountDelegate2 implements JavaDelegate {
     

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -31,8 +31,8 @@ import org.activiti.engine.test.Deployment;
  */
 public class BoundaryTimerEventTest extends PluggableActivitiTestCase {
   
-  private static boolean listenerExcecutedStartEvent = false;
-  private static boolean listenerExcecutedEndEvent = false;
+  private static boolean listenerExcecutedStartEvent;
+  private static boolean listenerExcecutedEndEvent;
   
   public static class MyExecutionListener implements ExecutionListener {
     private static final long serialVersionUID = 1L;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/RetryFailingDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/RetryFailingDelegate.java
@@ -11,7 +11,7 @@ public class RetryFailingDelegate implements JavaDelegate {
 
   public static final String EXCEPTION_MESSAGE = "Expected exception.";
   
-	public static boolean shallThrow = false;
+	public static boolean shallThrow;
 	public static List<Long> times;
 	 
 	static public void resetTimeList() {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/MDCLoggingTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/MDCLoggingTest.java
@@ -14,7 +14,7 @@ import org.apache.log4j.PatternLayout;
 public class MDCLoggingTest extends PluggableActivitiTestCase {
 
 	MemoryLogAppender console = new MemoryLogAppender();
-	List<Appender> appenders = null;
+	List<Appender> appenders;
 
 	private void setCustomLogger() {
 		String PATTERN = "Modified Log *** ProcessDefinitionId=%X{mdcProcessDefinitionID} executionId=%X{mdcExecutionId} mdcProcessInstanceID=%X{mdcProcessInstanceID} mdcBusinessKey=%X{mdcBusinessKey} mdcTaskId=%X{mdcTaskId}  %m%n";

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/TestService.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/TestService.java
@@ -4,10 +4,10 @@ import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.JavaDelegate;
 
 public class TestService implements JavaDelegate{
-	static String processInstanceId = null;
-	static String processDefinitionId = null;
-	static String executionId = null;
-	static String businessKey = null;
+	static String processInstanceId;
+	static String processDefinitionId;
+	static String executionId;
+	static String businessKey;
 	
 
 	@Override

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ToUpperCaseSetterInjected.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ToUpperCaseSetterInjected.java
@@ -24,7 +24,7 @@ import org.activiti.engine.delegate.JavaDelegate;
 public class ToUpperCaseSetterInjected implements JavaDelegate {
   
   private Expression text;
-  private boolean setterInvoked = false;
+  private boolean setterInvoked;
   
   public void execute(DelegateExecution execution) {
     

--- a/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/JPAVariableTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/JPAVariableTest.java
@@ -68,7 +68,7 @@ public class JPAVariableTest extends AbstractActivitiTestCase {
   private static FieldAccessJPAEntity entityToQuery;
   private static FieldAccessJPAEntity entityToUpdate;
   
-  private static boolean entitiesInitialized = false;
+  private static boolean entitiesInitialized;
 
   private static EntityManagerFactory entityManagerFactory;
   

--- a/modules/activiti-explorer/src/main/java/org/activiti/editor/ui/ImportUploadReceiver.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/editor/ui/ImportUploadReceiver.java
@@ -60,7 +60,7 @@ public class ImportUploadReceiver implements Receiver, FinishedListener, ModelDa
   protected String fileName;
   
   // Will be assigned after deployment
-  protected boolean validFile = false;
+  protected boolean validFile;
   protected Model modelData;
   
   public ImportUploadReceiver() {

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ExplorerApp.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ExplorerApp.java
@@ -61,15 +61,15 @@ public class ExplorerApp extends Application implements HttpServletRequestListen
   protected SimpleWorkflowJsonConverter simpleWorkflowJsonConverter;
   
   // Flag to see if the session has been invalidated, when the application was closed
-  protected boolean invalidatedSession = false;
+  protected boolean invalidatedSession;
   
   protected List<String> adminGroups;
   protected List<String> userGroups;
   
-  protected String crystalBallCurrentDefinitionId = null;
-  protected String crystalBallCurrentInstanceId = null;
-  protected List<SimulationEvent> crystalBallSimulationEvents = null;
-  protected transient SimulationDebugger crystalBallSimulationDebugger = null;
+  protected String crystalBallCurrentDefinitionId;
+  protected String crystalBallCurrentInstanceId;
+  protected List<SimulationEvent> crystalBallSimulationEvents;
+  protected transient SimulationDebugger crystalBallSimulationDebugger;
   
   public void init() {
     setMainWindow(mainWindow);

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/content/file/FileAttachmentEditorComponent.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/content/file/FileAttachmentEditorComponent.java
@@ -56,7 +56,7 @@ public class FileAttachmentEditorComponent extends VerticalLayout implements Att
   protected String fileName;
   protected ByteArrayOutputStream byteArrayOutputStream;
   protected String mimeType;
-  protected boolean fileUploaded = false;
+  protected boolean fileUploaded;
   
   protected I18nManager i18nManager;
   protected transient TaskService taskService;

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/form/AbstractFormPropertyRenderer.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/form/AbstractFormPropertyRenderer.java
@@ -77,5 +77,5 @@ public abstract class AbstractFormPropertyRenderer implements FormPropertyRender
   /**
    * The form that contains this renderer
    */
-  transient private com.vaadin.ui.Form theForm = null;
+  transient private com.vaadin.ui.Form theForm;
 }

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/management/deployment/DeploymentUploadReceiver.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/management/deployment/DeploymentUploadReceiver.java
@@ -51,7 +51,7 @@ public class DeploymentUploadReceiver implements Receiver, FinishedListener {
   protected String fileName;
   
   // Will be assigned after deployment
-  protected boolean validFile = false;
+  protected boolean validFile;
   protected Deployment deployment;
   
   public DeploymentUploadReceiver() {

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/profile/ProfilePanel.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/profile/ProfilePanel.java
@@ -79,7 +79,7 @@ public class ProfilePanel extends Panel {
   
   // ui
   protected boolean isCurrentLoggedInUser;
-  protected boolean editable = false;
+  protected boolean editable;
   protected HorizontalLayout profilePanelLayout;
   protected VerticalLayout imageLayout;
   protected VerticalLayout infoPanelLayout;

--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramCanvas.java
@@ -94,7 +94,7 @@ public class DefaultProcessDiagramCanvas {
   protected static Color SUBPROCESS_BORDER_COLOR = new Color(0, 0, 0);
   
   // Fonts
-  protected static Font LABEL_FONT = null;
+  protected static Font LABEL_FONT;
   protected static Font ANNOTATION_FONT = new Font("Arial", Font.PLAIN, FONT_SIZE);
   protected static Font TASK_FONT = new Font("Arial", Font.PLAIN, FONT_SIZE);
 

--- a/modules/activiti-ldap/src/main/java/org/activiti/ldap/LDAPConfigurator.java
+++ b/modules/activiti-ldap/src/main/java/org/activiti/ldap/LDAPConfigurator.java
@@ -58,7 +58,7 @@ public class LDAPConfigurator extends AbstractProcessEngineConfigurator {
   protected String baseDn;
   protected String userBaseDn;
   protected String groupBaseDn;
-  protected int searchTimeLimit = 0; // Default '0' == wait forever
+  protected int searchTimeLimit; // Default '0' == wait forever
 
   protected String queryUserByUserId;
   protected String queryGroupsForUser;

--- a/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LDAPTestCase.java
+++ b/modules/activiti-ldap/src/test/java/org/activiti/test/ldap/LDAPTestCase.java
@@ -30,9 +30,9 @@ import org.springframework.security.ldap.server.ApacheDSContainer;
  */
 public class LDAPTestCase extends SpringActivitiTestCase {
 
-  private static int testCount = 0;
+  private static int testCount;
   private static int totalTestCount = -1;
-  private static boolean disableAfterTestCase = false;
+  private static boolean disableAfterTestCase;
   
   @Resource(name="org.springframework.security.apacheDirectoryServerContainer")
   private ApacheDSContainer apacheDSContainer;

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/identity/GroupRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/identity/GroupRequest.java
@@ -19,8 +19,8 @@ package org.activiti.rest.service.api.identity;
  */
 public class GroupRequest extends GroupResponse {
 
-  protected boolean isNameChanged = false;
-  protected boolean isTypeChanged = false;
+  protected boolean isNameChanged;
+  protected boolean isTypeChanged;
   
   @Override
   public void setType(String type) {

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/identity/UserRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/identity/UserRequest.java
@@ -21,10 +21,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class UserRequest extends UserResponse {
 
-  protected boolean firstNameChanged = false;
-  protected boolean lastNameChanged = false;
-  protected boolean passwordChanged = false;
-  protected boolean emailChanged = false;
+  protected boolean firstNameChanged;
+  protected boolean lastNameChanged;
+  protected boolean passwordChanged;
+  protected boolean emailChanged;
   
   @Override
   public void setEmail(String email) {

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/repository/ProcessDefinitionActionRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/repository/ProcessDefinitionActionRequest.java
@@ -26,7 +26,7 @@ public class ProcessDefinitionActionRequest extends RestActionRequest {
   public static final String ACTION_SUSPEND = "suspend";
   public static final String ACTION_ACTIVATE = "activate";
   
-  private boolean includeProcessInstances = false;
+  private boolean includeProcessInstances;
   private Date date;
   private String category;
   

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/repository/ProcessDefinitionResponse.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/repository/ProcessDefinitionResponse.java
@@ -30,9 +30,9 @@ public class ProcessDefinitionResponse {
   private String resource;
   private String diagramResource;
   private String category;
-  private boolean graphicalNotationDefined = false;
-  private boolean suspended = false;
-  private boolean startFormDefined = false;
+  private boolean graphicalNotationDefined;
+  private boolean suspended;
+  private boolean startFormDefined;
   
   public String getId() {
     return id;

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/SignalEventReceivedRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/SignalEventReceivedRequest.java
@@ -26,7 +26,7 @@ public class SignalEventReceivedRequest {
   private String signalName;
   private List<RestVariable> variables;
   private String tenantId;
-  private boolean async = false;
+  private boolean async;
   
   public void setTenantId(String tenantId) {
 	  this.tenantId = tenantId;

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/task/TaskRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/task/TaskRequest.java
@@ -35,17 +35,17 @@ public class TaskRequest {
   private String tenantId;
   private String formKey;
   
-  private boolean ownerSet = false;
-  private boolean assigneeSet = false;
-  private boolean delegationStateSet = false;
-  private boolean nameSet = false;
-  private boolean descriptionSet = false;
-  private boolean duedateSet = false;
-  private boolean prioritySet = false;
-  private boolean parentTaskIdSet = false;
-  private boolean categorySet = false;
-  private boolean tenantIdSet = false;
-  private boolean formKeySet = false;
+  private boolean ownerSet;
+  private boolean assigneeSet;
+  private boolean delegationStateSet;
+  private boolean nameSet;
+  private boolean descriptionSet;
+  private boolean duedateSet;
+  private boolean prioritySet;
+  private boolean parentTaskIdSet;
+  private boolean categorySet;
+  private boolean tenantIdSet;
+  private boolean formKeySet;
   
   public String getOwner() {
     return owner;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/api/jpa/BaseJPARestTestCase.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/api/jpa/BaseJPARestTestCase.java
@@ -400,7 +400,7 @@ public class BaseJPARestTestCase extends PvmTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
     public InteruptTask(Thread thread) {
       this.thread = thread;

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/BaseSpringRestTestCase.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/BaseSpringRestTestCase.java
@@ -459,7 +459,7 @@ public class BaseSpringRestTestCase extends PvmTestCase {
   }
 
   private static class InteruptTask extends TimerTask {
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
     public InteruptTask(Thread thread) {
       this.thread = thread;

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/conversion/script/PropertyReference.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/conversion/script/PropertyReference.java
@@ -41,7 +41,7 @@ public class PropertyReference {
   
 	protected String propertyName;
 	protected String additionalProperties;
-	protected boolean isPrefixed = false;
+	protected boolean isPrefixed;
 	
 	public PropertyReference(String propertyName) {
 		this(propertyName, null);

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2AssociationSource.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2AssociationSource.java
@@ -23,9 +23,9 @@ public class M2AssociationSource {
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
 	private String role;
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean mandatory = false;
+	private boolean mandatory;
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean many = false;
+	private boolean many;
 
 	public String getRole() {
 		return role;

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2AssociationTarget.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2AssociationTarget.java
@@ -26,9 +26,9 @@ public class M2AssociationTarget {
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
 	private String role;
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean mandatory = false;
+	private boolean mandatory;
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean many = false;
+	private boolean many;
 
 	public String getClassName() {
 		return className;

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Mandatory.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Mandatory.java
@@ -25,7 +25,7 @@ public class M2Mandatory {
 	private Boolean enforced;
 	
 	@XmlValue
-	private boolean mandatory = false;
+	private boolean mandatory;
 	
 	public M2Mandatory() {
 		

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Model.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Model.java
@@ -33,13 +33,13 @@ import javax.xml.bind.annotation.XmlType;
 public class M2Model {
 
 	@XmlAttribute
-	private String name = null;
+	private String name;
 	
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private String description = null;
+	private String description;
 	
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private String author = null;
+	private String author;
 	
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")	
 	private String version;

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2NamedValue.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2NamedValue.java
@@ -28,11 +28,11 @@ public class M2NamedValue {
 	private String name;
 	
 	@XmlElement(name="value", namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private String simpleValue = null;
+	private String simpleValue;
 	
 	@XmlElementWrapper(name="list", namespace="http://www.alfresco.org/model/dictionary/1.0")
 	@XmlElement(name="value", namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private List<String> listValue = null;
+	private List<String> listValue;
 
 	public M2NamedValue() {
   }

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Property.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/M2Property.java
@@ -40,10 +40,10 @@ public class M2Property {
 	private String propertyType;
 
 	@XmlElement(name="protected", namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean isProtected = false;
+	private boolean isProtected;
 	
 	@XmlElement(name="multiple", namespace="http://www.alfresco.org/model/dictionary/1.0")
-	private boolean multiValued = false;
+	private boolean multiValued;
 	
 	@XmlElement(namespace="http://www.alfresco.org/model/dictionary/1.0")
 	private M2Mandatory mandatory;

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/config/Form.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/model/config/Form.java
@@ -30,7 +30,7 @@ import javax.xml.bind.annotation.XmlTransient;
 public class Form
 {
 		@XmlTransient
-		private boolean startForm = false;
+		private boolean startForm;
 		
     @XmlElement(name="field-visibility")
     private FormFieldVisibility formFieldVisibility = new FormFieldVisibility();

--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/step/AlfrescoReviewStepDefinition.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/step/AlfrescoReviewStepDefinition.java
@@ -46,7 +46,7 @@ public class AlfrescoReviewStepDefinition extends AbstractStepDefinitionContaine
   protected HumanStepAssignmentType assignmentType = HumanStepAssignmentType.USER;
   protected FormDefinition form;
   protected String requiredApprovalCount;
-  protected boolean endProcessOnReject = false;
+  protected boolean endProcessOnReject;
   
   protected String name;
   protected String description;

--- a/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/definition/form/DatePropertyDefinition.java
+++ b/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/definition/form/DatePropertyDefinition.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("date")
 public class DatePropertyDefinition extends FormPropertyDefinition {
 	
-	protected boolean showTime = false;
+	protected boolean showTime;
 	
 	/**
 	 * Creates a new field, showing both time and date components.

--- a/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/definition/form/TextPropertyDefinition.java
+++ b/modules/activiti-simple-workflow/src/main/java/org/activiti/workflow/simple/definition/form/TextPropertyDefinition.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 @JsonTypeName("text")
 public class TextPropertyDefinition extends FormPropertyDefinition {
 	
-	protected boolean multiline = false;
+	protected boolean multiline;
 
 	/**
 	 * Creates a single-lined text-property.

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
@@ -10,7 +10,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ActivitiProperties {
 
   private boolean checkProcessDefinitions = true;
-  private boolean jobExecutorActivate = false;
+  private boolean jobExecutorActivate;
   private boolean asyncExecutorEnabled = true;
   private boolean asyncExecutorActivate = true;
   private boolean restApiEnabled;

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/SpringProcessEngineConfiguration.java
@@ -50,7 +50,7 @@ public class SpringProcessEngineConfiguration extends ProcessEngineConfiguration
     protected Resource[] deploymentResources = new Resource[0];
     protected String deploymentMode = "default";
     protected ApplicationContext applicationContext;
-    protected Integer transactionSynchronizationAdapterOrder = null;
+    protected Integer transactionSynchronizationAdapterOrder;
     private Collection<AutoDeploymentStrategy> deploymentStrategies = new ArrayList<AutoDeploymentStrategy>();
 
     public SpringProcessEngineConfiguration() {

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/StatefulObject.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/StatefulObject.java
@@ -21,7 +21,7 @@ public class StatefulObject implements Serializable, InitializingBean {
     public static final long serialVersionUID = 1L;
 
     private String name;
-    private int visitedCount = 0;
+    private int visitedCount;
 
     private long customerId;
 


### PR DESCRIPTION
Remove redundant initialization of fields to null, false, or 0.  Ran "mvn -Pcheck clean install" and everything was clean.
