### PR TITLE
Fix empty of enum form property of model created by Activiti modeler

### DIFF
--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -520,6 +520,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
                                 for (JsonNode enumNode : enumValuesNode) {
                                     if (enumNode.get("value") != null && enumNode.get("value").isNull() == false) {
                                         FormValue formValue = new FormValue();
+                                        formValue.setId(enumNode.get("value").asText());
                                         formValue.setName(enumNode.get("value").asText());
                                         formValueList.add(formValue);
                                     }


### PR DESCRIPTION
According to my issue:
http://jira.codehaus.org/browse/ACT-2220

I have found the way to workaround with it.  Hope it helps.

Generally, Activiti modeler stores enum type form property in JSON as:
"enumValues":[ { "value":"yes", "$$hashKey":"0RN" }, { "value":"no", "$$hashKey":"0RO" }]

However, when deploy a model (i.e. converting a model from JSON to BPMN20.xml), we need to add nodes of value with id and name attributes, otherwise when start the process the combo box will be empty. For example:

\<activiti:formProperty id="approved" name="approved" type="enum"\>
\<activiti:value id="yes" name="yes"\>\</activiti:value\>
\<activiti:value id="no" name="no"\>\</activiti:value\>
\</activiti:formProperty\>

At the moment, in activiti-json-converter module, the call of setter of formValue for id was missing, so I added it. However, since Activiti modeler only store value for enum type (not id, nor name), so I just set id to value. 

In the next version of Activiti modeler, we perhaps need to change the way to define the enum with id and name instead of just value.