### PR TITLE
HouseKeeping: Fix the wrong order of arguments in the assertEquals

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/DatabaseEventLoggerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/DatabaseEventLoggerTest.java
@@ -102,7 +102,7 @@ public class DatabaseEventLoggerTest extends PluggableActivitiTestCase {
 			if (i == 1) {
 				
 				assertNotNull(entry.getType());
-				assertEquals(entry.getType(), "PROCESSINSTANCE_START");
+				assertEquals("PROCESSINSTANCE_START", entry.getType());
 				assertNotNull(entry.getProcessDefinitionId());
 				assertNotNull(entry.getProcessInstanceId());
 				assertNotNull(entry.getTimeStamp());
@@ -385,7 +385,7 @@ public class DatabaseEventLoggerTest extends PluggableActivitiTestCase {
 				
 			if (i == 14) {
 				assertNotNull(entry.getType());
-				assertEquals(entry.getType(), "PROCESSINSTANCE_END");
+				assertEquals("PROCESSINSTANCE_END", entry.getType());
 				assertNotNull(entry.getProcessDefinitionId());
 				assertNotNull(entry.getProcessInstanceId());
 				assertNotNull(entry.getTimeStamp());
@@ -449,7 +449,7 @@ public class DatabaseEventLoggerTest extends PluggableActivitiTestCase {
 			
 			// process instance start
 			if (i == 1) {
-				assertEquals(entry.getType(), "PROCESSINSTANCE_START");
+				assertEquals("PROCESSINSTANCE_START", entry.getType());
 				Map<String, Object> data = objectMapper.readValue(entry.getData(), new TypeReference<HashMap<String, Object>>(){});
 				assertNull(data.get(Fields.TENANT_ID));
 			}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/JobQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/JobQueryTest.java
@@ -276,7 +276,7 @@ public class JobQueryTest extends PluggableActivitiTestCase {
     assertNotNull(job);
     
     List<Job> list = managementService.createJobQuery().withException().list();
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
     
     deleteJobInDatabase();
     
@@ -287,7 +287,7 @@ public class JobQueryTest extends PluggableActivitiTestCase {
     assertNotNull(job);
     
     list = managementService.createJobQuery().withException().list();
-    assertEquals(list.size(), 1);
+    assertEquals(1, list.size());
     
     deleteJobInDatabase();
     

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -75,8 +75,8 @@ public class TaskDueDateExtensionsTest extends PluggableActivitiTestCase {
     
     assertNotNull(task.getDueDate());
     Period period = new Period(task.getCreateTime().getTime(), task.getDueDate().getTime());
-    assertEquals(period.getDays(), 2);
-    assertEquals(period.getHours(), 5);
-    assertEquals(period.getMinutes(), 40);
+    assertEquals(2, period.getDays());
+    assertEquals(5, period.getHours());
+    assertEquals(40, period.getMinutes());
   }
 }

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/management/JobResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/management/JobResourceTest.java
@@ -51,7 +51,7 @@ public class JobResourceTest extends BaseSpringRestTestCase {
     assertEquals(timerJob.getProcessInstanceId(), responseNode.get("processInstanceId").textValue());
     assertEquals(timerJob.getRetries(), responseNode.get("retries").intValue());
     assertEquals(timerJob.getDuedate(), getDateFromISOString(responseNode.get("dueDate").textValue()));
-    assertEquals(responseNode.get("tenantId").textValue(), "");
+    assertEquals("", responseNode.get("tenantId").textValue());
     
     // Set tenant on deployment
     managementService.executeCommand(new ChangeDeploymentTenantIdCmd(deploymentId, "myTenant"));

--- a/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
+++ b/modules/activiti-rest/src/test/java/org/activiti/rest/service/api/runtime/ProcessInstanceCollectionResourceTest.java
@@ -85,7 +85,7 @@ public class ProcessInstanceCollectionResourceTest extends BaseSpringRestTestCas
     assertEquals(1, variableNodes.size());
     
     variableNodes = dataNode.get("variables");
-    assertEquals(variableNodes.size(), 1);
+    assertEquals(1, variableNodes.size());
     assertNotNull(variableNodes.get(0).get("name"));
     assertNotNull(variableNodes.get(0).get("value"));
    

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/test/java/org/activiti/spring/boot/ProcessEngineAutoConfigurationTest.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/test/java/org/activiti/spring/boot/ProcessEngineAutoConfigurationTest.java
@@ -48,7 +48,7 @@ public class ProcessEngineAutoConfigurationTest {
         Assert.assertNotNull(processDefinitionList);
         Assert.assertTrue(!processDefinitionList.isEmpty());
         ProcessDefinition processDefinition = processDefinitionList.iterator().next();
-        Assert.assertEquals(processDefinition.getKey(), "waiter");
+        Assert.assertEquals("waiter", processDefinition.getKey());
     }
 
     private AnnotationConfigApplicationContext context(Class<?>... clzz) {

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/test/java/org/activiti/spring/boot/SecurityAutoConfigurationTest.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/test/java/org/activiti/spring/boot/SecurityAutoConfigurationTest.java
@@ -36,8 +36,8 @@ public class SecurityAutoConfigurationTest {
         this.applicationContext.refresh();
         UserDetailsService userDetailsService = this.applicationContext.getBean(UserDetailsService.class);
         Assert.assertNotNull("the userDetailsService should not be null", userDetailsService);
-        assertEquals("there should only be 1 authority", userDetailsService.loadUserByUsername("jlong").getAuthorities().size(), 1);
-        assertEquals("there should be 2 authorities", userDetailsService.loadUserByUsername("jbarrez").getAuthorities().size(), 2);
+        assertEquals("there should only be 1 authority", 1, userDetailsService.loadUserByUsername("jlong").getAuthorities().size());
+        assertEquals("there should be 2 authorities", 2, userDetailsService.loadUserByUsername("jbarrez").getAuthorities().size());
     }
 
     @Configuration

--- a/modules/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/ProcessScopeTestEngine.java
+++ b/modules/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/ProcessScopeTestEngine.java
@@ -43,20 +43,20 @@ class ProcessScopeTestEngine {
         StatefulObject scopedObject = (StatefulObject) runtimeService.getVariable(processInstance.getId(), statefulObjectVariableKey);
         assertNotNull(scopedObject);
         assertTrue(StringUtils.hasText(scopedObject.getName()));
-        assertEquals(scopedObject.getVisitedCount(), 2);
+        assertEquals(2, scopedObject.getVisitedCount());
 
         // the process has paused
         String procId = processInstance.getProcessInstanceId();
 
         List<Task> tasks = taskService.createTaskQuery().executionId(procId).list();
-        assertEquals(tasks.size(), 1);
+        assertEquals(1, tasks.size());
 
         Task t = tasks.iterator().next();
         this.taskService.claim(t.getId(), "me");
         this.taskService.complete(t.getId());
 
         scopedObject = (StatefulObject) runtimeService.getVariable(processInstance.getId(), statefulObjectVariableKey);
-        assertEquals(scopedObject.getVisitedCount(), 3);
+        assertEquals(3, scopedObject.getVisitedCount());
 
         assertEquals(customerId, scopedObject.getCustomerId());
         return scopedObject;


### PR DESCRIPTION
Fix the wrong order in the assertEquals is indeed misleading especially when the default assert fails message is generated.  This change puts the constant/expected value as the first argument in the assert.   

Ran "mvn -Pcheck clean install" and everything was clean.
