### PR TITLE
Refactor setting variables into a method to allow for a subclass to over...

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
@@ -43,10 +43,7 @@ public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior imp
     }
 
     // initialize the template-defined data objects as variables
-    Map<String, Object> dataObjectVars = ((ActivityImpl) activity).getVariables();
-    if (dataObjectVars != null) {
-      execution.setVariablesLocal(dataObjectVars);
-    }
+    initializeDataObjects(execution, activity);
 
     execution.executeActivity(initialActivity);
   }
@@ -63,4 +60,11 @@ public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior imp
     bpmnActivityBehavior.performDefaultOutgoingBehavior(execution);
   }
 
+  protected void initializeDataObjects(ActivityExecution execution, PvmActivity activity)
+  {
+    Map<String, Object> dataObjectVars = ((ActivityImpl) activity).getVariables();
+    if (dataObjectVars != null) {
+      execution.setVariablesLocal(dataObjectVars);
+    }
+  }
 }


### PR DESCRIPTION
...ride.

Justification: Our custom extensions support attributes for process variables (DataObjects). For our use case the attributes need to be set prior to executing the activity in addition to after the variables have been created since we have database referential integrity between the extension table and the ACT_RU_VARIABLE table. 