### PR TITLE
Match getLogger() classname parameter to actual classname

### DIFF
--- a/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/ScriptEventHandler.java
+++ b/modules/activiti-crystalball/src/main/java/org/activiti/crystalball/simulator/impl/ScriptEventHandler.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ScriptEventHandler implements SimulationEventHandler {
 
-  private static Logger log = LoggerFactory.getLogger(StartProcessByIdEventHandler.class);
+  private static Logger log = LoggerFactory.getLogger(ScriptEventHandler.class);
 
   protected String scriptPropertyName;
   protected String language;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/concurrency/CompetingJobAcquisitionTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/concurrency/CompetingJobAcquisitionTest.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CompetingJobAcquisitionTest extends PluggableActivitiTestCase {
 
-  private static Logger log = LoggerFactory.getLogger(CompetingSignalsTest.class);
+  private static Logger log = LoggerFactory.getLogger(CompetingJobAcquisitionTest.class);
   
   Thread testThread = Thread.currentThread();
   static ControllableThread activeThread;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/concurrency/CompetingJoinTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/concurrency/CompetingJoinTest.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CompetingJoinTest extends PluggableActivitiTestCase {
 
-  private static Logger log = LoggerFactory.getLogger(CompetingSignalsTest.class);
+  private static Logger log = LoggerFactory.getLogger(CompetingJoinTest.class);
   
   Thread testThread = Thread.currentThread();
   static ControllableThread activeThread;


### PR DESCRIPTION
Seeing pull request #540, I wrote a quick script to look for cases for other cases where the getLogger() classname did not match the name of the file.  The script found 3 occurrences.