### PR TITLE
[Fix] - DestroyScopeOperation does not remove variables in the scope …

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/DestroyScopeOperation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/DestroyScopeOperation.java
@@ -11,6 +11,8 @@ import org.activiti.engine.impl.persistence.entity.JobEntity;
 import org.activiti.engine.impl.persistence.entity.JobEntityManager;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;
 import org.activiti.engine.impl.persistence.entity.TaskEntityManager;
+import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
+import org.activiti.engine.impl.persistence.entity.VariableInstanceEntityManager;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
 
 /**
@@ -72,6 +74,14 @@ public class DestroyScopeOperation extends AbstractOperation {
       jobEntityManager.delete(job);
     }
 
+    // Remove variables associated with this scope
+    VariableInstanceEntityManager variableInstanceEntityManager = commandContext.getVariableInstanceEntityManager();
+    Collection<VariableInstanceEntity> variablesForExecution = variableInstanceEntityManager.findVariableInstancesByExecutionId(parentScopeExecution.getId());
+    for(VariableInstanceEntity variable : variablesForExecution)
+    {
+      variableInstanceEntityManager.delete(variable);
+    }
+    
     // Not a scope anymore
     parentScopeExecution.setScope(false);
     parentScopeExecution.setCurrentFlowElement(currentFlowElement);

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.java
@@ -409,7 +409,7 @@ public class SubProcessTest extends PluggableActivitiTestCase {
     // the subprocess scope is destroyed and the main process continues
     taskService.complete(currentTask.getId());
 
-    // verify main process scoped variables - subprocess variables are gone
+    // verify main process scoped variables
     variables = runtimeService.getVariables(pi.getId());
     assertEquals(2, variables.size());
     varNameIt = variables.keySet().iterator();
@@ -424,12 +424,17 @@ public class SubProcessTest extends PluggableActivitiTestCase {
       }
     }
 
+    currentTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
+    
+    // Verify there are no local variables assigned to the current task. (subprocess variables are gone).
+    variables = runtimeService.getVariablesLocal(currentTask.getExecutionId());
+    assertEquals(0, variables.size());
+    
     // After completing the final task in the main process,
     // the process scope is destroyed and the process ends
-    currentTask = taskService.createTaskQuery().processInstanceId(pi.getId()).singleResult();
     assertEquals("Complete Task B", currentTask.getName());
-
+    
     taskService.complete(currentTask.getId());
     assertNull(runtimeService.createProcessInstanceQuery().processInstanceId(pi.getId()).singleResult());
-  }
+  }  
 }


### PR DESCRIPTION
…being destroyed.

Problem:
Variables defined on a subprocess are not removed when the subprocess scope ends. 

Fix: 
Update DestroyScopeOperation to remove local variables from the execution scope being destroyed.