### PR TITLE
use Collections.singletonList() for performance

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessDefinitionStateCmd.java
@@ -14,6 +14,7 @@ package org.activiti.engine.impl.cmd;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
@@ -84,7 +85,7 @@ public abstract class AbstractSetProcessDefinitionStateCmd implements Command<Vo
     // we don't need to do an extra database fetch and we can simply return
     // it, wrapped in a list
     if (processDefinitionEntity != null) {
-      return Arrays.asList(processDefinitionEntity);
+      return Collections.singletonList(processDefinitionEntity);
     }
 
     // Validation of input parameters

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ActivitiVersion.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ActivitiVersion.java
@@ -1,6 +1,7 @@
 package org.activiti.engine.impl.db;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -19,7 +20,7 @@ public class ActivitiVersion {
 
   public ActivitiVersion(String mainVersion) {
     this.mainVersion = mainVersion;
-    this.alternativeVersionStrings = Arrays.asList(mainVersion);
+    this.alternativeVersionStrings = Collections.singletonList(mainVersion);
   }
 
   public ActivitiVersion(String mainVersion, List<String> alternativeVersionStrings) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/scripting/JuelScriptEngineFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/scripting/JuelScriptEngineFactory.java
@@ -33,7 +33,7 @@ public class JuelScriptEngineFactory implements ScriptEngineFactory {
   private static List<String> mimeTypes;
 
   static {
-    names = Collections.unmodifiableList(Arrays.asList("juel"));
+    names = Collections.unmodifiableList(Collections.singletonList("juel"));
     extensions = names;
     mimeTypes = Collections.unmodifiableList(new ArrayList<String>(0));
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/AbstractActivitiTestCase.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/AbstractActivitiTestCase.java
@@ -15,6 +15,7 @@ package org.activiti.engine.impl.test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -52,7 +53,7 @@ import org.junit.Assert;
  */
 public abstract class AbstractActivitiTestCase extends PvmTestCase {
 
-  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList("ACT_GE_PROPERTY");
+  private static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Collections.singletonList("ACT_GE_PROPERTY");
 
   protected ProcessEngine processEngine;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
@@ -16,6 +16,7 @@ package org.activiti.engine.impl.test;
 import java.io.InputStream;
 import java.lang.reflect.Method;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +54,7 @@ public abstract class TestHelper {
 
   public static final String EMPTY_LINE = "\n";
 
-  public static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Arrays.asList("ACT_GE_PROPERTY");
+  public static final List<String> TABLENAMES_EXCLUDED_FROM_DB_CLEAN_CHECK = Collections.singletonList("ACT_GE_PROPERTY");
 
   static Map<String, ProcessEngine> processEngines = new HashMap<String, ProcessEngine>();
 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/DelegateTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/DelegateTaskTest.java
@@ -13,6 +13,7 @@
 package org.activiti.engine.test.api.task;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +58,8 @@ public class DelegateTaskTest extends PluggableActivitiTestCase {
 
     // Start process instance
     Map<String, Object> variables = new HashMap<String, Object>();
-    variables.put("approvers", Arrays.asList("kermit")); // , "gonzo",
-                                                         // "mispiggy"));
+    variables.put("approvers", Collections.singletonList("kermit")); // , "gonzo",
+                                                                    // "mispiggy"));
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("delegateTaskTest", variables);
 
     // Assert there are three tasks with the default category

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -1723,24 +1723,25 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
   public void testProcessInstanceIdIn() throws Exception {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    final Task task = taskService.createTaskQuery().processInstanceIdIn(Arrays.asList(processInstance.getId())).singleResult();
+    final Task task = taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList(processInstance.getId())).singleResult();
     assertNotNull(task);
     assertEquals("theTask", task.getTaskDefinitionKey());
     assertEquals(processInstance.getId(), task.getProcessInstanceId());
 
-    assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Arrays.asList("unexisting")).count());
+    assertEquals(0, taskService.createTaskQuery().processInstanceIdIn(Collections.singletonList("unexisting")).count());
   }
 
   @Deployment(resources = { "org/activiti/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })
   public void testProcessInstanceIdInOr() throws Exception {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
-    final Task task = taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList(processInstance.getId())).singleResult();
+    final Task task = taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList(
+                    processInstance.getId())).singleResult();
     assertNotNull(task);
     assertEquals("theTask", task.getTaskDefinitionKey());
     assertEquals(processInstance.getId(), task.getProcessInstanceId());
 
-    assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Arrays.asList("unexisting")).count());
+    assertEquals(0, taskService.createTaskQuery().or().taskId("invalid").processInstanceIdIn(Collections.singletonList("unexisting")).count());
   }
 
   @Deployment(resources = { "org/activiti/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml" })

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskServiceTest.java
@@ -1428,19 +1428,19 @@ public class TaskServiceTest extends PluggableActivitiTestCase {
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()));
+      taskService.deleteTasks(Collections.singletonList(task.getId()));
     } catch (ActivitiException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), true);
+      taskService.deleteTasks(Collections.singletonList(task.getId()), true);
     } catch (ActivitiException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }
 
     try {
-      taskService.deleteTasks(Arrays.asList(task.getId()), "test");
+      taskService.deleteTasks(Collections.singletonList(task.getId()), "test");
     } catch (ActivitiException ae) {
       assertEquals("The task cannot be deleted because is part of a running process", ae.getMessage());
     }

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/async/AsyncEmailTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/async/AsyncEmailTaskTest.java
@@ -13,6 +13,7 @@
 package org.activiti.engine.test.bpmn.async;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.activiti.engine.test.Deployment;
