### PR TITLE
UserGuide: Fixed Call Activity super process example image

### DIFF
--- a/userguide/src/en/ch07b-BPMN-Constructs.adoc
+++ b/userguide/src/en/ch07b-BPMN-Constructs.adoc
@@ -4591,7 +4591,7 @@ So in the end z = y+5 = x+5+5
 
 The following process diagram shows a simple handling of an order. Since the checking of the customer's credit could be common to many other processes, the _check credit step_ is modeled here as a call activity.
 
-image::images/image::images/bpmn.conditional.sequence.flow.png[align="center"][align="center"]Ω
+image::images/bpmn.call.activity.super.process.png[align="center"]
 
 The process looks as follows:
 


### PR DESCRIPTION
Call Activity super process image for credit check example was not displaying correctly, nor was it linking to the correct image.  

Corrected link syntax and found correct image file.