### PR TITLE
Remove redundant initializers.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -109,8 +109,8 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String mailServerPassword; // means no authentication for mail
                                        // server
   protected int mailServerPort = 25;
-  protected boolean useSSL = false;
-  protected boolean useTLS = false;
+  protected boolean useSSL;
+  protected boolean useTLS;
   protected String mailServerDefaultFrom = "activiti@localhost";
   protected String mailSessionJndi;
   protected Map<String, MailServerInfo> mailServers = new HashMap<String, MailServerInfo>();
@@ -122,7 +122,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String jdbcUrl = "jdbc:h2:tcp://localhost/~/activiti";
   protected String jdbcUsername = "sa";
   protected String jdbcPassword = "";
-  protected String dataSourceJndiName = null;
+  protected String dataSourceJndiName;
   protected boolean isDbIdentityUsed = true;
   protected boolean isDbHistoryUsed = true;
   protected HistoryLevel historyLevel;
@@ -130,12 +130,12 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected int jdbcMaxIdleConnections;
   protected int jdbcMaxCheckoutTime;
   protected int jdbcMaxWaitTime;
-  protected boolean jdbcPingEnabled = false;
-  protected String jdbcPingQuery = null;
+  protected boolean jdbcPingEnabled;
+  protected String jdbcPingQuery;
   protected int jdbcPingConnectionNotUsedFor;
   protected int jdbcDefaultTransactionIsolationLevel;
   protected DataSource dataSource;
-  protected boolean transactionsExternallyManaged = false;
+  protected boolean transactionsExternallyManaged;
 
   protected String jpaPersistenceUnitName;
   protected Object jpaEntityManagerFactory;
@@ -181,7 +181,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
    * In some situations you want to set the schema to use for table checks / generation if the database metadata doesn't return that correctly, see https://jira.codehaus.org/browse/ACT-1220,
    * https://jira.codehaus.org/browse/ACT-1062
    */
-  protected String databaseSchema = null;
+  protected String databaseSchema;
 
   /**
    * Set to true in case the defined databaseTablePrefix is a schema-name, instead of an actual table name prefix. This is relevant for checking if Activiti-tables exist, the databaseTablePrefix will
@@ -189,7 +189,7 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
    * 
    * @since 5.15
    */
-  protected boolean tablePrefixIsSchema = false;
+  protected boolean tablePrefixIsSchema;
 
   protected boolean isCreateDiagramOnDeploy = true;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngines.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngines.java
