### PR TITLE
enables StringStreamSource.getInputStream() return a byte array in given charset

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/io/StringStreamSource.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/io/StringStreamSource.java
@@ -14,6 +14,7 @@ package org.activiti.engine.impl.util.io;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 
 
 /**
@@ -22,13 +23,26 @@ import java.io.InputStream;
 public class StringStreamSource implements StreamSource {
   
   String string;
+  String byteArrayEncoding="utf-8";
   
   public StringStreamSource(String string) {
-    this.string = string;
-  }
+	    this.string = string;
+	  }
+
+  public StringStreamSource(String string, String byteArrayEncoding) {
+	    this.string = string;
+	    this.byteArrayEncoding = byteArrayEncoding;
+	  }
 
   public InputStream getInputStream() {
-    return new ByteArrayInputStream(string.getBytes());
+    try
+	{
+		return new ByteArrayInputStream(byteArrayEncoding == null ? string.getBytes() : string.getBytes(byteArrayEncoding));
+	}
+	catch (UnsupportedEncodingException e)
+	{
+		throw new RuntimeException(e);
+	}
   }
 
   public String toString() {


### PR DESCRIPTION
When users attempt to parse a 'UTF-8'-encoded BPMN file (while the locale charset is not set as 'UTF-8') using following codes:

		String fileContent = IOUtils.readStringAndClose(new InputStreamReader(new FileInputStream(modelFile), "utf-8"), (int) modelFile.length());
		BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(new StringStreamSource(fileContent), false, false); 

the result bpmnModel is wrong because properties of all model elements are parsed in locale charset, Chinese 'gb2312' for example.

 I think this error is caused by that StringStreamSource.getInputStream() returns a byte array stream using locale charset encoding, and that is why I add a new two-arguments constructor for StringStreamSource class.

Now, codes could be written as below:

		BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(new StringStreamSource(fileContent, "utf-8"), false, false); 
