### PR TITLE
[Fix] Resolve foreign key violation on Identity Link table 

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -406,12 +406,6 @@ public class ExecutionEntityManager extends AbstractEntityManager<ExecutionEntit
       }
     }
 
-    IdentityLinkEntityManager identityLinkEntityManager = Context.getCommandContext().getIdentityLinkEntityManager();
-    List<IdentityLinkEntity> identityLinkEntities = identityLinkEntityManager.findIdentityLinksByProcessInstanceId(processInstanceEntity.getId());
-    for (IdentityLinkEntity identityLinkEntity : identityLinkEntities) {
-      identityLinkEntityManager.delete(identityLinkEntity);
-    }
-
     // delete event scope executions
     for (ExecutionEntity childExecution : processInstanceEntity.getExecutions()) {
       if (childExecution.isEventScope()) {
@@ -476,6 +470,15 @@ public class ExecutionEntityManager extends AbstractEntityManager<ExecutionEntit
     executionEntity.setEnded(true);
     executionEntity.setActive(false);
 
+    if (executionEntity.getId().equals(executionEntity.getProcessInstanceId())) {
+      IdentityLinkEntityManager identityLinkEntityManager = commandContext.getIdentityLinkEntityManager();
+      Collection<IdentityLinkEntity> identityLinks = identityLinkEntityManager.findIdentityLinksByProcessInstanceId(executionEntity.getProcessInstanceId());
+      for(IdentityLinkEntity identityLink : identityLinks)
+      {
+        identityLinkEntityManager.delete(identityLink);
+      }
+    }
+    
     // Get variables related to execution and delete them
     VariableInstanceEntityManager variableInstanceEntityManager = commandContext.getVariableInstanceEntityManager();
     Collection<VariableInstanceEntity> executionVariables = variableInstanceEntityManager.findVariableInstancesByExecutionId(executionEntity.getId());

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.JavaDelegate;
 import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.impl.identity.Authentication;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -66,6 +67,27 @@ public class TerminateEndEventTest extends PluggableActivitiTestCase {
 		taskService.complete(task.getId());
 
 		assertProcessEnded(pi.getId());
+	}
+	
+	@Deployment
+	public void testSimpleProcessTerminateWithAuthenticatedUser() throws Exception {
+	  try
+	  {
+	    Authentication.setAuthenticatedUserId("user1");
+  	  ProcessInstance pi = runtimeService.startProcessInstanceByKey("simpleProcessTerminateWithAuthenticatedUser");
+  
+  	  long executionEntities = runtimeService.createExecutionQuery().processInstanceId(pi.getId()).count();
+  	  assertEquals(2, executionEntities);
+  
+  	  Task task = taskService.createTaskQuery().processInstanceId(pi.getId()).taskDefinitionKey("ID_6").singleResult();
+  	  taskService.complete(task.getId());
+
+      assertProcessEnded(pi.getId());
+	  }
+	  finally
+	  {
+	    Authentication.setAuthenticatedUserId(null);
+	  }
 	}
 
 	@Deployment

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.testSimpleProcessTerminateWithAuthenticatedUser.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.testSimpleProcessTerminateWithAuthenticatedUser.bpmn20.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:sasbpmn="http://www.sas.com/xml/schema/bpmn" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:ns8="http://sas.com/workflow" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://sas.com/workflow">
+  <process isExecutable="true" name="Simple Process Terminate with Authenticated User" id="simpleProcessTerminateWithAuthenticatedUser">
+    <startEvent id="ID_1" />
+    
+    <userTask name="Task1" id="ID_6"/>
+    <sequenceFlow targetRef="ID_6" sourceRef="ID_1" id="ID_7" />
+    <endEvent id="ID_8">
+      <terminateEventDefinition id="ID_9"/>
+    </endEvent>
+    <sequenceFlow targetRef="ID_8" sourceRef="ID_6" id="ID_10" />
+  </process>
+</definitions>


### PR DESCRIPTION
when process is started with an authenticated user and ends via a Terminate End Event.

A foreign key violation occurs when a process is started with an authenticated user and then is terminated via a Terminate End Event. The code path current fails to clean up the associated "starter" identity link.