### PR TITLE
Fix for #2198 & #2185

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
@@ -32,6 +32,7 @@ import org.activiti.engine.runtime.ProcessInstance;
 /**
  * @author Daniel Meyer
  * @author Joram Barrez
+ * @author Vasile Dirla
  */
 public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance> {
 
@@ -73,7 +74,13 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
     if (processDefinition == null) {
       throw new ActivitiObjectNotFoundException("No process definition found for id '" + processDefinitionId + "'", ProcessDefinition.class);
     }
-  
+
+    // Do not start process a process instance if the process definition is suspended
+    if (processDefinition.isSuspended()) {
+      throw new ActivitiException("Cannot start process instance. Process definition "
+          + processDefinition.getName() + " (id = " + processDefinition.getId() + ") is suspended");
+    }
+    
     ActivityImpl startActivity = processDefinition.findActivity(messageEventSubscription.getActivityId());
     ExecutionEntity processInstance = processDefinition.createProcessInstance(businessKey, startActivity);
 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -1,0 +1,151 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.bpmn.subprocess;
+
+import org.activiti.bpmn.converter.BpmnXMLConverter;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.impl.test.ResourceActivitiTestCase;
+import org.activiti.engine.impl.util.io.InputStreamSource;
+import org.activiti.engine.impl.util.io.StreamSource;
+import org.activiti.engine.repository.Deployment;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.runtime.ProcessInstance;
+
+import java.io.InputStream;
+import java.util.List;
+
+public class CallActivityTest extends ResourceActivitiTestCase {
+
+  private static String MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
+  private static String CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
+  private static String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
+
+  public CallActivityTest() {
+    super("org/activiti/standalone/parsing/encoding.activiti.cfg.xml");
+  }
+
+  public void testInstantiateProcessByMessage() throws Exception {
+    BpmnModel messageTriggeredBpmnModel = loadBPMNModel(MESSAGE_TRIGGERED_PROCESS_RESOURCE);
+
+    Deployment messageTriggeredBpmnDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("messageTriggeredProcessDeployment")
+        .addBpmnModel("messageTriggered.bpmn20.xml", messageTriggeredBpmnModel).deploy();
+
+    ProcessInstance childProcessInstance = runtimeService.startProcessInstanceByMessage("TRIGGER_PROCESS_MESSAGE");
+    assertNotNull(childProcessInstance);
+  }
+
+  public void testInstantiateSuspendedProcessByMessage() throws Exception {
+    BpmnModel messageTriggeredBpmnModel = loadBPMNModel(MESSAGE_TRIGGERED_PROCESS_RESOURCE);
+
+    Deployment messageTriggeredBpmnDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("messageTriggeredProcessDeployment")
+        .addBpmnModel("messageTriggered.bpmn20.xml", messageTriggeredBpmnModel).deploy();
+
+    suspendProcessDefinitions(messageTriggeredBpmnDeployment);
+
+    try {
+      ProcessInstance childProcessInstance = runtimeService.startProcessInstanceByMessage("TRIGGER_PROCESS_MESSAGE");
+      fail("Exception expected");
+    } catch (ActivitiException ae) {
+      assertTextPresent("Cannot start process instance. Process definition Message Triggered Process", ae.getMessage());
+    }
+
+  }
+
+  public void testInstantiateChildProcess() throws Exception {
+    BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
+
+    Deployment childDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("childProcessDeployment")
+        .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+
+    ProcessInstance childProcessInstance = runtimeService.startProcessInstanceByKey("childProcess");
+    assertNotNull(childProcessInstance);
+  }
+
+  public void testInstantiateSuspendedChildProcess() throws Exception {
+    BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
+
+    Deployment childDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("childProcessDeployment")
+        .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+
+    suspendProcessDefinitions(childDeployment);
+
+    try {
+      ProcessInstance childProcessInstance = runtimeService.startProcessInstanceByKey("childProcess");
+      fail("Exception expected");
+    } catch (ActivitiException ae) {
+      assertTextPresent("Cannot start process instance. Process definition Child Process", ae.getMessage());
+    }
+
+  }
+
+
+  public void testInstantiateSubprocess() throws Exception {
+    BpmnModel mainBpmnModel = loadBPMNModel(MAIN_PROCESS_RESOURCE);
+    BpmnModel childBpmnModel = loadBPMNModel(CHILD_PROCESS_RESOURCE);
+
+    Deployment childDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("childProcessDeployment")
+        .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+
+    Deployment masterDeployment = processEngine.getRepositoryService()
+        .createDeployment()
+        .name("masterProcessDeployment")
+        .addBpmnModel("masterProcess.bpmn20.xml", mainBpmnModel).deploy();
+
+    suspendProcessDefinitions(childDeployment);
+
+    try {
+      ProcessInstance masterProcessInstance = runtimeService.startProcessInstanceByKey("masterProcess");
+      fail("Exception expected");
+    } catch (ActivitiException ae) {
+      assertTextPresent("Cannot start process instance. Process definition Child Process", ae.getMessage());
+    }
+
+  }
+
+  private void suspendProcessDefinitions(Deployment childDeployment) {
+    List<ProcessDefinition> childProcessDefinitionList = repositoryService.createProcessDefinitionQuery().deploymentId(childDeployment.getId()).list();
+
+    for (ProcessDefinition processDefinition : childProcessDefinitionList) {
+      repositoryService.suspendProcessDefinitionById(processDefinition.getId());
+    }
+  }
+
+  protected void tearDown() throws Exception {
+    for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+      repositoryService.deleteDeployment(deployment.getId(), true);
+    }
+    super.tearDown();
+  }
+
+
+  protected BpmnModel loadBPMNModel(String bpmnModelFilePath) throws Exception {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream(bpmnModelFilePath);
+    StreamSource xmlSource = new InputStreamSource(xmlStream);
+    BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xmlSource, false, false, processEngineConfiguration.getXmlEncoding());
+    return bpmnModel;
+  }
+
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/ImportExportTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/ImportExportTest.java
@@ -1,0 +1,62 @@
+package org.activiti.engine.test.bpmn.usertask;
+
+import org.activiti.bpmn.converter.BpmnXMLConverter;
+import org.activiti.bpmn.model.*;
+import org.activiti.engine.impl.test.ResourceActivitiTestCase;
+import org.activiti.engine.impl.util.io.InputStreamSource;
+import org.activiti.engine.impl.util.io.StreamSource;
+import org.activiti.engine.runtime.Execution;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+/**
+ * Created by p3700487 on 23/02/15.
+ */
+public class ImportExportTest extends ResourceActivitiTestCase {
+
+    public ImportExportTest() {
+        super("org/activiti/standalone/parsing/encoding.activiti.cfg.xml");
+    }
+
+    public void testConvertXMLToModel() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        bpmnModel = exportAndReadXMLFile(bpmnModel);
+
+        byte[] xml = new BpmnXMLConverter().convertToXML(bpmnModel);
+
+        org.activiti.engine.repository.Deployment deployment = processEngine.getRepositoryService().createDeployment().name("test1").addString("test1.bpmn20.xml", new String(xml)).deploy();
+
+        String processInstanceKey = runtimeService.startProcessInstanceByKey("process").getId();
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstanceKey).messageEventSubscriptionName("InterruptMessage").singleResult();
+
+        assertNotNull(execution);
+    }
+
+    protected void tearDown() throws Exception {
+        for (org.activiti.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+            repositoryService.deleteDeployment(deployment.getId(), true);
+        }
+        super.tearDown();
+    }
+
+
+    protected String getResource() {
+        return "org/activiti/engine/test/bpmn/usertask/ImportExportTest.testImportExport.bpmn20.xml";
+    }
+
+    protected BpmnModel readXMLFile() throws Exception {
+        InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream(getResource());
+        StreamSource xmlSource = new InputStreamSource(xmlStream);
+        BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xmlSource, false, false, processEngineConfiguration.getXmlEncoding());
+        return bpmnModel;
+    }
+
+    protected BpmnModel exportAndReadXMLFile(BpmnModel bpmnModel) throws Exception {
+        byte[] xml = new BpmnXMLConverter().convertToXML(bpmnModel, processEngineConfiguration.getXmlEncoding());
+        StreamSource xmlSource = new InputStreamSource(new ByteArrayInputStream(xml));
+        BpmnModel parsedModel = new BpmnXMLConverter().convertToBpmnModel(xmlSource, false, false, processEngineConfiguration.getXmlEncoding());
+        return parsedModel;
+    }
+
+}

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.activiti.org/processdef">
+    <process id="childProcess" isExecutable="true" name="Child Process">
+        <startEvent id="sp_Start" name="Start"></startEvent>
+        <userTask id="sp_UserTask" name="User Task"></userTask>
+        <endEvent id="sp_Stop" name="Stop"></endEvent>
+        <sequenceFlow id="link1" name="link1" sourceRef="sp_Start" targetRef="sp_UserTask"></sequenceFlow>
+        <sequenceFlow id="link2" name="Link 2" sourceRef="sp_UserTask" targetRef="sp_Stop"></sequenceFlow>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+        <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+            <bpmndi:BPMNShape bpmnElement="sp_Start" id="BPMNShape_sp_Start">
+                <omgdc:Bounds height="30.0" width="30.0" x="180.0" y="123.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="sp_UserTask" id="BPMNShape_sp_UserTask">
+                <omgdc:Bounds height="80.0" width="100.0" x="331.5" y="98.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="sp_Stop" id="BPMNShape_sp_Stop">
+                <omgdc:Bounds height="28.0" width="28.0" x="570.0" y="124.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="link2" id="BPMNEdge_link2">
+                <omgdi:waypoint x="431.5" y="138.0"></omgdi:waypoint>
+                <omgdi:waypoint x="570.0" y="138.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="link1" id="BPMNEdge_link1">
+                <omgdi:waypoint x="210.0" y="138.0"></omgdi:waypoint>
+                <omgdi:waypoint x="331.5" y="138.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.activiti.org/processdef">
+    <message id="bMessageRef" name="bMessageRef"></message>
+    <process id="masterProcess" isExecutable="true" name="Mater Process">
+        <startEvent id="Start1" name="Nstart1"></startEvent>
+        <userTask id="ut" name="User Task"></userTask>
+        <callActivity id="subprocessCall" name="Call Subprocess" calledElement="childProcess"></callActivity>
+        <sequenceFlow id="s2sp" name="startToSp" sourceRef="Start1" targetRef="subprocessCall"></sequenceFlow>
+        <endEvent id="endNode" name="End Node"></endEvent>
+        <sequenceFlow id="ut2end" name="UserTask -&gt; End" sourceRef="ut" targetRef="endNode"></sequenceFlow>
+        <sequenceFlow id="sp2ut" name="SP to User Task" sourceRef="subprocessCall" targetRef="ut"></sequenceFlow>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+        <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+            <bpmndi:BPMNShape bpmnElement="Start1" id="BPMNShape_Start1">
+                <omgdc:Bounds height="30.0" width="30.0" x="180.0" y="161.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="ut" id="BPMNShape_ut">
+                <omgdc:Bounds height="80.0" width="100.0" x="630.0" y="136.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="subprocessCall" id="BPMNShape_subprocessCall">
+                <omgdc:Bounds height="80.0" width="100.0" x="375.0" y="136.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="endNode" id="BPMNShape_endNode">
+                <omgdc:Bounds height="28.0" width="28.0" x="900.0" y="162.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="s2sp" id="BPMNEdge_s2sp">
+                <omgdi:waypoint x="210.0" y="176.0"></omgdi:waypoint>
+                <omgdi:waypoint x="375.0" y="176.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="ut2end" id="BPMNEdge_ut2end">
+                <omgdi:waypoint x="730.0" y="176.0"></omgdi:waypoint>
+                <omgdi:waypoint x="900.0" y="176.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sp2ut" id="BPMNEdge_sp2ut">
+                <omgdi:waypoint x="475.0" y="176.0"></omgdi:waypoint>
+                <omgdi:waypoint x="630.0" y="176.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef">
+    <message id="TRIGGER_PROCESS_MESSAGE" name="TRIGGER_PROCESS_MESSAGE"></message>
+    <process id="process" isExecutable="true" name="Message Triggered Process">
+        <startEvent id="msgStart" name="Message Trigger">
+            <messageEventDefinition messageRef="TRIGGER_PROCESS_MESSAGE"></messageEventDefinition>
+        </startEvent>
+        <userTask id="userStep" name="userStep"></userTask>
+        <endEvent id="endNode" name="endNode"></endEvent>
+        <sequenceFlow id="link1" name="link1" sourceRef="msgStart" targetRef="userStep"></sequenceFlow>
+        <sequenceFlow id="link2" name="link2" sourceRef="userStep" targetRef="endNode"></sequenceFlow>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+        <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+            <bpmndi:BPMNShape bpmnElement="msgStart" id="BPMNShape_msgStart">
+                <omgdc:Bounds height="30.0" width="30.5" x="341.25" y="136.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="userStep" id="BPMNShape_userStep">
+                <omgdc:Bounds height="80.0" width="100.0" x="465.0" y="111.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="endNode" id="BPMNShape_endNode">
+                <omgdc:Bounds height="28.0" width="28.0" x="675.0" y="137.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="link2" id="BPMNEdge_link2">
+                <omgdi:waypoint x="565.0" y="151.0"></omgdi:waypoint>
+                <omgdi:waypoint x="675.0" y="151.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="link1" id="BPMNEdge_link1">
+                <omgdi:waypoint x="372.25" y="151.0"></omgdi:waypoint>
+                <omgdi:waypoint x="465.0" y="151.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/ImportExportTest.testImportExport.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/ImportExportTest.testImportExport.bpmn20.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef">
+    <message id="InterruptMessage" name="InterruptMessage"></message>
+    <process id="process" isExecutable="true">
+        
+        <boundaryEvent id="MessageEvent1" name="MessageEvent1" cancelActivity="false" attachedToRef="userTask1">
+            <messageEventDefinition messageRef="InterruptMessage"></messageEventDefinition>
+        </boundaryEvent>
+        
+        <userTask id="userTask1" name="userTask1"></userTask>
+        <sequenceFlow id="sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D" sourceRef="MessageEvent1" targetRef="userTask1"></sequenceFlow>
+        <endEvent id="endElement" name="endElement"></endEvent>
+        <sequenceFlow id="sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326" sourceRef="userTask1" targetRef="endElement"></sequenceFlow>
+        <startEvent id="startEvent" name="StartEvent1"></startEvent>
+        <sequenceFlow id="sid-73CD596D-48C3-4324-BC07-14EBD34653A8" sourceRef="startEvent" targetRef="userTask1"></sequenceFlow>
+    </process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+        <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+            <bpmndi:BPMNShape bpmnElement="MessageEvent1" id="BPMNShape_MessageEvent1">
+                <omgdc:Bounds height="30.0" width="30.0" x="611.1111093123427" y="555.5555539203116"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+                <omgdc:Bounds height="80.0" width="100.0" x="645.0" y="380.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="endElement" id="BPMNShape_endElement">
+                <omgdc:Bounds height="28.0" width="28.0" x="900.0" y="406.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+                <omgdc:Bounds height="30.0" width="30.0" x="273.888888038562" y="365.2469124610132"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326" id="BPMNEdge_sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326">
+                <omgdi:waypoint x="745.0" y="420.0"></omgdi:waypoint>
+                <omgdi:waypoint x="900.0" y="420.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D" id="BPMNEdge_sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D">
+                <omgdi:waypoint x="632.3522634374735" y="556.9156127479179"></omgdi:waypoint>
+                <omgdi:waypoint x="676.6974162974765" y="460.0"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sid-73CD596D-48C3-4324-BC07-14EBD34653A8" id="BPMNEdge_sid-73CD596D-48C3-4324-BC07-14EBD34653A8">
+                <omgdi:waypoint x="303.8175360889286" y="381.7082363088603"></omgdi:waypoint>
+                <omgdi:waypoint x="645.0" y="415.10563902733577"></omgdi:waypoint>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/ImportExportTest.testImportExport.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/ImportExportTest.testImportExport.bpmn20.xml
@@ -2,43 +2,46 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef">
     <message id="InterruptMessage" name="InterruptMessage"></message>
     <process id="process" isExecutable="true">
