### PR TITLE
[FIX] Cast conflicts with 'instanceof'

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventDispatcherImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventDispatcherImpl.java
@@ -102,7 +102,7 @@ public class ActivitiEventDispatcherImpl implements ActivitiEventDispatcher {
 
     if (event instanceof ActivitiEntityEvent) {
       Object entity = ((ActivitiEntityEvent) event).getEntity();
-      if (entity instanceof ProcessDefinition) {
+      if (entity instanceof ProcessDefinitionEntity) {
         result = (ProcessDefinitionEntity) entity;
       }
     }


### PR DESCRIPTION
The cast in ActivitiEventDispatcherImpl.java conflicts with 'instanceOf'

Change the `instanceof` operand.
From:
```java
      if (entity instanceof ProcessDefinition) {
         result = (ProcessDefinitionEntity) entity;
```
To:
```java
      if (entity instanceof ProcessDefinitionEntity) {`
          result = (ProcessDefinitionEntity) entity;
```

It is most likely OK the way it is but this is more correct.