@@ -56,7 +56,7 @@ public abstract class ProcessEngines {
 
   public static final String NAME_DEFAULT = "default";
 
-  protected static boolean isInitialized = false;
+  protected static boolean isInitialized;
   protected static Map<String, ProcessEngine> processEngines = new HashMap<String, ProcessEngine>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByName = new HashMap<String, ProcessEngineInfo>();
   protected static Map<String, ProcessEngineInfo> processEngineInfosByResourceUrl = new HashMap<String, ProcessEngineInfo>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/cfg/MailServerInfo.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/cfg/MailServerInfo.java
@@ -23,8 +23,8 @@ public class MailServerInfo {
   protected int mailServerPort;
   protected String mailServerUsername;
   protected String mailServerPassword;
-  protected boolean mailServerUseSSL = false;
-  protected boolean mailServerUseTLS = false;
+  protected boolean mailServerUseSSL;
+  protected boolean mailServerUseTLS;
 
   public String getMailServerDefaultFrom() {
     return mailServerDefaultFrom;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/BaseEntityEventListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/BaseEntityEventListener.java
@@ -22,7 +22,7 @@ package org.activiti.engine.delegate.event;
  */
 public class BaseEntityEventListener implements ActivitiEventListener {
 
-  protected boolean failOnException = false;
+  protected boolean failOnException;
   protected Class<?> entityClass;
 
   /**

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -43,7 +43,7 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
   protected transient CommandContext commandContext;
 
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected ResultType resultType;
 
   private Map<String, Object> parameters = new HashMap<String, Object>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricDetailQueryImpl.java
@@ -39,7 +39,7 @@ public class HistoricDetailQueryImpl extends AbstractQuery<HistoricDetailQuery, 
   protected String activityId;
   protected String activityInstanceId;
   protected String type;
-  protected boolean excludeTaskRelated = false;
+  protected boolean excludeTaskRelated;
 
   public HistoricDetailQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -39,10 +39,10 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String businessKey;
   protected String deploymentId;
   protected List<String> deploymentIds;
-  protected boolean finished = false;
-  protected boolean unfinished = false;
-  protected boolean deleted = false;
-  protected boolean notDeleted = false;
+  protected boolean finished;
+  protected boolean unfinished;
+  protected boolean deleted;
+  protected boolean notDeleted;
   protected String startedBy;
   protected String superProcessInstanceId;
   protected boolean excludeSubprocesses;
@@ -63,7 +63,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected String nameLike;
   protected String nameLikeIgnoreCase;
   protected HistoricProcessInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
 
   public HistoricProcessInstanceQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -83,7 +83,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected Date dueDate;
   protected Date dueAfter;
   protected Date dueBefore;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected Date creationDate;
   protected Date creationAfterDate;
   protected Date creationBeforeDate;
@@ -94,10 +94,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected String tenantId;
   protected String tenantIdLike;
   protected boolean withoutTenantId;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected HistoricTaskInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
 
   public HistoricTaskInstanceQueryImpl() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -41,8 +41,8 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   protected String activityInstanceId;
   protected String variableName;
   protected String variableNameLike;
-  protected boolean excludeTaskRelated = false;
-  protected boolean excludeVariableInitialization = false;
+  protected boolean excludeTaskRelated;
+  protected boolean excludeVariableInitialization;
   protected QueryVariableValue queryVariableValue;
 
   public HistoricVariableInstanceQueryImpl() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -49,7 +49,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   protected String resourceName;
   protected String resourceNameLike;
   protected Integer version;
-  protected boolean latest = false;
+  protected boolean latest;
   protected SuspensionState suspensionState;
   protected String authorizationUserId;
   protected String procDefId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -62,7 +62,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean withoutTenantId;
 
   protected ProcessInstanceQueryImpl orQueryObject;
-  protected boolean inOrStatement = false;
+  protected boolean inOrStatement;
 
   // Unused, see dynamic query
   protected String activityId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -57,8 +57,8 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String owner;
   protected String ownerLike;
   protected String ownerLikeIgnoreCase;
-  protected boolean unassigned = false;
-  protected boolean noDelegationState = false;
+  protected boolean unassigned;
+  protected boolean noDelegationState;
   protected DelegationState delegationState;
   protected String candidateUser;
   protected String candidateGroup;
@@ -91,13 +91,13 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected Date dueDate;
   protected Date dueBefore;
   protected Date dueAfter;
-  protected boolean withoutDueDate = false;
+  protected boolean withoutDueDate;
   protected SuspensionState suspensionState;
-  protected boolean excludeSubtasks = false;
-  protected boolean includeTaskLocalVariables = false;
-  protected boolean includeProcessVariables = false;
+  protected boolean excludeSubtasks;
+  protected boolean includeTaskLocalVariables;
+  protected boolean includeProcessVariables;
   protected String userIdForCandidateAndAssignee;
-  protected boolean bothCandidateAndAssigned = false;
+  protected boolean bothCandidateAndAssigned;
   protected boolean orActive;
   protected TaskQueryImpl orQueryObject;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireAsyncJobsDueRunnable.java
@@ -30,11 +30,11 @@ public class AcquireAsyncJobsDueRunnable implements Runnable {
 
   protected final AsyncExecutor asyncExecutor;
 
-  protected volatile boolean isInterrupted = false;
+  protected volatile boolean isInterrupted;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
 
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireAsyncJobsDueRunnable(AsyncExecutor asyncExecutor) {
     this.asyncExecutor = asyncExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/AcquireTimerJobsRunnable.java
@@ -31,11 +31,11 @@ public class AcquireTimerJobsRunnable implements Runnable {
 
   protected final AsyncExecutor asyncExecutor;
 
-  protected volatile boolean isInterrupted = false;
+  protected volatile boolean isInterrupted;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
 
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireTimerJobsRunnable(AsyncExecutor asyncExecutor) {
     this.asyncExecutor = asyncExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultAsyncJobExecutor.java
@@ -56,8 +56,8 @@ public class DefaultAsyncJobExecutor implements AsyncExecutor {
   protected AcquireTimerJobsRunnable timerJobRunnable;
   protected AcquireAsyncJobsDueRunnable asyncJobsDueRunnable;
 
-  protected boolean isAutoActivate = false;
-  protected boolean isActive = false;
+  protected boolean isAutoActivate;
+  protected boolean isActive;
 
   protected int maxTimerJobsPerAcquisition = 1;
   protected int maxAsyncJobsDuePerAcquisition = 1;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BusinessRuleTaskActivityBehavior.java
@@ -39,7 +39,7 @@ public class BusinessRuleTaskActivityBehavior extends TaskActivityBehavior {
   
   protected Set<Expression> variablesInputExpressions = new HashSet<Expression>();
   protected Set<Expression> rulesExpressions = new HashSet<Expression>();
-  protected boolean exclude = false;
+  protected boolean exclude;
   protected String resultVariable;
 
   public BusinessRuleTaskActivityBehavior() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptExecutionListener.java
@@ -25,9 +25,9 @@ public class ScriptExecutionListener implements ExecutionListener {
 
   private Expression script;
 
-  private Expression language = null;
+  private Expression language;
 
-  private Expression resultVariable = null;
+  private Expression resultVariable;
 
   @Override
   public void notify(DelegateExecution execution) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ScriptTaskListener.java
@@ -29,9 +29,9 @@ public class ScriptTaskListener implements TaskListener {
 
   protected Expression script;
 
-  protected Expression language = null;
+  protected Expression language;
 
-  protected Expression resultVariable = null;
+  protected Expression resultVariable;
 
   protected boolean autoStoreVariables;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/CronExpression.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/CronExpression.java
@@ -194,8 +194,8 @@ public class CronExpression implements Serializable, Cloneable {
     dayMap.put("SAT", Integer.valueOf(7));
   }
 
-  private String cronExpression = null;
-  private TimeZone timeZone = null;
+  private String cronExpression;
+  private TimeZone timeZone;
   protected transient TreeSet<Integer> seconds;
   protected transient TreeSet<Integer> minutes;
   protected transient TreeSet<Integer> hours;
@@ -204,12 +204,12 @@ public class CronExpression implements Serializable, Cloneable {
   protected transient TreeSet<Integer> daysOfWeek;
   protected transient TreeSet<Integer> years;
 
-  protected transient boolean lastdayOfWeek = false;
-  protected transient int nthdayOfWeek = 0;
-  protected transient boolean lastdayOfMonth = false;
-  protected transient boolean nearestWeekday = false;
-  protected transient int lastdayOffset = 0;
-  protected transient boolean expressionParsed = false;
+  protected transient boolean lastdayOfWeek;
+  protected transient int nthdayOfWeek;
+  protected transient boolean lastdayOfMonth;
+  protected transient boolean nearestWeekday;
+  protected transient int lastdayOffset;
+  protected transient boolean expressionParsed;
 
   public static final int MAX_YEAR = Calendar.getInstance().get(Calendar.YEAR) + 100;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -382,7 +382,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
    * Unfortunately, this feature is not available on some platforms (JDK 6, JBoss), hence the reason why it is disabled by default. If your platform allows the use of StaxSource during XML parsing, do
    * enable it.
    */
-  protected boolean enableSafeBpmnXml = false;
+  protected boolean enableSafeBpmnXml;
 
   /**
    * The following settings will determine the amount of entities loaded at once when the engine needs to load multiple entities (eg. when suspending a process definition with all its process
@@ -399,7 +399,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected Map<String, List<ActivitiEventListener>> typedEventListeners;
 
   // Event logging to database
-  protected boolean enableDatabaseEventLogging = false;
+  protected boolean enableDatabaseEventLogging;
   
   /**
   *  Define a max length for storing String variable types in the database.
@@ -408,7 +408,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
   protected int maxLengthStringVariableType = 4000;
 
   // Backwards compatibility
-  protected boolean isActiviti5CompatibilityEnabled = false; // Default activiti 5 backwards compatibility is disabled!
+  protected boolean isActiviti5CompatibilityEnabled; // Default activiti 5 backwards compatibility is disabled!
   protected Activiti5CompatibilityHandlerFactory activiti5CompatibilityHandlerFactory;
   protected Activiti5CompatibilityHandler activiti5CompatibilityHandler;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/standalone/StandaloneMybatisTransactionContext.java
@@ -33,7 +33,7 @@ public class StandaloneMybatisTransactionContext implements TransactionContext {
   private static Logger log = LoggerFactory.getLogger(StandaloneMybatisTransactionContext.class);
 
   protected CommandContext commandContext;
-  protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners = null;
+  protected Map<TransactionState, List<TransactionListener>> stateTransactionListeners;
 
   public StandaloneMybatisTransactionContext(CommandContext commandContext) {
     this.commandContext = commandContext;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetEventLogEntriesCmd.java
@@ -11,9 +11,9 @@ import org.activiti.engine.impl.interceptor.CommandContext;
  */
 public class GetEventLogEntriesCmd implements Command<List<EventLogEntry>> {
 
-  protected String processInstanceId = null;
-  protected Long startLogNr = null;
-  protected Long pageSize = null;
+  protected String processInstanceId;
+  protected Long startLogNr;
+  protected Long pageSize;
 
   public GetEventLogEntriesCmd() {
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbIdGenerator.java
@@ -24,7 +24,7 @@ import org.activiti.engine.impl.interceptor.CommandExecutor;
 public class DbIdGenerator implements IdGenerator {
 
   protected int idBlockSize;
-  protected long nextId = 0;
+  protected long nextId;
   protected long lastId = -1;
 
   protected CommandExecutor commandExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/ListQueryParameterObject.java
@@ -19,7 +19,7 @@ package org.activiti.engine.impl.db;
 public class ListQueryParameterObject {
 
   protected int maxResults = Integer.MAX_VALUE;
-  protected int firstResult = 0;
+  protected int firstResult;
   protected Object parameter;
   protected String databaseType;
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -75,7 +75,7 @@ public class CommandContext {
   protected TransactionContext transactionContext;
   protected Map<Class<?>, SessionFactory> sessionFactories;
   protected Map<Class<?>, Session> sessions = new HashMap<Class<?>, Session>();
-  protected Throwable exception = null;
+  protected Throwable exception;
   protected ProcessEngineConfigurationImpl processEngineConfiguration;
   protected FailedJobCommandFactory failedJobCommandFactory;
   protected List<CommandContextCloseListener> closeListeners;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/javax/el/BeanELResolver.java
@@ -181,7 +181,7 @@ public class BeanELResolver extends ELResolver {
         return Collections.<FeatureDescriptor> emptyList().iterator();
       }
       return new Iterator<FeatureDescriptor>() {
-        int next = 0;
+        int next;
 
         public boolean hasNext() {
           return properties != null && next < properties.length;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AcquireJobsRunnableImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/AcquireJobsRunnableImpl.java
@@ -30,12 +30,12 @@ public class AcquireJobsRunnableImpl implements AcquireJobsRunnable {
 
   protected final JobExecutor jobExecutor;
 
-  protected volatile boolean isInterrupted = false;
-  protected volatile boolean isJobAdded = false;
+  protected volatile boolean isInterrupted;
+  protected volatile boolean isJobAdded;
   protected final Object MONITOR = new Object();
   protected final AtomicBoolean isWaiting = new AtomicBoolean(false);
 
-  protected long millisToWait = 0;
+  protected long millisToWait;
 
   public AcquireJobsRunnableImpl(JobExecutor jobExecutor) {
     this.jobExecutor = jobExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/DefaultJobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/DefaultJobExecutor.java
@@ -46,7 +46,7 @@ public class DefaultJobExecutor extends JobExecutor {
   protected int queueSize = 3;
   protected int corePoolSize = 3;
   protected int maxPoolSize = 10;
-  protected long keepAliveTime = 0L;
+  protected long keepAliveTime;
 
   protected BlockingQueue<Runnable> threadPoolQueue;
   protected ThreadPoolExecutor threadPoolExecutor;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/JobExecutor.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/JobExecutor.java
@@ -54,8 +54,8 @@ public abstract class JobExecutor {
   protected RejectedJobsHandler rejectedJobsHandler;
   protected Thread jobAcquisitionThread;
 
-  protected boolean isAutoActivate = false;
-  protected boolean isActive = false;
+  protected boolean isAutoActivate;
+  protected boolean isActive;
 
   /**
    * To avoid deadlocks, the default for this is one. This way, in a clustered setup, multiple job executors can acquire jobs without creating a deadlock due to fetching multiple jobs at once and

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerDeclarationImpl.java
@@ -38,7 +38,7 @@ public class TimerDeclarationImpl implements Serializable {
   protected Expression endDateExpression;
 
   protected String jobHandlerType;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerConfiguration;
   protected String repeat;
   protected boolean exclusive = TimerEntity.DEFAULT_EXCLUSIVE;
   protected int retries = TimerEntity.DEFAULT_RETRIES;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ByteArrayRef.java
@@ -30,7 +30,7 @@ public final class ByteArrayRef implements Serializable {
   private String id;
   private String name;
   private ByteArrayEntity entity;
-  protected boolean deleted = false;
+  protected boolean deleted;
 
   public ByteArrayRef() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -105,15 +105,15 @@ public class ExecutionEntity extends VariableScopeImpl implements ActivityExecut
    */
   protected boolean isActive = true;
   protected boolean isScope = true;
-  protected boolean isConcurrent = false;
-  protected boolean isEnded = false;
-  protected boolean isEventScope = false;
+  protected boolean isConcurrent;
+  protected boolean isEnded;
+  protected boolean isEventScope;
 
   // events
   // ///////////////////////////////////////////////////////////////////
 
   protected String eventName;
-  protected int executionListenerIndex = 0;
+  protected int executionListenerIndex;
 
   // associated entities /////////////////////////////////////////////////////
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/JobEntity.java
@@ -52,19 +52,19 @@ public abstract class JobEntity implements Job, PersistentObject, HasRevision, B
 
   protected Date duedate;
 
-  protected String lockOwner = null;
-  protected Date lockExpirationTime = null;
+  protected String lockOwner;
+  protected Date lockExpirationTime;
 
-  protected String executionId = null;
-  protected String processInstanceId = null;
-  protected String processDefinitionId = null;
+  protected String executionId;
+  protected String processInstanceId;
+  protected String processDefinitionId;
 
   protected boolean isExclusive = DEFAULT_EXCLUSIVE;
 
   protected int retries = DEFAULT_RETRIES;
 
-  protected String jobHandlerType = null;
-  protected String jobHandlerConfiguration = null;
+  protected String jobHandlerType;
+  protected String jobHandlerConfiguration;
 
   protected final ByteArrayRef exceptionByteArrayRef = new ByteArrayRef();
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/MessageEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/MessageEntity.java
@@ -21,7 +21,7 @@ public class MessageEntity extends JobEntity {
 
   private static final long serialVersionUID = 1L;
 
-  private String repeat = null;
+  private String repeat;
 
   @Override
   public void execute(CommandContext commandContext) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ProcessDefinitionEntity.java
@@ -59,7 +59,7 @@ public class ProcessDefinitionEntity implements ReadOnlyProcessDefinition, Proce
   protected Map<String, Object> variables;
   protected boolean hasStartFormKey;
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> definitionIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
   protected Set<Expression> candidateStarterUserIdExpressions = new HashSet<Expression>();
   protected Set<Expression> candidateStarterGroupIdExpressions = new HashSet<Expression>();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ResourceEntity.java
@@ -28,7 +28,7 @@ public class ResourceEntity implements PersistentObject, Serializable {
   protected String name;
   protected byte[] bytes;
   protected String deploymentId;
-  protected boolean generated = false;
+  protected boolean generated;
 
   public String getId() {
     return id;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntity.java
@@ -75,7 +75,7 @@ public class TaskEntity extends VariableScopeImpl implements Task, DelegateTask,
   protected int suspensionState = SuspensionState.ACTIVE.getStateCode();
   protected String category;
 
-  protected boolean isIdentityLinksInitialized = false;
+  protected boolean isIdentityLinksInitialized;
   protected List<IdentityLinkEntity> taskIdentityLinkEntities = new ArrayList<IdentityLinkEntity>();
 
   protected String executionId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -50,7 +50,7 @@ public class VariableInstanceEntity implements ValueFields, PersistentObject, Ha
 
   protected Object cachedValue;
   protected boolean forcedUpdate;
-  protected boolean deleted = false;
+  protected boolean deleted;
 
   // Default constructor for SQL mapping
   protected VariableInstanceEntity() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -41,7 +41,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
   private static final long serialVersionUID = 1L;
 
   // The cache used when fetching all variables
-  protected Map<String, VariableInstanceEntity> variableInstances = null; // needs
+  protected Map<String, VariableInstanceEntity> variableInstances; // needs
                                                                           // to
                                                                           // be
                                                                           // null,
@@ -63,7 +63,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
   protected ELContext cachedElContext;
 
-  protected String id = null;
+  protected String id;
 
   protected abstract Collection<VariableInstanceEntity> loadVariableInstances();
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -46,7 +46,7 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   protected DeploymentEntity deployment = new DeploymentEntity();
   protected boolean isBpmn20XsdValidationEnabled = true;
   protected boolean isProcessValidationEnabled = true;
-  protected boolean isDuplicateFilterEnabled = false;
+  protected boolean isDuplicateFilterEnabled;
   protected Date processDefinitionsActivationDate;
   protected Map<String, Object> deploymentProperties = new HashMap<String, Object>();
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/JobTestHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/JobTestHelper.java
@@ -189,7 +189,7 @@ public class JobTestHelper {
 
   private static class InteruptTask extends TimerTask {
 
-    protected boolean timeLimitExceeded = false;
+    protected boolean timeLimitExceeded;
     protected Thread thread;
 
     public InteruptTask(Thread thread) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/DefaultClockImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/DefaultClockImpl.java
@@ -22,7 +22,7 @@ import java.util.TimeZone;
  */
 public class DefaultClockImpl implements org.activiti.engine.runtime.Clock {
 
-  private static volatile Calendar CURRENT_TIME = null;
+  private static volatile Calendar CURRENT_TIME;
 
   @Override
   public void setCurrentTime(Date currentTime) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/EntityMetaData.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Method;
  */
 public class EntityMetaData {
 
-  private boolean isJPAEntity = false;
+  private boolean isJPAEntity;
   private Class<?> entityClass;
   private Method idMethod;
   private Field idField;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityListVariableType.java
@@ -24,7 +24,7 @@ public class JPAEntityListVariableType implements VariableType, CacheableVariabl
 
   protected JPAEntityMappings mappings;
 
-  protected boolean forceCachedValue = false;
+  protected boolean forceCachedValue;
 
   public JPAEntityListVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/JPAEntityVariableType.java
@@ -27,7 +27,7 @@ public class JPAEntityVariableType implements VariableType, CacheableVariable {
 
   private JPAEntityMappings mappings;
 
-  private boolean forceCacheable = false;
+  private boolean forceCacheable;
 
   public JPAEntityVariableType() {
     mappings = new JPAEntityMappings();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/logging/LogMDC.java
@@ -17,7 +17,7 @@ public class LogMDC {
   public static final String LOG_MDC_BUSINESS_KEY = "mdcBusinessKey";
   public static final String LOG_MDC_TASK_ID = "mdcTaskId";
 
-  static boolean enabled = false;
+  static boolean enabled;
 
   public static boolean isMDCEnabled() {
     return enabled;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramEdgeWaypoint.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramEdgeWaypoint.java
@@ -24,8 +24,8 @@ public class DiagramEdgeWaypoint implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private Double x = null;
-  private Double y = null;
+  private Double x;
+  private Double y;
 
   public Double getX() {
     return x;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramElement.java
@@ -24,7 +24,7 @@ abstract public class DiagramElement implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  protected String id = null;
+  protected String id;
 
   public DiagramElement() {
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/DiagramNode.java
@@ -22,10 +22,10 @@ public class DiagramNode extends DiagramElement {
 
   private static final long serialVersionUID = 1L;
 
-  private Double x = null;
-  private Double y = null;
-  private Double width = null;
-  private Double height = null;
+  private Double x;
+  private Double y;
+  private Double width;
+  private Double height;
 
   public DiagramNode() {
     super();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiRule.java
@@ -76,7 +76,7 @@ import org.junit.runners.model.Statement;
 public class ActivitiRule implements TestRule {
 
   protected String configurationResource = "activiti.cfg.xml";
-  protected String deploymentId = null;
+  protected String deploymentId;
 
   protected ProcessEngineConfiguration processEngineConfiguration;
   protected ProcessEngine processEngine;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiTestCase.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/ActivitiTestCase.java
@@ -52,7 +52,7 @@ import org.activiti.engine.test.mock.ActivitiMockSupport;
 public abstract class ActivitiTestCase extends TestCase {
 
   protected String configurationResource = "activiti.cfg.xml";
-  protected String deploymentId = null;
+  protected String deploymentId;
 
   protected ProcessEngineConfiguration processEngineConfiguration;
   protected ProcessEngine processEngine;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestBaseEntityEventListener.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestBaseEntityEventListener.java
@@ -17,11 +17,11 @@ import org.activiti.engine.delegate.event.BaseEntityEventListener;
 
 public class TestBaseEntityEventListener extends BaseEntityEventListener {
 
-  private boolean updateReceived = false;
-  private boolean createReceived = false;
-  private boolean deleteReceived = false;
-  private boolean initializeReceived = false;
-  private boolean customReceived = false;
+  private boolean updateReceived;
+  private boolean createReceived;
+  private boolean deleteReceived;
+  private boolean initializeReceived;
+  private boolean customReceived;
 
   public TestBaseEntityEventListener() {
     super();

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/DeployInvalidXmlTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/DeployInvalidXmlTest.java
@@ -91,7 +91,7 @@ public class DeployInvalidXmlTest extends PluggableActivitiTestCase {
 
   static class MyRunnable implements Runnable {
 
-    public boolean finished = false;
+    public boolean finished;
 
     protected RepositoryService repositoryService;
 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/IntermediateNoneEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/IntermediateNoneEventTest.java
@@ -20,7 +20,7 @@ import org.activiti.engine.test.Deployment;
 
 public class IntermediateNoneEventTest extends PluggableActivitiTestCase {
 
-  private static boolean listenerExecuted = false;
+  private static boolean listenerExecuted;
 
   public static class MyExecutionListener implements ExecutionListener {
     public void notify(DelegateExecution execution) {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/compensate/helper/SetVariablesDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/compensate/helper/SetVariablesDelegate.java
@@ -28,7 +28,7 @@ public class SetVariablesDelegate implements JavaDelegate {
   public static Map<Object, Integer> variablesMap = new HashMap<Object, Integer>();
 
   // activiti creates a single instance of the delegate
-  protected int lastInt = 0;
+  protected int lastInt;
 
   public void execute(DelegateExecution execution) {
     Object nrOfCompletedInstances = execution.getVariable("nrOfCompletedInstances");

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/EndEventTestJavaDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/EndEventTestJavaDelegate.java
@@ -20,7 +20,7 @@ import org.activiti.engine.delegate.JavaDelegate;
  */
 public class EndEventTestJavaDelegate implements JavaDelegate {
 
-  public static int timesCalled = 0;
+  public static int timesCalled;
 
   public void execute(DelegateExecution execution) {
     timesCalled++;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/end/TerminateEndEventTest.java
@@ -34,7 +34,7 @@ import org.activiti.engine.test.Deployment;
  */
 public class TerminateEndEventTest extends PluggableActivitiTestCase {
 
-	public static int serviceTaskInvokedCount = 0;
+	public static int serviceTaskInvokedCount;
 
 	public static class CountDelegate implements JavaDelegate {
 
@@ -46,7 +46,7 @@ public class TerminateEndEventTest extends PluggableActivitiTestCase {
 		}
 	}
 
-	public static int serviceTaskInvokedCount2 = 0;
+	public static int serviceTaskInvokedCount2;
 
 	public static class CountDelegate2 implements JavaDelegate {
 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/mapError/FlagDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/mapError/FlagDelegate.java
@@ -19,7 +19,7 @@ import org.activiti.engine.delegate.JavaDelegate;
  * @author Saeid Mirzaei
  */
 public class FlagDelegate implements JavaDelegate {
-  static boolean visited = false;
+  static boolean visited;
 
   public static void reset() {
     visited = false;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.java
@@ -31,8 +31,8 @@ import org.activiti.engine.test.Deployment;
  */
 public class BoundaryTimerEventTest extends PluggableActivitiTestCase {
 
-  private static boolean listenerExecutedStartEvent = false;
-  private static boolean listenerExecutedEndEvent = false;
+  private static boolean listenerExecutedStartEvent;
+  private static boolean listenerExecutedEndEvent;
 
   public static class MyExecutionListener implements ExecutionListener {
     private static final long serialVersionUID = 1L;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/RetryFailingDelegate.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/RetryFailingDelegate.java
@@ -11,7 +11,7 @@ public class RetryFailingDelegate implements JavaDelegate {
 
   public static final String EXCEPTION_MESSAGE = "Expected exception.";
 
-  public static boolean shallThrow = false;
+  public static boolean shallThrow;
   public static List<Long> times;
 
   static public void resetTimeList() {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/MDCLoggingTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/MDCLoggingTest.java
@@ -15,7 +15,7 @@ import org.apache.log4j.PatternLayout;
 public class MDCLoggingTest extends PluggableActivitiTestCase {
 
   MemoryLogAppender console = new MemoryLogAppender();
-  List<Appender> appenders = null;
+  List<Appender> appenders;
 
   private void setCustomLogger() {
     String PATTERN = "Modified Log *** ProcessDefinitionId=%X{mdcProcessDefinitionID} executionId=%X{mdcExecutionId} mdcProcessInstanceID=%X{mdcProcessInstanceID} mdcBusinessKey=%X{mdcBusinessKey} mdcTaskId=%X{mdcTaskId}  %m%n";

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/TestService.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/logging/mdc/TestService.java
@@ -4,10 +4,10 @@ import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.JavaDelegate;
 
 public class TestService implements JavaDelegate {
-  static String processInstanceId = null;
-  static String processDefinitionId = null;
-  static String executionId = null;
-  static String businessKey = null;
+  static String processInstanceId;
+  static String processDefinitionId;
+  static String executionId;
+  static String businessKey;
 
   @Override
   public void execute(DelegateExecution execution) {

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ToUpperCaseSetterInjected.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ToUpperCaseSetterInjected.java
@@ -22,7 +22,7 @@ import org.activiti.engine.delegate.JavaDelegate;
 public class ToUpperCaseSetterInjected implements JavaDelegate {
 
   private Expression text;
-  private boolean setterInvoked = false;
+  private boolean setterInvoked;
 
   public void execute(DelegateExecution execution) {
 

--- a/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/JPAVariableTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/JPAVariableTest.java
@@ -65,7 +65,7 @@ public class JPAVariableTest extends AbstractActivitiTestCase {
   private static FieldAccessJPAEntity entityToQuery;
   private static FieldAccessJPAEntity entityToUpdate;
 
-  private static boolean entitiesInitialized = false;
+  private static boolean entitiesInitialized;
 
   private static EntityManagerFactory entityManagerFactory;
 


### PR DESCRIPTION
Initializing fields to 0, null, or false is not needed and just duplicates work.

I ran a mvn clean test on the engine module successfully.
