### PR TITLE
Json variable type

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -154,7 +154,15 @@
       <version>2.1.3</version>
       <scope>test</scope>
     </dependency>
-    
+
+    <!-- Required for native JSON ssupport -->    
+    <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.2</version>
+      <optional>true</optional>
+    </dependency>
+
   </dependencies>
   
   <properties>

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -204,6 +204,7 @@ import org.activiti.engine.impl.variable.EntityManagerSessionFactory;
 import org.activiti.engine.impl.variable.IntegerType;
 import org.activiti.engine.impl.variable.JPAEntityListVariableType;
 import org.activiti.engine.impl.variable.JPAEntityVariableType;
+import org.activiti.engine.impl.variable.JsonType;
 import org.activiti.engine.impl.variable.LongStringType;
 import org.activiti.engine.impl.variable.LongType;
 import org.activiti.engine.impl.variable.NullType;
@@ -1260,6 +1261,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       variableTypes.addType(new DateType());
       variableTypes.addType(new DoubleType());
       variableTypes.addType(new UUIDType());
+      variableTypes.addType(new JsonType(4001));
       variableTypes.addType(new ByteArrayType());
       variableTypes.addType(new SerializableType());
       variableTypes.addType(new CustomObjectType("item", ItemInstance.class));

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -38,6 +38,7 @@ import org.activiti.engine.impl.db.PersistentObject;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.jobexecutor.AsyncContinuationJobHandler;
 import org.activiti.engine.impl.jobexecutor.TimerDeclarationImpl;
+import org.activiti.engine.impl.persistence.entity.json.JsonVariableScopeImpl;
 import org.activiti.engine.impl.pvm.PvmActivity;
 import org.activiti.engine.impl.pvm.PvmException;
 import org.activiti.engine.impl.pvm.PvmExecution;
@@ -71,7 +72,7 @@ import org.slf4j.LoggerFactory;
  * @author Saeid Mirzaei
  */
 