-        
-        <boundaryEvent id="MessageEvent1" name="MessageEvent1" cancelActivity="false" attachedToRef="userTask1">
+        <startEvent id="start1" name="Start 1"></startEvent>
+        <userTask id="userTask1" name="User Task"></userTask>
+        <sequenceFlow id="sid-0A7A4470-CF60-467E-BB33-8601B5C48600" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+        <endEvent id="stop1" name="Stop 1"></endEvent>
+        <sequenceFlow id="sid-D3A13A9C-D68D-4460-A4E1-20487B8BE030" sourceRef="userTask1" targetRef="stop1"></sequenceFlow>
+        <boundaryEvent id="bm1" name="Boundary Message1" attachedToRef="userTask1" cancelActivity="false">
             <messageEventDefinition messageRef="InterruptMessage"></messageEventDefinition>
         </boundaryEvent>
-        
-        <userTask id="userTask1" name="userTask1"></userTask>
-        <sequenceFlow id="sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D" sourceRef="MessageEvent1" targetRef="userTask1"></sequenceFlow>
-        <endEvent id="endElement" name="endElement"></endEvent>
-        <sequenceFlow id="sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326" sourceRef="userTask1" targetRef="endElement"></sequenceFlow>
-        <startEvent id="startEvent" name="StartEvent1"></startEvent>
-        <sequenceFlow id="sid-73CD596D-48C3-4324-BC07-14EBD34653A8" sourceRef="startEvent" targetRef="userTask1"></sequenceFlow>
+        <endEvent id="stop2" name="Stop 2"></endEvent>
+        <sequenceFlow id="sid-0CDD0039-66F8-4BFF-9E7B-A2610FDB5CE0" sourceRef="bm1" targetRef="stop2"></sequenceFlow>
     </process>
     <bpmndi:BPMNDiagram id="BPMNDiagram_process">
         <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
