### PR TITLE
Update of joda-time library (from 2.1 to 2.6) to support timezone changes.

### DIFF
--- a/modules/activiti-osgi/src/test/java/org/activiti/osgi/blueprint/BlueprintBasicTest.java
+++ b/modules/activiti-osgi/src/test/java/org/activiti/osgi/blueprint/BlueprintBasicTest.java
@@ -89,7 +89,7 @@ public class BlueprintBasicTest {
         mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-databind").version("2.2.3"),
         mavenBundle().groupId("com.fasterxml.jackson.core").artifactId("jackson-annotations").version("2.2.3"),
         mavenBundle().groupId("log4j").artifactId("log4j").version("1.2.17"),
-        mavenBundle().groupId("joda-time").artifactId("joda-time").version("2.1"),
+        mavenBundle().groupId("joda-time").artifactId("joda-time").version("2.6"),
         mavenBundle().groupId("com.h2database").artifactId("h2").version("1.3.176"),
         mavenBundle().groupId("org.mybatis").artifactId("mybatis").version("3.2.5"),
         mavenBundle().groupId("org.slf4j").artifactId("slf4j-api").version("1.7.6"),

--- a/pom.xml
+++ b/pom.xml
@@ -498,7 +498,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.1</version>
+        <version>2.6</version>
       </dependency>
       <!-- Activiti Modeler -->
       <dependency>

--- a/userguide/src/en/ch02-GettingStarted.adoc
+++ b/userguide/src/en/ch02-GettingStarted.adoc
@@ -98,7 +98,7 @@ org.activiti:activiti-engine:jar:5.17.0
 +- org.mybatis:mybatis:jar:3.2.5:compile
 +- org.springframework:spring-beans:jar:4.0.6.RELEASE:compile
 |  \- org.springframework:spring-core:jar:4.0.6.RELEASE:compile
-+- joda-time:joda-time:jar:2.1:compile
++- joda-time:joda-time:jar:2.6:compile
 +- org.slf4j:slf4j-api:jar:1.7.6:compile
 +- org.slf4j:jcl-over-slf4j:jar:1.7.6:compile
 ----


### PR DESCRIPTION
This is _joda-time_ library upgrade, since we have experienced a problem with running some of your tests, that depends on old joda-time. More precisely, _TimeExpressionTest_. The cause is in time zones changes from 2.1 joda-time release. This is not cirtical, because we just can exclude the lib with maven _exclude_ directive and push the new one, but, I suppose it's better to have the fresh one.
