### PR TITLE
Refactor to support customized FormTypes with extra information

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/DateFormType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/DateFormType.java
@@ -16,31 +16,31 @@ package org.activiti.engine.impl.form;
 import java.text.Format;
 import java.text.ParseException;
 
+import org.activiti.bpmn.model.FormProperty;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.form.AbstractFormType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.FastDateFormat;
 
-
 /**
  * @author Tom Baeyens
  */
-public class DateFormType extends AbstractFormType {
-  
+public class DateFormType extends AbstractFormType implements FormTypeSupport<DateFormType> {
+
   private static final long serialVersionUID = 1L;
-  
-  protected String datePattern; 
-  protected Format dateFormat; 
+
+  protected String datePattern;
+  protected Format dateFormat;
 
   public DateFormType(String datePattern) {
     this.datePattern = datePattern;
     this.dateFormat = FastDateFormat.getInstance(datePattern);
   }
-  
+
   public String getName() {
     return "date";
   }
-  
+
   public Object getInformation(String key) {
     if ("datePattern".equals(key)) {
       return datePattern;
@@ -55,7 +55,7 @@ public class DateFormType extends AbstractFormType {
     try {
       return dateFormat.parseObject(propertyValue);
     } catch (ParseException e) {
-      throw new ActivitiIllegalArgumentException("invalid date value "+propertyValue);
+      throw new ActivitiIllegalArgumentException("invalid date value " + propertyValue);
     }
   }
 
@@ -65,4 +65,13 @@ public class DateFormType extends AbstractFormType {
     }
     return dateFormat.format(modelValue);
   }
+
+  public DateFormType newInstance(FormProperty formProperty) {
+    String datePattern = formProperty.getDatePattern();
+    if (StringUtils.isEmpty(datePattern)) {
+      return null;
+    }
+    return new DateFormType(datePattern);
+  }
+
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/EnumFormType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/EnumFormType.java
@@ -13,17 +13,19 @@
 
 package org.activiti.engine.impl.form;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.activiti.bpmn.model.FormProperty;
+import org.activiti.bpmn.model.FormValue;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.form.AbstractFormType;
-
 
 /**
  * @author Tom Baeyens
  */
-public class EnumFormType extends AbstractFormType {
-	
+public class EnumFormType extends AbstractFormType implements FormTypeSupport<EnumFormType> {
+
   private static final long serialVersionUID = 1L;
 
   protected Map<String, String> values;
@@ -35,7 +37,7 @@ public class EnumFormType extends AbstractFormType {
   public String getName() {
     return "enum";
   }
-  
+
   @Override
   public Object getInformation(String key) {
     if (key.equals("values")) {
@@ -52,18 +54,28 @@ public class EnumFormType extends AbstractFormType {
 
   @Override
   public String convertModelValueToFormValue(Object modelValue) {
-    if(modelValue != null) {
-      if(!(modelValue instanceof String)) {
+    if (modelValue != null) {
+      if (!(modelValue instanceof String)) {
         throw new ActivitiIllegalArgumentException("Model value should be a String");
       }
       validateValue((String) modelValue);
     }
     return (String) modelValue;
   }
-  
+
+  public EnumFormType newInstance(FormProperty formProperty) {
+    // ACT-1023: Using LinkedHashMap to preserve the order in which the entries
+    // are defined
+    Map<String, String> values = new LinkedHashMap<String, String>();
+    for (FormValue formValue : formProperty.getFormValues()) {
+      values.put(formValue.getId(), formValue.getName());
+    }
+    return new EnumFormType(values);
+  }
+
   protected void validateValue(String value) {
-    if(value != null) {
-      if(values != null && !values.containsKey(value)) {
+    if (value != null) {
+      if (values != null && !values.containsKey(value)) {
         throw new ActivitiIllegalArgumentException("Invalid value for enum form property: " + value);
       }
     }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/FormTypeSupport.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/form/FormTypeSupport.java
@@ -1,0 +1,12 @@
+package org.activiti.engine.impl.form;
+
+import org.activiti.bpmn.model.FormProperty;
+import org.activiti.engine.form.FormType;
+
+public interface FormTypeSupport<T extends FormType> {
+
+  String CONSTRUCTOR_WITH_FORM_PROPERTY = "newInstance";
+
+  T newInstance(FormProperty formProperty);
+
+}


### PR DESCRIPTION
Some FormTypes (e.g. DateFormType and EnumFormType) need to populate extra information (DatePattern and EnumValues). However, the FormTypes checks the name of FormType with hard code. This is inconvenient if the user want to add a new customized FormType with extra information.

I've refactored the FormTypes to eliminate the hard code checking of FormType name and moved the logic of processing extra information to DateFormType and EnumFormType.