-            <bpmndi:BPMNShape bpmnElement="MessageEvent1" id="BPMNShape_MessageEvent1">
-                <omgdc:Bounds height="30.0" width="30.0" x="611.1111093123427" y="555.5555539203116"></omgdc:Bounds>
+            <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+                <omgdc:Bounds height="30.0" width="30.0" x="158.5" y="114.0"></omgdc:Bounds>
             </bpmndi:BPMNShape>
             <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
-                <omgdc:Bounds height="80.0" width="100.0" x="645.0" y="380.0"></omgdc:Bounds>
+                <omgdc:Bounds height="80.0" width="100.0" x="233.5" y="89.0"></omgdc:Bounds>
             </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="endElement" id="BPMNShape_endElement">
-                <omgdc:Bounds height="28.0" width="28.0" x="900.0" y="406.0"></omgdc:Bounds>
+            <bpmndi:BPMNShape bpmnElement="stop1" id="BPMNShape_stop1">
+                <omgdc:Bounds height="28.0" width="28.0" x="378.5" y="115.0"></omgdc:Bounds>
             </bpmndi:BPMNShape>
-            <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
-                <omgdc:Bounds height="30.0" width="30.0" x="273.888888038562" y="365.2469124610132"></omgdc:Bounds>
+            <bpmndi:BPMNShape bpmnElement="bm1" id="BPMNShape_bm1">
+                <omgdc:Bounds height="30.0" width="30.0" x="282.0145920238293" y="154.54377607148803"></omgdc:Bounds>
             </bpmndi:BPMNShape>
