### PR TITLE
Refactor ProcessInstanceUtil & StartProcessInstanceCmd for extensibility

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -93,11 +93,15 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
       throw new ActivitiIllegalArgumentException("processDefinitionKey and processDefinitionId are null");
     }
 
-    ProcessInstance processInstance = ProcessInstanceUtil.createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
+    ProcessInstance processInstance = createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
 
     return processInstance;
   }
 
+  protected ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, String businessKey, String processInstanceName, Map<String,Object> variables) {
+    return ProcessInstanceUtil.createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
+  }
+  
   protected Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
     Map<String, Object> variablesMap = new HashMap<String, Object>();
     // convert data objects to process variables

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SubmitStartFormCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SubmitStartFormCmd.java
@@ -55,7 +55,7 @@ public class SubmitStartFormCmd extends NeedsActiveProcessDefinitionCmd<ProcessI
     StartFormHandler startFormHandler = FormHandlerUtil.getStartFormHandler(commandContext, processDefinition); 
     startFormHandler.submitFormProperties(properties, processInstance);
     
-    commandContext.getAgenda().planContinueProcessOperation(processInstance.getExecutions().get(0)); // There will always be one child execution created
+    ProcessInstanceUtil.startProcessInstance(processInstance, commandContext);
 
     return processInstance;
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceUtil.java
@@ -191,7 +191,7 @@ public class ProcessInstanceUtil {
               EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
               if (eventDefinition instanceof MessageEventDefinition) {
                 MessageEventDefinition messageEventDefinition = (MessageEventDefinition) eventDefinition;
-                BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processDefinition.getId());
+                BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processInstance.getProcessDefinitionId());
                 if (bpmnModel.containsMessageId(messageEventDefinition.getMessageRef())) {
                   messageEventDefinition.setMessageRef(bpmnModel.getMessage(messageEventDefinition.getMessageRef()).getName());
                 }
@@ -207,12 +207,18 @@ public class ProcessInstanceUtil {
     }
     
     if (startProcessInstance) {
-      commandContext.getAgenda().planContinueProcessOperation(execution);
+      startProcessInstance(processInstance, commandContext);
     }
 
     return processInstance;
   }
-
+  
+  public static void startProcessInstance(ExecutionEntity processInstance, CommandContext commandContext)
+  {
+    ExecutionEntity execution = processInstance.getExecutions().get(0); // There will always be one child execution created
+    commandContext.getAgenda().planContinueProcessOperation(execution);
+  }
+  
   protected static Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
     Map<String, Object> variablesMap = new HashMap<String, Object>();
     // convert data objects to process variables


### PR DESCRIPTION
Our custom extensions (i.e attributes on process variables) require us to perform the following steps:
1) create a process instance
2) set variables 
3) set attributes (Hook needed for custom extensions)
3) start process.

This pull request refactors a few classes to allow us to extend the StartProcessInstanceCmd and still re-use the functionality provided in the ProcessInstanceUtil class. A similar PR was submitted to version 5 but was not brought forward with the Activiti 6 refactoring.  
