### PR TITLE
Conditional BoundaryTimer dueDate - based on NULL duration expression support.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -258,14 +258,15 @@ public class BpmnDeployer implements Deployer {
     if (timerDeclarations!=null) {
       for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
         TimerEntity timer = timerDeclaration.prepareTimerEntity(null);
-        timer.setProcessDefinitionId(processDefinition.getId());
-        
-        // Inherit timer (if appliccable)
-        if (processDefinition.getTenantId() != null) {
-        	timer.setTenantId(processDefinition.getTenantId());
+        if(timer!=null){
+	      timer.setProcessDefinitionId(processDefinition.getId());
+	        
+	      // Inherit timer (if appliccable)
+	      if (processDefinition.getTenantId() != null) {
+	      	timer.setTenantId(processDefinition.getTenantId());
+	      }
+          timers.add(timer);
         }
-        
-        timers.add(timer);
       }
     }
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -349,10 +349,12 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
     if (timerDeclarations!=null) {
       for (TimerDeclarationImpl timerDeclaration : timerDeclarations) {
         TimerEntity timer = timerDeclaration.prepareTimerEntity(this);
-        Context
-          .getCommandContext()
-          .getJobEntityManager()
-          .schedule(timer);        
+        if(timer!=null){
+          Context
+            .getCommandContext()
+            .getJobEntityManager()
+            .schedule(timer);
+        }
       }
     }
     

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -125,6 +125,31 @@ public class BoundaryTimerEventTest extends PluggableActivitiTestCase {
     assertProcessEnded(pi.getId());
   }
   
+
+  @Deployment
+  public void testNullExpressionOnTimer(){
+	  
+    HashMap<String, Object> variables = new HashMap<String, Object>();
+    variables.put("duration", null);
+    
+    // After process start, there should be a timer created
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("testNullExpressionOnTimer", variables);
+
+    //NO job scheduled as null expression set
+    JobQuery jobQuery = managementService.createJobQuery().processInstanceId(pi.getId());
+    List<Job> jobs = jobQuery.list();
+    assertEquals(0, jobs.size());
+
+    // which means the process is still running waiting for human task input.
+    ProcessInstance processInstance = processEngine
+    	      .getRuntimeService()
+    	      .createProcessInstanceQuery()
+    	      .processInstanceId(pi.getId())
+    	      .singleResult();
+    assertNotNull(processInstance);
+  }
+  
+  
   @Deployment
   public void testTimerInSingleTransactionProcess() {
     // make sure that if a PI completes in single transaction, JobEntities associated with the execution are deleted.

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testNullExpressionOnTimer.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testNullExpressionOnTimer.bpmn20.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="Examples" id="definitions">
+  <process id="testNullExpressionOnTimer" isExecutable="true">
+    <startEvent id="theStart"></startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="task"></sequenceFlow>
+    <userTask id="task" name="Task rigged with timer"></userTask>
+    <sequenceFlow id="flow2" sourceRef="task" targetRef="theEnd"></sequenceFlow>
+    <boundaryEvent id="boundaryTimer" attachedToRef="task" cancelActivity="true">
+      <extensionElements>
+        <activiti:executionListener event="start" class="org.activiti.engine.test.bpmn.event.timer.BoundaryTimerEventTest$MyExecutionListener"></activiti:executionListener>
+        <activiti:executionListener event="end" class="org.activiti.engine.test.bpmn.event.timer.BoundaryTimerEventTest$MyExecutionListener"></activiti:executionListener>
+      </extensionElements>
+      <timerEventDefinition>
+        <timeDuration>${duration}</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="flow3" sourceRef="boundaryTimer" targetRef="theEnd"></sequenceFlow>
+    <endEvent id="theEnd"></endEvent>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_testNullExpressionOnTimer">
+    <bpmndi:BPMNPlane bpmnElement="testNullExpressionOnTimer" id="BPMNPlane_testNullExpressionOnTimer">
+      <bpmndi:BPMNShape bpmnElement="theStart" id="BPMNShape_theStart">
+        <omgdc:Bounds height="35.0" width="35.0" x="0.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="task" id="BPMNShape_task">
+        <omgdc:Bounds height="60.0" width="100.0" x="80.0" y="0.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="boundaryTimer" id="BPMNShape_boundaryTimer">
+        <omgdc:Bounds height="30.0" width="30.0" x="145.0" y="45.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="theEnd" id="BPMNShape_theEnd">
+        <omgdc:Bounds height="35.0" width="35.0" x="230.0" y="15.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="35.0" y="32.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="42.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="80.0" y="30.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="180.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="192.0" y="30.0"></omgdi:waypoint>
+        <omgdi:waypoint x="230.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="160.0" y="75.0"></omgdi:waypoint>
+        <omgdi:waypoint x="160.0" y="85.0"></omgdi:waypoint>
+        <omgdi:waypoint x="245.0" y="85.0"></omgdi:waypoint>
+        <omgdi:waypoint x="245.0" y="55.0"></omgdi:waypoint>
+        <omgdi:waypoint x="265.0" y="32.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
This allows schedule *or not* a BoundaryTimer Job, depending on dueDate execution variable value.
Null value  expression (dueDate or ISO duration) is supported; if NULL - BoundaryTimer ignored.