-            <bpmndi:BPMNEdge bpmnElement="sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326" id="BPMNEdge_sid-7E4FAE23-9053-4D5C-99FC-9E15532DD326">
-                <omgdi:waypoint x="745.0" y="420.0"></omgdi:waypoint>
-                <omgdi:waypoint x="900.0" y="420.0"></omgdi:waypoint>
+            <bpmndi:BPMNShape bpmnElement="stop2" id="BPMNShape_stop2">
+                <omgdc:Bounds height="28.0" width="28.0" x="378.5" y="300.0"></omgdc:Bounds>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sid-0CDD0039-66F8-4BFF-9E7B-A2610FDB5CE0" id="BPMNEdge_sid-0CDD0039-66F8-4BFF-9E7B-A2610FDB5CE0">
+                <omgdi:waypoint x="297.0145920238293" y="184.54377607148803"></omgdi:waypoint>
+                <omgdi:waypoint x="297.0145920238293" y="314.0"></omgdi:waypoint>
+                <omgdi:waypoint x="378.5" y="314.0"></omgdi:waypoint>
             </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D" id="BPMNEdge_sid-33A8C195-DD0A-48B5-88D5-3BD44A896E8D">
-                <omgdi:waypoint x="632.3522634374735" y="556.9156127479179"></omgdi:waypoint>
-                <omgdi:waypoint x="676.6974162974765" y="460.0"></omgdi:waypoint>
+            <bpmndi:BPMNEdge bpmnElement="sid-D3A13A9C-D68D-4460-A4E1-20487B8BE030" id="BPMNEdge_sid-D3A13A9C-D68D-4460-A4E1-20487B8BE030">
+                <omgdi:waypoint x="333.5" y="129.0"></omgdi:waypoint>
+                <omgdi:waypoint x="378.5" y="129.0"></omgdi:waypoint>
             </bpmndi:BPMNEdge>
