### PR TITLE
Move to Spring Boot 1.2.1 and Spring Framework 4.1

### DIFF
--- a/modules/activiti-spring-boot/pom.xml
+++ b/modules/activiti-spring-boot/pom.xml
@@ -27,7 +27,7 @@
             org.activiti.spring.boot
         </activiti.artifact>
 
-        <spring.boot.version>1.1.6.RELEASE</spring.boot.version>
+        <spring.boot.version>1.2.1.RELEASE</spring.boot.version>
         <!--<spring.framework.version>${spring.framework.version}</spring.framework.version>-->
 
     </properties>

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-actuator/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-actuator/src/main/java/activiti/Application.java
@@ -8,16 +8,18 @@ import org.activiti.engine.TaskService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * Demonstrates the actuator
+ * Demonstrates the Activiti Actuator endpoints
+ * available <a href="http://localhost:8080/activiti/processes/waiter">on localhost</a>
+ * where, in this case, {@code waiter} is the name of the process definition.
+ *
  */
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
+@SpringBootApplication
 public class Application {
 
     @Bean

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-basic/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-basic/src/main/java/activiti/Application.java
@@ -3,24 +3,20 @@ package activiti;
 import org.activiti.engine.RuntimeService;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.transaction.PlatformTransactionManager;
 
 import java.util.Collections;
 
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
+/**
+ *
+ */
+@SpringBootApplication
 public class Application {
 
-     //  establish that it's detected the processes and that we can deploy one.
+    //  establish that it's detected the processes and that we can deploy one.
     @Bean
-    CommandLineRunner basics(
-            final PlatformTransactionManager platformTransactionManager,
-            final RuntimeService runtimeService) {
+    CommandLineRunner basics(final RuntimeService runtimeService) {
         return new CommandLineRunner() {
             @Override
             public void run(String... strings) throws Exception {

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-integration/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-integration/src/main/java/activiti/Application.java
@@ -7,10 +7,8 @@ import org.activiti.spring.integration.ActivitiInboundGateway;
 import org.activiti.spring.integration.IntegrationActivityBehavior;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.support.GenericHandler;
@@ -20,10 +18,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-@Configuration
-@EnableAutoConfiguration
-@ComponentScan
+@SpringBootApplication
 public class Application {
+
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
@@ -44,6 +41,7 @@ public class Application {
     }
 
     public static class AnalysingService {
+
         private final AtomicReference<String> stringAtomicReference
                 = new AtomicReference<String>();
 
@@ -86,7 +84,6 @@ public class Application {
 
 
                 System.out.println("projectId=" + analysingService.getStringAtomicReference().get());
-
 
             }
         };

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-jpa/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-jpa/src/main/java/activiti/Application.java
@@ -8,10 +8,8 @@ import org.activiti.engine.task.Task;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,13 +19,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.util.*;
 
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
+@SpringBootApplication
 public class Application {
-    public static void main(String args[]) {
-        SpringApplication.run(Application.class, args);
-    }
 
     @Bean
     CommandLineRunner init(final PhotoService photoService) {
@@ -38,6 +31,10 @@ public class Application {
             }
         };
 
+    }
+
+    public static void main(String args[]) {
+        SpringApplication.run(Application.class, args);
     }
 }
 

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/main/java/activiti/Application.java
@@ -4,26 +4,23 @@ package activiti;
 import org.activiti.engine.IdentityService;
 import org.activiti.engine.identity.Group;
 import org.activiti.engine.identity.User;
-import org.springframework.boot.CommandLineRunner;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 
 /**
- * Demonstrates the REST API
+ * Demonstrates the <A href="http://localhost:8080/">REST API</A>
  */
-@Configuration
-@ComponentScan
-@EnableAutoConfiguration
+@SpringBootApplication
 public class Application {
-    @Bean
-    CommandLineRunner seedUsersAndGroups(final IdentityService identityService) {
-        return new CommandLineRunner() {
-            @Override
-            public void run(String... strings) throws Exception {
 
+    @Bean
+    InitializingBean usersAndGroupsInitializer(final IdentityService identityService) {
+
+        return new InitializingBean() {
+            @Override
+            public void afterPropertiesSet() throws Exception {
 
                 // install groups & users
                 Group group = identityService.newGroup("user");

--- a/modules/activiti-spring-boot/spring-boot-starters/pom.xml
+++ b/modules/activiti-spring-boot/spring-boot-starters/pom.xml
@@ -13,7 +13,7 @@
 
     <packaging>pom</packaging>
     <properties>
-        <spring-integration-java-dsl.version>1.0.0.M3</spring-integration-java-dsl.version>
+        <spring-integration-java-dsl.version>1.0.0.RELEASE</spring-integration-java-dsl.version>
     </properties>
     <modules>
         <module>spring-boot-starter-basic</module>

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/pom.xml
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/pom.xml
@@ -21,6 +21,13 @@
 
 
     <dependencies>
+        <!-- Support for auto-completion support in Boot 1.2 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
         <!-- common -->
         <dependency>
             <groupId>org.activiti</groupId>

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/pom.xml
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/pom.xml
@@ -10,6 +10,14 @@
     </parent>
 
     <artifactId>spring-boot-starter-basic</artifactId>
+<!--
+
+    <properties>
+        <spring.framework.version>4.1.4.RELEASE</spring.framework.version>
+    </properties>
+
+-->
+
 
 
     <dependencies>
@@ -21,6 +29,7 @@
         <dependency>
             <groupId>org.activiti</groupId>
             <artifactId>activiti-spring</artifactId>
+
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
@@ -43,19 +43,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ConditionalOnClass(name = {"org.activiti.rest.service.api.RestUrls", "org.springframework.web.servlet.DispatcherServlet"})
 public class RestApiAutoConfiguration {
 
-  @Bean()
+  @Bean
   public RestResponseFactory restResponseFactory() {
     RestResponseFactory restResponseFactory = new RestResponseFactory();
     return restResponseFactory;
   }
 
-  @Bean()
+  @Bean
   public ContentTypeResolver contentTypeResolver() {
     ContentTypeResolver resolver = new DefaultContentTypeResolver();
     return resolver;
   }
   
-  @Bean()
+  @Bean
   public ObjectMapper objectMapper() {
     // To avoid instantiating and configuring the mapper everywhere
     ObjectMapper mapper = new ObjectMapper();

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <version>5.17.1-SNAPSHOT</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.framework.version>4.0.6.RELEASE</spring.framework.version>
+    <spring.framework.version>4.1.4.RELEASE</spring.framework.version>
     <spring.security.version>3.2.3.RELEASE</spring.security.version>
     <mule.version>3.5.0</mule.version>
     <cxf.version>2.6.14</cxf.version>
@@ -45,7 +45,7 @@
     <activiti.osgi.activator />
     <activiti.osgi.failok>false</activiti.osgi.failok>
     <activiti.osgi.export>${activiti.osgi.export.pkg};${activiti.osgi.version};-noimport:=true</activiti.osgi.export>
-    <!-- <activiti.osgi.export.pkg>!*.impl;${activiti.artifact}*</activiti.osgi.export.pkg> 
+    <!-- <activiti.osgi.export.pkg>!*.impl;${activiti.artifact}*</activiti.osgi.export.pkg>
       <activiti.osgi.private.pkg>${activiti.artifact}*.impl</activiti.osgi.private.pkg> -->
     <activiti.osgi.export.pkg>
       ${activiti.artifact}*,
@@ -695,7 +695,7 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>2.3.2</version>
         </plugin>
-        <!--This plugin's configuration is used to store Eclipse m2e settings 
+        <!--This plugin's configuration is used to store Eclipse m2e settings
           only. It has no influence on the Maven build itself. -->
         <plugin>
           <groupId>org.eclipse.m2e</groupId>
@@ -863,7 +863,7 @@
       </modules>
     </profile>
     <profile>
-      <!-- this profile prevents that tests are executed while running the 
+      <!-- this profile prevents that tests are executed while running the
         qa/build.xml test.demo.setup target -->
       <id>nodocs</id>
       <activation>
@@ -916,7 +916,7 @@
       </modules>
     </profile>
     <profile>
-      <!-- Profile used by the start-explorer.sh script to build the Explorer 
+      <!-- Profile used by the start-explorer.sh script to build the Explorer
         webapp and all its dependencies -->
       <id>buildWebappDependencies</id>
       <modules>
@@ -957,7 +957,7 @@
       </build>
     </profile>
     <profile>
-      <!-- Profile used by the start-rest.sh script to build the Explorer 
+      <!-- Profile used by the start-rest.sh script to build the Explorer
         webapp and all its dependencies -->
       <id>buildRestappDependencies</id>
       <modules>


### PR DESCRIPTION
This change is backwards compatible for Spring framework revisions. The samples are using features new in Spring Boot 1.2, but they're just samples.