-public class ExecutionEntity extends VariableScopeImpl implements ActivityExecution, ExecutionListenerExecution, Execution, PvmExecution, 
+public class ExecutionEntity extends JsonVariableScopeImpl implements ActivityExecution, ExecutionListenerExecution, Execution, PvmExecution,
 	ProcessInstance, InterpretableExecution, PersistentObject, HasRevision {
 
   private static final long serialVersionUID = 1L;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -13,6 +13,7 @@
 package org.activiti.engine.impl.persistence.entity;
 
 import java.io.Serializable;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,6 +31,9 @@ import org.activiti.engine.impl.javax.el.ELContext;
 import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.impl.variable.VariableTypes;
 
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
 
 
 /**
@@ -37,6 +41,7 @@ import org.activiti.engine.impl.variable.VariableTypes;
  * @author Joram Barrez
  * @author Tijs Rademakers
  * @author Saeid Mirzaei
+ * @author Tim Stephenson
  */
 public abstract class VariableScopeImpl implements Serializable, VariableScope {
   
@@ -143,7 +148,13 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
   public Object getVariable(String variableName) {
     return getVariable(variableName, true);
   }
-  
+
+  public JsonObject getJsonVariable(String variableName) {
+    String var = (String) getVariable(variableName, true);
+    JsonReader jsonReader = Json.createReader(new StringReader(var));
+    return jsonReader.readObject();
+  }
+
   /**
    * The same operation as {@link VariableScopeImpl#getVariable(String)}, but with
    * an extra parameter to indicate whether or not all variables need to be fetched.

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/json/JsonVariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/json/JsonVariableScopeImpl.java
@@ -1,0 +1,35 @@
+package org.activiti.engine.impl.persistence.entity.json;
+
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.persistence.entity.VariableScopeImpl;
+import org.activiti.engine.impl.variable.JsonType;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import java.io.StringReader;
+import java.util.Map;
+
+/**
+ * @author Tim Stephenson.
+ */
+public abstract class JsonVariableScopeImpl extends VariableScopeImpl {
+  @Override
+  protected void setVariable(String variableName, Object value, ExecutionEntity sourceActivityExecution, boolean fetchAllVariables) {
+    if (JsonType.appearsToBeJson(value)) {
+      super.setVariable(variableName, JsonType.parse((String) value), sourceActivityExecution, fetchAllVariables);
+    } else {
+      super.setVariable(variableName, value, sourceActivityExecution, fetchAllVariables);
+    }
+  }
+
+  @Override
+  public Object setVariableLocal(String variableName, Object value, ExecutionEntity sourceActivityExecution, boolean fetchAllVariables) {
+    if (JsonType.appearsToBeJson(value)) {
+      return super.setVariableLocal(variableName, JsonType.parse((String) value), sourceActivityExecution, fetchAllVariables);
+    } else {
+      return super.setVariableLocal(variableName, value, sourceActivityExecution, fetchAllVariables);
+    }
+  }
+
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
@@ -14,8 +14,6 @@ package org.activiti.engine.impl.variable;
 
 
 import org.activiti.engine.impl.persistence.entity.json.JsonVariableScopeImpl;
-import sun.org.mozilla.javascript.Context;
-import sun.org.mozilla.javascript.EvaluatorException;
 
 import javax.json.*;
 import java.io.StringReader;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
@@ -1,0 +1,77 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.variable;
+
+
+import org.activiti.engine.impl.persistence.entity.json.JsonVariableScopeImpl;
+import sun.org.mozilla.javascript.Context;
+import sun.org.mozilla.javascript.EvaluatorException;
+
+import javax.json.*;
+import java.io.StringReader;
+import java.io.StringWriter;
+
+/**
+ * @author Tim Stephenson
+ */
+public class JsonType extends StringType implements VariableType {
+
+  public JsonType(int maxLength) {super(maxLength);}
+
+  public String getTypeName() {
+    return "json";
+  }
+
+  public Object getValue(ValueFields valueFields) {
+    return parse(valueFields.getTextValue());
+  }
+
+  public void setValue(Object value, ValueFields valueFields) {
+    valueFields.setTextValue(stringify((JsonStructure) value));
+    valueFields.setCachedValue(valueFields.getTextValue());
+  }
+
+  public boolean isAbleToStore(Object value) {
+    if (value instanceof JsonStructure || (super.isAbleToStore(value) && appearsToBeJson(value))) {
+      return true;
+    }
+    return false;
+  }
+
+  public static JsonObject toObject(String value) {
+    JsonReader jsonReader = Json.createReader(new StringReader((String) value));
+    return jsonReader.readObject();
+  }
+
+
+  public static JsonArray toArray(String value) {
+    JsonReader jsonReader = Json.createReader(new StringReader((String) value));
+    return jsonReader.readArray();
+  }
+
+  public static boolean appearsToBeJson(Object value) {
+    return value instanceof String && (value.toString().trim().startsWith("{") || value.toString().trim().startsWith("["));
+  }
+
+  public static JsonStructure parse(String value) {
+    return value.trim().startsWith("[") ? toArray(value) : toObject(value);
+  }
+
+  public String stringify(JsonStructure value) {
+    StringWriter sw = new StringWriter();
+    JsonWriter jsonWriter = Json.createWriter(sw);
+    jsonWriter.write(value);
+    jsonWriter.close();
+    return sw.toString();
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JsonType.java
@@ -66,6 +66,8 @@ public class JsonType extends StringType implements VariableType {
   }
 
   public String stringify(JsonStructure value) {
+    if (value == null)
+      return null;
     StringWriter sw = new StringWriter();
     JsonWriter jsonWriter = Json.createWriter(sw);
     jsonWriter.write(value);

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/json/JsonTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/json/JsonTest.java
@@ -1,0 +1,136 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.json;
+
+import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Tim Stephenson
+ */
+public class JsonTest extends PluggableActivitiTestCase {
+  
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+  
+  @Deployment
+  public void testJsonObjectAvailable() {
+    Map<String, Object> vars = new HashMap<String, Object>();
+   
+    vars.put("myJsonObj", "{\"var\":\"myValue\"}");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJsonAvailableProcess", vars);
+    
+    // Check JSON has been parsed as expected
+    JsonObject value = (JsonObject) runtimeService.getVariable(processInstance.getId(), "myJsonObj");
+    assertNotNull(value);
+    assertEquals("myValue", value.getString("var"));
+
+//    JsonObjectBuilder builder= Json.createObjectBuilder();
+//    value.put("var2",builder.add("var2", "myOtherValue").build());
+    runtimeService.setVariable(processInstance.getId(), "myJsonObj", "{\"var\":\"myValue\",\"var2\":\"myOtherValue\"}");
+
+    // Check JSON has been updated as expected
+    value = (JsonObject) runtimeService.getVariable(processInstance.getId(), "myJsonObj");
+    assertNotNull(value);
+    assertEquals("myValue", value.getString("var"));
+    assertEquals("myOtherValue", value.getString("var2"));
+
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+    assertNotNull(task);
+    vars.put("myJsonObj", "{\"var\":\"myValue\",\"var2\":\"myOtherValue\", \"var3\":\"myThirdValue\"}");
+    taskService.complete(task.getId(), vars);
+    value = (JsonObject) runtimeService.getVariable(processInstance.getId(), "myJsonObj");
+    assertNotNull(value);
+    assertEquals("myValue", value.getString("var"));
+    assertEquals("myOtherValue", value.getString("var2"));
+    assertEquals("myThirdValue", value.getString("var3"));
+
+    task = taskService.createTaskQuery().active().singleResult();
+    assertNotNull(task);
+    assertEquals("userTaskSuccess", task.getTaskDefinitionKey());
+
+//    HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+//        .processInstanceId(processInstance.getProcessInstanceId()).finished().singleResult();
+//    assertNotNull(historicProcessInstance);
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
+        .processInstanceId(processInstance.getProcessInstanceId()).singleResult();
+    value = (JsonObject) historicVariableInstance.getValue();
+    assertNotNull(value);
+    assertEquals("myValue", value.getString("var"));
+    assertEquals("myOtherValue", value.getString("var2"));
+    assertEquals("myThirdValue", value.getString("var3"));
+  }
+
+  @Deployment
+  public void testJsonArrayAvailable() {
+    Map<String, Object> vars = new HashMap<String, Object>();
+
+    vars.put("myJsonArr", "[{\"var\":\"myValue\"}]");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testJsonAvailableProcess", vars);
+
+    // Check JSON has been parsed as expected
+    JsonArray value = (JsonArray) runtimeService.getVariable(processInstance.getId(), "myJsonArr");
+    assertNotNull(value);
+    assertEquals("myValue", value.getJsonObject(0).getString("var"));
+
+    runtimeService.setVariable(processInstance.getId(), "myJsonArr",
+        "[{\"var\":\"myValue\"},{\"var\":\"myOtherValue\"}]");
+
+    // Check JSON has been updated as expected
+    value = (JsonArray) runtimeService.getVariable(processInstance.getId(), "myJsonArr");
+    assertNotNull(value);
+    assertEquals("myValue", value.getJsonObject(0).getString("var"));
+    assertEquals("myOtherValue", value.getJsonObject(1).getString("var"));
+
+
+    Task task = taskService.createTaskQuery().active().singleResult();
+    assertNotNull(task);
+    vars.put("myJsonArr", "[{\"var\":\"myValue\"},{\"var\":\"myOtherValue\"},{\"var\":\"myThirdValue\"}]");
+    taskService.complete(task.getId(), vars);
+    value = (JsonArray) runtimeService.getVariable(processInstance.getId(), "myJsonArr");
+    assertNotNull(value);
+    assertEquals("myValue", value.getJsonObject(0).getString("var"));
+    assertEquals("myOtherValue", value.getJsonObject(1).getString("var"));
+    assertEquals("myThirdValue", value.getJsonObject(2).getString("var"));
+
+    task = taskService.createTaskQuery().active().singleResult();
+    assertNotNull(task);
+    assertEquals("userTaskSuccess", task.getTaskDefinitionKey());
+
+//    HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery()
+//        .processInstanceId(processInstance.getProcessInstanceId()).finished().singleResult();
+//    assertNotNull(historicProcessInstance);
+
+    HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
+        .processInstanceId(processInstance.getProcessInstanceId()).singleResult();
+    value = (JsonArray) historicVariableInstance.getValue();
+    assertNotNull(value);
+    assertEquals("myValue", value.getJsonObject(0).getString("var"));
+    assertEquals("myOtherValue", value.getJsonObject(1).getString("var"));
+    assertEquals("myThirdValue", value.getJsonObject(2).getString("var"));
+  }
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.impl.variable.JsonType;
 import org.activiti.engine.impl.variable.ValueFields;
 import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -48,6 +49,8 @@ public class VariablesTest extends PluggableActivitiTestCase {
     serializable.add("three");
     byte[] bytes1 = "somebytes1".getBytes();
     byte[] bytes2 = "somebytes2".getBytes();
+    String json = "{ \"name\": \"Kermit\" }";
+    String jsonArray = "[{ \"name\": \"Kermit\" },{ \"name\": \"Fozzie\" }]";
 
     // Start process instance with different types of variables
     Map<String, Object> variables = new HashMap<String, Object>();
@@ -61,6 +64,8 @@ public class VariablesTest extends PluggableActivitiTestCase {
     variables.put("bytesVar", bytes1);
     variables.put("customVar1", new CustomType(bytes2));
     variables.put("customVar2", null);
+    variables.put("jsonVar", json);
+    variables.put("jsonArrayVar", jsonArray);
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("taskAssigneeProcess", variables);
 
     variables = runtimeService.getVariables(processInstance.getId());
@@ -74,7 +79,9 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertTrue(Arrays.equals(bytes1, (byte[]) variables.get("bytesVar")));
     assertEquals(new CustomType(bytes2), variables.get("customVar1"));
     assertEquals(null, variables.get("customVar2"));
-    assertEquals(10, variables.size());
+    assertEquals(JsonType.parse("{ \"name\": \"Kermit\" }"), variables.get("jsonVar"));
+    assertEquals(JsonType.parse("[{ \"name\": \"Kermit\" },{ \"name\": \"Fozzie\" }]"), variables.get("jsonArrayVar"));
+    assertEquals(12, variables.size());
 
     // Set all existing variables values to null
     runtimeService.setVariable(processInstance.getId(), "longVar", null);
@@ -87,6 +94,8 @@ public class VariablesTest extends PluggableActivitiTestCase {
     runtimeService.setVariable(processInstance.getId(), "bytesVar", null);
     runtimeService.setVariable(processInstance.getId(), "customVar1", null);
     runtimeService.setVariable(processInstance.getId(), "customVar2", null);
+    runtimeService.setVariable(processInstance.getId(), "jsonVar", null);
+    runtimeService.setVariable(processInstance.getId(), "jsonArrayVar", null);
 
     variables = runtimeService.getVariables(processInstance.getId());
     assertEquals(null, variables.get("longVar"));
@@ -99,7 +108,9 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertEquals(null, variables.get("bytesVar"));
     assertEquals(null, variables.get("customVar1"));
     assertEquals(null, variables.get("customVar2"));
-    assertEquals(10, variables.size());
+    assertEquals(null, variables.get("jsonVar"));
+    assertEquals(null, variables.get("jsonArrayVar"));
+    assertEquals(12, variables.size());
 
     // Update existing variable values again, and add a new variable
     runtimeService.setVariable(processInstance.getId(), "new var", "hi");
@@ -112,6 +123,8 @@ public class VariablesTest extends PluggableActivitiTestCase {
     runtimeService.setVariable(processInstance.getId(), "bytesVar", bytes1);
     runtimeService.setVariable(processInstance.getId(), "customVar1", new CustomType(bytes2));
     runtimeService.setVariable(processInstance.getId(), "customVar2", new CustomType(bytes1));
+    runtimeService.setVariable(processInstance.getId(), "jsonVar", JsonType.parse("{ \"name\": \"Kermit\" }"));
+    runtimeService.setVariable(processInstance.getId(), "jsonArrayVar", JsonType.parse("[{ \"name\": \"Kermit\" },{ \"name\": \"Fozzie\" }]"));
 
     variables = runtimeService.getVariables(processInstance.getId());
     assertEquals("hi", variables.get("new var"));
@@ -125,7 +138,9 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertTrue(Arrays.equals(bytes1, (byte[]) variables.get("bytesVar")));
     assertEquals(new CustomType(bytes2), variables.get("customVar1"));
     assertEquals(new CustomType(bytes1), variables.get("customVar2"));
-    assertEquals(11, variables.size());
+    assertEquals(JsonType.parse("{ \"name\": \"Kermit\" }"), variables.get("jsonVar"));
+    assertEquals(JsonType.parse("[{ \"name\": \"Kermit\" },{ \"name\": \"Fozzie\" }]"), variables.get("jsonArrayVar"));
+    assertEquals(13, variables.size());
     
     Collection<String> varFilter = new ArrayList<String>(2);
     varFilter.add("stringVar");

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/json/JsonTest.testJsonArrayAvailable.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/json/JsonTest.testJsonArrayAvailable.bpmn20.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="testJsonAvailableProcess" name="Test JSON available process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask" />
+    <userTask id="userTask" />
+    <sequenceFlow id="flow2" sourceRef="userTask" targetRef="script1" />
+    <scriptTask id="script1" scriptFormat="JavaScript">
+        <script><![CDATA[var jsonArr = execution.getVariable("myJsonArr");
+println('JSON:'+jsonArr);
+println('  var:'+jsonArr.getJsonObject(0));
+println('  var2:'+jsonArr.getJsonObject(1));
+        ]]></script>
+    </scriptTask>
+    <sequenceFlow sourceRef="script1" targetRef="haveVar2"/>
+    <exclusiveGateway id="haveVar2" name="Have var2?"/>
+    <sequenceFlow sourceRef="haveVar2" targetRef="userTaskFailure">
+      <conditionExpression><![CDATA[${empty myJsonArr.getJsonObject(2)}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow sourceRef="haveVar2" targetRef="userTaskSuccess"/>
+    <userTask id="userTaskFailure" />
+    <sequenceFlow id="flow3" sourceRef="userTaskFailure" targetRef="theEndFailure" />
+    <endEvent id="theEndFailure" />
+    <userTask id="userTaskSuccess" />
+    <sequenceFlow id="flow4" sourceRef="userTaskSuccess" targetRef="theEndSuccess" />
+    <endEvent id="theEndSuccess" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/json/JsonTest.testJsonObjectAvailable.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/json/JsonTest.testJsonObjectAvailable.bpmn20.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="testJsonAvailableProcess" name="Test JSON available process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask" />
+    <userTask id="userTask" />
+    <sequenceFlow id="flow2" sourceRef="userTask" targetRef="script1" />
+    <scriptTask id="script1" scriptFormat="JavaScript">
+        <script><![CDATA[var jsonObj = execution.getVariable("myJsonObj");
+println('JSON:'+jsonObj);
+println('  var:'+jsonObj.getString('var'));
+println('  var2:'+jsonObj.getString('var2'));
+        ]]></script>
+    </scriptTask>
+    <sequenceFlow sourceRef="script1" targetRef="haveVar2"/>
+    <exclusiveGateway id="haveVar2" name="Have var2?"/>
+    <sequenceFlow sourceRef="haveVar2" targetRef="userTaskFailure">
+      <conditionExpression><![CDATA[${empty myJsonObj.getString('var3')}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow sourceRef="haveVar2" targetRef="userTaskSuccess"/>
+    <userTask id="userTaskFailure" />
+    <sequenceFlow id="flow3" sourceRef="userTaskFailure" targetRef="theEndFailure" />
+    <endEvent id="theEndFailure" />
+    <userTask id="userTaskSuccess" />
+    <sequenceFlow id="flow4" sourceRef="userTaskSuccess" targetRef="theEndSuccess" />
+    <endEvent id="theEndSuccess" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
This pull request uses a heuristic to spot strings that are in fact JSON and then parses such variables as a javax.json.JsonStructures. 

This allows expressions to refer to child elements in conditions, when passing data to call activities etc. For example in a parent process that has a JSON variable named 'contact':  
```
    <callActivity calledElement="FollowUpContact" completionQuantity="1" id="_2" isForCompensation="false" name="Follow Up" startQuantity="1">
      <extensionElements>
        <activiti:in sourceExpression="${contact.getString('contactId')}" target="contactId"/>
        <activiti:in sourceExpression="${contact.getString('tenantId')}" target="tenantId"/>
      </extensionElements>
    </callActivity>
```