### PR TITLE
Subprocess start triggers Process execution listeners to run

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
@@ -65,7 +65,7 @@ public class ContinueProcessOperation extends AbstractOperation {
     	
       // Check if it's the initial flow element. If so, we must fire the execution listeners for the process too
       FlowNode currentFlowNode = (FlowNode) currentFlowElement;
-      if (currentFlowNode.getIncomingFlows() != null && currentFlowNode.getIncomingFlows().size() == 0) {
+      if (currentFlowNode.getIncomingFlows() != null && currentFlowNode.getIncomingFlows().size() == 0 && null == currentFlowNode.getSubProcess()) {
     	  executeProcessStartExecutionListeners();
       }
     	

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
@@ -6,13 +6,17 @@ import java.util.List;
 
 import org.activiti.bpmn.model.Activity;
 import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.CompensateEventDefinition;
 import org.activiti.bpmn.model.EndEvent;
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.FlowNode;
+import org.activiti.bpmn.model.HasExecutionListeners;
+import org.activiti.bpmn.model.Process;
 import org.activiti.bpmn.model.SubProcess;
 import org.activiti.bpmn.model.Transaction;
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.delegate.ExecutionListener;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.bpmn.behavior.MultiInstanceActivityBehavior;
@@ -24,6 +28,7 @@ import org.activiti.engine.impl.persistence.entity.ExecutionEntityManager;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
 import org.activiti.engine.impl.pvm.delegate.SubProcessActivityBehavior;
 import org.activiti.engine.impl.pvm.runtime.InterpretableExecution;
+import org.activiti.engine.impl.util.ProcessDefinitionUtil;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +55,7 @@ public class EndExecutionOperation extends AbstractOperation {
     if (executionEntity.getParentId() != null) {
       parentExecution = executionEntityManager.get(executionEntity.getParentId());
     }
-
+    
     if (parentExecution != null) {
 
       // If the execution is a scope, all the child executions must be deleted first.
@@ -171,6 +176,13 @@ public class EndExecutionOperation extends AbstractOperation {
         logger.debug("Active executions found. Process instance {} will not be ended.", processInstanceId);
       }
 
+      Process process = getProcess(executionEntity.getProcessDefinitionId());
+      
+      // Execute execution listeners for process end.
+      if (CollectionUtils.isNotEmpty(process.getExecutionListeners())) { 
+        executeExecutionListeners(process, executionEntity, ExecutionListener.EVENTNAME_END, false);
+      }
+      
       // and trigger execution afterwards
       if (superExecution != null) {
         superExecution.setSubProcessInstance(null);
@@ -184,7 +196,7 @@ public class EndExecutionOperation extends AbstractOperation {
           throw new ActivitiException("Error while completing sub process of execution " + executionEntity, e);
         }
 
-      } else {
+      } else {        
         // dispatch process completed event
         if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
           Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.PROCESS_COMPLETED, execution));
@@ -246,4 +258,9 @@ public class EndExecutionOperation extends AbstractOperation {
     return allEventScopeExecutions;
   }
 
+  protected Process getProcess(String processDefinitionId)
+  {
+    BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(processDefinitionId);
+    return bpmnModel.getMainProcess();
+  }
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.activiti.engine.impl.agenda.TakeOutgoingSequenceFlowsOperation;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
@@ -149,5 +150,35 @@ public class ExecutionListenerTest extends PluggableActivitiTestCase {
 
     assertEquals("theEnd", currentActivities.get(2).getActivityId());
     assertEquals("End Event", currentActivities.get(2).getActivityName());
+  }
+  
+  @Deployment(resources = { "org/activiti/examples/bpmn/executionlistener/ExecutionListenersForSubprocessStartEndEvent.bpmn20.xml" })
+  public void testExecutionListenersForSubprocessStartEndEvents() {
+    RecorderExecutionListener.clear();
+
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess");
+    
+    List<RecordedEvent> recordedEvents = RecorderExecutionListener.getRecordedEvents();
+    assertEquals(1, recordedEvents.size());
+    assertEquals("Process Start", recordedEvents.get(0).getParameter());
+    
+    RecorderExecutionListener.clear();
+    
+    Task task = taskService.createTaskQuery().singleResult();
+    taskService.complete(task.getId());
+    
+    assertProcessEnded(processInstance.getId());
+
+    recordedEvents = RecorderExecutionListener.getRecordedEvents();
+    
+    for(RecordedEvent re : recordedEvents)
+    {
+      System.out.println(re.getParameter());
+    }
+    
+    assertEquals(3, recordedEvents.size());
+    assertEquals("Subprocess Start", recordedEvents.get(0).getParameter());
+    assertEquals("Subprocess End", recordedEvents.get(1).getParameter());
+    assertEquals("Process End", recordedEvents.get(2).getParameter());
   }
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -31,7 +31,8 @@ public class ExecutionListenerTest extends PluggableActivitiTestCase {
 
   @Deployment(resources = { "org/activiti/examples/bpmn/executionlistener/ExecutionListenersProcess.bpmn20.xml" })
   public void testExecutionListenersOnAllPossibleElements() {
-
+    RecorderExecutionListener.clear();
+    
     // Process start executionListener will have executionListener class
     // that sets 2 variables
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess", "businessKey123");
@@ -73,6 +74,12 @@ public class ExecutionListenerTest extends PluggableActivitiTestCase {
     taskService.complete(task.getId());
 
     assertProcessEnded(processInstance.getId());
+    
+    List<RecordedEvent> events = RecorderExecutionListener.getRecordedEvents();
+    assertEquals(1, events.size());
+    RecordedEvent event = events.get(0);
+    assertEquals("End Process Listener", event.getParameter());
+    
   }
 
   @Deployment(resources = { "org/activiti/examples/bpmn/executionlistener/ExecutionListenersStartEndEvent.bpmn20.xml" })
@@ -106,7 +113,7 @@ public class ExecutionListenerTest extends PluggableActivitiTestCase {
     assertEquals("start", recordedEvents.get(3).getEventName());
 
   }
-
+  
   @Deployment(resources = { "org/activiti/examples/bpmn/executionlistener/ExecutionListenersFieldInjectionProcess.bpmn20.xml" })
   public void testExecutionListenerFieldInjection() {
     Map<String, Object> variables = new HashMap<String, Object>();

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/RecorderExecutionListener.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/RecorderExecutionListener.java
@@ -73,7 +73,7 @@ public class RecorderExecutionListener implements ExecutionListener {
     
     recordedEvents.add(new RecordedEvent(
         executionCasted.getActivityId(),
-        currentFlowElement.getName(),
+        (null != currentFlowElement) ? currentFlowElement.getName() : null,
         execution.getEventName(), 
         (String) parameter.getValue(execution)));
   }

--- a/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersForSubprocessStartEndEvent.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersForSubprocessStartEndEvent.bpmn20.xml
@@ -1,0 +1,51 @@
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+  
+  <signal id="alertSignal" name="alert" /> 
+  
+  <process id="executionListenersProcess">
+	  <extensionElements>
+        <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener" event="start">
+          <activiti:field name="parameter" stringValue="Process Start" />
+        </activiti:executionListener>
+        <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener" event="end">
+          <activiti:field name="parameter" stringValue="Process End" />
+        </activiti:executionListener>
+      </extensionElements> 
+    
+    <startEvent id="theStart" name="Start Event"/>
+
+    <sequenceFlow sourceRef="theStart" targetRef="userTask" /> 
+    
+	<userTask id="userTask"/>
+	
+    <sequenceFlow sourceRef="userTask" targetRef="subprocess" />    
+    
+    <subProcess id="subprocess">
+	  <extensionElements>
+        <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener" event="start">
+          <activiti:field name="parameter" stringValue="Subprocess Start" />
+        </activiti:executionListener>
+        <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener" event="end">
+          <activiti:field name="parameter" stringValue="Subprocess End" />
+        </activiti:executionListener>
+      </extensionElements>   
+      
+      <startEvent id="subStart" name="Start Event"/>
+      <endEvent id="subEnd" name="End Event"/>
+      
+      <sequenceFlow sourceRef="subStart" targetRef="manualTask" />
+      <manualTask id="manualTask"/>
+      <sequenceFlow sourceRef="manualTask" targetRef="subEnd" />
+      
+    </subProcess>
+
+
+    <sequenceFlow sourceRef="subprocess" targetRef="theEnd" />
+
+    <endEvent id="theEnd" name="End Event"/>
+    
+  </process>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersProcess.bpmn20.xml
@@ -7,6 +7,9 @@
   
     <extensionElements>
       <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.ExampleExecutionListenerOne" event="start" />
+      <activiti:executionListener class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener" event="end">
+      	<activiti:field name="parameter" stringValue="End Process Listener" />
+      </activiti:executionListener>
     </extensionElements>
     
     <startEvent id="theStart" />


### PR DESCRIPTION
ContinueProcessOperation triggers execution listeners defined on the process to run when starting a subprocess. 

Fix: Update condition to check the currentFlowNode for a subprocess. 

Note: This pull request is dependent on my earlier pull request (https://github.com/Activiti/Activiti/commit/7330f77d87d9d41ef84f9a6713f1d00b34e7cca1) .