-            <bpmndi:BPMNEdge bpmnElement="sid-73CD596D-48C3-4324-BC07-14EBD34653A8" id="BPMNEdge_sid-73CD596D-48C3-4324-BC07-14EBD34653A8">
-                <omgdi:waypoint x="303.8175360889286" y="381.7082363088603"></omgdi:waypoint>
-                <omgdi:waypoint x="645.0" y="415.10563902733577"></omgdi:waypoint>
+            <bpmndi:BPMNEdge bpmnElement="sid-0A7A4470-CF60-467E-BB33-8601B5C48600" id="BPMNEdge_sid-0A7A4470-CF60-467E-BB33-8601B5C48600">
+                <omgdi:waypoint x="188.5" y="129.0"></omgdi:waypoint>
+                <omgdi:waypoint x="233.5" y="129.0"></omgdi:waypoint>
             </bpmndi:BPMNEdge>
         </bpmndi:BPMNPlane>
     </bpmndi:BPMNDiagram>

--- a/modules/activiti-explorer/src/main/java/org/activiti/editor/ui/ImportUploadReceiver.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/editor/ui/ImportUploadReceiver.java
@@ -88,12 +88,11 @@ public class ImportUploadReceiver implements Receiver, FinishedListener, ModelDa
       try {
         if (fileName.endsWith(".bpmn20.xml") || fileName.endsWith(".bpmn")) {
           validFile = true;
-          BpmnXMLConverter xmlConverter = new BpmnXMLConverter();
+            
           XMLInputFactory xif = XmlUtil.createSafeXmlInputFactory();
           InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(outputStream.toByteArray()), "UTF-8");
           XMLStreamReader xtr = xif.createXMLStreamReader(in);
           BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
-          xmlConverter.convertToBpmnModel(xtr);
           
           if (bpmnModel.getMainProcess() == null || bpmnModel.getMainProcess().getId() == null) {
             notificationManager.showErrorNotification(Messages.MODEL_IMPORT_FAILED, 

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
@@ -89,6 +89,11 @@ public interface StencilConstants {
   final String PROPERTY_TIMER_DATE = "timerdatedefinition";
   final String PROPERTY_TIMER_CYCLE = "timercycledefinition";
 
+  final String PROPERTY_MESSAGES = "messages";
+  final String PROPERTY_MESSAGE_ID = "message_id";
+  final String PROPERTY_MESSAGE_NAME = "message_name";
+  final String PROPERTY_MESSAGE_ITEM_REF = "message_item_ref";
+
   final String PROPERTY_MESSAGEREF = "messageref";
 
   final String PROPERTY_SIGNALREF = "signalref";

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BoundaryEventJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BoundaryEventJsonConverter.java
@@ -101,39 +101,36 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
             convertJsonToMessageDefinition(elementNode, boundaryEvent);
             boundaryEvent.setCancelActivity(getPropertyValueAsBoolean(PROPERTY_CANCEL_ACTIVITY, elementNode));
         }
-        boundaryEvent.setAttachedToRefId(lookForAttachedRef(elementNode.get(EDITOR_SHAPE_ID).asText(), modelNode.get(EDITOR_CHILD_SHAPES)));
+        boundaryEvent.setAttachedToRefId(lookForAttachedRef(elementNode, modelNode.get(EDITOR_CHILD_SHAPES)));
         return boundaryEvent;
     }
 
-    private String lookForAttachedRef(String boundaryEventId, JsonNode childShapesNode) {
+    private String lookForAttachedRef(JsonNode boundaryEventNode, JsonNode childShapesNode) {
         String attachedRefId = null;
-
+        
+        ArrayNode boundaryEventOutgoings = (ArrayNode) boundaryEventNode.get("outgoing");
+        
+        if (boundaryEventOutgoings==null || boundaryEventOutgoings.size()==0) return null;
+        
         if (childShapesNode != null) {
-
-            for (JsonNode childNode : childShapesNode) {
-                ArrayNode outgoingNode = (ArrayNode) childNode.get("outgoing");
-                if (outgoingNode != null && outgoingNode.size() > 0) {
-                    for (JsonNode outgoingChildNode : outgoingNode) {
-                        JsonNode resourceNode = outgoingChildNode.get(EDITOR_SHAPE_ID);
-                        if (resourceNode != null && boundaryEventId.equals(resourceNode.asText())) {
-                            attachedRefId = BpmnJsonConverterUtil.getElementId(childNode);
-                            break;
+            for (JsonNode outgoingCandidateNode : boundaryEventOutgoings) {
+                String outgoingCandidateId = BpmnJsonConverterUtil.getElementId(outgoingCandidateNode);
+                for (JsonNode globalNode : childShapesNode) {
+                    String nodeIdInGlobal = BpmnJsonConverterUtil.getElementId(globalNode);
+                   
+                    if(nodeIdInGlobal.equalsIgnoreCase(outgoingCandidateId)){//found the first level outgoing (The arrow)
+                        ArrayNode outgoingNextNodes = (ArrayNode) globalNode.get("outgoing");
+                        for (JsonNode outgoingCandidateNextNode : outgoingNextNodes) {
+                            attachedRefId = BpmnJsonConverterUtil.getElementId(outgoingCandidateNextNode);
+                            if (attachedRefId!=null) return attachedRefId; //found the second level outgoing (the target)
                         }
                     }
-
-                    if (attachedRefId != null) {
-                        break;
-                    }
+                    
                 }
 
-                attachedRefId = lookForAttachedRef(boundaryEventId, childNode.get(EDITOR_CHILD_SHAPES));
-
-                if (attachedRefId != null) {
-                    break;
-                }
             }
         }
-
-        return attachedRefId;
+      return attachedRefId;
     }
+    
 }

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BoundaryEventJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BoundaryEventJsonConverter.java
@@ -101,41 +101,39 @@ public class BoundaryEventJsonConverter extends BaseBpmnJsonConverter {
             convertJsonToMessageDefinition(elementNode, boundaryEvent);
             boundaryEvent.setCancelActivity(getPropertyValueAsBoolean(PROPERTY_CANCEL_ACTIVITY, elementNode));
         }
-      boundaryEvent.setAttachedToRefId(lookForAttachedRef(elementNode.get(EDITOR_SHAPE_ID).asText(), modelNode.get(EDITOR_CHILD_SHAPES)));
-
-      return boundaryEvent;
+        boundaryEvent.setAttachedToRefId(lookForAttachedRef(elementNode.get(EDITOR_SHAPE_ID).asText(), modelNode.get(EDITOR_CHILD_SHAPES)));
+        return boundaryEvent;
     }
 
-  private String lookForAttachedRef(String boundaryEventId, JsonNode childShapesNode) {
-    String attachedRefId = null;
+    private String lookForAttachedRef(String boundaryEventId, JsonNode childShapesNode) {
+        String attachedRefId = null;
 
-    if (childShapesNode != null) {
+        if (childShapesNode != null) {
 
-      for (JsonNode childNode : childShapesNode) {
+            for (JsonNode childNode : childShapesNode) {
+                ArrayNode outgoingNode = (ArrayNode) childNode.get("outgoing");
+                if (outgoingNode != null && outgoingNode.size() > 0) {
+                    for (JsonNode outgoingChildNode : outgoingNode) {
+                        JsonNode resourceNode = outgoingChildNode.get(EDITOR_SHAPE_ID);
+                        if (resourceNode != null && boundaryEventId.equals(resourceNode.asText())) {
+                            attachedRefId = BpmnJsonConverterUtil.getElementId(childNode);
+                            break;
+                        }
+                    }
 
-        ArrayNode outgoingNode = (ArrayNode) childNode.get("outgoing");
-        if (outgoingNode != null && outgoingNode.size() > 0) {
-          for (JsonNode outgoingChildNode : outgoingNode) {
-            JsonNode resourceNode = outgoingChildNode.get(EDITOR_SHAPE_ID);
-            if (resourceNode != null && boundaryEventId.equals(resourceNode.asText())) {
-              attachedRefId = BpmnJsonConverterUtil.getElementId(childNode);
-              break;
+                    if (attachedRefId != null) {
+                        break;
+                    }
+                }
+
+                attachedRefId = lookForAttachedRef(boundaryEventId, childNode.get(EDITOR_CHILD_SHAPES));
+
+                if (attachedRefId != null) {
+                    break;
+                }
             }
-          }
-
-          if (attachedRefId != null) {
-            break;
-          }
         }
 
-        attachedRefId = lookForAttachedRef(boundaryEventId, childNode.get(EDITOR_CHILD_SHAPES));
-
-        if (attachedRefId != null) {
-          break;
-        }
-      }
+        return attachedRefId;
     }
-
-    return attachedRefId;
-  }
 }

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BpmnJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BpmnJsonConverter.java
@@ -234,7 +234,12 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
         if (mainProcess.isExecutable() == false) {
           propertiesNode.put(PROPERTY_PROCESS_EXECUTABLE, "No");
         }
-        
+        if (StringUtils.isNoneEmpty(model.getTargetNamespace())){
+            propertiesNode.put(PROPERTY_PROCESS_NAMESPACE, model.getTargetNamespace());
+        }
+
+        BpmnJsonConverterUtil.convertMessagesToJson(model.getMessages(), propertiesNode);
+
         BpmnJsonConverterUtil.convertListenersToJson(mainProcess.getExecutionListeners(), true, propertiesNode);
         BpmnJsonConverterUtil.convertEventListenersToJson(mainProcess.getEventListeners(), propertiesNode);
         
@@ -477,7 +482,10 @@ public class BpmnJsonConverter implements EditorJsonConstants, StencilConstants,
             if (processExecutableNode != null && StringUtils.isNotEmpty(processExecutableNode.asText())) {
               process.setExecutable(JsonConverterUtil.getPropertyValueAsBoolean(PROPERTY_PROCESS_EXECUTABLE, modelNode));
             }
-            
+
+            BpmnJsonConverterUtil.convertJsonToMessages(modelNode,bpmnModel);
+
+
             BpmnJsonConverterUtil.convertJsonToListeners(modelNode, process);
             JsonNode eventListenersNode = BpmnJsonConverterUtil.getProperty(PROPERTY_EVENT_LISTENERS, modelNode);
             if (eventListenersNode != null) {

--- a/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/BoundaryEventConverterTest.java
+++ b/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/BoundaryEventConverterTest.java
@@ -39,22 +39,26 @@ public class BoundaryEventConverterTest extends AbstractConverterTest {
     ErrorEventDefinition errorEvent = (ErrorEventDefinition)extractEventDefinition(errorElement);
     assertTrue(errorElement.isCancelActivity()); //always true
     assertEquals("errorRef", errorEvent.getErrorCode());
-    
+    assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+
     BoundaryEvent signalElement = (BoundaryEvent)model.getMainProcess().getFlowElement("signalEvent");
     SignalEventDefinition signalEvent = (SignalEventDefinition)extractEventDefinition(signalElement);
     assertFalse(signalElement.isCancelActivity());
     assertEquals("signalRef", signalEvent.getSignalRef());
-    
+    assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+
     BoundaryEvent messageElement = (BoundaryEvent)model.getMainProcess().getFlowElement("messageEvent");
     MessageEventDefinition messageEvent = (MessageEventDefinition)extractEventDefinition(messageElement);
     assertFalse(messageElement.isCancelActivity());
     assertEquals("messageRef", messageEvent.getMessageRef());
-    
+    assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+
     BoundaryEvent timerElement = (BoundaryEvent)model.getMainProcess().getFlowElement("timerEvent");
     TimerEventDefinition timerEvent = (TimerEventDefinition)extractEventDefinition(timerElement);
     assertFalse(timerElement.isCancelActivity());
     assertEquals("PT5M", timerEvent.getTimeDuration());
-    
+    assertEquals("sid-F21E9F4D-EA19-44DF-B1D3-14663A809CAE", errorElement.getAttachedToRefId());
+
   }
   
 }


### PR DESCRIPTION
- fixed the namespace issue after exporting the model
- fixed the targetNamespace -- after the exporting the model also the targetNamespace was wrong (it was always set to http://activiti.org/test)
- for a BoundaryEvent the "attachedToRef" attribute was not correctly calculated after the model was imported -> edited -> updated -> exported (if fact it was null but it is supposed to be required)