@@ -41,7 +42,7 @@ public class AsyncEmailTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Collections.singletonList("kermit@activiti.org"), null);
     assertProcessEnded(procId);
   }
 
@@ -59,7 +60,8 @@ public class AsyncEmailTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    EmailServiceTaskTest.assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Collections.singletonList(
+            "kermit@activiti.org"), null);
   }
 
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/mail/EmailSendTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/mail/EmailSendTaskTest.java
@@ -48,7 +48,7 @@ public class EmailSendTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Collections.singletonList("kermit@activiti.org"), null);
   }
 
   @Deployment
@@ -91,7 +91,8 @@ public class EmailSendTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, subject, "Hello " + recipientName + ", this is an e-mail", sender, Arrays.asList(recipient), null);
+    assertEmailSend(message, false, subject, "Hello " + recipientName + ", this is an e-mail", sender,
+                    Collections.singletonList(recipient), null);
   }
 
   @Deployment
@@ -99,7 +100,8 @@ public class EmailSendTaskTest extends EmailTestCase {
     runtimeService.startProcessInstanceByKey("ccAndBcc");
 
     List<WiserMessage> messages = wiser.getMessages();
-    assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "activiti@localhost", Arrays.asList("kermit@activiti.org"), Arrays.asList("fozzie@activiti.org"));
+    assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "activiti@localhost", Collections.singletonList("kermit@activiti.org"),
+                    Collections.singletonList("fozzie@activiti.org"));
 
     // Bcc is not stored in the header (obviously)
     // so the only way to verify the bcc, is that there are three messages
@@ -113,7 +115,7 @@ public class EmailSendTaskTest extends EmailTestCase {
 
     List<WiserMessage> messages = wiser.getMessages();
     assertEquals(1, messages.size());
-    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Collections.singletonList("kermit@activiti.org"), null);
   }
 
   @Deployment

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/mail/EmailServiceTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/mail/EmailServiceTaskTest.java
@@ -48,7 +48,7 @@ public class EmailServiceTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Collections.singletonList("kermit@activiti.org"), null);
     assertProcessEnded(procId);
   }
 
@@ -63,7 +63,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@myTenant.com", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@myTenant.com", Collections.singletonList(
+                            "kermit@activiti.org"), null);
     assertProcessEnded(procId);
 
     repositoryService.deleteDeployment(deployment.getId(), true);
@@ -80,7 +81,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(message, false, "Hello Kermit!", "This a text only e-mail.", "activiti@localhost", Collections.singletonList(
+                            "kermit@activiti.org"), null);
     assertProcessEnded(procId);
 
     repositoryService.deleteDeployment(deployment.getId(), true);
@@ -126,7 +128,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
     assertEquals(1, messages.size());
 
     WiserMessage message = messages.get(0);
-    assertEmailSend(message, false, subject, "Hello " + recipientName + ", this is an e-mail", sender, Arrays.asList(recipient), null);
+    assertEmailSend(message, false, subject, "Hello " + recipientName + ", this is an e-mail", sender, Collections.singletonList(
+                            recipient), null);
   }
 
   @Deployment
@@ -134,7 +137,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
     runtimeService.startProcessInstanceByKey("ccAndBcc");
 
     List<WiserMessage> messages = wiser.getMessages();
-    assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "activiti@localhost", Arrays.asList("kermit@activiti.org"), Arrays.asList("fozzie@activiti.org"));
+    assertEmailSend(messages.get(0), false, "Hello world", "This is the content", "activiti@localhost", Collections.singletonList(
+                            "kermit@activiti.org"), Collections.singletonList("fozzie@activiti.org"));
 
     // Bcc is not stored in the header (obviously)
     // so the only way to verify the bcc, is that there are three messages
@@ -148,7 +152,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
 
     List<WiserMessage> messages = wiser.getMessages();
     assertEquals(1, messages.size());
-    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Collections.singletonList(
+            "kermit@activiti.org"), null);
   }
 
   @Deployment
@@ -161,7 +166,8 @@ public class EmailServiceTaskTest extends EmailTestCase {
 
     List<WiserMessage> messages = wiser.getMessages();
     assertEquals(1, messages.size());
-    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Arrays.asList("kermit@activiti.org"), null);
+    assertEmailSend(messages.get(0), true, "Test", "Mr. <b>Kermit</b>", "activiti@localhost", Collections.singletonList(
+            "kermit@activiti.org"), null);
   }
 
   @Deployment

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -16,6 +16,7 @@ package org.activiti.engine.test.history;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -157,7 +158,7 @@ public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstance.getId()).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionId(processInstance.getProcessDefinitionId()).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("oneTaskProcess").count());
-    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(Arrays.asList("oneTaskProcess")).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(Collections.singletonList("oneTaskProcess")).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(Arrays.asList("undefined", "oneTaskProcess")).count());
     assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(Arrays.asList("undefined1", "undefined2")).count());
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().processInstanceBusinessKey("businessKey123").count());

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/processdefinitions/ProcessDefinitionsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/processdefinitions/ProcessDefinitionsTest.java
@@ -15,6 +15,7 @@ package org.activiti.examples.processdefinitions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -144,7 +145,7 @@ public class ProcessDefinitionsTest extends PluggableActivitiTestCase {
     ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).singleResult();
     assertEquals("This is a test", processDefinition.getDescription());
 
-    deleteDeployments(Arrays.asList(deploymentId));
+    deleteDeployments(Collections.singletonList(deploymentId));
   }
 
   private String deployProcessString(String processString) {


### PR DESCRIPTION
This change replaces calls to `Arrays.asList()` with a single argument with `Collections.singletonList()` which saves some memory.