### PR TITLE
ACT-2217 - JPAEntityScanner fix - Method.isBridge() check in getIdMethod

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityScanner.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityScanner.java
@@ -71,7 +71,7 @@ public class JPAEntityScanner {
     Id idAnnotation = null;
     for(Method method : methods) {
       idAnnotation = method.getAnnotation(Id.class);
-      if(idAnnotation != null) {
+      if(idAnnotation != null && !method.isBridge()) {
         idMethod = method;
         break;
       }


### PR DESCRIPTION
Fix to address the issue described in ACT-2217:

JPAEntityScanner.getIdMethod() cannot cope with the case where the annotated @Id method overrides a generic method in the superclass.

In this case, Class.getMethods() will return both the declared method with the declared return type and a bridge method with a return type of the upper bounds from the generic class.

The fix involves adding a check on Method.isBridge() to ensure the method is not a bridge method.