### PR TITLE
[FIX] skip expression test case

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/servicetask/ExpressionServiceTaskTest.java
@@ -37,10 +37,10 @@ public class ExpressionServiceTaskTest extends PluggableActivitiTestCase {
     assertEquals(null, runtimeService.getVariable(pi2.getId(), "result"));
 
     Map<String, Object> variables3 = new HashMap<String, Object>();
-    variables3.put("bean", new ValueBean("ok"));
-    variables3.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", true);
-    ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables2);
-    assertEquals(null, runtimeService.getVariable(pi3.getId(), "result"));
+    variables3.put("bean", new ValueBean("okBean"));
+    variables3.put("_ACTIVITI_SKIP_EXPRESSION_ENABLED", false);
+    ProcessInstance pi3 = runtimeService.startProcessInstanceByKey("setServiceResultToProcessVariablesWithSkipExpression", variables3);
+    assertEquals("okBean", runtimeService.getVariable(pi3.getId(), "result"));
   }
 
   @Deployment


### PR DESCRIPTION
The skip expression test case was using the wrong variable for the process (using `variable2` instead of `variable3`).

While in the test changed the last test to test case where `_ACTIVITI_SKIP_EXPRESSION_ENABLED` is false.