### PR TITLE
Remove dependence of GroupEntity on SaveGroupCmd command

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/IdentityServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/IdentityServiceImpl.java
@@ -58,7 +58,7 @@ public class IdentityServiceImpl extends ServiceImpl implements IdentityService 
   }
 
   public void saveGroup(Group group) {
-    commandExecutor.execute(new SaveGroupCmd((GroupEntity) group));
+    commandExecutor.execute(new SaveGroupCmd(group));
   }
 
   public void saveUser(User user) {


### PR DESCRIPTION
The saveGroup method of the IdentityServiceImpl class executes the SaveGroupCmd command with the GroupEntity implementation. This forces inherit from GroupEntity instead of implement directly from the "Group" interface.