### PR TITLE
fix creating processEngine with instance of ProcessEngineConfigurationIm...

### DIFF
--- a/modules/activiti-spring/src/main/java/org/activiti/spring/ProcessEngineFactoryBean.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/ProcessEngineFactoryBean.java
@@ -69,9 +69,11 @@ public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, Dis
     }
 
     protected void configureExternallyManagedTransactions() {
-        SpringProcessEngineConfiguration engineConfiguration = (SpringProcessEngineConfiguration) processEngineConfiguration;
-        if (engineConfiguration.getTransactionManager() != null) {
-            processEngineConfiguration.setTransactionsExternallyManaged(true);
+        if (processEngineConfiguration instanceof SpringProcessEngineConfiguration) { // remark: any config can be injected, so we cannot have SpringConfiguration as member
+            SpringProcessEngineConfiguration engineConfiguration = (SpringProcessEngineConfiguration) processEngineConfiguration;
+            if (engineConfiguration.getTransactionManager() != null) {
+                processEngineConfiguration.setTransactionsExternallyManaged(true);
+            }
         }
     }
 


### PR DESCRIPTION
I get an error trying to create engine bean using an instance of `org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration`, which is a descendant of  `org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl`, but has no transaction manager unlike `org.activiti.spring.SpringProcessEngineConfiguration`.

An error occurs in `org.activiti.spring.ProcessEngineFactoryBean` when it tries to cast configuration bean to `org.activiti.spring.SpringProcessEngineConfiguration`:

```
Caused by: java.lang.ClassCastException: org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration cannot be cast to org.activiti.spring.SpringProcessEngineConfiguration
at org.activiti.spring.ProcessEngineFactoryBean.configureExternallyManagedTransactions(ProcessEngineFactoryBean.java:72)
```

The same code works on previous versions of Activiti bacause of the appropriate type checking:

```java
public class ProcessEngineFactoryBean implements FactoryBean<ProcessEngine>, DisposableBean, ApplicationContextAware {
    // ...
    protected void initializeTransactionExternallyManaged() {
        if (processEngineConfiguration instanceof SpringProcessEngineConfiguration) { // remark: any config can be injected, so we cannot have SpringConfiguration as member
            SpringProcessEngineConfiguration engineConfiguration = (SpringProcessEngineConfiguration) processEngineConfiguration;
            if (engineConfiguration.getTransactionManager() != null) {
                processEngineConfiguration.setTransactionsExternallyManaged(true);
            }
        }
    }
    // ...
}
```

I hope, that check was not deleted intentionally, but removed accidently during refactoring [here](https://github.com/Activiti/Activiti/commit/93e45b8d3637c0f858a6dd751c34c966f59a0b56#diff-535b61785ec17bf42ecf9fc8864ad66fL68) when `initializeTransactionExternallyManaged()` was renamed to `configureExternallyManagedTransactions()`.

So, I want it to be there, to be able to use any  `ProcessEngineConfigurationImpl` (`StandaloneProcessEngineConfiguration` in my case).