### PR TITLE
Update references in readme.html to use new JIRA location.

### DIFF
--- a/distro/src/readme.html
+++ b/distro/src/readme.html
@@ -1,301 +1,301 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
-  <head>
+<head>
     <title>Activiti Readme</title>
-  </head>
-  <body>
-  
-    <img src="docs/userguide/images/activiti_readme.png"/>
-    
-    <h1>License</h1>
-    <p>All the software included in this distribution is distributed under <a href="license.txt">Apache license V2</a>
-    unless for these exceptions:
-    </p>
-    <ul>
-      <li>We are including slightly modified source code of the Apache Licensed <a href="http://juel.sourceforge.net/" title="JUEL project page">JUEL 2.2.1</a>, created by Odysseus Software GmbH.</li>
-    </ul>
-    
-    <h1>Documentation</h1>
-    <ul>
-      <li><a href="docs/userguide/index.html#10minutetutorial">10 Minute Tutorial</a></li>
-      <li><a href="docs/userguide/index.html">The User Guide</a></li>
-      <li><a href="docs/javadocs/index.html">Javadocs</a></li>
-    </ul>
-    
-    <h1>Links</h1>
-    <ul>
-      <li><a href="http://forums.activiti.org/en/viewforum.php?f=3">Activiti User Forum</a></li>
-      <li><a href="http://forums.activiti.org/en/viewforum.php?f=4">Activiti Developer Forum</a></li>
-      <li><a href="http://docs.codehaus.org/display/ACT/Home">Activiti Wiki</a></li>
-      <li><a href="http://jira.codehaus.org/browse/ACT">Activiti bug tracking system</a></li>
-    </ul>
-    A more elaborate collection of Activiti-links can be found on the 
-    <a href="http://activiti.org/community.html">Activiti Community page</a>
+</head>
+<body>
 
-  <h1>Activiti Release Notes</h1>
-  
-  <h3>Release Notes - Activiti - 6.0.0-SNAPSHOT</h3>
-  
-  <h4>Backwards incompatible changes</h4>
-  <ul>
-    <li><a href="http://jira.codehaus.org/browse/ACT-2186">http://jira.codehaus.org/browse/ACT-2186</a> : When variables are removed, the historic variable entry is also removed. In earlier versions, the value of the historic variable was set to <i>null</i>.</li>
-  </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.17.0</h3>
-  
-  <h4>Highlights</h4>
-   <ul>
-    <li>We introduced a fully tested and brand new Async executor, which supersedes the old Job executor. 
-    The new Async executor uses less database queries to execute asynchronous jobs and is more performant in general. 
-    By default the Activiti Engine still uses the old Job executor, so you have to explicitly choose for the new Async executor by setting the asyncExecutorEnabled property in the process engine configuration.
-    For more details you can look at the advanced section of the user guide.</li>
-    <li>The Activiti Modeler is fully revised and is implemented using Angular JS. This is donated from the Alfresco Activiti BPMN editor that's part of the <a href="http://www.alfresco.com/products/activiti">Alfresco Activiti Enterprise offering</a>. The new Angular JS Activiti Modeler is LGPL licensed. 
-    Note that some dialogs are not yet ported to the new Activiti Modeler, but you'll also find quite a bit of new functionality, including Mule and Camel tasks and being able to define a sequence flow order for an exclusive gateway. Any help with adding new features is really appreciated.</li>
+<img src="docs/userguide/images/activiti_readme.png" alt="readme"/>
+
+<h1>License</h1>
+<p>All the software included in this distribution is distributed under <a href="license.txt">Apache license V2</a>
+    unless for these exceptions:
+</p>
+<ul>
+    <li>We are including slightly modified source code of the Apache Licensed <a href="http://juel.sourceforge.net/" title="JUEL project page">JUEL 2.2.1</a>, created by Odysseus Software GmbH.</li>
+</ul>
+
+<h1>Documentation</h1>
+<ul>
+    <li><a href="docs/userguide/index.html#10minutetutorial">10 Minute Tutorial</a></li>
+    <li><a href="docs/userguide/index.html">The User Guide</a></li>
+    <li><a href="docs/javadocs/index.html">Javadocs</a></li>
+</ul>
+
+<h1>Links</h1>
+<ul>
+    <li><a href="http://forums.activiti.org/forums/activiti-users">Activiti User Forum</a></li>
+    <li><a href="http://forums.activiti.org/forums/activiti-developers">Activiti Developer Forum</a></li>
+    <li><a href="http://docs.codehaus.org/display/ACT/Home">Activiti Wiki</a></li>
+    <li><a href="https://activiti.atlassian.net/browse/ACT">Activiti bug tracking system</a></li>
+</ul>
+A more elaborate collection of Activiti-links can be found on the
+<a href="http://activiti.org/community.html">Activiti Community page</a>
+
+<h1>Activiti Release Notes</h1>
+
+<h3>Release Notes - Activiti - 6.0.0-SNAPSHOT</h3>
+
+<h4>Backwards incompatible changes</h4>
+<ul>
+    <li><a href="https://activiti.atlassian.net/browse/ACT-2186">https://activiti.atlassian.net/browse/ACT-2186</a> : When variables are removed, the historic variable entry is also removed. In earlier versions, the value of the historic variable was set to <i>null</i>.</li>
+</ul>
+
+<h3>Release Notes - Activiti - Version 5.17.0</h3>
+
+<h4>Highlights</h4>
+<ul>
+    <li>We introduced a fully tested and brand new Async executor, which supersedes the old Job executor.
+        The new Async executor uses less database queries to execute asynchronous jobs and is more performant in general.
+        By default the Activiti Engine still uses the old Job executor, so you have to explicitly choose for the new Async executor by setting the asyncExecutorEnabled property in the process engine configuration.
+        For more details you can look at the advanced section of the user guide.</li>
+    <li>The Activiti Modeler is fully revised and is implemented using Angular JS. This is donated from the Alfresco Activiti BPMN editor that's part of the <a href="http://www.alfresco.com/products/activiti">Alfresco Activiti Enterprise offering</a>. The new Angular JS Activiti Modeler is LGPL licensed.
+        Note that some dialogs are not yet ported to the new Activiti Modeler, but you'll also find quite a bit of new functionality, including Mule and Camel tasks and being able to define a sequence flow order for an exclusive gateway. Any help with adding new features is really appreciated.</li>
     <li>The user guide has been revamped with a rewrite to AsciiDoc</li>
     <li>It's now possible to start a process instance a skip tasks based on a skipExpression. This is very handy when you are migrating process instances to the Activiti Engine (thanks to Robert Hafner for the pull request).
     <li>We added a new module named activiti-jmx to the Activiti project, which enables JMX for the Activiti Engine. Read <a href="http://tech.blog.saeidmirzaei.com/?p=251">Saeids blog</a> for more details (thanks Saeid).
     <li>Variable fetching has been optimized for process instances and executions in general.</li>
     <li>The database upgrade scripts use a different minor version than the JAR version. With the 5.17.0 release, the database version is 5.17.0.2. This versioning enables us to release snapshots and still be able to upgrade from a snapshot release to a stable release.
-    For a 5.17.1 release the database version will be 5.17.1.x where x can be any number. So only the last minor version number can differ from the Activiti Engine release version.</li>
-   </ul>
-   
-   <h4>Specific notes</h4>
-  
-  <ul>
+        For a 5.17.1 release the database version will be 5.17.1.x where x can be any number. So only the last minor version number can differ from the Activiti Engine release version.</li>
+</ul>
+
+<h4>Specific notes</h4>
+
+<ul>
     <li>
-    	Note that the version number is 5.17.0 instead of 5.17. Make sure you use version 5.17.0 for your Maven dependency.
+        Note that the version number is 5.17.0 instead of 5.17. Make sure you use version 5.17.0 for your Maven dependency.
     </li>
-  </ul>
-   
-   <h4>Bug fixes and various smaller improvements</h4>
-   
-   <p>Check out the <a href="http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=20537">Release notes</a> for more details</p>
-            
+</ul>
+
+<h4>Bug fixes and various smaller improvements</h4>
+
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10015">Release notes</a> for more details</p>
+
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1527'>ACT-1527</a>] -         ProcessDiagramGenerator misses instructions for message start event
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1544'>ACT-1544</a>] -         Asynchronous Continuations join exception
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1849'>ACT-1849</a>] -         Null pointer exception when deploying a workflow created by Activiti explorer integrated workflow editor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1900'>ACT-1900</a>] -         RuntimeService.getVariables(String, Collection) fetches all variables from DB
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2061'>ACT-2061</a>] -         Suspicious instanceOf test
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2062'>ACT-2062</a>] -         FeatureDescriptor&#39;s setValue method will not accept a null value
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2068'>ACT-2068</a>] -         update for redundant namespace usage
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2071'>ACT-2071</a>] -         Non executable processes are no validation failure
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2083'>ACT-2083</a>] -         Autolayout fails with subprocess data objects
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2084'>ACT-2084</a>] -         TaskService.unclaim(taskId) does not fire an ActivitiEvent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2088'>ACT-2088</a>] -         drawEventBasedGateway does not work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2093'>ACT-2093</a>] -         the label of sequenceFlow is wrong
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2096'>ACT-2096</a>] -         Deadlock while concurrently finishing process instances on MSSQL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2102'>ACT-2102</a>] -         Duplicate condition in &#39;if&#39; statement
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2103'>ACT-2103</a>] -         Sql bug with task query when using OR statement
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2116'>ACT-2116</a>] -         Fix unreachable code in org.activiti.engine.test.api.event.DatabaseEventLoggerTest
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2120'>ACT-2120</a>] -         JobRetryCmd doesn&#39;t use tenantId to query the activity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2145'>ACT-2145</a>] -         Activiti Modeler UserTask form property expression problem
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2151'>ACT-2151</a>] -         Deployment fails when Intermediate Event is waiting for same message as start message
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2155'>ACT-2155</a>] -         Boolean field form is converted to String
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2157'>ACT-2157</a>] -         Activiti diagram drawing missing some nodes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2159'>ACT-2159</a>] -         Infinite loop when using multi instance service task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2164'>ACT-2164</a>] -         The converter BPMN to XML does not manage correctly /definitions/message/@itemRef
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2166'>ACT-2166</a>] -         Missing ${prefix} before ACT_ID_MEMBERSHIP in script /org/activiti/db/mapping/entity/Task.xml
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2168'>ACT-2168</a>] -         Standard XML preamble is missing on SOAP request sent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2171'>ACT-2171</a>] -         NPE, integrity constraint violation, and timers firing after task completion on processes with certain combinations of timers, messages, and user tasks
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1527'>ACT-1527</a>] -         ProcessDiagramGenerator misses instructions for message start event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1544'>ACT-1544</a>] -         Asynchronous Continuations join exception
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1849'>ACT-1849</a>] -         Null pointer exception when deploying a workflow created by Activiti explorer integrated workflow editor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1900'>ACT-1900</a>] -         RuntimeService.getVariables(String, Collection) fetches all variables from DB
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2061'>ACT-2061</a>] -         Suspicious instanceOf test
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2062'>ACT-2062</a>] -         FeatureDescriptor&#39;s setValue method will not accept a null value
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2068'>ACT-2068</a>] -         update for redundant namespace usage
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2071'>ACT-2071</a>] -         Non executable processes are no validation failure
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2083'>ACT-2083</a>] -         Autolayout fails with subprocess data objects
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2084'>ACT-2084</a>] -         TaskService.unclaim(taskId) does not fire an ActivitiEvent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2088'>ACT-2088</a>] -         drawEventBasedGateway does not work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2093'>ACT-2093</a>] -         the label of sequenceFlow is wrong
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2096'>ACT-2096</a>] -         Deadlock while concurrently finishing process instances on MSSQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2102'>ACT-2102</a>] -         Duplicate condition in &#39;if&#39; statement
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2103'>ACT-2103</a>] -         Sql bug with task query when using OR statement
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2116'>ACT-2116</a>] -         Fix unreachable code in org.activiti.engine.test.api.event.DatabaseEventLoggerTest
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2120'>ACT-2120</a>] -         JobRetryCmd doesn&#39;t use tenantId to query the activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2145'>ACT-2145</a>] -         Activiti Modeler UserTask form property expression problem
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2151'>ACT-2151</a>] -         Deployment fails when Intermediate Event is waiting for same message as start message
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2155'>ACT-2155</a>] -         Boolean field form is converted to String
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2157'>ACT-2157</a>] -         Activiti diagram drawing missing some nodes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2159'>ACT-2159</a>] -         Infinite loop when using multi instance service task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2164'>ACT-2164</a>] -         The converter BPMN to XML does not manage correctly /definitions/message/@itemRef
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2166'>ACT-2166</a>] -         Missing ${prefix} before ACT_ID_MEMBERSHIP in script /org/activiti/db/mapping/entity/Task.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2168'>ACT-2168</a>] -         Standard XML preamble is missing on SOAP request sent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2171'>ACT-2171</a>] -         NPE, integrity constraint violation, and timers firing after task completion on processes with certain combinations of timers, messages, and user tasks
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2089'>ACT-2089</a>] -         Task sorting on due date needs to place those with due date null after those with a duedate
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2091'>ACT-2091</a>] -         Add likeIgnoreCase for most used properties with like query
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2092'>ACT-2092</a>] -         Create parent interface for TaskQuery and HistoricTaskInstanceQuery that groups all common methods
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2094'>ACT-2094</a>] -         New method &quot;getVariableInstances()&quot; on VariableScopeImpl
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2089'>ACT-2089</a>] -         Task sorting on due date needs to place those with due date null after those with a duedate
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2091'>ACT-2091</a>] -         Add likeIgnoreCase for most used properties with like query
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2092'>ACT-2092</a>] -         Create parent interface for TaskQuery and HistoricTaskInstanceQuery that groups all common methods
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2094'>ACT-2094</a>] -         New method &quot;getVariableInstances()&quot; on VariableScopeImpl
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1963'>ACT-1963</a>] -         Data Object support for Activiti Modeler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2073'>ACT-2073</a>] -         Document custom identity link feature in User Guide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2074'>ACT-2074</a>] -         add support for custom identity links to Modeler
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1963'>ACT-1963</a>] -         Data Object support for Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2073'>ACT-2073</a>] -         Document custom identity link feature in User Guide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2074'>ACT-2074</a>] -         add support for custom identity links to Modeler
+    </li>
 </ul>
-                
-  
-  <h3>Release Notes - Activiti - Version 5.16.4</h3>
-  
-  <h4>Highlights</h4>
-   <ul>
+
+
+<h3>Release Notes - Activiti - Version 5.16.4</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>First implementation of a new lock free job executor (<a href="https://github.com/Activiti/Activiti/wiki/Notes-on-the-new-Actviti-Jobexecutor-(Oct-2014)">New job executor wiki</a>). Note that exclusive jobs and suspended process instances are not supported yet.</li>
     <li>Restlet has been replaced with Spring MVC for the REST API</li>
-   </ul>
-  
-  <h4>Implementation changes</h4>
-  
-  <ul>
+</ul>
+
+<h4>Implementation changes</h4>
+
+<ul>
     <li>
-    	<a href="https://jira.codehaus.org/browse/ACT-2071">https://jira.codehaus.org/browse/ACT-2071</a>:
-    	A deployment must always contain at least one executable (property 'isExecutable' on the process element) process definition
-    	to be deployable. However, a deployment can now contain process definitions that are not executable.  
-    	Before, any non-executable process definition would result in a validation error.
-    	Now, these are warnings which do not prevent the deployment.
+        <a href="https://activiti.atlassian.net/browse/ACT-2071">https://activiti.atlassian.net/browse/ACT-2071</a>:
+        A deployment must always contain at least one executable (property 'isExecutable' on the process element) process definition
+        to be deployable. However, a deployment can now contain process definitions that are not executable.
+        Before, any non-executable process definition would result in a validation error.
+        Now, these are warnings which do not prevent the deployment.
     </li>
-  </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.16.1</h3>
-  
-   <h4>Highlights</h4>
-   <ul>
+</ul>
+
+<h3>Release Notes - Activiti - Version 5.16.1</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Bug fix for database constraint issue, introduced in 5.16</li>
     <li>Basic OR query support for process instances and task. You can now query with one OR statement chain included using the query api</li>
-   </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.16</h3>
-  
-   <h4>Highlights</h4>
-   <ul>
+</ul>
+
+<h3>Release Notes - Activiti - Version 5.16</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Added Spring boot support and more Spring annotation support in general (thanks to Josh Long)</li>
     <li>Refactoring of the job executor to simplify its logic and prevent possible long wait times.</li>
     <li>Added new event log table that stores process engine events when wanted, by default this is switched off.</li>
     <li>Introduction of Crystalball, which is an experimental new project that allows you to replay and simulate process instances (Thanks to Martin)</li>
     <li>Upgraded to Spring 4.x and Restlet 2.2.x</li>
     <li>Various fixes and improvements</li>
-   </ul>
-   
-   <h4>Bug fixes and various smaller improvements</h4>
-   
-   <p>Check out the <a href="http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=19620">Release notes</a> for more details</p>
-  
-  <h2>        Bug
+</ul>
+
+<h4>Bug fixes and various smaller improvements</h4>
+
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10014">Release notes</a> for more details</p>
+
+<h2>        Bug
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1945'>ACT-1945</a>] -         Empty diagram produces xml parse error
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1955'>ACT-1955</a>] -         Can not use table-driven editor (Kickstart) with LDAP-User
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1977'>ACT-1977</a>] -         5.15.1 release missing activiti-process-validation jar file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1978'>ACT-1978</a>] -         Obsolete signal subscriptions are not being removed, causing signals to be fired in old process definitons
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1988'>ACT-1988</a>] -         Camel routes containing activiti consumers cannot be adviced.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1995'>ACT-1995</a>] -         ExtensionElement does not parse correctly and xml generation contains redundant namespace declarations
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2000'>ACT-2000</a>] -         custom attribute parser fails with empty string for namespace
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2005'>ACT-2005</a>] -         NPE ValuedDataObjectXMLConverter class for empty-valued data objects
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2016'>ACT-2016</a>] -         Tenancy does not work for call activity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2023'>ACT-2023</a>] -         Optimize namespace usage - redundant namespace usage in XML
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2026'>ACT-2026</a>] -         Modeler workspace never opens
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2027'>ACT-2027</a>] -         MessageEventDefinitionParseHandler does not set extension elements.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2033'>ACT-2033</a>] -         Camel component cannot be multi instance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2042'>ACT-2042</a>] -         runtimeService.deleteProcessInstance does not set process instance end time when current activity is a scope
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2047'>ACT-2047</a>] -         Incorrect self comparison of value with itself
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2048'>ACT-2048</a>] -         Redundant null check in org.activiti.engine.impl.persistence.entity.JobEntity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2049'>ACT-2049</a>] -         Multi tenancy support is not working in case of duplicate filtering while deploying processes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2050'>ACT-2050</a>] -         Suspicious equals() test in org.activiti.engine.impl.persistence.entity.DeploymentEntityManager
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2052'>ACT-2052</a>] -         Subprocess DataObjects created in wrong scope.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2055'>ACT-2055</a>] -         Subprocess extensions are not getting parsed
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2056'>ACT-2056</a>] -         Incorrect &#39;contains&#39; comparision
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2057'>ACT-2057</a>] -         Equals method for ValuedDataObject should use .equals()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2058'>ACT-2058</a>] -         Null deference possible
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2059'>ACT-2059</a>] -         Redundant null test in execute method
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2060'>ACT-2060</a>] -         Method uses the same code for two branches
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1945'>ACT-1945</a>] -         Empty diagram produces xml parse error
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1955'>ACT-1955</a>] -         Can not use table-driven editor (Kickstart) with LDAP-User
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1977'>ACT-1977</a>] -         5.15.1 release missing activiti-process-validation jar file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1978'>ACT-1978</a>] -         Obsolete signal subscriptions are not being removed, causing signals to be fired in old process definitions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1988'>ACT-1988</a>] -         Camel routes containing activiti consumers cannot be adviced.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1995'>ACT-1995</a>] -         ExtensionElement does not parse correctly and xml generation contains redundant namespace declarations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2000'>ACT-2000</a>] -         custom attribute parser fails with empty string for namespace
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2005'>ACT-2005</a>] -         NPE ValuedDataObjectXMLConverter class for empty-valued data objects
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2016'>ACT-2016</a>] -         Tenancy does not work for call activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2023'>ACT-2023</a>] -         Optimize namespace usage - redundant namespace usage in XML
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2026'>ACT-2026</a>] -         Modeler workspace never opens
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2027'>ACT-2027</a>] -         MessageEventDefinitionParseHandler does not set extension elements.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2033'>ACT-2033</a>] -         Camel component cannot be multi instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2042'>ACT-2042</a>] -         runtimeService.deleteProcessInstance does not set process instance end time when current activity is a scope
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2047'>ACT-2047</a>] -         Incorrect self comparison of value with itself
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2048'>ACT-2048</a>] -         Redundant null check in org.activiti.engine.impl.persistence.entity.JobEntity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2049'>ACT-2049</a>] -         Multi tenancy support is not working in case of duplicate filtering while deploying processes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2050'>ACT-2050</a>] -         Suspicious equals() test in org.activiti.engine.impl.persistence.entity.DeploymentEntityManager
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2052'>ACT-2052</a>] -         Subprocess DataObjects created in wrong scope.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2055'>ACT-2055</a>] -         Subprocess extensions are not getting parsed
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2056'>ACT-2056</a>] -         Incorrect &#39;contains&#39; comparison
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2057'>ACT-2057</a>] -         Equals method for ValuedDataObject should use .equals()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2058'>ACT-2058</a>] -         Null deference possible
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2059'>ACT-2059</a>] -         Redundant null test in execute method
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2060'>ACT-2060</a>] -         Method uses the same code for two branches
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1987'>ACT-1987</a>] -         Portuguese brazilian translation of Activiti
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2002'>ACT-2002</a>] -         Upgrade Restlet &amp; Jackson libraries
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2037'>ACT-2037</a>] -         Performance - Bulk deletion of variables at process end
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2051'>ACT-2051</a>] -         Code change: a null check is not needed before using instanceof.
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1987'>ACT-1987</a>] -         Portuguese brazilian translation of Activiti
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2002'>ACT-2002</a>] -         Upgrade Restlet &amp; Jackson libraries
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2037'>ACT-2037</a>] -         Performance - Bulk deletion of variables at process end
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2051'>ACT-2051</a>] -         Code change: a null check is not needed before using instanceof.
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1996'>ACT-1996</a>] -         DiagramGenerator does not give possibility to change icons for custom service tasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2011'>ACT-2011</a>] -         Expose formKey on Task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2038'>ACT-2038</a>] -         Custom IdentityLinkType support
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1996'>ACT-1996</a>] -         DiagramGenerator does not give possibility to change icons for custom service tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2011'>ACT-2011</a>] -         Expose formKey on Task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2038'>ACT-2038</a>] -         Custom IdentityLinkType support
+    </li>
 </ul>
-                
+
 <h2>        Wish
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-2013'>ACT-2013</a>] -         support candidateGroupIn for runtime tasks in activiti-rest
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2013'>ACT-2013</a>] -         support candidateGroupIn for runtime tasks in activiti-rest
+    </li>
 </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.15.1</h3>
-  
-   <h4>Highlights</h4>
-   <ul>
+
+<h3>Release Notes - Activiti - Version 5.15.1</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Bug fix release for a MySQL upgrade issue (more details <a href="http://forums.activiti.org/content/important-activiti-515-and-mysql-56-users">here</a>)</li>
     <li>Some small improvements from pull requests</li>
-   </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.15</h3>
-  
-   <h4>Highlights</h4>
-   <ul>
+</ul>
+
+<h3>Release Notes - Activiti - Version 5.15</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Multi tanancy support added to Activiti, including the Java and REST API.</li>
     <li>Added new event support to listen for events in the Activiti Engine, like task deleted, variable updated, process engine created and many more.</li>
     <li>Introduction of data object support (thanks to Lori Small and team)</li>
@@ -303,521 +303,521 @@
     <li>Added an easy way to do custom sql execution (<a href="http://www.jorambarrez.be/blog/2014/01/17/execute-custom-sql-in-activiti/">http://www.jorambarrez.be/blog/2014/01/17/execute-custom-sql-in-activiti/</a>)</li>
     <li>Improved OSGi support + added OSGi unit testing using Tinybundles</li>
     <li>Various fixes and improvements</li>
-   </ul>
-   
-   <h4>Bug fixes and various smaller improvements</h4>
-   
-   <p>Check out the <a href="http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=19344">Release notes</a> for more details</p>
-   
-   <h2>        Sub-task
+</ul>
+
+<h4>Bug fixes and various smaller improvements</h4>
+
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10013">Release notes</a> for more details</p>
+
+<h2>        Sub-task
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1608'>ACT-1608</a>] -         Fix DB2 metadata problem
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1608'>ACT-1608</a>] -         Fix DB2 metadata problem
+    </li>
 </ul>
-        
+
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1339'>ACT-1339</a>] -         MultipleInstance UserTask does not use AtomicOperation -&gt; CDI Event Listener fails
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1549'>ACT-1549</a>] -         endTime of joining parallel gateway is not set: HistoricActivityInstance.getEndTime() returns null
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1589'>ACT-1589</a>] -         NPE when executing SignalThrowingEvent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1610'>ACT-1610</a>] -         DbSqlSession isTablePresent method adds table prefix which causes check to fail
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1627'>ACT-1627</a>] -         Save task will throw assignment-event even if assignee is not altered
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1712'>ACT-1712</a>] -         Duplicate task when signal is sent to User Task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1733'>ACT-1733</a>] -         REST API documentation for Task Query points to wrong URL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1745'>ACT-1745</a>] -         ProcessDiagramGenerator misses some diagram flow elements and truncates labels
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1752'>ACT-1752</a>] -         In BpmnDeployer, only schedule start timers AFTER process definition has been persisted
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1794'>ACT-1794</a>] -         LDAP - Group lookups for a user fail if the DN has special characters
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1795'>ACT-1795</a>] -         lineChart report hasn&#39;t been rendered
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1816'>ACT-1816</a>] -         ManagementService doesn&#39;t seem to give actual table Name for EventSubscriptionEntity.class
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1822'>ACT-1822</a>] -         MultiInstance loopIndexVariable support
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1823'>ACT-1823</a>] -         CancelEndEvent goes into dead lock
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1825'>ACT-1825</a>] -         Infinite recursion in TestActivityBehaviorFactory
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1826'>ACT-1826</a>] -         OSGI bundle activiti-engine/5.14 failed to deploy due to duplicated imported org.activiti.osgi + WorkAround
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1828'>ACT-1828</a>] -         Completing a task in DelegationState.PENDING does not throw ActivitiException
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1838'>ACT-1838</a>] -         Activiti 5.14 did not ship incremental upgrade DB schema migration script (to auto upgrade 5.13 -&gt; 5.14)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1839'>ACT-1839</a>] -         ACT_FK_VAR_BYTEARRAY violated on variable update
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1842'>ACT-1842</a>] -         Add taskService.complete() method that takes an option boolean to determine the scope of variables
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1844'>ACT-1844</a>] -         ActivitiRule fails if test methods are declared in a super class
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1848'>ACT-1848</a>] -         ClassCastException when using CdiEventSupportBpmnParseHandler with multi instance user task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1854'>ACT-1854</a>] -         ExtensionElements parsing causes NullpointerException in non Process/Activity Context
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1858'>ACT-1858</a>] -         Groovy generated classes aren&#39;t garbage collected
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1859'>ACT-1859</a>] -         TaskListeners configured for ALL event types do not receive DELETE events
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1863'>ACT-1863</a>] -         NPE on HistoricVariableInstanceQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1872'>ACT-1872</a>] -         Text Annotation is not generated in export and in viewer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1879'>ACT-1879</a>] -         Job Executor job acquisition can lead to deadlocks in clustered setup
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1881'>ACT-1881</a>] -         activiti-engine OSGi bundle requires junit classes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1882'>ACT-1882</a>] -         activiti-spring OSGi bundle requires spring-test classes.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1883'>ACT-1883</a>] -         Listener end event is not notified when compensation done
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1884'>ACT-1884</a>] -         add missing type of serviceTask in activiti-bpmn-extensions-5.15.xsd
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1887'>ACT-1887</a>] -         Inserting a variable with the same name on the same process-instance from 2 threads results in duplicate name/revision entry in ACT_RU_VARIABLE 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1888'>ACT-1888</a>] -         UserTask XML converter error when it has default sequence flow
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1889'>ACT-1889</a>] -         Boundary event don&#39;t follow pool position.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1891'>ACT-1891</a>] -         After edit or click form properties typed enum lose values
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1892'>ACT-1892</a>] -         Repeat add listener
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1894'>ACT-1894</a>] -         the parameter name of HistoricActivityInstanceQuery.activityInstanceId() should be activityInstanceId, not processInstanceId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1896'>ACT-1896</a>] -         Using activityId(..) and processInstanceBusinessKey(.., true) on Execution-query causes SQL-exception
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1897'>ACT-1897</a>] -         Form-properties (and some other table-based properties) no longer selectable/editable/removable in Designer 5.14.0
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1901'>ACT-1901</a>] -         The coordinates of activity nodes contained in  a DiagramLayout are sometime not correct.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1908'>ACT-1908</a>] -         Activiti designer 5.14 removes custom form property information 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1909'>ACT-1909</a>] -         REST queries should support paging like their normal GET counterparts do
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1912'>ACT-1912</a>] -         Task Listener Bug
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1914'>ACT-1914</a>] -         Activiti designer does not update sequence flow references
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1918'>ACT-1918</a>] -         deploying a process fails with hibernate 4.2.6.Final &quot;The object is already closed&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1923'>ACT-1923</a>] -         Setting task assignee and using updateTask() does not update task history
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1927'>ACT-1927</a>] -         Manual tasks are actually created as generic tasks in the BPMN source
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1928'>ACT-1928</a>] -         Changing the id of elements in the Properties view does not change references to it leading to broken models
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1929'>ACT-1929</a>] -         Co-ordinates of BPMNEdge labels are relative to the wrong origin
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1930'>ACT-1930</a>] -         Activiti designer 5.14 form editor prevents editing of fields
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1935'>ACT-1935</a>] -         BeanELResolver hides target exception in ELException when catching InvocationTargetException
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1937'>ACT-1937</a>] -         StackOverflowError when using an EndErrorEvent from an Event Sub-Process
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1939'>ACT-1939</a>] -         HistoryService loads invalid task local variables for completed task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1940'>ACT-1940</a>] -         Possible bug in MS-SQL server configuration with  schema
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1941'>ACT-1941</a>] -         IdentityService interface leaking implementation details 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1944'>ACT-1944</a>] -         LDAP-Authentication fails if LDAP-User has no forename
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1949'>ACT-1949</a>] -         Jobs are not being removed from ACT_RU_JOB for for &lt;timeCycle&gt; timers
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1951'>ACT-1951</a>] -         ACT_RU_JOBS has orphaned rows after deleting Process with repeat timers
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1953'>ACT-1953</a>] -         multi instance sub process,variable conflict?
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1339'>ACT-1339</a>] -         MultipleInstance UserTask does not use AtomicOperation -&gt; CDI Event Listener fails
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1549'>ACT-1549</a>] -         endTime of joining parallel gateway is not set: HistoricActivityInstance.getEndTime() returns null
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1589'>ACT-1589</a>] -         NPE when executing SignalThrowingEvent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1610'>ACT-1610</a>] -         DbSqlSession isTablePresent method adds table prefix which causes check to fail
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1627'>ACT-1627</a>] -         Save task will throw assignment-event even if assignee is not altered
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1712'>ACT-1712</a>] -         Duplicate task when signal is sent to User Task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1733'>ACT-1733</a>] -         REST API documentation for Task Query points to wrong URL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1745'>ACT-1745</a>] -         ProcessDiagramGenerator misses some diagram flow elements and truncates labels
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1752'>ACT-1752</a>] -         In BpmnDeployer, only schedule start timers AFTER process definition has been persisted
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1794'>ACT-1794</a>] -         LDAP - Group lookups for a user fail if the DN has special characters
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1795'>ACT-1795</a>] -         lineChart report hasn&#39;t been rendered
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1816'>ACT-1816</a>] -         ManagementService doesn&#39;t seem to give actual table Name for EventSubscriptionEntity.class
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1822'>ACT-1822</a>] -         MultiInstance loopIndexVariable support
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1823'>ACT-1823</a>] -         CancelEndEvent goes into dead lock
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1825'>ACT-1825</a>] -         Infinite recursion in TestActivityBehaviorFactory
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1826'>ACT-1826</a>] -         OSGI bundle activiti-engine/5.14 failed to deploy due to duplicated imported org.activiti.osgi + WorkAround
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1828'>ACT-1828</a>] -         Completing a task in DelegationState.PENDING does not throw ActivitiException
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1838'>ACT-1838</a>] -         Activiti 5.14 did not ship incremental upgrade DB schema migration script (to auto upgrade 5.13 -&gt; 5.14)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1839'>ACT-1839</a>] -         ACT_FK_VAR_BYTEARRAY violated on variable update
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1842'>ACT-1842</a>] -         Add taskService.complete() method that takes an option boolean to determine the scope of variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1844'>ACT-1844</a>] -         ActivitiRule fails if test methods are declared in a super class
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1848'>ACT-1848</a>] -         ClassCastException when using CdiEventSupportBpmnParseHandler with multi instance user task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1854'>ACT-1854</a>] -         ExtensionElements parsing causes NullpointerException in non Process/Activity Context
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1858'>ACT-1858</a>] -         Groovy generated classes aren&#39;t garbage collected
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1859'>ACT-1859</a>] -         TaskListeners configured for ALL event types do not receive DELETE events
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1863'>ACT-1863</a>] -         NPE on HistoricVariableInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1872'>ACT-1872</a>] -         Text Annotation is not generated in export and in viewer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1879'>ACT-1879</a>] -         Job Executor job acquisition can lead to deadlocks in clustered setup
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1881'>ACT-1881</a>] -         activiti-engine OSGi bundle requires junit classes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1882'>ACT-1882</a>] -         activiti-spring OSGi bundle requires spring-test classes.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1883'>ACT-1883</a>] -         Listener end event is not notified when compensation done
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1884'>ACT-1884</a>] -         add missing type of serviceTask in activiti-bpmn-extensions-5.15.xsd
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1887'>ACT-1887</a>] -         Inserting a variable with the same name on the same process-instance from 2 threads results in duplicate name/revision entry in ACT_RU_VARIABLE
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1888'>ACT-1888</a>] -         UserTask XML converter error when it has default sequence flow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1889'>ACT-1889</a>] -         Boundary event don&#39;t follow pool position.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1891'>ACT-1891</a>] -         After edit or click form properties typed enum lose values
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1892'>ACT-1892</a>] -         Repeat add listener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1894'>ACT-1894</a>] -         the parameter name of HistoricActivityInstanceQuery.activityInstanceId() should be activityInstanceId, not processInstanceId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1896'>ACT-1896</a>] -         Using activityId(..) and processInstanceBusinessKey(.., true) on Execution-query causes SQL-exception
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1897'>ACT-1897</a>] -         Form-properties (and some other table-based properties) no longer selectable/editable/removable in Designer 5.14.0
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1901'>ACT-1901</a>] -         The coordinates of activity nodes contained in  a DiagramLayout are sometime not correct.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1908'>ACT-1908</a>] -         Activiti designer 5.14 removes custom form property information
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1909'>ACT-1909</a>] -         REST queries should support paging like their normal GET counterparts do
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1912'>ACT-1912</a>] -         Task Listener Bug
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1914'>ACT-1914</a>] -         Activiti designer does not update sequence flow references
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1918'>ACT-1918</a>] -         deploying a process fails with hibernate 4.2.6.Final &quot;The object is already closed&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1923'>ACT-1923</a>] -         Setting task assignee and using updateTask() does not update task history
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1927'>ACT-1927</a>] -         Manual tasks are actually created as generic tasks in the BPMN source
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1928'>ACT-1928</a>] -         Changing the id of elements in the Properties view does not change references to it leading to broken models
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1929'>ACT-1929</a>] -         Co-ordinates of BPMNEdge labels are relative to the wrong origin
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1930'>ACT-1930</a>] -         Activiti designer 5.14 form editor prevents editing of fields
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1935'>ACT-1935</a>] -         BeanELResolver hides target exception in ELException when catching InvocationTargetException
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1937'>ACT-1937</a>] -         StackOverflowError when using an EndErrorEvent from an Event Sub-Process
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1939'>ACT-1939</a>] -         HistoryService loads invalid task local variables for completed task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1940'>ACT-1940</a>] -         Possible bug in MS-SQL server configuration with  schema
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1941'>ACT-1941</a>] -         IdentityService interface leaking implementation details
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1944'>ACT-1944</a>] -         LDAP-Authentication fails if LDAP-User has no forename
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1949'>ACT-1949</a>] -         Jobs are not being removed from ACT_RU_JOB for for &lt;timeCycle&gt; timers
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1951'>ACT-1951</a>] -         ACT_RU_JOBS has orphaned rows after deleting Process with repeat timers
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1953'>ACT-1953</a>] -         multi instance sub process,variable conflict?
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1491'>ACT-1491</a>] -         Parsing association, drawing Annotation and connections
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1496'>ACT-1496</a>] -         Replace JSON.org with GSON dependencies
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1781'>ACT-1781</a>] -         Diagram improvement: curved flows, annotations, associations, label position.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1860'>ACT-1860</a>] -         Remove unique constraint on business key
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1867'>ACT-1867</a>] -         MySQL DATETIME and TIMESTAMP precision
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1911'>ACT-1911</a>] -         Adopt MyBatis 3.2.4
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1916'>ACT-1916</a>] -         Double-check all REST-resources for explicit authenticate() call, to improve overall security
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1952'>ACT-1952</a>] -         Refactor process definition validation + allow to plugin in custom validation
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1491'>ACT-1491</a>] -         Parsing association, drawing Annotation and connections
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1496'>ACT-1496</a>] -         Replace JSON.org with GSON dependencies
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1781'>ACT-1781</a>] -         Diagram improvement: curved flows, annotations, associations, label position.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1860'>ACT-1860</a>] -         Remove unique constraint on business key
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1867'>ACT-1867</a>] -         MySQL DATETIME and TIMESTAMP precision
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1911'>ACT-1911</a>] -         Adopt MyBatis 3.2.4
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1916'>ACT-1916</a>] -         Double-check all REST-resources for explicit authenticate() call, to improve overall security
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1952'>ACT-1952</a>] -         Refactor process definition validation + allow to plugin in custom validation
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1448'>ACT-1448</a>] -         Support for expressions in candidate/assignee/...
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1797'>ACT-1797</a>] -         Send events for major state changes of domain objects
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1840'>ACT-1840</a>] -         Allow to set a &#39;category&#39; on tasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1890'>ACT-1890</a>] -         Multi tenancy support
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1898'>ACT-1898</a>] -         Allow to execute custom SQL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1904'>ACT-1904</a>] -         Introduce Process Engine Configurator concept
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1907'>ACT-1907</a>] -         Add ProcessInstanceHistoryLog
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1910'>ACT-1910</a>] -         Introduce @EnableActiviti for Spring
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1933'>ACT-1933</a>] -         Delete Identity Link from RuntimeService IdentityLink list
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1936'>ACT-1936</a>] -         Query Tasks by process category
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1954'>ACT-1954</a>] -         Warning Date on Task
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1448'>ACT-1448</a>] -         Support for expressions in candidate/assignee/...
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1797'>ACT-1797</a>] -         Send events for major state changes of domain objects
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1840'>ACT-1840</a>] -         Allow to set a &#39;category&#39; on tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1890'>ACT-1890</a>] -         Multi tenancy support
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1898'>ACT-1898</a>] -         Allow to execute custom SQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1904'>ACT-1904</a>] -         Introduce Process Engine Configurator concept
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1907'>ACT-1907</a>] -         Add ProcessInstanceHistoryLog
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1910'>ACT-1910</a>] -         Introduce @EnableActiviti for Spring
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1933'>ACT-1933</a>] -         Delete Identity Link from RuntimeService IdentityLink list
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1936'>ACT-1936</a>] -         Query Tasks by process category
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1954'>ACT-1954</a>] -         Warning Date on Task
+    </li>
 </ul>
-        
+
 <h2>        Task
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1631'>ACT-1631</a>] -         Deploy artifacts to central maven repository
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1833'>ACT-1833</a>] -         get BusinessCalendar from BusinessCalendarManager except new a instance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1869'>ACT-1869</a>] -         Document signal event scope
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1631'>ACT-1631</a>] -         Deploy artifacts to central maven repository
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1833'>ACT-1833</a>] -         get BusinessCalendar from BusinessCalendarManager except new a instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1869'>ACT-1869</a>] -         Document signal event scope
+    </li>
 </ul>
-  
-  <h3>Release Notes - Activiti - Version 5.14</h3>
-  
-   <h4>Highlights</h4>
-   <ul>
+
+<h3>Release Notes - Activiti - Version 5.14</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Version 5.14 is focused on bug fixes and small improvements.</li>
     <li>Improved process and task query support</li>
     <li>Add OSGi bundle headers to all Activiti module JARs</li>
     <li>Thanks to the community for the large number of pull requests, especially Martin Grofcik, Mike Dias and Saeid Mirzaei</li>
-   </ul>
-   
-   <h4>Important Note for MSSQL and DB2 users</h4>
-    
-   <p>
-        Activiti 5.13 and 5.14 contain changes to the default indexes that are created when using
-        MSSQL or DB2 as database. These indexes <b>are not created automatically when upgrading Activiti</b>,
-        as they may conflict with custom indexes or impact the database load. The purpose if the indexes
-        is to avoid deadlock exceptions when using Activiti under high load.
-   </p>
-   
-   <p>
-        As such, please review carefully following commits and apply to your database (where applicable):
-        <ul>
-            <li><a href="https://github.com/Activiti/Activiti/commit/4911bd176b78fa4c466e3fcbd3617af3bd95eba0">https://github.com/Activiti/Activiti/commit/4911bd176b78fa4c466e3fcbd3617af3bd95eba0</a></li>
-            <li><a href="https://github.com/Activiti/Activiti/commit/22f6c8d0cf126320addb90f86495e89e7d656939">https://github.com/Activiti/Activiti/commit/22f6c8d0cf126320addb90f86495e89e7d656939</a></li>
-        </ul>   
-   </p>
-   
-   <h4>Bug fixes and various smaller improvements</h4>
-   
-   <p>Check out the <a href="https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=19143">Release notes</a> for more details</p>
+</ul>
+
+<h4>Important Note for MSSQL and DB2 users</h4>
+
+<p>
+    Activiti 5.13 and 5.14 contain changes to the default indexes that are created when using
+    MSSQL or DB2 as database. These indexes <b>are not created automatically when upgrading Activiti</b>,
+    as they may conflict with custom indexes or impact the database load. The purpose if the indexes
+    is to avoid deadlock exceptions when using Activiti under high load.
+</p>
+
+<p>
+    As such, please review carefully following commits and apply to your database (where applicable):
+<ul>
+    <li><a href="https://github.com/Activiti/Activiti/commit/4911bd176b78fa4c466e3fcbd3617af3bd95eba0">https://github.com/Activiti/Activiti/commit/4911bd176b78fa4c466e3fcbd3617af3bd95eba0</a></li>
+    <li><a href="https://github.com/Activiti/Activiti/commit/22f6c8d0cf126320addb90f86495e89e7d656939">https://github.com/Activiti/Activiti/commit/22f6c8d0cf126320addb90f86495e89e7d656939</a></li>
+</ul>
+</p>
+
+<h4>Bug fixes and various smaller improvements</h4>
+
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10012">Release notes</a> for more details</p>
 
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-821'>ACT-821</a>] -         HistoryService.deleteHistoricProcessInstance() does not delete sub processes
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1186'>ACT-1186</a>] -         ActivitiRule services not initialized when using SpringJUnit4ClassRunner together with @ContextConfiguration
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1438'>ACT-1438</a>] -         Target expressions for call activities are not supported
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1454'>ACT-1454</a>] -         Support for custom type of comment
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1600'>ACT-1600</a>] -         Activiti Modeler target namespace not saved to BPMN XML
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1609'>ACT-1609</a>] -         problem evaluating script while click &quot;Reports-&gt;Process Instance Overview&quot; on activiti-explorer.(DB2 datasource)
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1612'>ACT-1612</a>] -         Modeler missing cancelActivity
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1625'>ACT-1625</a>] -         Text-annotation elements are ignored when parsed, but the corresponding BPMN-DI is not which causes a warning
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1649'>ACT-1649</a>] -         Deadlock occured in load test with db2
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1663'>ACT-1663</a>] -         StartEvent hasn&#39;t the attribute &quot;formKey&quot; in the Activiti Modeler
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1720'>ACT-1720</a>] -         Redundant space between table prefix and table name in org\activiti\db\mapping\entity\User.xml
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1723'>ACT-1723</a>] -         ORA-01747: select count(RES.*)   from ACT_HI_VARINST RES    WHERE RES.PROC_INST_ID_ = ?
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1725'>ACT-1725</a>] -         Incorrect display subprocess in subprocess, when it open in Activiti Modeler. (Problem with coordinates of elements after convertation BPMN to JSON)
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1727'>ACT-1727</a>] -         activiti-exploer process instance highlight diagram is incorrent
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1728'>ACT-1728</a>] -         If the process instance was started by a callActivity, it will be not have the startEvent activity in ACT_HI_ACTINST table
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1731'>ACT-1731</a>] -         Fail start process with variables
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1740'>ACT-1740</a>] -         REST-status cannot be created when exception contains newlines
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1741'>ACT-1741</a>] -         activiti-spring POM should not depend on slf4j-log4j12
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1743'>ACT-1743</a>] -         candidateGroup can&#39;t use expression with comma
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1749'>ACT-1749</a>] -         Impossible to remove identity-links from create-listener
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1755'>ACT-1755</a>] -         ACT_HI_ACTINST does not record parallel gateway end times and durations
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1756'>ACT-1756</a>] -         Changing ID of an activity or event makes a copy of BPMNShape element
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1758'>ACT-1758</a>] -         MySQL + BTM fails on schema create
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1762'>ACT-1762</a>] -         Support multiple occurrences of extension elements and attributes with same id
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1770'>ACT-1770</a>] -         Model query for lastest version is broken
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1771'>ACT-1771</a>] -         VariableScope#getVariableLocal should take parameter of type String rather than Object
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1775'>ACT-1775</a>] -         NPE when retrieving JPA Entity process variables via REST API /runtime/tasks
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1777'>ACT-1777</a>] -         Activiti sql file problem for MySQL 5.6
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1780'>ACT-1780</a>] -         User Guide: Create a User (new api) does not list password for body
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1788'>ACT-1788</a>] -         Fields of Java services obtained with a delegateExpression aren&#39;t injected when handling signals.
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1789'>ACT-1789</a>] -         Make HistoricTaskInstanceQuery to support &quot;taskCandidateUser&quot; 
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1791'>ACT-1791</a>] -         Modeler does not allow creation ENUM type fields in forms.
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1793'>ACT-1793</a>] -         Process flow through boundary events not rendered in diagram viewer
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1801'>ACT-1801</a>] -         JSON Serialization of Process with Lane leads to infinite recursion
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1806'>ACT-1806</a>] -         Race condition during BPMN deployment
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-821'>ACT-821</a>] -         HistoryService.deleteHistoricProcessInstance() does not delete sub processes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1186'>ACT-1186</a>] -         ActivitiRule services not initialized when using SpringJUnit4ClassRunner together with @ContextConfiguration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1438'>ACT-1438</a>] -         Target expressions for call activities are not supported
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1454'>ACT-1454</a>] -         Support for custom type of comment
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1600'>ACT-1600</a>] -         Activiti Modeler target namespace not saved to BPMN XML
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1609'>ACT-1609</a>] -         problem evaluating script while click &quot;Reports-&gt;Process Instance Overview&quot; on activiti-explorer.(DB2 datasource)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1612'>ACT-1612</a>] -         Modeler missing cancelActivity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1625'>ACT-1625</a>] -         Text-annotation elements are ignored when parsed, but the corresponding BPMN-DI is not which causes a warning
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1649'>ACT-1649</a>] -         Deadlock occurred in load test with db2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1663'>ACT-1663</a>] -         StartEvent hasn&#39;t the attribute &quot;formKey&quot; in the Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1720'>ACT-1720</a>] -         Redundant space between table prefix and table name in org\activiti\db\mapping\entity\User.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1723'>ACT-1723</a>] -         ORA-01747: select count(RES.*)   from ACT_HI_VARINST RES    WHERE RES.PROC_INST_ID_ = ?
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1725'>ACT-1725</a>] -         Incorrect display subprocess in subprocess, when it open in Activiti Modeler. (Problem with coordinates of elements after conversation BPMN to JSON)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1727'>ACT-1727</a>] -         activiti-explorer process instance highlight diagram is incorrect
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1728'>ACT-1728</a>] -         If the process instance was started by a callActivity, it will be not have the startEvent activity in ACT_HI_ACTINST table
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1731'>ACT-1731</a>] -         Fail start process with variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1740'>ACT-1740</a>] -         REST-status cannot be created when exception contains newlines
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1741'>ACT-1741</a>] -         activiti-spring POM should not depend on slf4j-log4j12
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1743'>ACT-1743</a>] -         candidateGroup can&#39;t use expression with comma
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1749'>ACT-1749</a>] -         Impossible to remove identity-links from create-listener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1755'>ACT-1755</a>] -         ACT_HI_ACTINST does not record parallel gateway end times and durations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1756'>ACT-1756</a>] -         Changing ID of an activity or event makes a copy of BPMNShape element
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1758'>ACT-1758</a>] -         MySQL + BTM fails on schema create
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1762'>ACT-1762</a>] -         Support multiple occurrences of extension elements and attributes with same id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1770'>ACT-1770</a>] -         Model query for latest version is broken
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1771'>ACT-1771</a>] -         VariableScope#getVariableLocal should take parameter of type String rather than Object
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1775'>ACT-1775</a>] -         NPE when retrieving JPA Entity process variables via REST API /runtime/tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1777'>ACT-1777</a>] -         Activiti sql file problem for MySQL 5.6
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1780'>ACT-1780</a>] -         User Guide: Create a User (new api) does not list password for body
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1788'>ACT-1788</a>] -         Fields of Java services obtained with a delegateExpression aren&#39;t injected when handling signals.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1789'>ACT-1789</a>] -         Make HistoricTaskInstanceQuery to support &quot;taskCandidateUser&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1791'>ACT-1791</a>] -         Modeler does not allow creation ENUM type fields in forms.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1793'>ACT-1793</a>] -         Process flow through boundary events not rendered in diagram viewer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1801'>ACT-1801</a>] -         JSON Serialization of Process with Lane leads to infinite recursion
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1806'>ACT-1806</a>] -         Race condition during BPMN deployment
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1076'>ACT-1076</a>] -         Draw transitions names in diagram generator
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1529'>ACT-1529</a>] -         Declare activiti-webapp-explorer2 as distributable in web.xml
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1630'>ACT-1630</a>] -         Extend SerializableType to *not* support entities with null id
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1634'>ACT-1634</a>] -         FormKey and TargetNameSpace attributes using Activiti Modeler
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1665'>ACT-1665</a>] -         Add support for UUIDs as queryable process variables
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1699'>ACT-1699</a>] -         Mail server configuration using JNDI
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1722'>ACT-1722</a>] -         Property isExecutable aren&#39;t avaliable in Activiti Modeler
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1732'>ACT-1732</a>] -         Updating Procecss Busienss Key
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1738'>ACT-1738</a>] -         Adding MDC (Mapped Diagnostic Context) logging
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1747'>ACT-1747</a>] -         Upgrade some legacy dependencies (commons-lang, jackson)
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1753'>ACT-1753</a>] -         Add missing sql mapping for &#39;selectProcessDefinition&#39;
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1782'>ACT-1782</a>] -         Provide hook to create custom UserTaskActivityBehavior
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1786'>ACT-1786</a>] -         Shared packages between activiti-common-rest &amp; activit-rest modules
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1798'>ACT-1798</a>] -         Provide getter for field MultiInstanceActivityBehavior#innerActivityBehavior
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1807'>ACT-1807</a>] -         Add support for Async Message/Signal triggering from RuntimeService
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1815'>ACT-1815</a>] -         Add getJobExecutor/setJobExecutor to ProcessEngineConfiguration interface
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1076'>ACT-1076</a>] -         Draw transitions names in diagram generator
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1529'>ACT-1529</a>] -         Declare activiti-webapp-explorer2 as distributable in web.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1630'>ACT-1630</a>] -         Extend SerializableType to *not* support entities with null id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1634'>ACT-1634</a>] -         FormKey and TargetNameSpace attributes using Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1665'>ACT-1665</a>] -         Add support for UUIDs as queryable process variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1699'>ACT-1699</a>] -         Mail server configuration using JNDI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1722'>ACT-1722</a>] -         Property isExecutable aren&#39;t available in Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1732'>ACT-1732</a>] -         Updating Process Business Key
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1738'>ACT-1738</a>] -         Adding MDC (Mapped Diagnostic Context) logging
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1747'>ACT-1747</a>] -         Upgrade some legacy dependencies (commons-lang, jackson)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1753'>ACT-1753</a>] -         Add missing sql mapping for &#39;selectProcessDefinition&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1782'>ACT-1782</a>] -         Provide hook to create custom UserTaskActivityBehavior
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1786'>ACT-1786</a>] -         Shared packages between activiti-common-rest &amp; activiti-rest modules
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1798'>ACT-1798</a>] -         Provide getter for field MultiInstanceActivityBehavior#innerActivityBehavior
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1807'>ACT-1807</a>] -         Add support for Async Message/Signal triggering from RuntimeService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1815'>ACT-1815</a>] -         Add getJobExecutor/setJobExecutor to ProcessEngineConfiguration interface
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-830'>ACT-830</a>] -         Provide API ProcessInstanceQuery#processDefinitionName
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1746'>ACT-1746</a>] -         Query for failed process instances
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1751'>ACT-1751</a>] -         Catch Mail sending fail exception
-</li>
-</ul>  
-  
-  <h3>Release Notes - Activiti - Version 5.13</h3>
-   
-   <h4>Highlights</h4>
-   <ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-830'>ACT-830</a>] -         Provide API ProcessInstanceQuery#processDefinitionName
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1746'>ACT-1746</a>] -         Query for failed process instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1751'>ACT-1751</a>] -         Catch Mail sending fail exception
+    </li>
+</ul>
+
+<h3>Release Notes - Activiti - Version 5.13</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Fully refactored REST API. The REST API should now offer the same functionality as the Java API.</li>
     <li>Out-of-the-box LDAP integration</li>
     <li>Include process and task variables in the result of the process, historic process, task and historic task queries</li>
     <li>Lots of fixes</li>
-   </ul>
-   
-   <h4>Bug fixes and various smaller improvements</h4>
-    <p>Check out the <a href="https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=18880">Release notes</a> for more details</p>
-    
+</ul>
+
+<h4>Bug fixes and various smaller improvements</h4>
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10011">Release notes</a> for more details</p>
+
 <h2>        Sub-task
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1264'>ACT-1264</a>] -         Reintroduce ExportMarshaller invocation
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1264'>ACT-1264</a>] -         Reintroduce ExportMarshaller invocation
+    </li>
 </ul>
-        
+
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1388'>ACT-1388</a>] -         NPE in ExecutionEntity#ensureExecutionsInitialized()
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1426'>ACT-1426</a>] -         Nested multi-instance activities do not work
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1542'>ACT-1542</a>] -         CommandContext Logs and Re-throws Exceptions
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1578'>ACT-1578</a>] -         Update documentation: sort parameter in REST-API method /process-definitions 
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1591'>ACT-1591</a>] -         Referential integrity constraint violation on PROC_INST and IDENTITY_LINK
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1605'>ACT-1605</a>] -         The execution of many processes at once will cause constraint violations with the ID_ field.
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1607'>ACT-1607</a>] -         org.activiti.engine.ActivitiIllegalArgumentException: taskId is null when using taskService.addComment with process instance
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1619'>ACT-1619</a>] -         NullPointerException when no script is given to the script task,leading to process failure
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1620'>ACT-1620</a>] -         My Instances view fails to generate process diagram
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1623'>ACT-1623</a>] -         NPE when eventbased gateway is after referenced event
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1626'>ACT-1626</a>] -         Make not storing variable automatically in scripts the default
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1641'>ACT-1641</a>] -         Process diagram not shown for certain hostnames
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1653'>ACT-1653</a>] -         Deleting candidate users/groups for any user task
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1654'>ACT-1654</a>] -         Camel integration does not handle exceptions propagated back by Camel DefaultErrorHandler 
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1655'>ACT-1655</a>] -         Wrong execution order 
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1656'>ACT-1656</a>] -         Designer puts Task listener class where Execution listener class should be
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1657'>ACT-1657</a>] -         Wrong execution order of execution-listeners on event-based gateway and service-task
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1664'>ACT-1664</a>] -         Parsing results in exception when using textannotation on collaboration tag
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1668'>ACT-1668</a>] -         Auto refresh of task counts after task completion in Explorer
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1669'>ACT-1669</a>] -         Possible NPE in ActivitiDiagramMatchingStrategy
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1673'>ACT-1673</a>] -         CamelBehavior throws Exception when using with StrongUuidGenerator
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1674'>ACT-1674</a>] -         Classloading bug when using ExpressionFactory in OSGI environment
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1679'>ACT-1679</a>] -         Activiti 5.12.1 not compatiable with Mybatis 3.2.2
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1685'>ACT-1685</a>] -         In activiti-web-explorer2, when call method &quot;drawCollapsedCallActivity&quot; throw an error &quot;Object#&lt;Object&gt; has no method &#39;drawCollapsedTask&#39;&quot;
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1688'>ACT-1688</a>] -         Add identity-links to history and allow querying history based on involvedUser
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1690'>ACT-1690</a>] -         NPE when converting to BPMN a model with boundary event that is not attached to a task
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1698'>ACT-1698</a>] -         Activiti fails to build when default charset is Windows-1252
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1702'>ACT-1702</a>] -         Setting the databaseTablePrefix not possible directly on the ProcessEngineConfiguration
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1703'>ACT-1703</a>] -         The &quot;result variable name&quot; attribute of a Java service task is lost when exporting a process
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1709'>ACT-1709</a>] -         Some fields cannot be set directly on the ProcessEngineConfiguration
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1388'>ACT-1388</a>] -         NPE in ExecutionEntity#ensureExecutionsInitialized()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1426'>ACT-1426</a>] -         Nested multi-instance activities do not work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1542'>ACT-1542</a>] -         CommandContext Logs and Re-throws Exceptions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1578'>ACT-1578</a>] -         Update documentation: sort parameter in REST-API method /process-definitions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1591'>ACT-1591</a>] -         Referential integrity constraint violation on PROC_INST and IDENTITY_LINK
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1605'>ACT-1605</a>] -         The execution of many processes at once will cause constraint violations with the ID_ field.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1607'>ACT-1607</a>] -         org.activiti.engine.ActivitiIllegalArgumentException: taskId is null when using taskService.addComment with process instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1619'>ACT-1619</a>] -         NullPointerException when no script is given to the script task,leading to process failure
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1620'>ACT-1620</a>] -         My Instances view fails to generate process diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1623'>ACT-1623</a>] -         NPE when eventbased gateway is after referenced event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1626'>ACT-1626</a>] -         Make not storing variable automatically in scripts the default
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1641'>ACT-1641</a>] -         Process diagram not shown for certain hostnames
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1653'>ACT-1653</a>] -         Deleting candidate users/groups for any user task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1654'>ACT-1654</a>] -         Camel integration does not handle exceptions propagated back by Camel DefaultErrorHandler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1655'>ACT-1655</a>] -         Wrong execution order
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1656'>ACT-1656</a>] -         Designer puts Task listener class where Execution listener class should be
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1657'>ACT-1657</a>] -         Wrong execution order of execution-listeners on event-based gateway and service-task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1664'>ACT-1664</a>] -         Parsing results in exception when using textannotation on collaboration tag
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1668'>ACT-1668</a>] -         Auto refresh of task counts after task completion in Explorer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1669'>ACT-1669</a>] -         Possible NPE in ActivitiDiagramMatchingStrategy
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1673'>ACT-1673</a>] -         CamelBehavior throws Exception when using with StrongUuidGenerator
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1674'>ACT-1674</a>] -         Classloading bug when using ExpressionFactory in OSGI environment
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1679'>ACT-1679</a>] -         Activiti 5.12.1 not compatible with Mybatis 3.2.2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1685'>ACT-1685</a>] -         In activiti-web-explorer2, when call method &quot;drawCollapsedCallActivity&quot; throw an error &quot;Object#&lt;Object&gt; has no method &#39;drawCollapsedTask&#39;&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1688'>ACT-1688</a>] -         Add identity-links to history and allow querying history based on involvedUser
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1690'>ACT-1690</a>] -         NPE when converting to BPMN a model with boundary event that is not attached to a task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1698'>ACT-1698</a>] -         Activiti fails to build when default charset is Windows-1252
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1702'>ACT-1702</a>] -         Setting the databaseTablePrefix not possible directly on the ProcessEngineConfiguration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1703'>ACT-1703</a>] -         The &quot;result variable name&quot; attribute of a Java service task is lost when exporting a process
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1709'>ACT-1709</a>] -         Some fields cannot be set directly on the ProcessEngineConfiguration
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1523'>ACT-1523</a>] -         Always set ProcessDefinitionId available on JobEntity
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1576'>ACT-1576</a>] -         Rest API improvements for getting tasks
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1606'>ACT-1606</a>] -         Create a convenience method in TaskService to set a task&#39;s due date
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1616'>ACT-1616</a>] -         Expose activityID in interface Execution (add a public getter for activityID)
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1642'>ACT-1642</a>] -         Deprecated IMAGE datatype under MS SQL Server
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1672'>ACT-1672</a>] -         Add getKey() to PvmProcessDefinition
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1704'>ACT-1704</a>] -         Option to exclude subprocesses in ProcessInstancesQuery and HistoricProcessInstanceQuery
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1705'>ACT-1705</a>] -         Some methods on the {{ProcessEngineConfiguration}} are not supporting the builder pattern
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1523'>ACT-1523</a>] -         Always set ProcessDefinitionId available on JobEntity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1576'>ACT-1576</a>] -         Rest API improvements for getting tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1606'>ACT-1606</a>] -         Create a convenience method in TaskService to set a task&#39;s due date
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1616'>ACT-1616</a>] -         Expose activityID in interface Execution (add a public getter for activityID)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1642'>ACT-1642</a>] -         Deprecated IMAGE datatype under MS SQL Server
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1672'>ACT-1672</a>] -         Add getKey() to PvmProcessDefinition
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1704'>ACT-1704</a>] -         Option to exclude subprocesses in ProcessInstancesQuery and HistoricProcessInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1705'>ACT-1705</a>] -         Some methods on the {{ProcessEngineConfiguration}} are not supporting the builder pattern
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1588'>ACT-1588</a>] -         Native query support paging
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1647'>ACT-1647</a>] -         Enable querying TaskService for Tasks including local variables
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1652'>ACT-1652</a>] -         Add support for message start events to the REST-API
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1680'>ACT-1680</a>] -         Support for custom ProcessEngine selection in REST
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1691'>ACT-1691</a>] -         Allow to update process definition category through RepositoryService
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1696'>ACT-1696</a>] -         Provide out of the box LDAP integration
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1706'>ACT-1706</a>] -         Add fullNameLike to UserQuery
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1588'>ACT-1588</a>] -         Native query support paging
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1647'>ACT-1647</a>] -         Enable querying TaskService for Tasks including local variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1652'>ACT-1652</a>] -         Add support for message start events to the REST-API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1680'>ACT-1680</a>] -         Support for custom ProcessEngine selection in REST
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1691'>ACT-1691</a>] -         Allow to update process definition category through RepositoryService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1696'>ACT-1696</a>] -         Provide out of the box LDAP integration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1706'>ACT-1706</a>] -         Add fullNameLike to UserQuery
+    </li>
 </ul>
-        
+
 <h2>        Task
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1396'>ACT-1396</a>] -         Bring REST api in sync with Java API
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1707'>ACT-1707</a>] -         Remove UserCache from Activiti Explorer
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1396'>ACT-1396</a>] -         Bring REST api in sync with Java API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1707'>ACT-1707</a>] -         Remove UserCache from Activiti Explorer
+    </li>
 </ul>
-        
-   
-   <h3>Release Notes - Activiti - Version 5.12.1</h3>
-   
-   <h4>Highlights</h4>
-   <ul>
-    <li>Fix for ACT-1591, with referential contraint error (<a href="https://jira.codehaus.org/browse/ACT-1591">JIRA link</a>)</li>
+
+
+<h3>Release Notes - Activiti - Version 5.12.1</h3>
+
+<h4>Highlights</h4>
+<ul>
+    <li>Fix for ACT-1591, with referential constraint error (<a href="https://activiti.atlassian.net/browse/ACT-1591">JIRA link</a>)</li>
     <li>Resolved javascript JDK 7 issue (<a href="http://www.jorambarrez.be/blog/2013/03/25/bug-on-jdk-1-7-0_17-when-using-scripttask-in-activiti/">link to blog post</a>)</li>
     <li>Small Explorer and Modeler bug fixes</li>
     <li>Other small fixes</li>
-   </ul>
-   
-   <h4>Important upgrade notes when using script tasks and auto storage of variables</h4>
-   
-   <p>
-    Due to recent changes to the JDK (removing Serializable from sun.org.mozilla.javascript.internal.Undefined), the auto storing of variables is not possible anymore
-    with the built-in Javascript scriping engine. See <a href="http://www.jorambarrez.be/blog/2013/03/25/bug-on-jdk-1-7-0_17-when-using-scripttask-in-activiti/">this link</a>
-    for more information. Each script variable that needs to be stored as process variable needs to be explicitely 
-    stored by calling <i>execution.setVariable("variableName", variableValue)</i>. 
-   </p>
-   
-   <p>
-    For backwards compatibility reasons, the old behavior can still be used by setting the <i>autoStoreVariables</i> property
-    on a <i>scriptTask</i> to true. As written in the linked articale from above, this might not work when using a recent JDK version
-    and the built-in Javascript scripting engine.
-   </p>
+</ul>
 
-  <h3>Release Notes - Activiti - Version 5.12</h3>
-  
-  <h4>Highlights</h4>
-  <ul>
+<h4>Important upgrade notes when using script tasks and auto storage of variables</h4>
+
+<p>
+    Due to recent changes to the JDK (removing Serializable from sun.org.mozilla.javascript.internal.Undefined), the auto storing of variables is not possible anymore
+    with the built-in Javascript scripting engine. See <a href="http://www.jorambarrez.be/blog/2013/03/25/bug-on-jdk-1-7-0_17-when-using-scripttask-in-activiti/">this link</a>
+    for more information. Each script variable that needs to be stored as process variable needs to be explicitly
+    stored by calling <i>execution.setVariable("variableName", variableValue)</i>.
+</p>
+
+<p>
+    For backwards compatibility reasons, the old behavior can still be used by setting the <i>autoStoreVariables</i> property
+    on a <i>scriptTask</i> to true. As written in the linked article from above, this might not work when using a recent JDK version
+    and the built-in Javascript scripting engine.
+</p>
+
+<h3>Release Notes - Activiti - Version 5.12</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Added new javascript-based diagram viewer to Explorer (thanks to Dmitry Farafonov)</li>
     <li>Unified the BPMN parser and model for the Engine, Modeler and Designer</li>
     <li>Added Activiti Kickstart to the Explorer to quickly create processes without deep BPMN knowledge</li>
@@ -826,185 +826,185 @@
     <li>Added auto-layout module for Kickstart and BPMN import in Modeler (TBD) and Designer</li>
     <li>Added script task and execution listeners</li>
     <li>Lots of bug fixes</li>
-  </ul>
-  
-  <h4>Important upgrade note</h4>
-  
-  <p>
+</ul>
+
+<h4>Important upgrade note</h4>
+
+<p>
     The internal <i>org.activiti.engine.impl.bpmn.parser.BpmnParseListener</i> interface and related classes have been removed.
-  </p>
-    
-  <p>  
+</p>
+
+<p>
     Yes, we know many people relied on its capabilities, although it was a class in an internal package. But do not worry:
     we have introduced a replacement in the <b>api package</b> that offers similar (and even more powerful) functionality.
     The code is not backwards compatible, but the required changes should be minimal (eg the XML element is replaced by a
     Java pojo representation of the element). Read more about it in the new 'Advanced' chapter of the userguide.
-  </p>
-  
-  <h4>Bug fixes and various smaller improvements</h4>
-  <p>Check out the <a href="https://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=18879">Release notes</a> for more details</p>
-    
+</p>
+
+<h4>Bug fixes and various smaller improvements</h4>
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10010">Release notes</a> for more details</p>
+
 <h2>        Sub-task
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1565'>ACT-1565</a>] -         activiti-bpmn-converter BaseBpmnXMLConverter ignores defaultFlow for Gateways
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1565'>ACT-1565</a>] -         activiti-bpmn-converter BaseBpmnXMLConverter ignores defaultFlow for Gateways
+    </li>
 </ul>
-        
+
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-863'>ACT-863</a>] -         HistoricVariableUpdate#getValue() throws NPE for JPA entities
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-995'>ACT-995</a>] -         Not possible to update/overwrite a JPA entity in workflow
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1025'>ACT-1025</a>] -         Methods deleteDeployment(String deploymentId, ...) and deleteDeploymentCascade(String deploymentId, ...) do not throw an exception with passed a non-existent deployementId
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1026'>ACT-1026</a>] -         Inclusive gateway isn&#39;t properly joining sequence flows coming from call activities
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1040'>ACT-1040</a>] -         TaskManager.findTaskById does not utilize session cache
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1054'>ACT-1054</a>] -         Unable to complete user task coming from parallel gateway
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1196'>ACT-1196</a>] -         Invalid login screen localization on non-utf-8 based hosts
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1204'>ACT-1204</a>] -         InclusiveGateway with two subprocesses does not join correctly
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1317'>ACT-1317</a>] -         Wrong task event generated when setting assignee to null
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1345'>ACT-1345</a>] -         method name orderByHistoricActivityInstanceStartTime in class HistoricTaskInstanceQuery should be orderByHistoricTaskInstanceStartTime
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1372'>ACT-1372</a>] -         User Task with form: form will be not displayed if the value expression in next line used
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1377'>ACT-1377</a>] -         removeVariables() in VariableScopeImpl does not consider parent scopes
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1414'>ACT-1414</a>] -         ClassCastException when completing a referenced sub process after Boundary Event with cancelActivity = false
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1417'>ACT-1417</a>] -         Fix Explorer session serialization
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1418'>ACT-1418</a>] -         NullPointerException if throw a not catched exception/error
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1470'>ACT-1470</a>] -         Import definition type fails with CxfWSDLImporter when using complex data types
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1477'>ACT-1477</a>] -         In user guide error api for form property from history detail
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1479'>ACT-1479</a>] -         activiti-engine has invalid symbolic name
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1486'>ACT-1486</a>] -         The ability to add an attachment to a process instance is broken
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1494'>ACT-1494</a>] -         Get garbled string when render form in chines
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1499'>ACT-1499</a>] -         Form properties not initialized when null or empty
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1502'>ACT-1502</a>] -         Custom font name in the engine for diagram
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1504'>ACT-1504</a>] -         Cannot create new user and membership in JavaDelegate using identityService
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1512'>ACT-1512</a>] -         HistoricVariableUpdates no longer returned when using postgres
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1516'>ACT-1516</a>] -         BPMN Converter: Adding a listener to a script task produces erroneous XML content.
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1524'>ACT-1524</a>] -         Variable update detection does not work for byte[]
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1528'>ACT-1528</a>] -         All variables are deleted after delete a history processinstance
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1533'>ACT-1533</a>] -         Undeployment of old process versions deletes jobs for TimerStartEvents
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1540'>ACT-1540</a>] -         HistoricVariableInstance does not expose taskId, nor does HistoricVariableQuery expose querying based on taskId
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1546'>ACT-1546</a>] -         Impossible to assign default flow on exclusive gateways
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1553'>ACT-1553</a>] -         Refactor BpmnParse to use separate handlers for each bpmn element
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1555'>ACT-1555</a>] -         ProgrammaticBeanLookup doesn&#39;t regard alternatives
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1556'>ACT-1556</a>] -         BpmnDeployer creates duplicates identity links when deploying processes with initiation authorization active
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1579'>ACT-1579</a>] -         Process engine can be DoS&#39;ed when deploying unsafe XML
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1586'>ACT-1586</a>] -         ExecutionQuery returns wrong results when using multi instance on a receive task
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1596'>ACT-1596</a>] -         Not generated boundary event in diagram created by RaphaÃ«l
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-863'>ACT-863</a>] -         HistoricVariableUpdate#getValue() throws NPE for JPA entities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-995'>ACT-995</a>] -         Not possible to update/overwrite a JPA entity in workflow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1025'>ACT-1025</a>] -         Methods deleteDeployment(String deploymentId, ...) and deleteDeploymentCascade(String deploymentId, ...) do not throw an exception with passed a non-existent deployementId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1026'>ACT-1026</a>] -         Inclusive gateway isn&#39;t properly joining sequence flows coming from call activities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1040'>ACT-1040</a>] -         TaskManager.findTaskById does not utilize session cache
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1054'>ACT-1054</a>] -         Unable to complete user task coming from parallel gateway
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1196'>ACT-1196</a>] -         Invalid login screen localization on non-utf-8 based hosts
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1204'>ACT-1204</a>] -         InclusiveGateway with two subprocesses does not join correctly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1317'>ACT-1317</a>] -         Wrong task event generated when setting assignee to null
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1345'>ACT-1345</a>] -         method name orderByHistoricActivityInstanceStartTime in class HistoricTaskInstanceQuery should be orderByHistoricTaskInstanceStartTime
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1372'>ACT-1372</a>] -         User Task with form: form will be not displayed if the value expression in next line used
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1377'>ACT-1377</a>] -         removeVariables() in VariableScopeImpl does not consider parent scopes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1414'>ACT-1414</a>] -         ClassCastException when completing a referenced sub process after Boundary Event with cancelActivity = false
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1417'>ACT-1417</a>] -         Fix Explorer session serialization
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1418'>ACT-1418</a>] -         NullPointerException if throw a not catched exception/error
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1470'>ACT-1470</a>] -         Import definition type fails with CxfWSDLImporter when using complex data types
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1477'>ACT-1477</a>] -         In user guide error api for form property from history detail
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1479'>ACT-1479</a>] -         activiti-engine has invalid symbolic name
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1486'>ACT-1486</a>] -         The ability to add an attachment to a process instance is broken
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1494'>ACT-1494</a>] -         Get garbled string when render form in chines
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1499'>ACT-1499</a>] -         Form properties not initialized when null or empty
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1502'>ACT-1502</a>] -         Custom font name in the engine for diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1504'>ACT-1504</a>] -         Cannot create new user and membership in JavaDelegate using identityService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1512'>ACT-1512</a>] -         HistoricVariableUpdates no longer returned when using postgres
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1516'>ACT-1516</a>] -         BPMN Converter: Adding a listener to a script task produces erroneous XML content.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1524'>ACT-1524</a>] -         Variable update detection does not work for byte[]
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1528'>ACT-1528</a>] -         All variables are deleted after delete a history processinstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1533'>ACT-1533</a>] -         Undeployment of old process versions deletes jobs for TimerStartEvents
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1540'>ACT-1540</a>] -         HistoricVariableInstance does not expose taskId, nor does HistoricVariableQuery expose querying based on taskId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1546'>ACT-1546</a>] -         Impossible to assign default flow on exclusive gateways
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1553'>ACT-1553</a>] -         Refactor BpmnParse to use separate handlers for each bpmn element
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1555'>ACT-1555</a>] -         ProgrammaticBeanLookup doesn&#39;t regard alternatives
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1556'>ACT-1556</a>] -         BpmnDeployer creates duplicates identity links when deploying processes with initiation authorization active
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1579'>ACT-1579</a>] -         Process engine can be DoS&#39;ed when deploying unsafe XML
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1586'>ACT-1586</a>] -         ExecutionQuery returns wrong results when using multi instance on a receive task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1596'>ACT-1596</a>] -         Not generated boundary event in diagram created by RaphaÃ«l
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1274'>ACT-1274</a>] -         Remove SEVERE level logging for expected exception in taskservice.claim()
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1324'>ACT-1324</a>] -         Add specific exceptions for common error scenarios (TaskNotFoundException if a task if not found etc)
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1463'>ACT-1463</a>] -         Review rest-response codes and error-body response
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1498'>ACT-1498</a>] -         IntermediateCatchEventActivitiBehaviour name does not match other ActivityBehavior&#39;s
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1505'>ACT-1505</a>] -         Should throw an exception if the picture is not generated
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1561'>ACT-1561</a>] -         Add the ability to register a TaskListener for all event types
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1568'>ACT-1568</a>] -         Query API documentation out of sync with codebase
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1274'>ACT-1274</a>] -         Remove SEVERE level logging for expected exception in taskservice.claim()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1324'>ACT-1324</a>] -         Add specific exceptions for common error scenarios (TaskNotFoundException if a task if not found etc)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1463'>ACT-1463</a>] -         Review rest-response codes and error-body response
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1498'>ACT-1498</a>] -         IntermediateCatchEventActivitiBehaviour name does not match other ActivityBehavior&#39;s
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1505'>ACT-1505</a>] -         Should throw an exception if the picture is not generated
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1561'>ACT-1561</a>] -         Add the ability to register a TaskListener for all event types
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1568'>ACT-1568</a>] -         Query API documentation out of sync with codebase
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-432'>ACT-432</a>] -         Terminate end event
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1164'>ACT-1164</a>] -         Add possibility to hook in own implementation of BusinessRuleTask
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1493'>ACT-1493</a>] -         Make DeploymentCache pluggable and allow to set cache limit
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1511'>ACT-1511</a>] -         Extract ActivityBehavior and Task/ExecutionListener instantiation in a pluggable factory
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1518'>ACT-1518</a>] -         Add generic simple workflow creator API to activiti
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1537'>ACT-1537</a>] -         Allow to configure whether script variables are stored as process variables
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1569'>ACT-1569</a>] -         Introduce process instance scope for signal events
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1571'>ACT-1571</a>] -         Auto layout for BPMN 2.0 processes
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1572'>ACT-1572</a>] -         Designer should generate XML with delegationExpression
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1574'>ACT-1574</a>] -         Loop type for subprocess in Modeler
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1580'>ACT-1580</a>] -         Add method to retrieve BpmnModel (Pojo version of BPMN 2.0 process) to RepositoryService
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1588'>ACT-1588</a>] -         Native query support paging
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1593'>ACT-1593</a>] -         Basic reporting for Explorer
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-432'>ACT-432</a>] -         Terminate end event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1164'>ACT-1164</a>] -         Add possibility to hook in own implementation of BusinessRuleTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1493'>ACT-1493</a>] -         Make DeploymentCache pluggable and allow to set cache limit
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1511'>ACT-1511</a>] -         Extract ActivityBehavior and Task/ExecutionListener instantiation in a pluggable factory
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1518'>ACT-1518</a>] -         Add generic simple workflow creator API to activiti
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1537'>ACT-1537</a>] -         Allow to configure whether script variables are stored as process variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1569'>ACT-1569</a>] -         Introduce process instance scope for signal events
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1571'>ACT-1571</a>] -         Auto layout for BPMN 2.0 processes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1572'>ACT-1572</a>] -         Designer should generate XML with delegationExpression
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1574'>ACT-1574</a>] -         Loop type for subprocess in Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1580'>ACT-1580</a>] -         Add method to retrieve BpmnModel (Pojo version of BPMN 2.0 process) to RepositoryService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1588'>ACT-1588</a>] -         Native query support paging
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1593'>ACT-1593</a>] -         Basic reporting for Explorer
+    </li>
 </ul>
-        
+
 <h2>        Task
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1031'>ACT-1031</a>] -         Rename JobQuery methods
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1397'>ACT-1397</a>] -         Remove Account related service operations from IdentityService
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1465'>ACT-1465</a>] -         Document services in userguide
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1538'>ACT-1538</a>] -         Move BpmnParseListener to public API package
-</li>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1581'>ACT-1581</a>] -         Refactor ProcessDiagramGenerator to take BpmnModel as input instead of ProcessDefinitionEntity
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1031'>ACT-1031</a>] -         Rename JobQuery methods
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1397'>ACT-1397</a>] -         Remove Account related service operations from IdentityService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1465'>ACT-1465</a>] -         Document services in userguide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1538'>ACT-1538</a>] -         Move BpmnParseListener to public API package
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1581'>ACT-1581</a>] -         Refactor ProcessDiagramGenerator to take BpmnModel as input instead of ProcessDefinitionEntity
+    </li>
 </ul>
-        
+
 <h2>        Wish
 </h2>
 <ul>
-<li>[<a href='https://jira.codehaus.org/browse/ACT-1362'>ACT-1362</a>] -         Extend JPAEntityMappings to support UUID as Id
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1362'>ACT-1362</a>] -         Extend JPAEntityMappings to support UUID as Id
+    </li>
 </ul>
 
 
-  <h3>Release Notes - Activiti - Version 5.11</h3>
+<h3>Release Notes - Activiti - Version 5.11</h3>
 
-  <h4>Highlights</h4>
-  <ul>
+<h4>Highlights</h4>
+<ul>
     <li>Added Activiti Modeler to the Activiti Explorer web application</li>
     <li>Removed buggy demo script and replaced with simpler distribution</li>
     <li>Support for doing queries that are not out-of-the-box possible with the query api (called 'native queries')</li>
@@ -1013,966 +1013,966 @@
     <li>Improved Activiti QA and added DB2 and MSSQL servers</li>
     <li>Added support for using a service call in aJava delegates (see <a href="http://www.jorambarrez.be/blog/2012/10/25/call-a-service-in-a-service-tas/">here</a> for more details)</li>
     <li>Lots of bug fixes</li>
-  </ul>
+</ul>
 
-  <h4>Important upgrade note</h4>
-  <p>In 5.11 we introduce a new history table for process variables. There is an optional migration database script
-  that you can run to generate historic variables for existing process instances.  This is optional because 
-  the engine will just create those records upon update of the variable if they don't exist.  
-  </p>
-  <p>The files can be found in the database directory of the Activiti distribution
-  <code>org/activiti/db/upgrade/optional</code>.
-  </p> 
-  
-  <h4>API Change</h4>
-  <p>The functionality of the repositoryService.suspendProcessDefinitionByXXX has been slightly altered.
-  Previously, calling this method would stop the execution of jobs related to this process definition.
-  Now, calling this method will <b>not</b> do this, but rather make sure a process instance 
-  cannot be created from this process definition. We've added a new method with an additional
-  parameter 'suspendProcessInstances' which can be used to get the same behavior: when set to 'true',
-  all the associated process instances will be suspended. This will avoid process instance continuation,
-  including the execution of jobs related to the process instance.</p>
-  
-  <h4>Bug fixes and various smaller improvements</h4>
-  <p>Check out the <a href="http://jira.codehaus.org/secure/ReleaseNote.jspa?version=18342&styleName=Html&projectId=12091">Release notes</a> for more details</p>
-    
+<h4>Important upgrade note</h4>
+<p>In 5.11 we introduce a new history table for process variables. There is an optional migration database script
+    that you can run to generate historic variables for existing process instances.  This is optional because
+    the engine will just create those records upon update of the variable if they don't exist.
+</p>
+<p>The files can be found in the database directory of the Activiti distribution
+    <code>org/activiti/db/upgrade/optional</code>.
+</p>
+
+<h4>API Change</h4>
+<p>The functionality of the repositoryService.suspendProcessDefinitionByXXX has been slightly altered.
+    Previously, calling this method would stop the execution of jobs related to this process definition.
+    Now, calling this method will <b>not</b> do this, but rather make sure a process instance
+    cannot be created from this process definition. We've added a new method with an additional
+    parameter 'suspendProcessInstances' which can be used to get the same behavior: when set to 'true',
+    all the associated process instances will be suspended. This will avoid process instance continuation,
+    including the execution of jobs related to the process instance.</p>
+
+<h4>Bug fixes and various smaller improvements</h4>
+<p>Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10009">Release notes</a> for more details</p>
+
 <h2>        Sub-task
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1406'>ACT-1406</a>] -         Extend Activiti BPMN XML Schema
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1407'>ACT-1407</a>] -         Marshall ID to BPMN when saving
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1408'>ACT-1408</a>] -         Read and use ID when parsing BPMN model
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1406'>ACT-1406</a>] -         Extend Activiti BPMN XML Schema
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1407'>ACT-1407</a>] -         Marshall ID to BPMN when saving
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1408'>ACT-1408</a>] -         Read and use ID when parsing BPMN model
+    </li>
 </ul>
-        
+
 <h2>        Bug
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-234'>ACT-234</a>] -         CompetingJobAcquisitionTest does not work on windows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-454'>ACT-454</a>] -         Variables not being escaped when mail is sent as HTML
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-700'>ACT-700</a>] -         Bug in DB2 supporting.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-734'>ACT-734</a>] -         Schema creation in mssql 2005
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-785'>ACT-785</a>] -         User Task Assignments are not handled correctly if the value of an expression holds more than one group-id or user-id
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-820'>ACT-820</a>] -         Serializable values altered in scriptTask aren&#39;t persisted to DB
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-847'>ACT-847</a>] -         activiti:field not injected for tasklistener on event=&quot;create&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-865'>ACT-865</a>] -         timeCycle requires seconds to be in the startDate
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-866'>ACT-866</a>] -         couldn&#39;t deduct database type from database product name &#39;DB2/LINUXX8664&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-870'>ACT-870</a>] -         Multiple documentation elements not supported
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-876'>ACT-876</a>] -         Activiti Designer creates NPE when dragging tab to second window
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-920'>ACT-920</a>] -         ActivityException thrown on ProcessEngineConfiguration.buildProcessEngine()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-927'>ACT-927</a>] -         nullpointer on empty sourceref in datainputassociation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-934'>ACT-934</a>] -         Inconsistent procvar behaviour
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-940'>ACT-940</a>] -         When starting the demo, support Windows 7 for &quot;explorer.browser.open&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1002'>ACT-1002</a>] -         The Database Specific Statement is not applied in some cases
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1057'>ACT-1057</a>] -         Custom tasks in Designer with only BOOLEAN_CHOICE do not write proper XML
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1063'>ACT-1063</a>] -         Typo in org.activiti.engine.impl.jobexecutor.TimerDeclarationType#caledarName
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1070'>ACT-1070</a>] -         activiti explorer shows mistakenly non-activiti tables if their name starts with &#39;ACT*&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1083'>ACT-1083</a>] -         Variables stored inside a subprocess are not linked to activity-id&#39;s.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1090'>ACT-1090</a>] -         There is not async attribute in activiti XML schema
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1102'>ACT-1102</a>] -         Beans specified in activiti.cfg.xml not available in expressions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1130'>ACT-1130</a>] -         Removing identity link  does not remove owner  in task entity.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1147'>ACT-1147</a>] -         Posting a comment to a task causes an exception (Bad value for type long) (After updating from 5.8 to 5.9)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1174'>ACT-1174</a>] -         historyLevel property not found when creating tables manually
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1180'>ACT-1180</a>] -         Add version fixing after running activiti.postgres.upgradestep.58.to.59.engine.sql to avoid the application try to autoupdate schema at restart
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1187'>ACT-1187</a>] -         Default image for CustomServiceTasks is not loaded correctly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1189'>ACT-1189</a>] -         displayHelpLong of a custom property is not displayed
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1239'>ACT-1239</a>] -         Exclusive gateway: Condition on default flow is not ignored
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1251'>ACT-1251</a>] -         Manual upgrade throwing ActivitiWrongDbException
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1252'>ACT-1252</a>] -         Signal Events and None intermediate event not rendered during Diagram Generation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1259'>ACT-1259</a>] -         Finishing last task (or signal last receive-task) of process doesn&#39;t do optimistic locking
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1295'>ACT-1295</a>] -         Error BoundaryEvent in multiInstance call activity does not work as intended
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1304'>ACT-1304</a>] -         EnumFormType always returns null when converting model value to form value
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1316'>ACT-1316</a>] -         org.activiti.spring.SpringTransactionContext#addTransactionListener, TransactionState.ROLLED_BACK registers listener that is also invoked for successful commit
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1320'>ACT-1320</a>] -         Start Timer is executed for suspended process definitions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1321'>ACT-1321</a>] -         Add NOT NULL constraint to PROCDEF table
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1328'>ACT-1328</a>] -         Typo : &quot;evalutaing&quot; in JuelExpression
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1329'>ACT-1329</a>] -         Add NOT NULL constraint on VERSION_ in PROCDEF table
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1331'>ACT-1331</a>] -         RuntimeService.getVariables(String, Collection) retrieves more than the specified variables
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1338'>ACT-1338</a>] -         SetProcessDefinitionVersionCmd should update TaskEntity.processDefinitionId as well
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1340'>ACT-1340</a>] -         BusinessProcess.isAssociated throws NPE if no execution is associated
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1341'>ACT-1341</a>] -         Activiti engine drop statement for MSSQL misses a foreign key constraint
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1342'>ACT-1342</a>] -         Suspending a process with active timer can cause AcquireJobsRunnable to get into a loop that causes heavy load on database
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1353'>ACT-1353</a>] -         do not generates eventBasedGateway with ProcessDiagramGenerator.generateDiagram
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1361'>ACT-1361</a>] -         Broken Build: Activiti webapp REST uses junit but does not declare dependency using maven
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1370'>ACT-1370</a>] -         DB2 upgrade failed from 5.9 to 5.10 because missing NOT NULL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1375'>ACT-1375</a>] -         Remove workspace with examples from distribution (maybe replace with website)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1380'>ACT-1380</a>] -         Engine should throw exception when flow out of XOR-Gateway neither has condition nor is default flow
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1381'>ACT-1381</a>] -         Add support for SQL pagination in DB2 &amp; MSSQL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1390'>ACT-1390</a>] -         Activiti incorrectly logs SEVERE level messages for expected lock collisions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1391'>ACT-1391</a>] -         Deploying a process with illegal expression doesn&#39;t cause deployment to fail
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1394'>ACT-1394</a>] -         NullPointerException in UserTaskAssignmentHandler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1402'>ACT-1402</a>] -         Interrupting boundary events don&#39;t cancel all parallel sub-process instances in case sub-process is multi-instance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1410'>ACT-1410</a>] -         Executing the TaskService.deleteAttachments(String attachmentId) does not remove the file data from ACT_GE_BYTEARRAY table
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1415'>ACT-1415</a>] -         TimeCycle expression is not evaluated on timer-start event
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1416'>ACT-1416</a>] -         RepositoryService startableByUser() method not identity-implementation agnostic, using ACT_ID_MEMBERSHIP
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1421'>ACT-1421</a>] -         Error Boundary Event - execution not closed properly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1423'>ACT-1423</a>] -         BusinessRuleTask are not converted/exported in between Activiti Modeler and Activiti Engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1424'>ACT-1424</a>] -         Job timestamp defaults to current date when set to null (MySQL)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1429'>ACT-1429</a>] -         Remaining flowNodeRef when deleting BPMN elements within lanes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1431'>ACT-1431</a>] -         Invalid warning with exception thrown when di information is missing
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1434'>ACT-1434</a>] -         Rest call contains incorrect mimetype for resource service
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1435'>ACT-1435</a>] -         Exception for Expressions with 2 params in BusinessRule ruleVariablesInput
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1436'>ACT-1436</a>] -         Activiti-Rest : Binding error with form properties
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1440'>ACT-1440</a>] -         Activiti Explorer : Null Pointer Exception for Users with a Picture
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1441'>ACT-1441</a>] -         Eclipse Plugin : Missing a parentheses on a text label.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1442'>ACT-1442</a>] -         EventBasedGateway not drawn in diagram
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1444'>ACT-1444</a>] -         Race condition in CallActivityBehavior
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1449'>ACT-1449</a>] -         Boundary events in designer are not deleted properly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1455'>ACT-1455</a>] -         Add support to filter on HistoricVariables values on HistoricProcessInstanceQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1456'>ACT-1456</a>] -         Add support for processVariableValueEquals(value)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1459'>ACT-1459</a>] -         Add support for filtering queries based on string variable values, ignoring case
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1461'>ACT-1461</a>] -         The startableByUser method on the ProcessDefinitionQuery object does not return process definitions records for &quot;candidate starter groups&quot; when a custom session factory has been implemented 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1468'>ACT-1468</a>] -         Task query: can&#39;t query by process id with ordering by due date
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-234'>ACT-234</a>] -         CompetingJobAcquisitionTest does not work on windows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-454'>ACT-454</a>] -         Variables not being escaped when mail is sent as HTML
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-700'>ACT-700</a>] -         Bug in DB2 supporting.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-734'>ACT-734</a>] -         Schema creation in mssql 2005
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-785'>ACT-785</a>] -         User Task Assignments are not handled correctly if the value of an expression holds more than one group-id or user-id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-820'>ACT-820</a>] -         Serializable values altered in scriptTask aren&#39;t persisted to DB
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-847'>ACT-847</a>] -         activiti:field not injected for tasklistener on event=&quot;create&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-865'>ACT-865</a>] -         timeCycle requires seconds to be in the startDate
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-866'>ACT-866</a>] -         couldn&#39;t deduct database type from database product name &#39;DB2/LINUXX8664&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-870'>ACT-870</a>] -         Multiple documentation elements not supported
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-876'>ACT-876</a>] -         Activiti Designer creates NPE when dragging tab to second window
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-920'>ACT-920</a>] -         ActivityException thrown on ProcessEngineConfiguration.buildProcessEngine()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-927'>ACT-927</a>] -         nullpointer on empty sourceref in datainputassociation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-934'>ACT-934</a>] -         Inconsistent procvar behaviour
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-940'>ACT-940</a>] -         When starting the demo, support Windows 7 for &quot;explorer.browser.open&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1002'>ACT-1002</a>] -         The Database Specific Statement is not applied in some cases
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1057'>ACT-1057</a>] -         Custom tasks in Designer with only BOOLEAN_CHOICE do not write proper XML
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1063'>ACT-1063</a>] -         Typo in org.activiti.engine.impl.jobexecutor.TimerDeclarationType#caledarName
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1070'>ACT-1070</a>] -         activiti explorer shows mistakenly non-activiti tables if their name starts with &#39;ACT*&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1083'>ACT-1083</a>] -         Variables stored inside a subprocess are not linked to activity-id&#39;s.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1090'>ACT-1090</a>] -         There is not async attribute in activiti XML schema
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1102'>ACT-1102</a>] -         Beans specified in activiti.cfg.xml not available in expressions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1130'>ACT-1130</a>] -         Removing identity link  does not remove owner  in task entity.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1147'>ACT-1147</a>] -         Posting a comment to a task causes an exception (Bad value for type long) (After updating from 5.8 to 5.9)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1174'>ACT-1174</a>] -         historyLevel property not found when creating tables manually
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1180'>ACT-1180</a>] -         Add version fixing after running activiti.postgres.upgradestep.58.to.59.engine.sql to avoid the application try to autoupdate schema at restart
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1187'>ACT-1187</a>] -         Default image for CustomServiceTasks is not loaded correctly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1189'>ACT-1189</a>] -         displayHelpLong of a custom property is not displayed
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1239'>ACT-1239</a>] -         Exclusive gateway: Condition on default flow is not ignored
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1251'>ACT-1251</a>] -         Manual upgrade throwing ActivitiWrongDbException
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1252'>ACT-1252</a>] -         Signal Events and None intermediate event not rendered during Diagram Generation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1259'>ACT-1259</a>] -         Finishing last task (or signal last receive-task) of process doesn&#39;t do optimistic locking
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1295'>ACT-1295</a>] -         Error BoundaryEvent in multiInstance call activity does not work as intended
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1304'>ACT-1304</a>] -         EnumFormType always returns null when converting model value to form value
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1316'>ACT-1316</a>] -         org.activiti.spring.SpringTransactionContext#addTransactionListener, TransactionState.ROLLED_BACK registers listener that is also invoked for successful commit
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1320'>ACT-1320</a>] -         Start Timer is executed for suspended process definitions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1321'>ACT-1321</a>] -         Add NOT NULL constraint to PROCDEF table
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1328'>ACT-1328</a>] -         Typo : &quot;evalutaing&quot; in JuelExpression
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1329'>ACT-1329</a>] -         Add NOT NULL constraint on VERSION_ in PROCDEF table
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1331'>ACT-1331</a>] -         RuntimeService.getVariables(String, Collection) retrieves more than the specified variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1338'>ACT-1338</a>] -         SetProcessDefinitionVersionCmd should update TaskEntity.processDefinitionId as well
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1340'>ACT-1340</a>] -         BusinessProcess.isAssociated throws NPE if no execution is associated
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1341'>ACT-1341</a>] -         Activiti engine drop statement for MSSQL misses a foreign key constraint
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1342'>ACT-1342</a>] -         Suspending a process with active timer can cause AcquireJobsRunnable to get into a loop that causes heavy load on database
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1353'>ACT-1353</a>] -         do not generates eventBasedGateway with ProcessDiagramGenerator.generateDiagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1361'>ACT-1361</a>] -         Broken Build: Activiti webapp REST uses junit but does not declare dependency using maven
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1370'>ACT-1370</a>] -         DB2 upgrade failed from 5.9 to 5.10 because missing NOT NULL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1375'>ACT-1375</a>] -         Remove workspace with examples from distribution (maybe replace with website)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1380'>ACT-1380</a>] -         Engine should throw exception when flow out of XOR-Gateway neither has condition nor is default flow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1381'>ACT-1381</a>] -         Add support for SQL pagination in DB2 &amp; MSSQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1390'>ACT-1390</a>] -         Activiti incorrectly logs SEVERE level messages for expected lock collisions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1391'>ACT-1391</a>] -         Deploying a process with illegal expression doesn&#39;t cause deployment to fail
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1394'>ACT-1394</a>] -         NullPointerException in UserTaskAssignmentHandler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1402'>ACT-1402</a>] -         Interrupting boundary events don&#39;t cancel all parallel sub-process instances in case sub-process is multi-instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1410'>ACT-1410</a>] -         Executing the TaskService.deleteAttachments(String attachmentId) does not remove the file data from ACT_GE_BYTEARRAY table
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1415'>ACT-1415</a>] -         TimeCycle expression is not evaluated on timer-start event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1416'>ACT-1416</a>] -         RepositoryService startableByUser() method not identity-implementation agnostic, using ACT_ID_MEMBERSHIP
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1421'>ACT-1421</a>] -         Error Boundary Event - execution not closed properly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1423'>ACT-1423</a>] -         BusinessRuleTask are not converted/exported in between Activiti Modeler and Activiti Engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1424'>ACT-1424</a>] -         Job timestamp defaults to current date when set to null (MySQL)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1429'>ACT-1429</a>] -         Remaining flowNodeRef when deleting BPMN elements within lanes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1431'>ACT-1431</a>] -         Invalid warning with exception thrown when di information is missing
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1434'>ACT-1434</a>] -         Rest call contains incorrect mimetype for resource service
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1435'>ACT-1435</a>] -         Exception for Expressions with 2 params in BusinessRule ruleVariablesInput
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1436'>ACT-1436</a>] -         Activiti-Rest : Binding error with form properties
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1440'>ACT-1440</a>] -         Activiti Explorer : Null Pointer Exception for Users with a Picture
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1441'>ACT-1441</a>] -         Eclipse Plugin : Missing a parentheses on a text label.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1442'>ACT-1442</a>] -         EventBasedGateway not drawn in diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1444'>ACT-1444</a>] -         Race condition in CallActivityBehavior
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1449'>ACT-1449</a>] -         Boundary events in designer are not deleted properly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1455'>ACT-1455</a>] -         Add support to filter on HistoricVariables values on HistoricProcessInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1456'>ACT-1456</a>] -         Add support for processVariableValueEquals(value)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1459'>ACT-1459</a>] -         Add support for filtering queries based on string variable values, ignoring case
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1461'>ACT-1461</a>] -         The startableByUser method on the ProcessDefinitionQuery object does not return process definitions records for &quot;candidate starter groups&quot; when a custom session factory has been implemented
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1468'>ACT-1468</a>] -         Task query: can&#39;t query by process id with ordering by due date
+    </li>
 </ul>
-            
+
 <h2>        Improvement
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-716'>ACT-716</a>] -         Add log guards to org.activiti.engine.impl.interceptor.LogInterceptor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-721'>ACT-721</a>] -         Usage of Collections.synchronizedMap might cause performance degradation or java deadlock in DbSqlSessionFactory
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-877'>ACT-877</a>] -          Allowing expressions in properties of CustomServiceTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-900'>ACT-900</a>] -         TaskService.deleteTask should allow a reason to be specified
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-969'>ACT-969</a>] -         Add description of JavaDelegate implementation for CustomServiceTasks to the user guide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-998'>ACT-998</a>] -         Add a ScripTaskListener
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1015'>ACT-1015</a>] -         Process formKey as an expression
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1023'>ACT-1023</a>] -         random order in enum fields
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1064'>ACT-1064</a>] -         Remove &#39;selectNextJobsToExecute_mysql&#39; and remove duplicate criterion where clause
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1067'>ACT-1067</a>] -         Make BpmnDeployer#addTimerDeclarations and BpmnDeployer#removeObsoleteTimers protected
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1112'>ACT-1112</a>] -         Ease integration of Activit Explorer / Split up explorer into a JAR and a WAR example application
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1122'>ACT-1122</a>] -         databaseSchemaUpdate should not downgrade, it leads to inconsistent databases
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1134'>ACT-1134</a>] -         Reduce number of compensate event subscription queries when a subprocess is completed
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1138'>ACT-1138</a>] -         Optimize job acquisition (exclusive jobs / maxJobsPerAcquisition)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1162'>ACT-1162</a>] -         activiti-spring pom.xml contains dependencies that should have scope &#39;test&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1169'>ACT-1169</a>] -         Redundant RETRIES predicate in &#39;selectExclusiveJobsToExecute&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1206'>ACT-1206</a>] -         GroupManager.findGroupsByUser called twice
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1224'>ACT-1224</a>] -         Remove Eclipse IDE Artifacts (.classpath,...) from SVN
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1273'>ACT-1273</a>] -         In the TaskService it is possible to removing variables
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1279'>ACT-1279</a>] -         Add foreign key to PROC_DEF_ID_ on ACT_RU_EXECUTION
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1291'>ACT-1291</a>] -         Allow subtask filtering
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1301'>ACT-1301</a>] -         Refactoring BpmnParse class
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1327'>ACT-1327</a>] -         activiti-osgi add blueprint context EL resolver
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1336'>ACT-1336</a>] -         Support start authorization in Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1350'>ACT-1350</a>] -         Can not send mail use gmail smtp with ssl
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1352'>ACT-1352</a>] -         Reduce the log level when a job could not found due to cancelActiviti
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1383'>ACT-1383</a>] -         Enable specialization of BusinessProcess bean by moving producer methods into separate bean
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1392'>ACT-1392</a>] -         Activities rendered by DiagramGenerator should show task-names on multiple lines, if too big for single line.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1405'>ACT-1405</a>] -         CustomServiceTask ID is not stored in model
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1430'>ACT-1430</a>] -         Add faster and more convenient methods for retrieving form keys
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1443'>ACT-1443</a>] -         Use the standard Activiti classloading mechanism for resolving serialized classes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1445'>ACT-1445</a>] -         Improve documentation for creating Designer Extensions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1447'>ACT-1447</a>] -         in Designer, The cancelActivity should not be shown for errorEventDefinition and cancelEventDefinition 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1450'>ACT-1450</a>] -          Modification on ProcessInstanceResource to insert taskDefinitionKey in results
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1451'>ACT-1451</a>] -         Rest API to see startableByUser process definitions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1453'>ACT-1453</a>] -         Rest API to list groups
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-716'>ACT-716</a>] -         Add log guards to org.activiti.engine.impl.interceptor.LogInterceptor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-721'>ACT-721</a>] -         Usage of Collections.synchronizedMap might cause performance degradation or java deadlock in DbSqlSessionFactory
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-877'>ACT-877</a>] -          Allowing expressions in properties of CustomServiceTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-900'>ACT-900</a>] -         TaskService.deleteTask should allow a reason to be specified
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-969'>ACT-969</a>] -         Add description of JavaDelegate implementation for CustomServiceTasks to the user guide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-998'>ACT-998</a>] -         Add a ScripTaskListener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1015'>ACT-1015</a>] -         Process formKey as an expression
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1023'>ACT-1023</a>] -         random order in enum fields
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1064'>ACT-1064</a>] -         Remove &#39;selectNextJobsToExecute_mysql&#39; and remove duplicate criterion where clause
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1067'>ACT-1067</a>] -         Make BpmnDeployer#addTimerDeclarations and BpmnDeployer#removeObsoleteTimers protected
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1112'>ACT-1112</a>] -         Ease integration of Activiti Explorer / Split up explorer into a JAR and a WAR example application
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1122'>ACT-1122</a>] -         databaseSchemaUpdate should not downgrade, it leads to inconsistent databases
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1134'>ACT-1134</a>] -         Reduce number of compensate event subscription queries when a subprocess is completed
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1138'>ACT-1138</a>] -         Optimize job acquisition (exclusive jobs / maxJobsPerAcquisition)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1162'>ACT-1162</a>] -         activiti-spring pom.xml contains dependencies that should have scope &#39;test&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1169'>ACT-1169</a>] -         Redundant RETRIES predicate in &#39;selectExclusiveJobsToExecute&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1206'>ACT-1206</a>] -         GroupManager.findGroupsByUser called twice
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1224'>ACT-1224</a>] -         Remove Eclipse IDE Artifacts (.classpath,...) from SVN
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1273'>ACT-1273</a>] -         In the TaskService it is possible to removing variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1279'>ACT-1279</a>] -         Add foreign key to PROC_DEF_ID_ on ACT_RU_EXECUTION
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1291'>ACT-1291</a>] -         Allow subtask filtering
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1301'>ACT-1301</a>] -         Refactoring BpmnParse class
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1327'>ACT-1327</a>] -         activiti-osgi add blueprint context EL resolver
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1336'>ACT-1336</a>] -         Support start authorization in Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1350'>ACT-1350</a>] -         Can not send mail use gmail smtp with ssl
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1352'>ACT-1352</a>] -         Reduce the log level when a job could not found due to cancelActiviti
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1383'>ACT-1383</a>] -         Enable specialization of BusinessProcess bean by moving producer methods into separate bean
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1392'>ACT-1392</a>] -         Activities rendered by DiagramGenerator should show task-names on multiple lines, if too big for single line.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1405'>ACT-1405</a>] -         CustomServiceTask ID is not stored in model
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1430'>ACT-1430</a>] -         Add faster and more convenient methods for retrieving form keys
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1443'>ACT-1443</a>] -         Use the standard Activiti classloading mechanism for resolving serialized classes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1445'>ACT-1445</a>] -         Improve documentation for creating Designer Extensions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1447'>ACT-1447</a>] -         in Designer, The cancelActivity should not be shown for errorEventDefinition and cancelEventDefinition
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1450'>ACT-1450</a>] -          Modification on ProcessInstanceResource to insert taskDefinitionKey in results
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1451'>ACT-1451</a>] -         Rest API to see startableByUser process definitions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1453'>ACT-1453</a>] -         Rest API to list groups
+    </li>
 </ul>
-    
+
 <h2>        New Feature
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-933'>ACT-933</a>] -         orderByDueDate for HistoricTaskInstanceQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-936'>ACT-936</a>] -         Provide custom navigator for Activiti projects
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1020'>ACT-1020</a>] -         Get Process Documentation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1293'>ACT-1293</a>] -         Add SQL Query extensions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1300'>ACT-1300</a>] -         Add own History table for HistoricProcessVariable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1302'>ACT-1302</a>] -         Add more information to HistoricActivityInstance 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1322'>ACT-1322</a>] -         Interrupting Message Event Sub-Process
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1330'>ACT-1330</a>] -         Imporve History Queries
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1374'>ACT-1374</a>] -         Add &quot;processVariableValueEquals&quot; to ExecutionQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1378'>ACT-1378</a>] -         Change behavior with HistoricProcessVariable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1379'>ACT-1379</a>] -         Add field injection to delegateExpression
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1387'>ACT-1387</a>] -         Allow service invocation in a JavaDelegate/ActivityBehavior
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1457'>ACT-1457</a>] -         Suspend/Activate a process instance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1458'>ACT-1458</a>] -         Allow to suspend/activate a process definition at a given date
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-933'>ACT-933</a>] -         orderByDueDate for HistoricTaskInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-936'>ACT-936</a>] -         Provide custom navigator for Activiti projects
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1020'>ACT-1020</a>] -         Get Process Documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1293'>ACT-1293</a>] -         Add SQL Query extensions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1300'>ACT-1300</a>] -         Add own History table for HistoricProcessVariable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1302'>ACT-1302</a>] -         Add more information to HistoricActivityInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1322'>ACT-1322</a>] -         Interrupting Message Event Sub-Process
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1330'>ACT-1330</a>] -         Improve History Queries
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1374'>ACT-1374</a>] -         Add &quot;processVariableValueEquals&quot; to ExecutionQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1378'>ACT-1378</a>] -         Change behavior with HistoricProcessVariable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1379'>ACT-1379</a>] -         Add field injection to delegateExpression
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1387'>ACT-1387</a>] -         Allow service invocation in a JavaDelegate/ActivityBehavior
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1457'>ACT-1457</a>] -         Suspend/Activate a process instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1458'>ACT-1458</a>] -         Allow to suspend/activate a process definition at a given date
+    </li>
 </ul>
-        
+
 <h2>        Task
 </h2>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-840'>ACT-840</a>] -         Userguide refers to JPAVariableTest, but isn&#39;t present in examples anymore
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1332'>ACT-1332</a>] -         Remove servlet api jar from activiti-explorer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1333'>ACT-1333</a>] -         Fix upgrade script
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1334'>ACT-1334</a>] -         ad hoc task has 2 owners
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1347'>ACT-1347</a>] -         Clean up cycle references
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1355'>ACT-1355</a>] -         Clean up jira issues
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1369'>ACT-1369</a>] -         Fix docs on starting h2 test console
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1425'>ACT-1425</a>] -         Add category to deployment
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-840'>ACT-840</a>] -         Userguide refers to JPAVariableTest, but isn&#39;t present in examples anymore
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1332'>ACT-1332</a>] -         Remove servlet api jar from activiti-explorer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1333'>ACT-1333</a>] -         Fix upgrade script
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1334'>ACT-1334</a>] -         ad hoc task has 2 owners
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1347'>ACT-1347</a>] -         Clean up cycle references
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1355'>ACT-1355</a>] -         Clean up jira issues
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1369'>ACT-1369</a>] -         Fix docs on starting h2 test console
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1425'>ACT-1425</a>] -         Add category to deployment
+    </li>
 </ul>
-        
 
-  <h3>Release Notes - Activiti - Version 5.10</h3>
 
-  <h4>Highlights</h4>
-  <ul>
+<h3>Release Notes - Activiti - Version 5.10</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Drastic performance improvements: See Joram's blog <a href="http://www.jorambarrez.be/blog/2012/06/28/the-activiti-performance-showdown/">The Activiti performance showdown</a> for the amazing details</li>
     <li>Tijs' book <a href="http://affiliate.manning.com/idevaffiliate.php?id=1203_262">Activiti in Action</a> published by Manning came out!</li>
     <li>Added support voor bpmn message start event</li>
     <li>Added capability for clients to validate a user's rights to start a process</li>
     <li>Added support for nested sub-processes and embedded subprocesses in designer</li>
     <li>Added support for catching intermediate and boundary message events</li>
-    <li>Bug fixes and various smaller improvements.  Check out the <a href="http://jira.codehaus.org/secure/ReleaseNote.jspa?projectId=12091&version=18341">Release notes</a> for more details</li>
-  </ul>
+    <li>Bug fixes and various smaller improvements.  Check out the <a href="https://activiti.atlassian.net/jira/secure/ReleaseNote.jspa?projectId=10000&version=10008">Release notes</a> for more details</li>
+</ul>
 
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-674'>ACT-674</a>] -         ClaimTaskCmd should verify userId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-697'>ACT-697</a>] -         Exception thrown when bpmndi:BPMNPlane elements does not reference a process id
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-714'>ACT-714</a>] -         Multi-threaded usage of non thread safe java.util.HashMap in ClassNameUtil
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-733'>ACT-733</a>] -         Potential Problem with ${empty someProcessVariable} or ${someProcessVariable != null} 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-832'>ACT-832</a>] -         Infinite loop in ErrorEndEventActivitiBehavior if errorEndEvent defined in a call-activity sub process and no matching boundary event
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-873'>ACT-873</a>] -         typo: TaskQuery.taskUnnassigned()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-886'>ACT-886</a>] -         Process Definition Query Using CategoryLike Is Missing &#39;like&#39; Clause 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-955'>ACT-955</a>] -         Integrity constraint ACT_FK_VAR_EXE violated - child record found
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-958'>ACT-958</a>] -         using a jobquery with processInstanceId AND executable filter fails with an SQLException
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-962'>ACT-962</a>] -         Failed Testcases because of Equal Check on Exception Messages
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-984'>ACT-984</a>] -         Activiti Designer: NullPointerException when saving arbitrary XML file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1000'>ACT-1000</a>] -         [Eclipse] Diagram modifications removes data in XML file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1016'>ACT-1016</a>] -         Eclipse freezes when opening xhtml page AND Activiti Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1019'>ACT-1019</a>] -         REST-API, getting process instance diagram error
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1039'>ACT-1039</a>] -         Broken Round Trip bpmn20.xml-.activiti in Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1048'>ACT-1048</a>] -         HistoricalActivityInstance missing for parallel GW
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1059'>ACT-1059</a>] -         Delegation state of task&#39;s  not saved in database 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1071'>ACT-1071</a>] -         Process Instance Diagram has wrong content-type
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1075'>ACT-1075</a>] -         getting process variables through rest does not work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1077'>ACT-1077</a>] -         Wrong URL for &quot;Delete Deployments&quot; in the User Guide REST API Documentation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1113'>ACT-1113</a>] -         Remove deprecated cycle tables
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1115'>ACT-1115</a>] -         Parsing of process definition files with several pools and DI information (for graphical represenation) fails
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1116'>ACT-1116</a>] -         Can&#39;t browse database tables with activiti-explorer when using Postgresql-9.1
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1125'>ACT-1125</a>] -         Missing &quot;import java.util.Date&quot; in HumanTimeTest causes build to fail
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1129'>ACT-1129</a>] -         BooleanFormPropertyRenderer: java.lang.IllegalArgumentException: CheckBox only accepts Boolean values
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1131'>ACT-1131</a>] -         Asynchronous Servicetasks with DB2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1132'>ACT-1132</a>] -         Regression: Process Diagram generation not possible in headless mode anymore
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1137'>ACT-1137</a>] -         BusinessProcess#getExecutionId() does not participate in current command 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1143'>ACT-1143</a>] -         Activiti Update from 5.8 to 5.9 (using PostgreSQL)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1144'>ACT-1144</a>] -         &quot;isExpanded&quot; attribute missing in DI for sub processes 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1146'>ACT-1146</a>] -         Class cast while saving changes - before closing editor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1150'>ACT-1150</a>] -         NullPointerException during application startup with autodeployment set to true
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1154'>ACT-1154</a>] -         Missing pictures in the user guide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1156'>ACT-1156</a>] -         Callactivity with Expression always use value of first evaluation 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1160'>ACT-1160</a>] -         Parsing results in Exception when using textannotation on association
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1170'>ACT-1170</a>] -         &#39;selectExclusiveJobsToExecute&#39; does not work for DB2 and MSSQL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1172'>ACT-1172</a>] -         activiti.mssql.create.engine.sql does not drop table ACT_RU_JOB
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1176'>ACT-1176</a>] -         Parsing Collaboration Tag fails because of DI reference
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1179'>ACT-1179</a>] -         Fix binary value on activiti.postgres.upgradestep.58.to.59.engine.sql
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1182'>ACT-1182</a>] -         REST: Error when trying to get process variables with null value.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1183'>ACT-1183</a>] -         TimerCatchingEvent not showing up when re-opening bpmn file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1185'>ACT-1185</a>] -         When using a multi-instance subprocess, the execution is ended after first loop
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1188'>ACT-1188</a>] -         JtaProcessEngineConfiguration does not use proper JTA Synchronizations
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1191'>ACT-1191</a>] -         Bug: NullPointerException in FailedJobListener
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1193'>ACT-1193</a>] -         REST-webapp: unable to get process instance diagram
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1200'>ACT-1200</a>] -         Location of labels of sequence flows move after reopening process definition
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1202'>ACT-1202</a>] -         History: tracking of multiple end events reached
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1209'>ACT-1209</a>] -         Mybatis pagination does not scale on MySQL &amp; H2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1216'>ACT-1216</a>] -         When receycling execution it is not activated correctly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1222'>ACT-1222</a>] -         Receycling the root execution leads to stuck process instance when using call activities
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1223'>ACT-1223</a>] -         Activiti Designer creates pom.xml with dependency to Activiti 5.8
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1237'>ACT-1237</a>] -         SubProcesses within pool
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1238'>ACT-1238</a>] -         SignalBoundaryEvent not displayed when inside subprocess that has another subprocess as fault handler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1242'>ACT-1242</a>] -         Designer removes &quot;Input variables&quot; attribute of BusinessRuleTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1245'>ACT-1245</a>] -         Diagram resource generation should only be triggered when deployment is new
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1249'>ACT-1249</a>] -         ORA-00918 when processUnfinished() and orderByHistoricTaskInstanceEndTime() called on HTIQ
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1253'>ACT-1253</a>] -         JobQuery &#39;selectJobByQueryCriteria.withExceptions&#39; doesn&#39;t find all jobs with failures
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1257'>ACT-1257</a>] -         CDI Injection for process variables does not work correctly in call stacks including other processes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1258'>ACT-1258</a>] -         ThreadpoolExecutor injection point is depending on actual class instead of Executor Interface
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1260'>ACT-1260</a>] -         REST: JSON field values have to be null instead of &quot;null&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1277'>ACT-1277</a>] -         activiti-engine-5.9.pom file has invalid URL for repository
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1278'>ACT-1278</a>] -         List&lt;HistoricProcessInstance&gt; is not serializable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1286'>ACT-1286</a>] -         REST: Starting a process instance does not handle StartEvent property datatypes correctly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1287'>ACT-1287</a>] -         HistoricTaskInstanceQuery orderByTaskDefinitionKey() does not work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1298'>ACT-1298</a>] -         Deploying two processes with same id breaks engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1305'>ACT-1305</a>] -         Parsing call-activity may lead to NullPointerException
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1308'>ACT-1308</a>] -         Null-Pointer Exception in ProcessInstanceResource.java
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1309'>ACT-1309</a>] -         NullPointerException in SignalEventHandler
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-674'>ACT-674</a>] -         ClaimTaskCmd should verify userId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-697'>ACT-697</a>] -         Exception thrown when bpmndi:BPMNPlane elements does not reference a process id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-714'>ACT-714</a>] -         Multi-threaded usage of non thread safe java.util.HashMap in ClassNameUtil
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-733'>ACT-733</a>] -         Potential Problem with ${empty someProcessVariable} or ${someProcessVariable != null}
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-832'>ACT-832</a>] -         Infinite loop in ErrorEndEventActivitiBehavior if errorEndEvent defined in a call-activity sub process and no matching boundary event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-873'>ACT-873</a>] -         typo: TaskQuery.taskUnnassigned()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-886'>ACT-886</a>] -         Process Definition Query Using CategoryLike Is Missing &#39;like&#39; Clause
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-955'>ACT-955</a>] -         Integrity constraint ACT_FK_VAR_EXE violated - child record found
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-958'>ACT-958</a>] -         using a jobquery with processInstanceId AND executable filter fails with an SQLException
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-962'>ACT-962</a>] -         Failed Testcases because of Equal Check on Exception Messages
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-984'>ACT-984</a>] -         Activiti Designer: NullPointerException when saving arbitrary XML file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1000'>ACT-1000</a>] -         [Eclipse] Diagram modifications removes data in XML file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1016'>ACT-1016</a>] -         Eclipse freezes when opening xhtml page AND Activiti Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1019'>ACT-1019</a>] -         REST-API, getting process instance diagram error
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1039'>ACT-1039</a>] -         Broken Round Trip bpmn20.xml-.activiti in Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1048'>ACT-1048</a>] -         HistoricalActivityInstance missing for parallel GW
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1059'>ACT-1059</a>] -         Delegation state of task&#39;s  not saved in database
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1071'>ACT-1071</a>] -         Process Instance Diagram has wrong content-type
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1075'>ACT-1075</a>] -         getting process variables through rest does not work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1077'>ACT-1077</a>] -         Wrong URL for &quot;Delete Deployments&quot; in the User Guide REST API Documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1113'>ACT-1113</a>] -         Remove deprecated cycle tables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1115'>ACT-1115</a>] -         Parsing of process definition files with several pools and DI information (for graphical representation) fails
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1116'>ACT-1116</a>] -         Can&#39;t browse database tables with activiti-explorer when using Postgresql-9.1
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1125'>ACT-1125</a>] -         Missing &quot;import java.util.Date&quot; in HumanTimeTest causes build to fail
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1129'>ACT-1129</a>] -         BooleanFormPropertyRenderer: java.lang.IllegalArgumentException: CheckBox only accepts Boolean values
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1131'>ACT-1131</a>] -         Asynchronous Servicetasks with DB2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1132'>ACT-1132</a>] -         Regression: Process Diagram generation not possible in headless mode anymore
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1137'>ACT-1137</a>] -         BusinessProcess#getExecutionId() does not participate in current command
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1143'>ACT-1143</a>] -         Activiti Update from 5.8 to 5.9 (using PostgreSQL)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1144'>ACT-1144</a>] -         &quot;isExpanded&quot; attribute missing in DI for sub processes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1146'>ACT-1146</a>] -         Class cast while saving changes - before closing editor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1150'>ACT-1150</a>] -         NullPointerException during application startup with autodeployment set to true
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1154'>ACT-1154</a>] -         Missing pictures in the user guide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1156'>ACT-1156</a>] -         Callactivity with Expression always use value of first evaluation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1160'>ACT-1160</a>] -         Parsing results in Exception when using textannotation on association
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1170'>ACT-1170</a>] -         &#39;selectExclusiveJobsToExecute&#39; does not work for DB2 and MSSQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1172'>ACT-1172</a>] -         activiti.mssql.create.engine.sql does not drop table ACT_RU_JOB
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1176'>ACT-1176</a>] -         Parsing Collaboration Tag fails because of DI reference
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1179'>ACT-1179</a>] -         Fix binary value on activiti.postgres.upgradestep.58.to.59.engine.sql
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1182'>ACT-1182</a>] -         REST: Error when trying to get process variables with null value.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1183'>ACT-1183</a>] -         TimerCatchingEvent not showing up when re-opening bpmn file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1185'>ACT-1185</a>] -         When using a multi-instance subprocess, the execution is ended after first loop
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1188'>ACT-1188</a>] -         JtaProcessEngineConfiguration does not use proper JTA Synchronizations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1191'>ACT-1191</a>] -         Bug: NullPointerException in FailedJobListener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1193'>ACT-1193</a>] -         REST-webapp: unable to get process instance diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1200'>ACT-1200</a>] -         Location of labels of sequence flows move after reopening process definition
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1202'>ACT-1202</a>] -         History: tracking of multiple end events reached
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1209'>ACT-1209</a>] -         Mybatis pagination does not scale on MySQL &amp; H2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1216'>ACT-1216</a>] -         When receycling execution it is not activated correctly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1222'>ACT-1222</a>] -         Receycling the root execution leads to stuck process instance when using call activities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1223'>ACT-1223</a>] -         Activiti Designer creates pom.xml with dependency to Activiti 5.8
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1237'>ACT-1237</a>] -         SubProcesses within pool
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1238'>ACT-1238</a>] -         SignalBoundaryEvent not displayed when inside subprocess that has another subprocess as fault handler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1242'>ACT-1242</a>] -         Designer removes &quot;Input variables&quot; attribute of BusinessRuleTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1245'>ACT-1245</a>] -         Diagram resource generation should only be triggered when deployment is new
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1249'>ACT-1249</a>] -         ORA-00918 when processUnfinished() and orderByHistoricTaskInstanceEndTime() called on HTIQ
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1253'>ACT-1253</a>] -         JobQuery &#39;selectJobByQueryCriteria.withExceptions&#39; doesn&#39;t find all jobs with failures
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1257'>ACT-1257</a>] -         CDI Injection for process variables does not work correctly in call stacks including other processes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1258'>ACT-1258</a>] -         ThreadpoolExecutor injection point is depending on actual class instead of Executor Interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1260'>ACT-1260</a>] -         REST: JSON field values have to be null instead of &quot;null&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1277'>ACT-1277</a>] -         activiti-engine-5.9.pom file has invalid URL for repository
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1278'>ACT-1278</a>] -         List&lt;HistoricProcessInstance&gt; is not serializable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1286'>ACT-1286</a>] -         REST: Starting a process instance does not handle StartEvent property datatypes correctly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1287'>ACT-1287</a>] -         HistoricTaskInstanceQuery orderByTaskDefinitionKey() does not work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1298'>ACT-1298</a>] -         Deploying two processes with same id breaks engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1305'>ACT-1305</a>] -         Parsing call-activity may lead to NullPointerException
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1308'>ACT-1308</a>] -         Null-Pointer Exception in ProcessInstanceResource.java
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1309'>ACT-1309</a>] -         NullPointerException in SignalEventHandler
+    </li>
 </ul>
-            
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-380'>ACT-380</a>] -         Add method getCandidates() to interface DelegateTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-656'>ACT-656</a>] -         Add support for schema prefixes for table names
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-897'>ACT-897</a>] -         Make JuelFormEngine.getFormTemplateString(FormData) protected
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-923'>ACT-923</a>] -         HistoricProcessInstance should hold the super processInstanceId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-946'>ACT-946</a>] -         Category in ProcessDefinition REST Response
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-974'>ACT-974</a>] -         Don&#39;t register Activiti XML editor as default XML editor in Eclipse
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-991'>ACT-991</a>] -         improve exception thrown by taskservice.claim() 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1056'>ACT-1056</a>] -         Contention in mybatis due to dynamic query creation in ExecutionEntity.remove()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1133'>ACT-1133</a>] -         Reduce number of task / event subscription queries when execution is removed
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1140'>ACT-1140</a>] -         Add RuntimeService.startProcessInstanceByMessage(String, String) Method
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1145'>ACT-1145</a>] -         Selecting the Activity&#39;s name from the DelegateExecution could be a convenience method
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1246'>ACT-1246</a>] -         FormService returns null instead of exception if no form is defined
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1276'>ACT-1276</a>] -         SetProcessDefinitionVersionCmd should work with CallActivities as well
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1280'>ACT-1280</a>] -         Add unique index to process-definitions on KEY and VERSION
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1284'>ACT-1284</a>] -         Improve error message if process definition with Message Start Events gets started by &quot;startProcessInstanceByKey&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1294'>ACT-1294</a>] -         Upgrade Spring dependency to 3.1.2.RELEASE
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-380'>ACT-380</a>] -         Add method getCandidates() to interface DelegateTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-656'>ACT-656</a>] -         Add support for schema prefixes for table names
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-897'>ACT-897</a>] -         Make JuelFormEngine.getFormTemplateString(FormData) protected
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-923'>ACT-923</a>] -         HistoricProcessInstance should hold the super processInstanceId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-946'>ACT-946</a>] -         Category in ProcessDefinition REST Response
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-974'>ACT-974</a>] -         Don&#39;t register Activiti XML editor as default XML editor in Eclipse
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-991'>ACT-991</a>] -         improve exception thrown by taskservice.claim()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1056'>ACT-1056</a>] -         Contention in mybatis due to dynamic query creation in ExecutionEntity.remove()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1133'>ACT-1133</a>] -         Reduce number of task / event subscription queries when execution is removed
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1140'>ACT-1140</a>] -         Add RuntimeService.startProcessInstanceByMessage(String, String) Method
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1145'>ACT-1145</a>] -         Selecting the Activity&#39;s name from the DelegateExecution could be a convenience method
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1246'>ACT-1246</a>] -         FormService returns null instead of exception if no form is defined
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1276'>ACT-1276</a>] -         SetProcessDefinitionVersionCmd should work with CallActivities as well
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1280'>ACT-1280</a>] -         Add unique index to process-definitions on KEY and VERSION
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1284'>ACT-1284</a>] -         Improve error message if process definition with Message Start Events gets started by &quot;startProcessInstanceByKey&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1294'>ACT-1294</a>] -         Upgrade Spring dependency to 3.1.2.RELEASE
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-638'>ACT-638</a>] -         Implement non interrupting boundaryEvent (cancelActivity=&quot;false&quot;)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-740'>ACT-740</a>] -         Mechanism of management rights on the start of process.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-892'>ACT-892</a>] -         Support nested sub-processes in designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-932'>ACT-932</a>] -         Support embedded subprocesses in Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-959'>ACT-959</a>] -         Retrieve process diagram through rest interface by processDefinitionId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-960'>ACT-960</a>] -         Retrieve active task list from processInstanceId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1020'>ACT-1020</a>] -         Get Process Documentation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1028'>ACT-1028</a>] -         Support default values for form properties
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1046'>ACT-1046</a>] -         Allow engine to configure a delay between retries and the amount of retries.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1117'>ACT-1117</a>] -         Add support for suffix &quot;.bpmn&quot; instead only &quot;.bpmn20.xml&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1136'>ACT-1136</a>] -         Add support for catching intermediate and boundary message events
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1139'>ACT-1139</a>] -         Add startProcessInstanceByMessage* methods to BusinessProcess bean
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1159'>ACT-1159</a>] -         BpmnError should be handled in expression based ServiceTasks.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1164'>ACT-1164</a>] -         Add possibility to hook in own implementation of BusinessRuleTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1167'>ACT-1167</a>] -         Start and End event should be able to have Execution Listeners as well
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1181'>ACT-1181</a>] -         Group provisioning &amp; group assignment missing in REST
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1190'>ACT-1190</a>] -         Add possibility to hook in own MyBatis Queries
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1213'>ACT-1213</a>] -         Add &quot;processVariableValueNotEquals&quot; to TaskQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1225'>ACT-1225</a>] -         Provide infrastructure for mock testing
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1282'>ACT-1282</a>] -         Add method TaskQuery#taskDelegationState(DelegationState)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1288'>ACT-1288</a>] -         Timer due date configured by expression can take java.util.Date directly - not only String with ISO 8601
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-638'>ACT-638</a>] -         Implement non interrupting boundaryEvent (cancelActivity=&quot;false&quot;)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-740'>ACT-740</a>] -         Mechanism of management rights on the start of process.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-892'>ACT-892</a>] -         Support nested sub-processes in designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-932'>ACT-932</a>] -         Support embedded subprocesses in Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-959'>ACT-959</a>] -         Retrieve process diagram through rest interface by processDefinitionId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-960'>ACT-960</a>] -         Retrieve active task list from processInstanceId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1020'>ACT-1020</a>] -         Get Process Documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1028'>ACT-1028</a>] -         Support default values for form properties
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1046'>ACT-1046</a>] -         Allow engine to configure a delay between retries and the amount of retries.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1117'>ACT-1117</a>] -         Add support for suffix &quot;.bpmn&quot; instead only &quot;.bpmn20.xml&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1136'>ACT-1136</a>] -         Add support for catching intermediate and boundary message events
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1139'>ACT-1139</a>] -         Add startProcessInstanceByMessage* methods to BusinessProcess bean
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1159'>ACT-1159</a>] -         BpmnError should be handled in expression based ServiceTasks.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1164'>ACT-1164</a>] -         Add possibility to hook in own implementation of BusinessRuleTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1167'>ACT-1167</a>] -         Start and End event should be able to have Execution Listeners as well
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1181'>ACT-1181</a>] -         Group provisioning &amp; group assignment missing in REST
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1190'>ACT-1190</a>] -         Add possibility to hook in own MyBatis Queries
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1213'>ACT-1213</a>] -         Add &quot;processVariableValueNotEquals&quot; to TaskQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1225'>ACT-1225</a>] -         Provide infrastructure for mock testing
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1282'>ACT-1282</a>] -         Add method TaskQuery#taskDelegationState(DelegationState)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1288'>ACT-1288</a>] -         Timer due date configured by expression can take java.util.Date directly - not only String with ISO 8601
+    </li>
 </ul>
-        
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1161'>ACT-1161</a>] -         Remove experimental Webservices from activiti-cxf project
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1161'>ACT-1161</a>] -         Remove experimental Webservices from activiti-cxf project
+    </li>
 </ul>
-        
+
 <h4>        Wish
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1197'>ACT-1197</a>] -         Spring based configuration with user specified expression manager
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1247'>ACT-1247</a>] -         Could u supply a WF graph with highlighted active node
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1197'>ACT-1197</a>] -         Spring based configuration with user specified expression manager
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1247'>ACT-1247</a>] -         Could u supply a WF graph with highlighted active node
+    </li>
 </ul>
 
 
 
-  <h3>Release Notes - Activiti - Version 5.9</h3>
+<h3>Release Notes - Activiti - Version 5.9</h3>
 
-  <h4>Highlights</h4>
-  <ul>
+<h4>Highlights</h4>
+<ul>
     <li>Support for Exclusive Jobs and Plugability of the Job Executor Infrastructure</li>
     <li>Persistent event subscriptions (infrastructure)</li>
     <li>Intermediate signal throw / catch</li>
     <li>Event based gateway</li>
-    <li>BPMN transaction (cancel end event & cancel boundary event)</li>
-    <li>BPMN compensation (compensation catch & compensation throw)</li>
+    <li>BPMN transaction (cancel end event &amp; cancel boundary event)</li>
+    <li>BPMN compensation (compensation catch &amp; compensation throw)</li>
     <li>Interrupting error event subprocesses</li>
     <li>(Multiple) message start events (not implemented yet, should be a quick win)</li>
     <li>Various bug fixes</li>
-  </ul>
+</ul>
 
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-583'>ACT-583</a>] -         Processes are not found in the bar file, if they are below root
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-736'>ACT-736</a>] -         SpringAutoDeployment deploymentsDiffer incorrect (results in unnecessary deployment each application restart)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-834'>ACT-834</a>] -         JavaDelegate instances should not be cached
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-848'>ACT-848</a>] -         Delete Reason not saved in database
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-861'>ACT-861</a>] -         Statement-Leak in Mybatis
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-862'>ACT-862</a>] -         VariableScopeImpl#getVariableNames does not take parent scopes into account
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-907'>ACT-907</a>] -         Timer start event triggers twice
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-930'>ACT-930</a>] -         startUserId missing in REST v2  /process-instances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-944'>ACT-944</a>] -         Activiti 5.7 &quot;Create deployment artifacts&quot; in Eclipse creates unusable .jar file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-953'>ACT-953</a>] -         Error catching boundary event that catches ALL errors doesn&#39;t work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-954'>ACT-954</a>] -         REST webapp doesn&#39;t set the authenticated user on the Authentication object
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-981'>ACT-981</a>] -         ActivitiOptimisticLockingException thrown on CallActivity with Async serviceTask and Multi-Instance construct. 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-983'>ACT-983</a>] -         Only test in Activiti Explorer fails
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-990'>ACT-990</a>] -         Activiti-cdi: CdiActivitiTestCase troubles Jboss AS7 classloader
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1001'>ACT-1001</a>] -         Activiti-cdi: taskService.claim() does not work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1003'>ACT-1003</a>] -         Exceptions thrown on a multi instance sub process with asynchronous property
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1027'>ACT-1027</a>] -         Activiti engine bundle has optional dependencies declared as mandatory in OSGi manifest
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1035'>ACT-1035</a>] -         Calling interrupt() on thread that access the database closes db connection and causes ConnectionClosed exceptions (H2 and Derby)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1047'>ACT-1047</a>] -         Possible infinite loop with log flooding in JobAcquisitionThread
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1050'>ACT-1050</a>] -         AtomicOperationProcessEnd does not propagate caught Exceptions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1053'>ACT-1053</a>] -         Activiti cdi: Remove CommandExecutor bean
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1061'>ACT-1061</a>] -         Process Image is cut off in &quot;My instances&quot; instead of scrolling
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1062'>ACT-1062</a>] -         Database table generation fails on Oracle if multiple activiti engine schematas are visible to the database user
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1087'>ACT-1087</a>] -         Add missing &quot;parseReceiveTask&quot; to BpmnParseListener
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1097'>ACT-1097</a>] -         Execution.takeAll() takes transitions with executions which have been deleted
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1098'>ACT-1098</a>] -         RuntimeService.deleteProcessInstance loses deleteReason
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1099'>ACT-1099</a>] -         Parsing results in exception when using text annotation connected with association
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1114'>ACT-1114</a>] -         Timer throw exception.
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-583'>ACT-583</a>] -         Processes are not found in the bar file, if they are below root
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-736'>ACT-736</a>] -         SpringAutoDeployment deploymentsDiffer incorrect (results in unnecessary deployment each application restart)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-834'>ACT-834</a>] -         JavaDelegate instances should not be cached
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-848'>ACT-848</a>] -         Delete Reason not saved in database
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-861'>ACT-861</a>] -         Statement-Leak in Mybatis
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-862'>ACT-862</a>] -         VariableScopeImpl#getVariableNames does not take parent scopes into account
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-907'>ACT-907</a>] -         Timer start event triggers twice
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-930'>ACT-930</a>] -         startUserId missing in REST v2  /process-instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-944'>ACT-944</a>] -         Activiti 5.7 &quot;Create deployment artifacts&quot; in Eclipse creates unusable .jar file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-953'>ACT-953</a>] -         Error catching boundary event that catches ALL errors doesn&#39;t work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-954'>ACT-954</a>] -         REST webapp doesn&#39;t set the authenticated user on the Authentication object
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-981'>ACT-981</a>] -         ActivitiOptimisticLockingException thrown on CallActivity with Async serviceTask and Multi-Instance construct.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-983'>ACT-983</a>] -         Only test in Activiti Explorer fails
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-990'>ACT-990</a>] -         Activiti-cdi: CdiActivitiTestCase troubles Jboss AS7 classloader
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1001'>ACT-1001</a>] -         Activiti-cdi: taskService.claim() does not work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1003'>ACT-1003</a>] -         Exceptions thrown on a multi instance sub process with asynchronous property
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1027'>ACT-1027</a>] -         Activiti engine bundle has optional dependencies declared as mandatory in OSGi manifest
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1035'>ACT-1035</a>] -         Calling interrupt() on thread that access the database closes db connection and causes ConnectionClosed exceptions (H2 and Derby)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1047'>ACT-1047</a>] -         Possible infinite loop with log flooding in JobAcquisitionThread
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1050'>ACT-1050</a>] -         AtomicOperationProcessEnd does not propagate caught Exceptions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1053'>ACT-1053</a>] -         Activiti cdi: Remove CommandExecutor bean
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1061'>ACT-1061</a>] -         Process Image is cut off in &quot;My instances&quot; instead of scrolling
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1062'>ACT-1062</a>] -         Database table generation fails on Oracle if multiple activiti engine schematas are visible to the database user
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1087'>ACT-1087</a>] -         Add missing &quot;parseReceiveTask&quot; to BpmnParseListener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1097'>ACT-1097</a>] -         Execution.takeAll() takes transitions with executions which have been deleted
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1098'>ACT-1098</a>] -         RuntimeService.deleteProcessInstance loses deleteReason
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1099'>ACT-1099</a>] -         Parsing results in exception when using text annotation connected with association
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1114'>ACT-1114</a>] -         Timer throw exception.
+    </li>
 </ul>
-        
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-249'>ACT-249</a>] -         Need a way to skip process where isExecutable=&#39;false&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-326'>ACT-326</a>] -         Store current authenticated user Id into HistoricDetail
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-702'>ACT-702</a>] -         All tests should also run with full history configuration on all DB&#39;s
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-831'>ACT-831</a>] -         CallActiviti to select subprocess based upon an expression evaluated at runtime. 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-889'>ACT-889</a>] -         Typo error in User guide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-948'>ACT-948</a>] -         Database in activiti.cfg.xml in REST is hardcoded to H2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-964'>ACT-964</a>] -         Also catch and handle Errors when generating diagram
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1005'>ACT-1005</a>] -         Activiti jpa integration does not merge detached entities
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1012'>ACT-1012</a>] -         REST - Get form properties from startform
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1036'>ACT-1036</a>] -         Check for isActive flag before going to sleep in JobAcqusitionThread
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1038'>ACT-1038</a>] -         Improve JobAcqusitionThread
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1045'>ACT-1045</a>] -         Finding a better way for executing task rejected by ThreadPoolExecutor.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1052'>ACT-1052</a>] -         Activiti-cdi: Upgrade Jboss Weld to resolve Issue with BeforeShutdown event in ActivitiExtension
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1055'>ACT-1055</a>] -         Activiti cdi: Change ProcessEngineLookup into a java.util.ServiceLoader like SPI
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1072'>ACT-1072</a>] -         Execution gets stuck after nested Sub-Process with no outgoing Sequence Flows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1079'>ACT-1079</a>] -         TimerEntity#getPersistentState() should include duedate field
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1104'>ACT-1104</a>] -         Overload method to pass in process variables to RuntimeService.signal
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1105'>ACT-1105</a>] -         Activiti -cdi: use signal method to pass in process variables to execution
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-249'>ACT-249</a>] -         Need a way to skip process where isExecutable=&#39;false&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-326'>ACT-326</a>] -         Store current authenticated user Id into HistoricDetail
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-702'>ACT-702</a>] -         All tests should also run with full history configuration on all DB&#39;s
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-831'>ACT-831</a>] -         CallActiviti to select subprocess based upon an expression evaluated at runtime.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-889'>ACT-889</a>] -         Typo error in User guide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-948'>ACT-948</a>] -         Database in activiti.cfg.xml in REST is hardcoded to H2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-964'>ACT-964</a>] -         Also catch and handle Errors when generating diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1005'>ACT-1005</a>] -         Activiti jpa integration does not merge detached entities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1012'>ACT-1012</a>] -         REST - Get form properties from startform
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1036'>ACT-1036</a>] -         Check for isActive flag before going to sleep in JobAcqusitionThread
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1038'>ACT-1038</a>] -         Improve JobAcqusitionThread
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1045'>ACT-1045</a>] -         Finding a better way for executing task rejected by ThreadPoolExecutor.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1052'>ACT-1052</a>] -         Activiti-cdi: Upgrade Jboss Weld to resolve Issue with BeforeShutdown event in ActivitiExtension
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1055'>ACT-1055</a>] -         Activiti cdi: Change ProcessEngineLookup into a java.util.ServiceLoader like SPI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1072'>ACT-1072</a>] -         Execution gets stuck after nested Sub-Process with no outgoing Sequence Flows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1079'>ACT-1079</a>] -         TimerEntity#getPersistentState() should include duedate field
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1104'>ACT-1104</a>] -         Overload method to pass in process variables to RuntimeService.signal
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1105'>ACT-1105</a>] -         Activiti -cdi: use signal method to pass in process variables to execution
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-441'>ACT-441</a>] -         Allow historic queries for a specific date range
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-456'>ACT-456</a>] -         Sending mails with Activiti with TLS (eg using Gmail as SMTP)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-461'>ACT-461</a>] -         Activity type for executing OS commands
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-846'>ACT-846</a>] -         Add Scrollbars to Process image in Explorer2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-883'>ACT-883</a>] -         Variable query support for HistoricProcessInstances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-903'>ACT-903</a>] -         RuntimeService.signal should be able to take signalName
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-945'>ACT-945</a>] -         Enable creating new users through rest interface
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-947'>ACT-947</a>] -         Retrieve process variables through REST interface
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-985'>ACT-985</a>] -         Support activiti:priority userTask extension at run-time
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-989'>ACT-989</a>] -         Implement exclusive jobs
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1004'>ACT-1004</a>] -         There is no ability to sort process instances by &#39;start time&#39; in Activiti-API. Good if it would be...
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1021'>ACT-1021</a>] -         Trigger BPMN Error Events from Java Delegate
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1028'>ACT-1028</a>] -         Support default values for form properties
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1034'>ACT-1034</a>] -         Fix synchronization on isActive and isJobAdded fields in JobAcquisitionThread
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1068'>ACT-1068</a>] -         Error Event Sub-Process
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1074'>ACT-1074</a>] -         Support suspension of JobExecution for particular ProcessDefinitions and ProcessInstances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1086'>ACT-1086</a>] -         Add &quot;businessKey&quot; query capabilities to TaskQuery and ExecutionQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1091'>ACT-1091</a>] -         Add support for persistent event subscriptions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1092'>ACT-1092</a>] -         Add support for bpmn20 signal throw and catch in engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1093'>ACT-1093</a>] -         Add support for bpmn20 event based gateway in engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1094'>ACT-1094</a>] -         Add support for bpmn20 compensation in engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1095'>ACT-1095</a>] -         Add support for bpmn20 transactions in engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1103'>ACT-1103</a>] -         Add support for bpmn20 message start event in engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-1107'>ACT-1107</a>] -         Implement None Intermediate Throw Event
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-441'>ACT-441</a>] -         Allow historic queries for a specific date range
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-456'>ACT-456</a>] -         Sending mails with Activiti with TLS (eg using Gmail as SMTP)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-461'>ACT-461</a>] -         Activity type for executing OS commands
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-846'>ACT-846</a>] -         Add Scrollbars to Process image in Explorer2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-883'>ACT-883</a>] -         Variable query support for HistoricProcessInstances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-903'>ACT-903</a>] -         RuntimeService.signal should be able to take signalName
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-945'>ACT-945</a>] -         Enable creating new users through rest interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-947'>ACT-947</a>] -         Retrieve process variables through REST interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-985'>ACT-985</a>] -         Support activiti:priority userTask extension at run-time
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-989'>ACT-989</a>] -         Implement exclusive jobs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1004'>ACT-1004</a>] -         There is no ability to sort process instances by &#39;start time&#39; in Activiti-API. Good if it would be...
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1021'>ACT-1021</a>] -         Trigger BPMN Error Events from Java Delegate
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1028'>ACT-1028</a>] -         Support default values for form properties
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1034'>ACT-1034</a>] -         Fix synchronization on isActive and isJobAdded fields in JobAcquisitionThread
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1068'>ACT-1068</a>] -         Error Event Sub-Process
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1074'>ACT-1074</a>] -         Support suspension of JobExecution for particular ProcessDefinitions and ProcessInstances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1086'>ACT-1086</a>] -         Add &quot;businessKey&quot; query capabilities to TaskQuery and ExecutionQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1091'>ACT-1091</a>] -         Add support for persistent event subscriptions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1092'>ACT-1092</a>] -         Add support for bpmn20 signal throw and catch in engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1093'>ACT-1093</a>] -         Add support for bpmn20 event based gateway in engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1094'>ACT-1094</a>] -         Add support for bpmn20 compensation in engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1095'>ACT-1095</a>] -         Add support for bpmn20 transactions in engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1103'>ACT-1103</a>] -         Add support for bpmn20 message start event in engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1107'>ACT-1107</a>] -         Implement None Intermediate Throw Event
+    </li>
 </ul>
-        
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-34'>ACT-34</a>] -         Refactor JobExecutor threading
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-994'>ACT-994</a>] -         Get contributor agreement from Thilo
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-34'>ACT-34</a>] -         Refactor JobExecutor threading
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-994'>ACT-994</a>] -         Get contributor agreement from Thilo
+    </li>
 </ul>
-          
 
-  <h3>Release Notes - Activiti - Version 5.8</h3>
 
-  <h4>Highlights</h4>
-  <ul>
-    <li>Asynchronous continations (tech preview)</li>
+<h3>Release Notes - Activiti - Version 5.8</h3>
+
+<h4>Highlights</h4>
+<ul>
+    <li>Asynchronous continuations (tech preview)</li>
     <li>Added BPMN inclusive gateway</li>
     <li>Improved Spring support</li>
     <li>CDI integration improvements</li>
     <li>Bug fixes</li>
-  </ul>
-            
+</ul>
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-908'>ACT-908</a>] -         Designer .activiti file won&#39;t compile and generate a BPMN 2.0 xml file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-910'>ACT-910</a>] -         duplication of flownodes when nodes are out of order 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-919'>ACT-919</a>] -         Activiti-cdi: make interceptors serializable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-922'>ACT-922</a>] -         Activiti-cdi: make sure to use the right BeanManager in ProgrammaticLookups
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-924'>ACT-924</a>] -         BPMN Export fails for Sequence Flows under IBM JDK because of wrong namespace definition in SequenceFlowExport.java
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-937'>ACT-937</a>] -         Desiger form property editor flips ID and Name fields
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-939'>ACT-939</a>] -         Mime-type and extension of uploaded attachments isn&#39;t handled correctly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-943'>ACT-943</a>] -         ReceiveTask with TimerBoundaryEvent not working as expected !
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-957'>ACT-957</a>] -         Unable to add 2 timerBoundaryEvents in sub process
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-908'>ACT-908</a>] -         Designer .activiti file won&#39;t compile and generate a BPMN 2.0 xml file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-910'>ACT-910</a>] -         duplication of flownodes when nodes are out of order
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-919'>ACT-919</a>] -         Activiti-cdi: make interceptors serializable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-922'>ACT-922</a>] -         Activiti-cdi: make sure to use the right BeanManager in ProgrammaticLookups
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-924'>ACT-924</a>] -         BPMN Export fails for Sequence Flows under IBM JDK because of wrong namespace definition in SequenceFlowExport.java
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-937'>ACT-937</a>] -         Designer form property editor flips ID and Name fields
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-939'>ACT-939</a>] -         Mime-type and extension of uploaded attachments isn&#39;t handled correctly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-943'>ACT-943</a>] -         ReceiveTask with TimerBoundaryEvent not working as expected !
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-957'>ACT-957</a>] -         Unable to add 2 timerBoundaryEvents in sub process
+    </li>
 </ul>
-        
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-288'>ACT-288</a>] -         Variable with authenticated user for be used inside form
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-909'>ACT-909</a>] -         Null-check for process name in explorer2 ui
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-918'>ACT-918</a>] -         Activiti-cdi: revisit process variable handling and interceptor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-926'>ACT-926</a>] -         Add method that is called when root-element of BPMN is parsed to BPMNParseListener
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-288'>ACT-288</a>] -         Variable with authenticated user for be used inside form
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-909'>ACT-909</a>] -         Null-check for process name in explorer2 ui
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-918'>ACT-918</a>] -         Activiti-cdi: revisit process variable handling and interceptor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-926'>ACT-926</a>] -         Add method that is called when root-element of BPMN is parsed to BPMNParseListener
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-126'>ACT-126</a>] -         Asynchronous continuations
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-890'>ACT-890</a>] -         Add Inclusive Gateway Support
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-916'>ACT-916</a>] -         Activiti-cdi: add thread context for thread-scoped associations
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-917'>ACT-917</a>] -         Activiti-cdi: add execution-based associations.
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-126'>ACT-126</a>] -         Asynchronous continuations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-890'>ACT-890</a>] -         Add Inclusive Gateway Support
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-916'>ACT-916</a>] -         Activiti-cdi: add thread context for thread-scoped associations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-917'>ACT-917</a>] -         Activiti-cdi: add execution-based associations.
+    </li>
 </ul>
-                
-  
-  <h3>Release Notes - Activiti - Version 5.7</h3>
 
-  <h4>Highlights</h4>
-  <ul>
+
+<h3>Release Notes - Activiti - Version 5.7</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>A new Activiti Explorer application completely rewritten in Vaadin</li>
     <li>The REST services have been rewritten to Restlet</li>
-  </ul>
+</ul>
 
-  <h4>Important</h4>
+<h4>Important</h4>
 
-  <p>
-    A couple of add-on applications have spun off from the Activiti download and 
-    started life on their own.  Activiti Modeler continues as a Google code project 
-    called <a href="http://code.google.com/p/signavio-core-components/">Signavio Core Components</a>.  
+<p>
+    A couple of add-on applications have spun off from the Activiti download and
+    started life on their own.  Activiti Modeler continues as a Google code project
+    called <a href="http://code.google.com/p/signavio-core-components/">Signavio Core Components</a>.
     Activiti Cycle now lives on as <a href="http://fox.camunda.com/doc/#cycle">Camunda Fox</a>.
-    An evolved version of Activiti KickStart will become part of a new Alfresco cloud case management 
-    solution.    
-  </p>
-  
-  <p>
-    Activiti Explorer has acquired Activiti Probe for an undisclosed amount :-)  The resulting 
-    Activiti Explorer has been restyled and includes more dynamic task management features. 
-  </p>
-  
-  <p>
-    The REST services were rewritten with the Restlet framework with backwards compatibility, so the REST interfaces haven't changed. 
+    An evolved version of Activiti KickStart will become part of a new Alfresco cloud case management
+    solution.
+</p>
+
+<p>
+    Activiti Explorer has acquired Activiti Probe for an undisclosed amount :-)  The resulting
+    Activiti Explorer has been restyled and includes more dynamic task management features.
+</p>
+
+<p>
+    The REST services were rewritten with the Restlet framework with backwards compatibility, so the REST interfaces haven't changed.
     The previous versions of Activiti included a REST services web application that used the Spring Surf and Webscripts framework.
     To implement a new or revised REST service you had to learn these frameworks. With moving to Restlet implementing new or revised REST services has become really simple.
-  </p>
-    
-  <p>
+</p>
+
+<p>
     The demo setup has been limited to H2 database only, as many people struggled with getting
     the demo setup to run on their databases. The demo setup is a quick way to get familiar
     with Activiti and its tools, but it is by no means meant for production purposes.
     A section <i>'Changing the database'</i> has been added to the userguide and is intended for advanced users
     who want to run the Activiti tools on their servers and databases.
-  </p>
-  
-  
+</p>
+
+
 <h4>        Sub-task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-705'>ACT-705</a>] -         Enable opening a call activity&#39;s process if it exists in the workspace
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-705'>ACT-705</a>] -         Enable opening a call activity&#39;s process if it exists in the workspace
+    </li>
 </ul>
-        
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-481'>ACT-481</a>] -         Replacing MailTask with ServiceTask by reconnecting connections renders different type of connection after deletion of MailTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-629'>ACT-629</a>] -         BPMN waypoints are not created accurately
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-768'>ACT-768</a>] -         JtaTransactionInterceptor should not rollback existing JTA transactions but use setRollbackOnly instead
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-803'>ACT-803</a>] -         Activiti-Designer creates activiti:field for empty field-values which causes an error on deployment of bar on activiti-probe
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-842'>ACT-842</a>] -         Activiti explorer pretty-time label tooltip doesn&#39;t show time, only date
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-856'>ACT-856</a>] -         Error format xml in parameters of Call-Activity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-867'>ACT-867</a>] -         Login page of activiti explorer 2 is not showing in ie
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-879'>ACT-879</a>] -         Designer plugin creates multiple extensionElements Nodes in a serviceTask Node
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-481'>ACT-481</a>] -         Replacing MailTask with ServiceTask by reconnecting connections renders different type of connection after deletion of MailTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-629'>ACT-629</a>] -         BPMN waypoints are not created accurately
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-768'>ACT-768</a>] -         JtaTransactionInterceptor should not rollback existing JTA transactions but use setRollbackOnly instead
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-803'>ACT-803</a>] -         Activiti-Designer creates activiti:field for empty field-values which causes an error on deployment of bar on activiti-probe
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-842'>ACT-842</a>] -         Activiti explorer pretty-time label tooltip doesn&#39;t show time, only date
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-856'>ACT-856</a>] -         Error format xml in parameters of Call-Activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-867'>ACT-867</a>] -         Login page of activiti explorer 2 is not showing in ie
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-879'>ACT-879</a>] -         Designer plugin creates multiple extensionElements Nodes in a serviceTask Node
+    </li>
 </ul>
-        
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-730'>ACT-730</a>] -         Easier way to retrieve businessKey from task listeners
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-833'>ACT-833</a>] -         [PATCH] make new explorer SSO friendly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-835'>ACT-835</a>] -         Make commands serializable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-841'>ACT-841</a>] -         Designer changes timer start event to none start event
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-843'>ACT-843</a>] -         Rendering variable values in process-instance view should be made pluggable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-860'>ACT-860</a>] -         Ability to set targetNamespace /process definition category
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-880'>ACT-880</a>] -         Add query capbility to search for historic process instances based on the parent process instance id
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-730'>ACT-730</a>] -         Easier way to retrieve businessKey from task listeners
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-833'>ACT-833</a>] -         [PATCH] make new explorer SSO friendly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-835'>ACT-835</a>] -         Make commands serializable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-841'>ACT-841</a>] -         Designer changes timer start event to none start event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-843'>ACT-843</a>] -         Rendering variable values in process-instance view should be made pluggable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-860'>ACT-860</a>] -         Ability to set targetNamespace /process definition category
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-880'>ACT-880</a>] -         Add query capability to search for historic process instances based on the parent process instance id
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-450'>ACT-450</a>] -         Use a Activiti XSD for the XML editor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-708'>ACT-708</a>] -         Allow dragging a shape and connector directly from the context buttons
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-846'>ACT-846</a>] -         Add Scrollbars to Process image in Explorer2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-852'>ACT-852</a>] -         Support timer start event
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-450'>ACT-450</a>] -         Use a Activiti XSD for the XML editor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-708'>ACT-708</a>] -         Allow dragging a shape and connector directly from the context buttons
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-846'>ACT-846</a>] -         Add Scrollbars to Process image in Explorer2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-852'>ACT-852</a>] -         Support timer start event
+    </li>
 </ul>
-        
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-436'>ACT-436</a>] -         Create retry interceptor
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-773'>ACT-773</a>] -         Define strategy for classloading
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-787'>ACT-787</a>] -         Enable probe functionality subset in the new webapp
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-836'>ACT-836</a>] -         Cleaning obsolete modules from codebase
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-839'>ACT-839</a>] -         Remove impl from the public javadocs
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-849'>ACT-849</a>] -         Integrate explorer 2 in demo setup
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-857'>ACT-857</a>] -         Limit demo setup to H2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-864'>ACT-864</a>] -         Add support for MS SQL bootstrap
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-436'>ACT-436</a>] -         Create retry interceptor
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-773'>ACT-773</a>] -         Define strategy for classloading
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-787'>ACT-787</a>] -         Enable probe functionality subset in the new webapp
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-836'>ACT-836</a>] -         Cleaning obsolete modules from codebase
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-839'>ACT-839</a>] -         Remove impl from the public javadocs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-849'>ACT-849</a>] -         Integrate explorer 2 in demo setup
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-857'>ACT-857</a>] -         Limit demo setup to H2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-864'>ACT-864</a>] -         Add support for MS SQL bootstrap
+    </li>
 </ul>
-        
 
-  <h3>Release Notes - Activiti - Version 5.6</h3>
-  <h4>Highlights</h4>
-  <ul>
+
+<h3>Release Notes - Activiti - Version 5.6</h3>
+<h4>Highlights</h4>
+<ul>
     <li>Added direct <a href="http://bpmn20inaction.blogspot.com/2011/05/supersize-activiti-with-mule-esb-and.html">Mule and Camel integration</a></li>
     <li>Easier way to retrieve businessKey from task listeners</li>
     <li>Improved support for Alfresco processes</li>
     <li>Added support for delegateExpressions in tasklistener</li>
     <li>Added support for BPMN multi instance in the eclipse designer</li>
     <li>Extended length of all user defined text columns to 4000</li>
-  </ul>
+</ul>
 
-  <h4>Known upgrade limitation</h4>
-  <p>In the DB schema creation scripts, we've enlarged the max size of certain varchar columns from 255 to 4000.
-  See <a href="http://jira.codehaus.org/browse/ACT-236">ACT-236</a>.  These schema updates are not part of the 
-  automatic upgrade procedure.
-  </p>
-  
-  <p>Max length of following columns has been set to 4000:
-  </p>
-  
-  <ul>
+<h4>Known upgrade limitation</h4>
+<p>In the DB schema creation scripts, we've enlarged the max size of certain varchar columns from 255 to 4000.
+    See <a href="https://activiti.atlassian.net/browse/ACT-236">ACT-236</a>.  These schema updates are not part of the
+    automatic upgrade procedure.
+</p>
+
+<p>Max length of following columns has been set to 4000:
+</p>
+
+<ul>
     <li>ACT_RU_JOB.EXCEPTION_MSG_</li>
     <li>ACT_RU_JOB.HANDLER_CFG_</li>
     <li>ACT_RE_PROCDEF.RESOURCE_NAME_</li>
@@ -1987,310 +1987,310 @@
     <li>ACT_HI_COMMENT.MESSAGE_</li>
     <li>ACT_HI_ATTACHMENT.DESCRIPTION_</li>
     <li>ACT_HI_ATTACHMENT.URL_</li>
-  </ul>
-  
-  <p>If you want to perform these changes, you can do that manually.  Check your database capabilities for the
-  easiest way on changing the type of columns from varchar(255) to varchar(4000).  As a fall back, 
-  for each table affected, you can: 
-  </p>
-  <ol>
+</ul>
+
+<p>If you want to perform these changes, you can do that manually.  Check your database capabilities for the
+    easiest way on changing the type of columns from varchar(255) to varchar(4000).  As a fall back,
+    for each table affected, you can:
+</p>
+<ol>
     <li>create a new temporary table</li>
     <li>copy the contents from the original to the temporary table</li>
     <li>delete the original table</li>
     <li>recreate the original table using the new create script with the proper lengths</li>
     <li>copy the contents from the temporary table back to the new original table</li>
     <li>drop the temporary table</li>
-  </ol>
-  
+</ol>
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-665'>ACT-665</a>] -         Activiti Designer 0.8.0 can not delete by keyboard
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-691'>ACT-691</a>] -         Cannot see property changes when clicking on new tasks (Activiti Engine)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-786'>ACT-786</a>] -         NPE on default sequenceFlow without id
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-803'>ACT-803</a>] -         Activiti-Designer creates activiti:field for empty field-values which causes an error on deployment of bar on activiti-probe
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-806'>ACT-806</a>] -         Bug: multi instance service task with collection doesnt inject collection element
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-808'>ACT-808</a>] -         Support for default sequence flow in Activiti Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-809'>ACT-809</a>] -         Deploying Webservice
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-813'>ACT-813</a>] -         deleting task cascading problem for new variable instances 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-826'>ACT-826</a>] -         Rules Filter in Business Rules Task
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-665'>ACT-665</a>] -         Activiti Designer 0.8.0 can not delete by keyboard
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-691'>ACT-691</a>] -         Cannot see property changes when clicking on new tasks (Activiti Engine)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-786'>ACT-786</a>] -         NPE on default sequenceFlow without id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-803'>ACT-803</a>] -         Activiti-Designer creates activiti:field for empty field-values which causes an error on deployment of bar on activiti-probe
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-806'>ACT-806</a>] -         Bug: multi instance service task with collection doesn&#39;t inject collection element
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-808'>ACT-808</a>] -         Support for default sequence flow in Activiti Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-809'>ACT-809</a>] -         Deploying Webservice
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-813'>ACT-813</a>] -         deleting task cascading problem for new variable instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-826'>ACT-826</a>] -         Rules Filter in Business Rules Task
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-730'>ACT-730</a>] -         Easier way to retrieve businessKey from task listeners
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-795'>ACT-795</a>] -         Refactor BPMN 2.0 validation to worker list
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-730'>ACT-730</a>] -         Easier way to retrieve businessKey from task listeners
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-795'>ACT-795</a>] -         Refactor BPMN 2.0 validation to worker list
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-236'>ACT-236</a>] -         Introduce new variable type text
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-781'>ACT-781</a>] -         Allow to set charset when sending email
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-797'>ACT-797</a>] -         Set a userTask priority on the bpmn20.xml
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-799'>ACT-799</a>] -         Implement support for specifying timer event definitions other than timeDuration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-805'>ACT-805</a>] -         Add Ant view to Activiti perspective
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-807'>ACT-807</a>] -         support definition of delegateExpressions in tasklistener
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-811'>ACT-811</a>] -         Support BPMN Multi-instance 
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-236'>ACT-236</a>] -         Introduce new variable type text
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-781'>ACT-781</a>] -         Allow to set charset when sending email
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-797'>ACT-797</a>] -         Set a userTask priority on the bpmn20.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-799'>ACT-799</a>] -         Implement support for specifying timer event definitions other than timeDuration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-805'>ACT-805</a>] -         Add Ant view to Activiti perspective
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-807'>ACT-807</a>] -         support definition of delegateExpressions in tasklistener
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-811'>ACT-811</a>] -         Support BPMN Multi-instance
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-703'>ACT-703</a>] -         Complement palette
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-780'>ACT-780</a>] -         Enhancing the create task input field
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-788'>ACT-788</a>] -         Enable Alfresco user repository integration in the new webapp
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-703'>ACT-703</a>] -         Complement palette
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-780'>ACT-780</a>] -         Enhancing the create task input field
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-788'>ACT-788</a>] -         Enable Alfresco user repository integration in the new webapp
+    </li>
 </ul>
-        
-  <h3>Release Notes - Activiti - Version 5.5</h3>
-  
-      <h4>Highlights</h4>
+
+<h3>Release Notes - Activiti - Version 5.5</h3>
+
+<h4>Highlights</h4>
 <ul>
-  <li>Added CDI support</li>
-  <li>Added dynamic sub task capabilities</li>
-  <li>Added support for event/activity streams</li>
-  <li>In the eclipse process designer,added support for default value for CustomServiceTask fields</li>
-  <li>Simplified persistence</li>
-  <li>Performance improvements</li>
-  <li>Many bug fixes</li>
+    <li>Added CDI support</li>
+    <li>Added dynamic sub task capabilities</li>
+    <li>Added support for event/activity streams</li>
+    <li>In the eclipse process designer,added support for default value for CustomServiceTask fields</li>
+    <li>Simplified persistence</li>
+    <li>Performance improvements</li>
+    <li>Many bug fixes</li>
 </ul>
 
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-477'>ACT-477</a>] -         Creating new diagram using wizard with existing name overwrites without warning
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-718'>ACT-718</a>] -         Ternary operator not working in Listener field expression
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-757'>ACT-757</a>] -         calledElement missing from call activity in generated bpmn
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-764'>ACT-764</a>] -         MultiInstance doesn&#39;t work for serviceTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-765'>ACT-765</a>] -         Initial priority from task is not stored on HistoricTaskInstanceEntity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-766'>ACT-766</a>] -         Querying tasks causes HistoricTaskInstanceEntity to be loaded for each result
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-782'>ACT-782</a>] -         Javadoc of org.activiti.engine.test.Deployment is inconsistent with its implementation
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-477'>ACT-477</a>] -         Creating new diagram using wizard with existing name overwrites without warning
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-718'>ACT-718</a>] -         Ternary operator not working in Listener field expression
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-757'>ACT-757</a>] -         calledElement missing from call activity in generated bpmn
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-764'>ACT-764</a>] -         MultiInstance doesn&#39;t work for serviceTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-765'>ACT-765</a>] -         Initial priority from task is not stored on HistoricTaskInstanceEntity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-766'>ACT-766</a>] -         Querying tasks causes HistoricTaskInstanceEntity to be loaded for each result
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-782'>ACT-782</a>] -         Javadoc of org.activiti.engine.test.Deployment is inconsistent with its implementation
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-653'>ACT-653</a>] -         When folders src/test/java and src/test/resources are missing my unittests are not generated
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-725'>ACT-725</a>] -         Expose task query criteria for priority &gt;= and &lt;= in addition to =
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-728'>ACT-728</a>] -         When creating a process model not in src/main/resources (e.g. test), the activiti file is created in the src/main/resources anyway
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-732'>ACT-732</a>] -         Upgrade to iBatis 3.04
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-735'>ACT-735</a>] -         Task owner is not stored on the HistoricTaskInstance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-742'>ACT-742</a>] -         Use spring to wire explorer 2 application
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-744'>ACT-744</a>] -         Management pages should only be visible for admins
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-750'>ACT-750</a>] -         Refactor task-lists in explorer 2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-752'>ACT-752</a>] -         Add more demo-data to explorer 2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-753'>ACT-753</a>] -         Navigate to task URL for task where user is not involved should be forbidden
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-653'>ACT-653</a>] -         When folders src/test/java and src/test/resources are missing my unittests are not generated
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-725'>ACT-725</a>] -         Expose task query criteria for priority &gt;= and &lt;= in addition to =
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-728'>ACT-728</a>] -         When creating a process model not in src/main/resources (e.g. test), the activiti file is created in the src/main/resources anyway
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-732'>ACT-732</a>] -         Upgrade to iBatis 3.04
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-735'>ACT-735</a>] -         Task owner is not stored on the HistoricTaskInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-742'>ACT-742</a>] -         Use spring to wire explorer 2 application
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-744'>ACT-744</a>] -         Management pages should only be visible for admins
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-750'>ACT-750</a>] -         Refactor task-lists in explorer 2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-752'>ACT-752</a>] -         Add more demo-data to explorer 2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-753'>ACT-753</a>] -         Navigate to task URL for task where user is not involved should be forbidden
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-559'>ACT-559</a>] -         Allow default value for CustomServiceTask fields
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-644'>ACT-644</a>] -         Add support for dynamic subtasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-743'>ACT-743</a>] -         Add screen to edit user profile
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-746'>ACT-746</a>] -         Add people involvement in task UI
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-747'>ACT-747</a>] -         Add support for dynamic tasks in explorer UI
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-748'>ACT-748</a>] -         Add support for showing/adding subtasks in UI
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-751'>ACT-751</a>] -         Show event-stream in new explorer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-755'>ACT-755</a>] -         Add/remove related URL to task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-759'>ACT-759</a>] -         Allow user assignable Id for process elements.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-760'>ACT-760</a>] -         Add Skype buttons
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-559'>ACT-559</a>] -         Allow default value for CustomServiceTask fields
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-644'>ACT-644</a>] -         Add support for dynamic subtasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-743'>ACT-743</a>] -         Add screen to edit user profile
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-746'>ACT-746</a>] -         Add people involvement in task UI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-747'>ACT-747</a>] -         Add support for dynamic tasks in explorer UI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-748'>ACT-748</a>] -         Add support for showing/adding subtasks in UI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-751'>ACT-751</a>] -         Show event-stream in new explorer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-755'>ACT-755</a>] -         Add/remove related URL to task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-759'>ACT-759</a>] -         Allow user assignable Id for process elements.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-760'>ACT-760</a>] -         Add Skype buttons
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-741'>ACT-741</a>] -         Refactoring persistence
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-754'>ACT-754</a>] -         Apply styling to vaadin-components
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-767'>ACT-767</a>] -         Add support for Events
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-790'>ACT-790</a>] -         Look at cycle persistence
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-741'>ACT-741</a>] -         Refactoring persistence
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-754'>ACT-754</a>] -         Apply styling to vaadin-components
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-767'>ACT-767</a>] -         Add support for Events
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-790'>ACT-790</a>] -         Look at cycle persistence
+    </li>
 </ul>
-    
+
 <h4>        Test
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-745'>ACT-745</a>] -         Incorporate user/group administration into explorer 2
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-745'>ACT-745</a>] -         Incorporate user/group administration into explorer 2
+    </li>
 </ul>
-        
-  <h3>Release Notes - Activiti - Version 5.4</h3>
-    
-      <h4>Compatibility note</h4>
-      <p>After releasing 5.3, we discovered that
-      execution listeners and task listeners and expressions were still in non-public api. Those classes were in subpackages 
-      of <code>org.activiti.engine.impl...</code>,  which has <code>impl</code> in it).  
-      <code>org.activiti.engine.impl.pvm.delegate.ExecutionListener</code>, 
-      <code>org.activiti.engine.impl.pvm.delegate.TaskListener</code> and 
-      <code>org.activiti.engine.impl.pvm.el.Expression</code> 
-      have been deprecated. From now on, you should use <code>org.activiti.engine.delegate.ExecutionListener</code>,
-      <code>org.activiti.engine.delegate.TaskListener</code> and <code>org.activiti.engine.delegate.Expression</code>.
-      In the new publicly available API, access to  
-      <code>ExecutionListenerExecution.getEventSource()</code> has been removed.  Apart from the deprecation 
-      compiler warning, the existing code should run fine.  But consider switching to the new public 
-      API interfaces (without .impl. in the package name).
-      </p>
 
-      <h4>Highlights</h4>
+<h3>Release Notes - Activiti - Version 5.4</h3>
+
+<h4>Compatibility note</h4>
+<p>After releasing 5.3, we discovered that
+    execution listeners and task listeners and expressions were still in non-public api. Those classes were in subpackages
+    of <code>org.activiti.engine.impl...</code>,  which has <code>impl</code> in it).
+    <code>org.activiti.engine.impl.pvm.delegate.ExecutionListener</code>,
+    <code>org.activiti.engine.impl.pvm.delegate.TaskListener</code> and
+    <code>org.activiti.engine.impl.pvm.el.Expression</code>
+    have been deprecated. From now on, you should use <code>org.activiti.engine.delegate.ExecutionListener</code>,
+    <code>org.activiti.engine.delegate.TaskListener</code> and <code>org.activiti.engine.delegate.Expression</code>.
+    In the new publicly available API, access to
+    <code>ExecutionListenerExecution.getEventSource()</code> has been removed.  Apart from the deprecation
+    compiler warning, the existing code should run fine.  But consider switching to the new public
+    API interfaces (without .impl. in the package name).
+</p>
+
+<h4>Highlights</h4>
 <ul>
-  <li>Added first version of BPM-Roundtrip with Activiti Cycle (see <a href="http://www.bpm-guide.de/2011/03/22/the-bpm-roundtrip-with-activiti-cycle/">this Screencast</a>)</li>
-  <li>Started building case management features in the engine: Added dynamic comments, attachments and due dates to tasks in Activiti Engine</li>
-  <li>IMAP folder scanning for new tasks</li>
-  <li>Added accounts to users in Activiti Engine</li>
-  <li>Provided support to specify form properties in Activiti Designer Eclipse plugin</li>
-  <li>Many bug fixes</li>
+    <li>Added first version of BPM-Roundtrip with Activiti Cycle (see <a href="http://www.bpm-guide.de/2011/03/22/the-bpm-roundtrip-with-activiti-cycle/">this Screencast</a>)</li>
+    <li>Started building case management features in the engine: Added dynamic comments, attachments and due dates to tasks in Activiti Engine</li>
+    <li>IMAP folder scanning for new tasks</li>
+    <li>Added accounts to users in Activiti Engine</li>
+    <li>Provided support to specify form properties in Activiti Designer Eclipse plugin</li>
+    <li>Many bug fixes</li>
 </ul>
 
 <h4>        Sub-task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-692'>ACT-692</a>] -         Activiti Designer 0.8.0 can not show diagram with callActivity tasks
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-692'>ACT-692</a>] -         Activiti Designer 0.8.0 can not show diagram with callActivity tasks
+    </li>
 </ul>
-    
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-607'>ACT-607</a>] -         Developer Friendly BPMN doesn&#39;t remove Pools/Lanes in DI
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-634'>ACT-634</a>] -         Generated Jar file is invalid
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-666'>ACT-666</a>] -         Activiti 5.3 demo setup does not work on JDK 5
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-667'>ACT-667</a>] -         Diagram is cut off in some cases
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-668'>ACT-668</a>] -         Mail task doesnt leave activity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-670'>ACT-670</a>] -         Designer 0.8.0 generates wrong bpmnElement references for subprocess elements
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-681'>ACT-681</a>] -         Db autodiscovery for DB2 does not work on all installations of DB2
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-685'>ACT-685</a>] -         Executing processes can cause StackOverflows 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-695'>ACT-695</a>] -         Exception when using HistoricVariables of type ByteArray on Postgres
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-731'>ACT-731</a>] -         Webservice invocation doesnt continue process execution
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-607'>ACT-607</a>] -         Developer Friendly BPMN doesn&#39;t remove Pools/Lanes in DI
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-634'>ACT-634</a>] -         Generated Jar file is invalid
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-666'>ACT-666</a>] -         Activiti 5.3 demo setup does not work on JDK 5
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-667'>ACT-667</a>] -         Diagram is cut off in some cases
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-668'>ACT-668</a>] -         Mail task doesn&#39;t leave activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-670'>ACT-670</a>] -         Designer 0.8.0 generates wrong bpmnElement references for subprocess elements
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-681'>ACT-681</a>] -         Db autodiscovery for DB2 does not work on all installations of DB2
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-685'>ACT-685</a>] -         Executing processes can cause StackOverflows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-695'>ACT-695</a>] -         Exception when using HistoricVariables of type ByteArray on Postgres
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-731'>ACT-731</a>] -         Webservice invocation doesn&#39;t continue process execution
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-655'>ACT-655</a>] -         Throw better exception when form is not found
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-669'>ACT-669</a>] -         FormService.submitStartFormData should provide a way to specify businessKey for process instance
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-655'>ACT-655</a>] -         Throw better exception when form is not found
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-669'>ACT-669</a>] -         FormService.submitStartFormData should provide a way to specify businessKey for process instance
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-459'>ACT-459</a>] -         Query for tasks for a specific process definition
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-564'>ACT-564</a>] -         Add dueDate to tasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-661'>ACT-661</a>] -         Parse process definition documentation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-663'>ACT-663</a>] -         Provide support to specify form properties
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-672'>ACT-672</a>] -         Allow querying task based on process-instance variable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-673'>ACT-673</a>] -         Extend HistoricTaskInstanceQuery sorting: assignee, taskId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-675'>ACT-675</a>] -         Allow querying HistoricTaskInstances based on the state of historic process-instance (running/completed)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-676'>ACT-676</a>] -         Allow querying HistoricTaskInstances based on the value of the last variable-update for a certain task-variable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-677'>ACT-677</a>] -         Query HistoricTaskInstances based on the process definition key, id and name
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-688'>ACT-688</a>] -         Add comments to tasks and process instances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-712'>ACT-712</a>] -         Create feature that scans a IMAP-folder and creates task for each email in it.
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-459'>ACT-459</a>] -         Query for tasks for a specific process definition
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-564'>ACT-564</a>] -         Add dueDate to tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-661'>ACT-661</a>] -         Parse process definition documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-663'>ACT-663</a>] -         Provide support to specify form properties
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-672'>ACT-672</a>] -         Allow querying task based on process-instance variable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-673'>ACT-673</a>] -         Extend HistoricTaskInstanceQuery sorting: assignee, taskId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-675'>ACT-675</a>] -         Allow querying HistoricTaskInstances based on the state of historic process-instance (running/completed)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-676'>ACT-676</a>] -         Allow querying HistoricTaskInstances based on the value of the last variable-update for a certain task-variable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-677'>ACT-677</a>] -         Query HistoricTaskInstances based on the process definition key, id and name
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-688'>ACT-688</a>] -         Add comments to tasks and process instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-712'>ACT-712</a>] -         Create feature that scans a IMAP-folder and creates task for each email in it.
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-628'>ACT-628</a>] -         Resolve publicly exposed implementation classes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-648'>ACT-648</a>] -         Fix activiti-cycle-maven-template.zip
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-649'>ACT-649</a>] -         Document process instance visualization in Probe &amp; REST 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-650'>ACT-650</a>] -         Verify links to jdk, eclipse and ant in userguide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-652'>ACT-652</a>] -         Ensure docs on how to deploy from designer to engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-679'>ACT-679</a>] -         Add attachments to tasks and to process instances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-687'>ACT-687</a>] -         Add owner property to tasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-690'>ACT-690</a>] -         Verify activiti dependency versions against the ones used in Alfresco 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-694'>ACT-694</a>] -         Add photo, skypeid and other account data to identities
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-696'>ACT-696</a>] -         Prototype new Explorer UI
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-628'>ACT-628</a>] -         Resolve publicly exposed implementation classes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-648'>ACT-648</a>] -         Fix activiti-cycle-maven-template.zip
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-649'>ACT-649</a>] -         Document process instance visualization in Probe &amp; REST
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-650'>ACT-650</a>] -         Verify links to jdk, eclipse and ant in userguide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-652'>ACT-652</a>] -         Ensure docs on how to deploy from designer to engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-679'>ACT-679</a>] -         Add attachments to tasks and to process instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-687'>ACT-687</a>] -         Add owner property to tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-690'>ACT-690</a>] -         Verify activiti dependency versions against the ones used in Alfresco
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-694'>ACT-694</a>] -         Add photo, skypeid and other account data to identities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-696'>ACT-696</a>] -         Prototype new Explorer UI
+    </li>
 </ul>
-        
 
-  <h3>Release Notes - Activiti - Version 5.3</h3>
-    
-  <h4>Highlights</h4>
-  <ul>
+
+<h3>Release Notes - Activiti - Version 5.3</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Added BPMN multi instance (==foreach) support</li>
     <li>Added BPMN intermediate timer catch event</li>
     <li>Added business rule task with Drools integration</li>
@@ -2298,138 +2298,138 @@
     <li>Added administrator console to manage users and groups</li>
     <li>Added automatic DB type discovery</li>
     <li>Various bug fixes</li>
-  </ul>
+</ul>
 
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-485'>ACT-485</a>] -         Fields in HistoricTaskInstance aren&#39;t updated when corresponding Task fields are updated using API
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-568'>ACT-568</a>] -         Deleting an gateway does not delete the associated sequence flows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-575'>ACT-575</a>] -         Name of node in diagram not updated in specific case
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-589'>ACT-589</a>] -         Kickstart does not display properly on 1024x768
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-592'>ACT-592</a>] -         Nullpointer when trying to set variables on process-instance which is waiting in a Task with a timer on it, when history-level is FULL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-598'>ACT-598</a>] -         Bug in drawing of process diagrams: sequence flow out of gateways can&#39;t have conditional markers
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-599'>ACT-599</a>] -         BPMN20ExportMarshaller generates wrong id for startEvent and endEvent elements of subProcesses
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-603'>ACT-603</a>] -         docs for generated processdefinition id not correct
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-604'>ACT-604</a>] -         Cannot add variables to standalone task when history level is &#39;full&#39;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-610'>ACT-610</a>] -         ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE does not work with Oracle
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-611'>ACT-611</a>] -         It&#39;s not possible to delete sequenceFlows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-612'>ACT-612</a>] -         ServiceTask: Switching the type from class to expression doesn&#39;t update BPMN2.0.xml
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-618'>ACT-618</a>] -         Call of setter before null check in file BpmnParse
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-621'>ACT-621</a>] -         When creating HistoricFormPropertyEntity query for HistoricActivityInstance isn&#39;t limited to the active one
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-625'>ACT-625</a>] -         Task form just displays a Failure error when deployed from Eclipse Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-627'>ACT-627</a>] -         Subprocess Start and End event ids incorrectly generated
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-629'>ACT-629</a>] -         BPMN waypoints are not created accurately
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-631'>ACT-631</a>] -         Investigate potential concurrency bug
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-637'>ACT-637</a>] -         Using a call activity with activiti: in extension for variable passing results in null pointer when history level set to &quot;full&quot;
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-485'>ACT-485</a>] -         Fields in HistoricTaskInstance aren&#39;t updated when corresponding Task fields are updated using API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-568'>ACT-568</a>] -         Deleting an gateway does not delete the associated sequence flows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-575'>ACT-575</a>] -         Name of node in diagram not updated in specific case
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-589'>ACT-589</a>] -         Kickstart does not display properly on 1024x768
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-592'>ACT-592</a>] -         Nullpointer when trying to set variables on process-instance which is waiting in a Task with a timer on it, when history-level is FULL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-598'>ACT-598</a>] -         Bug in drawing of process diagrams: sequence flow out of gateways can&#39;t have conditional markers
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-599'>ACT-599</a>] -         BPMN20ExportMarshaller generates wrong id for startEvent and endEvent elements of subProcesses
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-603'>ACT-603</a>] -         docs for generated processdefinition id not correct
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-604'>ACT-604</a>] -         Cannot add variables to standalone task when history level is &#39;full&#39;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-610'>ACT-610</a>] -         ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE does not work with Oracle
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-611'>ACT-611</a>] -         It&#39;s not possible to delete sequenceFlows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-612'>ACT-612</a>] -         ServiceTask: Switching the type from class to expression doesn&#39;t update BPMN2.0.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-618'>ACT-618</a>] -         Call of setter before null check in file BpmnParse
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-621'>ACT-621</a>] -         When creating HistoricFormPropertyEntity query for HistoricActivityInstance isn&#39;t limited to the active one
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-625'>ACT-625</a>] -         Task form just displays a Failure error when deployed from Eclipse Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-627'>ACT-627</a>] -         Subprocess Start and End event ids incorrectly generated
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-629'>ACT-629</a>] -         BPMN waypoints are not created accurately
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-631'>ACT-631</a>] -         Investigate potential concurrency bug
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-637'>ACT-637</a>] -         Using a call activity with activiti: in extension for variable passing results in null pointer when history level set to &quot;full&quot;
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-429'>ACT-429</a>] -         Allow to use expressions in timer duration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-484'>ACT-484</a>] -         Add task priority to HistoricTaskInstance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-529'>ACT-529</a>] -         Processimage name does not follow conventions used by explorer/API to show or get image
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-530'>ACT-530</a>] -         Deployment doesn&#39;t export process image
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-549'>ACT-549</a>] -         Need brief documentation of working with Eclipse Designer Sources
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-584'>ACT-584</a>] -         Add ability to delete IdentityLinks using API and DelegateTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-585'>ACT-585</a>] -         Limiting/disabling spring-beans in expressions should be possible
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-587'>ACT-587</a>] -         FieldInjection should try public setter first and revert to setting private field
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-600'>ACT-600</a>] -         Review and improve 10 minute tutorial
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-601'>ACT-601</a>] -         Review and improve Designer section in userguide
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-429'>ACT-429</a>] -         Allow to use expressions in timer duration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-484'>ACT-484</a>] -         Add task priority to HistoricTaskInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-529'>ACT-529</a>] -         Processimage name does not follow conventions used by explorer/API to show or get image
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-530'>ACT-530</a>] -         Deployment doesn&#39;t export process image
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-549'>ACT-549</a>] -         Need brief documentation of working with Eclipse Designer Sources
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-584'>ACT-584</a>] -         Add ability to delete IdentityLinks using API and DelegateTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-585'>ACT-585</a>] -         Limiting/disabling spring-beans in expressions should be possible
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-587'>ACT-587</a>] -         FieldInjection should try public setter first and revert to setting private field
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-600'>ACT-600</a>] -         Review and improve 10 minute tutorial
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-601'>ACT-601</a>] -         Review and improve Designer section in userguide
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-469'>ACT-469</a>] -         Add support for specifying a Form key for StartEvent in Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-483'>ACT-483</a>] -         Support for specifying a form (form key) on a StartEvent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-506'>ACT-506</a>] -         For each support (Multi instance)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-527'>ACT-527</a>] -         Implement a Business Rule Task with Drools integration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-581'>ACT-581</a>] -         CallActivity with in/out parameters: Add sourceExpression and documentation to User Guide
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-582'>ACT-582</a>] -         Add deleteHistoricProcessInstance() to HistoryService
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-588'>ACT-588</a>] -         Extend TaskQuery to add variableValue querying similar to the ProcessInstanceQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-593'>ACT-593</a>] -         Allow firing of custom events to the active node on a given execution
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-596'>ACT-596</a>] -         Result DTO of KickstartService.findKickstartWorkflowById() is missing Task-ID&#39;s
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-606'>ACT-606</a>] -         Open existing BPMN XML directly in the project with the Designer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-641'>ACT-641</a>] -         Implement intermediate timer catch event
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-469'>ACT-469</a>] -         Add support for specifying a Form key for StartEvent in Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-483'>ACT-483</a>] -         Support for specifying a form (form key) on a StartEvent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-506'>ACT-506</a>] -         For each support (Multi instance)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-527'>ACT-527</a>] -         Implement a Business Rule Task with Drools integration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-581'>ACT-581</a>] -         CallActivity with in/out parameters: Add sourceExpression and documentation to User Guide
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-582'>ACT-582</a>] -         Add deleteHistoricProcessInstance() to HistoryService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-588'>ACT-588</a>] -         Extend TaskQuery to add variableValue querying similar to the ProcessInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-593'>ACT-593</a>] -         Allow firing of custom events to the active node on a given execution
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-596'>ACT-596</a>] -         Result DTO of KickstartService.findKickstartWorkflowById() is missing Task-ID&#39;s
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-606'>ACT-606</a>] -         Open existing BPMN XML directly in the project with the Designer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-641'>ACT-641</a>] -         Implement intermediate timer catch event
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-97'>ACT-97</a>] -         Expose spring beans in Scripts
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-416'>ACT-416</a>] -         Document how to open mgr of the in memory db
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-422'>ACT-422</a>] -         Make spring parsing dependency optional
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-442'>ACT-442</a>] -         expose root cause for class not found exceptions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-526'>ACT-526</a>] -         Provide Money tasks example code from userguide in repository
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-540'>ACT-540</a>] -         Distill db name from the datasource
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-571'>ACT-571</a>] -         Upgrade KickStart to Vaadin 6.5.0
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-574'>ACT-574</a>] -         Rename service task resultVariableName to resultVariable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-623'>ACT-623</a>] -         Simplify access to process engine configuration through Context
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-632'>ACT-632</a>] -         Update repo link
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-642'>ACT-642</a>] -         Include MIT license file in the activiti-modeler.war distribution file
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-645'>ACT-645</a>] -         Merge Administrator branch into trunk
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-97'>ACT-97</a>] -         Expose spring beans in Scripts
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-416'>ACT-416</a>] -         Document how to open mgr of the in memory db
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-422'>ACT-422</a>] -         Make spring parsing dependency optional
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-442'>ACT-442</a>] -         expose root cause for class not found exceptions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-526'>ACT-526</a>] -         Provide Money tasks example code from userguide in repository
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-540'>ACT-540</a>] -         Distill db name from the datasource
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-571'>ACT-571</a>] -         Upgrade KickStart to Vaadin 6.5.0
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-574'>ACT-574</a>] -         Rename service task resultVariableName to resultVariable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-623'>ACT-623</a>] -         Simplify access to process engine configuration through Context
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-632'>ACT-632</a>] -         Update repo link
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-642'>ACT-642</a>] -         Include MIT license file in the activiti-modeler.war distribution file
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-645'>ACT-645</a>] -         Merge Administrator branch into trunk
+    </li>
 </ul>
-        
 
-  
-  <h3>Release Notes - Activiti - Version 5.2</h3>
-    
-  <h4>Highlights</h4>
-  <ul>
+
+
+<h3>Release Notes - Activiti - Version 5.2</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>First version of the jBPM-Activiti migration</li>
     <li>Visualization of the current activity in Activiti Probe</li>
     <li>Added support for BPMN error event in Activiti Engine</li>
@@ -2437,140 +2437,140 @@
     <li>Improved form datatypes</li>
     <li>Automated in container testing</li>
     <li>Various bug fixes</li>
-  </ul>
-    
+</ul>
+
 <h4>        Sub-task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-512'>ACT-512</a>] -         Add Checkbox control
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-513'>ACT-513</a>] -         Add static dropdown control
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-514'>ACT-514</a>] -         Add radio control
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-515'>ACT-515</a>] -         Add datepicker control
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-512'>ACT-512</a>] -         Add Checkbox control
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-513'>ACT-513</a>] -         Add static dropdown control
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-514'>ACT-514</a>] -         Add radio control
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-515'>ACT-515</a>] -         Add datepicker control
+    </li>
 </ul>
-    
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-428'>ACT-428</a>] -         It is not possible to use function with more then 1 argument as custom assignment handler for candidateGroups
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-473'>ACT-473</a>] -         ProcessEngineFactoryBean fails to register created process engine properly
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-474'>ACT-474</a>] -         Activiti Designer doesn&#39;t support multiple end events
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-479'>ACT-479</a>] -         Vacation Request form example code in user guide is not correct
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-505'>ACT-505</a>] -         Process definition cache not in sync when redeploying process definition with same generated id
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-509'>ACT-509</a>] -         Reported progress for ExportMarshallers and ProcessValidators is incorrect
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-533'>ACT-533</a>] -         In Eclipse the export process to bpmn20.xml fails in some attributes of &quot;UserTask&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-557'>ACT-557</a>] -         Field TASK_DEF_KEY_ is not populated on ACT_HI_TASK and not exposed on HistoricTaskInstance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-572'>ACT-572</a>] -         Maven &quot;check&quot; profile states successful build when there are test-failures
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-428'>ACT-428</a>] -         It is not possible to use function with more then 1 argument as custom assignment handler for candidateGroups
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-473'>ACT-473</a>] -         ProcessEngineFactoryBean fails to register created process engine properly
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-474'>ACT-474</a>] -         Activiti Designer doesn&#39;t support multiple end events
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-479'>ACT-479</a>] -         Vacation Request form example code in user guide is not correct
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-505'>ACT-505</a>] -         Process definition cache not in sync when redeploying process definition with same generated id
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-509'>ACT-509</a>] -         Reported progress for ExportMarshallers and ProcessValidators is incorrect
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-533'>ACT-533</a>] -         In Eclipse the export process to bpmn20.xml fails in some attributes of &quot;UserTask&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-557'>ACT-557</a>] -         Field TASK_DEF_KEY_ is not populated on ACT_HI_TASK and not exposed on HistoricTaskInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-572'>ACT-572</a>] -         Maven &quot;check&quot; profile states successful build when there are test-failures
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-467'>ACT-467</a>] -         Invalid small icon path throws unclear exception
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-492'>ACT-492</a>] -         Incorrect icon paths result in exceptions for CustomServiceTasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-498'>ACT-498</a>] -         Include active activity instance id on HistoricVariableUpdate when variable is updated
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-499'>ACT-499</a>] -         Start- and end-event should also be include as HistoricActivityInstance when history-level is at FULL
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-534'>ACT-534</a>] -         The BPMN validator should not fail validation if CustomServiceTasks are included
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-567'>ACT-567</a>] -         Allow assignee of a task to be set to null
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-467'>ACT-467</a>] -         Invalid small icon path throws unclear exception
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-492'>ACT-492</a>] -         Incorrect icon paths result in exceptions for CustomServiceTasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-498'>ACT-498</a>] -         Include active activity instance id on HistoricVariableUpdate when variable is updated
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-499'>ACT-499</a>] -         Start- and end-event should also be include as HistoricActivityInstance when history-level is at FULL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-534'>ACT-534</a>] -         The BPMN validator should not fail validation if CustomServiceTasks are included
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-567'>ACT-567</a>] -         Allow assignee of a task to be set to null
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-15'>ACT-15</a>] -         Implement BPMN boundary error event
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-281'>ACT-281</a>] -         BPMN default sequence flow
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-354'>ACT-354</a>] -         Add data mapping capabilities in call activity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-446'>ACT-446</a>] -         Add support for execution and task listener configuration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-447'>ACT-447</a>] -         Add support for a receive task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-511'>ACT-511</a>] -         Add support for simple controls in CustomServiceTasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-543'>ACT-543</a>] -         Capture initiator in KickStart
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-554'>ACT-554</a>] -         Return deploymentId when deploying process in AdhocWorkflowService (KickStart)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-555'>ACT-555</a>] -         Rename AdhocWorkflowService to KickstartService
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-560'>ACT-560</a>] -         Improve CallActivity for independant subprocess to support parameters
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-563'>ACT-563</a>] -         Start JBPM Migration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-569'>ACT-569</a>] -         Visualize current activities of process instances in probe
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-15'>ACT-15</a>] -         Implement BPMN boundary error event
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-281'>ACT-281</a>] -         BPMN default sequence flow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-354'>ACT-354</a>] -         Add data mapping capabilities in call activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-446'>ACT-446</a>] -         Add support for execution and task listener configuration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-447'>ACT-447</a>] -         Add support for a receive task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-511'>ACT-511</a>] -         Add support for simple controls in CustomServiceTasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-543'>ACT-543</a>] -         Capture initiator in KickStart
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-554'>ACT-554</a>] -         Return deploymentId when deploying process in AdhocWorkflowService (KickStart)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-555'>ACT-555</a>] -         Rename AdhocWorkflowService to KickstartService
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-560'>ACT-560</a>] -         Improve CallActivity for independant subprocess to support parameters
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-563'>ACT-563</a>] -         Start JBPM Migration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-569'>ACT-569</a>] -         Visualize current activities of process instances in probe
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-108'>ACT-108</a>] -         Create server script for continuous integration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-457'>ACT-457</a>] -         Support the documentation element
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-486'>ACT-486</a>] -         User library is not present by default
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-494'>ACT-494</a>] -         Refactor deployments
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-496'>ACT-496</a>] -         Change action icons to links
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-504'>ACT-504</a>] -         Document exception handling in service task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-510'>ACT-510</a>] -         Check export for each PropertyType to BPMN
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-544'>ACT-544</a>] -         Fix oracle metadata problem
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-108'>ACT-108</a>] -         Create server script for continuous integration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-457'>ACT-457</a>] -         Support the documentation element
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-486'>ACT-486</a>] -         User library is not present by default
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-494'>ACT-494</a>] -         Refactor deployments
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-496'>ACT-496</a>] -         Change action icons to links
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-504'>ACT-504</a>] -         Document exception handling in service task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-510'>ACT-510</a>] -         Check export for each PropertyType to BPMN
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-544'>ACT-544</a>] -         Fix oracle metadata problem
+    </li>
 </ul>
-        
+
 <h4>        Wish
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-188'>ACT-188</a>] -         Source jar files are not published on maven repository
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-476'>ACT-476</a>] -         document the activiti database tables
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-188'>ACT-188</a>] -         Source jar files are not published on maven repository
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-476'>ACT-476</a>] -         document the activiti database tables
+    </li>
 </ul>
 
-  
-  <h3>Release Notes - Activiti - Version 5.1</h3>
-  
-  <h4>Warning</h4>
-  <p>The automatic upgrade does not have enough coverage to have full confidence.
-  For more info, see <a href="docs/userguide/index.html#databaseUpgrade">the user guide, section Database upgrade</a>.
-  </p>
-  
-  <h4>Changes</h4>
-  <ul>
-    <li>In attribute &lt;serviceTask delegateExpression="..."&gt; previously always performed a leave after 
-    calling the delegate that was obtained by evaluating the expression.  Which means that it's always an automatic 
-    activity.  Now the leave is only performed only when the delegate object implements JavaDelegate.  In case the 
-    delegate object implements ActivityBehavior the leave will not be called.  In that case, the ActivityBehavior is 
-    responsible for calling leave if it wants to be an automatic activity. 
-    </li>
-  </ul>
 
-  <h4>Highlights</h4>
-  <ul>
+<h3>Release Notes - Activiti - Version 5.1</h3>
+
+<h4>Warning</h4>
+<p>The automatic upgrade does not have enough coverage to have full confidence.
+    For more info, see <a href="docs/userguide/index.html#databaseUpgrade">the user guide, section Database upgrade</a>.
+</p>
+
+<h4>Changes</h4>
+<ul>
+    <li>In attribute &lt;serviceTask delegateExpression="..."&gt; previously always performed a leave after
+        calling the delegate that was obtained by evaluating the expression.  Which means that it's always an automatic
+        activity.  Now the leave is only performed only when the delegate object implements JavaDelegate.  In case the
+        delegate object implements ActivityBehavior the leave will not be called.  In that case, the ActivityBehavior is
+        responsible for calling leave if it wants to be an automatic activity.
+    </li>
+</ul>
+
+<h4>Highlights</h4>
+<ul>
     <li>Added Activiti KickStart making the creation of new BPMN process models as easy as 1, 2, 3</li>
     <li>Added automatic upgrade of the DB schema from 5.0 to 5.1</li>
     <li>Added generation of process definition diagram based on DI information</li>
@@ -2579,85 +2579,85 @@
     <li>Added Comments to artifacts in Cycle</li>
     <li>Improved Cycle Plug-In Infrastructure (now using Annotations)</li>
     <li>Fixed various bugs</li>
-  </ul>
+</ul>
 
 <h4>        Sub-task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-386'>ACT-386</a>] -         Split the BPMN 2.0 marshalling into marshalling and validation parts
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-386'>ACT-386</a>] -         Split the BPMN 2.0 marshalling into marshalling and validation parts
+    </li>
 </ul>
-    
+
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-418'>ACT-418</a>] -         Missing groovy dependency in demo setup
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-419'>ACT-419</a>] -         Remove automatic leave when using delegateExpression in serviceTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-424'>ACT-424</a>] -         BPMN Export differs between manual and automatic and causes unnecessary exceptions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-430'>ACT-430</a>] -         SequenceFlows are only deleted for Task elements
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-434'>ACT-434</a>] -         SaveHandler is only invoked from key combination
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-443'>ACT-443</a>] -         HistoricDetail doesn&#39;t use activitiyInstanceId
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-418'>ACT-418</a>] -         Missing groovy dependency in demo setup
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-419'>ACT-419</a>] -         Remove automatic leave when using delegateExpression in serviceTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-424'>ACT-424</a>] -         BPMN Export differs between manual and automatic and causes unnecessary exceptions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-430'>ACT-430</a>] -         SequenceFlows are only deleted for Task elements
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-434'>ACT-434</a>] -         SaveHandler is only invoked from key combination
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-443'>ACT-443</a>] -         HistoricDetail doesn&#39;t use activitiyInstanceId
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-18'>ACT-18</a>] -         Show process definition diagram
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-226'>ACT-226</a>] -         Retrieve the expression from the PvmTransition
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-18'>ACT-18</a>] -         Show process definition diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-226'>ACT-226</a>] -         Retrieve the expression from the PvmTransition
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-336'>ACT-336</a>] -         Create email service task node
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-385'>ACT-385</a>] -         Create extension point to validate diagrams
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-408'>ACT-408</a>] -         Allow usage of lists as property of CustomServiceTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-413'>ACT-413</a>] -         Allow parametrization of PropertyTypes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-421'>ACT-421</a>] -         Introduce task-local variables
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-455'>ACT-455</a>] -         Make parselisteners configurable on ProcessEngineConfiguration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-464'>ACT-464</a>] -         Introduce HistoricTaskInstance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-470'>ACT-470</a>] -         Create and include Activiti KickStart in the distribution
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-336'>ACT-336</a>] -         Create email service task node
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-385'>ACT-385</a>] -         Create extension point to validate diagrams
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-408'>ACT-408</a>] -         Allow usage of lists as property of CustomServiceTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-413'>ACT-413</a>] -         Allow parametrization of PropertyTypes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-421'>ACT-421</a>] -         Introduce task-local variables
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-455'>ACT-455</a>] -         Make parselisteners configurable on ProcessEngineConfiguration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-464'>ACT-464</a>] -         Introduce HistoricTaskInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-470'>ACT-470</a>] -         Create and include Activiti KickStart in the distribution
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-293'>ACT-293</a>] -         Refactor variable map
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-420'>ACT-420</a>] -         Automatic upgrade
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-439'>ACT-439</a>] -         Extract image generation in code in module activiti-engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-440'>ACT-440</a>] -         Add process image generation to bpmn deployer
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-444'>ACT-444</a>] -         Add task query criteria for taskDefinitionKey and -Like
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-458'>ACT-458</a>] -         Check if seperate selectTaskByQueryCriteria is needed for MySQL in task.mapping.xml
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-471'>ACT-471</a>] -         Add taskId ref to HistoricDetail
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-293'>ACT-293</a>] -         Refactor variable map
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-420'>ACT-420</a>] -         Automatic upgrade
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-439'>ACT-439</a>] -         Extract image generation in code in module activiti-engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-440'>ACT-440</a>] -         Add process image generation to bpmn deployer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-444'>ACT-444</a>] -         Add task query criteria for taskDefinitionKey and -Like
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-458'>ACT-458</a>] -         Check if seperate selectTaskByQueryCriteria is needed for MySQL in task.mapping.xml
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-471'>ACT-471</a>] -         Add taskId ref to HistoricDetail
+    </li>
 </ul>
-        
-  <h3>Release Notes - Activiti - Version 5.0</h3>
 
-  <h4>Highlights</h4>
-  <ul>
+<h3>Release Notes - Activiti - Version 5.0</h3>
+
+<h4>Highlights</h4>
+<ul>
     <li>Various bug fixes</li>
     <li>Activiti Engine: Added more configuration options and synced standalone with Spring configuration</li>
     <li>Activiti Engine: Added task listeners</li>
@@ -2670,195 +2670,195 @@
     <li>Activiti Designer: Field extensions editor for the Service task and support for expressions</li>
     <li>Activiti Designer: Support for Formkey attribute for User tasks</li>
     <li>Activiti Designer: Automatic generation of the BPMN 2.0 XML and a process image after each save of the editor diagram (no need to for an explicit export).</li>
-  </ul>
+</ul>
 
 <h4>        Bug
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-194'>ACT-194</a>] -         Business model is not persisted when reconnecting SequenceFlow
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-215'>ACT-215</a>] -         TaskEntity does not populate processInstanceId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-217'>ACT-217</a>] -         Review documentation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-225'>ACT-225</a>] -         Cannot see database view in Probe
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-255'>ACT-255</a>] -         Access via url to Explorer lose url after authentication.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-295'>ACT-295</a>] -         Sorting processes on name doesn&#39;t work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-297'>ACT-297</a>] -         Error when creating link in activiti-cycle on postgres DB
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-306'>ACT-306</a>] -         Nullpointer exception when sequence flow has invalid destination
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-308'>ACT-308</a>] -         Review DeployBarTask handling when no ProcessEngine is found
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-314'>ACT-314</a>] -         REST-call task get doesn&#39;t return valid JSON
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-318'>ACT-318</a>] -         Cannot open PNG picture in Activiti-Cycle if the model name has whitespaces in the name
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-320'>ACT-320</a>] -         Replace of JAVA_OPTS in demo setup not working on Windows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-323'>ACT-323</a>] -         Business key not persisted in HistoricProcessInstance
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-329'>ACT-329</a>] -         HistoricProcessInstance startActivityId() and endActivityId() is always null
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-334'>ACT-334</a>] -         Remove check whether user/group exists when claim/addCandidateXX/etc.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-338'>ACT-338</a>] -         Pagination Links in Processes List in Activiti Explorer doesn&#39;t work
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-347'>ACT-347</a>] -         Fix Spring bean usage in ServiceTask
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-351'>ACT-351</a>] -         Possible illegal query results when querying ProcessInstances by date/long variable value
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-352'>ACT-352</a>] -         HistoricVariableUpdate of type byteArray/serializable throws NPE when calling getValue()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-353'>ACT-353</a>] -         Boolean variables are stored as bytearray
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-366'>ACT-366</a>] -         Problems with Umlauts in Modeler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-369'>ACT-369</a>] -         Modeler requires Java 6 to run
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-371'>ACT-371</a>] -         Latest SVG API doesn&#39;t work with Activiti Modeler examples
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-377'>ACT-377</a>] -         Empty diagrams have no Process entity by default
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-379'>ACT-379</a>] -         Methode getLabels() is missing in Shape
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-391'>ACT-391</a>] -         Exception with BPMN 2.0 XML Export of examples in Modeler.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-403'>ACT-403</a>] -         Cycle in demo-setup throws exception when opening &#39;Activiti Modeler&#39; node in tree
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-405'>ACT-405</a>] -         Cycle create-scripts for oracle contain errors
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-409'>ACT-409</a>] -         Task form properties not persisted on history level audit
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-194'>ACT-194</a>] -         Business model is not persisted when reconnecting SequenceFlow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-215'>ACT-215</a>] -         TaskEntity does not populate processInstanceId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-217'>ACT-217</a>] -         Review documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-225'>ACT-225</a>] -         Cannot see database view in Probe
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-255'>ACT-255</a>] -         Access via url to Explorer lose url after authentication.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-295'>ACT-295</a>] -         Sorting processes on name doesn&#39;t work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-297'>ACT-297</a>] -         Error when creating link in activiti-cycle on postgres DB
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-306'>ACT-306</a>] -         Nullpointer exception when sequence flow has invalid destination
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-308'>ACT-308</a>] -         Review DeployBarTask handling when no ProcessEngine is found
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-314'>ACT-314</a>] -         REST-call task get doesn&#39;t return valid JSON
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-318'>ACT-318</a>] -         Cannot open PNG picture in Activiti-Cycle if the model name has whitespaces in the name
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-320'>ACT-320</a>] -         Replace of JAVA_OPTS in demo setup not working on Windows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-323'>ACT-323</a>] -         Business key not persisted in HistoricProcessInstance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-329'>ACT-329</a>] -         HistoricProcessInstance startActivityId() and endActivityId() is always null
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-334'>ACT-334</a>] -         Remove check whether user/group exists when claim/addCandidateXX/etc.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-338'>ACT-338</a>] -         Pagination Links in Processes List in Activiti Explorer doesn&#39;t work
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-347'>ACT-347</a>] -         Fix Spring bean usage in ServiceTask
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-351'>ACT-351</a>] -         Possible illegal query results when querying ProcessInstances by date/long variable value
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-352'>ACT-352</a>] -         HistoricVariableUpdate of type byteArray/serializable throws NPE when calling getValue()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-353'>ACT-353</a>] -         Boolean variables are stored as bytearray
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-366'>ACT-366</a>] -         Problems with Umlauts in Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-369'>ACT-369</a>] -         Modeler requires Java 6 to run
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-371'>ACT-371</a>] -         Latest SVG API doesn&#39;t work with Activiti Modeler examples
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-377'>ACT-377</a>] -         Empty diagrams have no Process entity by default
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-379'>ACT-379</a>] -         Methode getLabels() is missing in Shape
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-391'>ACT-391</a>] -         Exception with BPMN 2.0 XML Export of examples in Modeler.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-403'>ACT-403</a>] -         Cycle in demo-setup throws exception when opening &#39;Activiti Modeler&#39; node in tree
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-405'>ACT-405</a>] -         Cycle create-scripts for oracle contain errors
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-409'>ACT-409</a>] -         Task form properties not persisted on history level audit
+    </li>
 </ul>
-    
+
 <h4>        Improvement
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-162'>ACT-162</a>] -         Simplify extensibility of identity component
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-212'>ACT-212</a>] -         Prefix foreign keys with FK_ACT_* instead of FK_*
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-252'>ACT-252</a>] -         Typo in warning message is misleading: &quot;XPath currently not supported as typeLanguage&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-274'>ACT-274</a>] -         Switch to Spring Surf/Webscripts 1.0 for all web applications &amp; rest api (and use its new abstract authenticator base class)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-292'>ACT-292</a>] -         Stop making default event being bookmarked
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-327'>ACT-327</a>] -         Add finished() to the HistoricActivityInstanceQuery to be able find all completed activities
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-328'>ACT-328</a>] -         add getId() into HisctoricActivitiInstance and add search by id into HistoricActivitiInstanceQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-359'>ACT-359</a>] -         Invoke export to BPMN 2.0 automatically via ExportMarshaller extension point
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-162'>ACT-162</a>] -         Simplify extensibility of identity component
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-212'>ACT-212</a>] -         Prefix foreign keys with FK_ACT_* instead of FK_*
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-252'>ACT-252</a>] -         Typo in warning message is misleading: &quot;XPath currently not supported as typeLanguage&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-274'>ACT-274</a>] -         Switch to Spring Surf/Webscripts 1.0 for all web applications &amp; rest api (and use its new abstract authenticator base class)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-292'>ACT-292</a>] -         Stop making default event being bookmarked
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-327'>ACT-327</a>] -         Add finished() to the HistoricActivityInstanceQuery to be able find all completed activities
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-328'>ACT-328</a>] -         add getId() into HisctoricActivitiInstance and add search by id into HistoricActivitiInstanceQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-359'>ACT-359</a>] -         Invoke export to BPMN 2.0 automatically via ExportMarshaller extension point
+    </li>
 </ul>
-    
+
 <h4>        New Feature
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-211'>ACT-211</a>] -         BPMN: assignment handler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-222'>ACT-222</a>] -         Make activiti jars valid OSGi bundles
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-235'>ACT-235</a>] -         Add an OSGi extender to deploy activiti processes as osgi bundles along with the needed URL handlers and fileinstall deployers
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-278'>ACT-278</a>] -         Add support for extending designer&#39;s functionality with custom service tasks
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-290'>ACT-290</a>] -         SVG API should not peform access to Signavio Academic Version in the Internet
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-300'>ACT-300</a>] -         Deploy business archive with Activiti Probe
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-301'>ACT-301</a>] -         Expose getFormService() for ActivitiRule
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-360'>ACT-360</a>] -         Provide an osgi web bundle for the rest api
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-363'>ACT-363</a>] -         Bug with relative paths in Modler Backend
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-364'>ACT-364</a>] -         The BPMN 2.0 serialization isn&#39;t the latest version
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-365'>ACT-365</a>] -         The BPMN 2.0 DI is still the early draft, not the spec version
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-367'>ACT-367</a>] -         Release a new Maven version of the Signavio core components and upload them to the alfresco repository
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-396'>ACT-396</a>] -         activiti.cfg.jar should go in webapps\activiti-rest\WEB-INF\lib as well
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-211'>ACT-211</a>] -         BPMN: assignment handler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-222'>ACT-222</a>] -         Make activiti jars valid OSGi bundles
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-235'>ACT-235</a>] -         Add an OSGi extender to deploy activiti processes as osgi bundles along with the needed URL handlers and fileinstall deployers
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-278'>ACT-278</a>] -         Add support for extending designer&#39;s functionality with custom service tasks
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-290'>ACT-290</a>] -         SVG API should not peform access to Signavio Academic Version in the Internet
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-300'>ACT-300</a>] -         Deploy business archive with Activiti Probe
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-301'>ACT-301</a>] -         Expose getFormService() for ActivitiRule
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-360'>ACT-360</a>] -         Provide an osgi web bundle for the rest api
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-363'>ACT-363</a>] -         Bug with relative paths in Modler Backend
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-364'>ACT-364</a>] -         The BPMN 2.0 serialization isn&#39;t the latest version
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-365'>ACT-365</a>] -         The BPMN 2.0 DI is still the early draft, not the spec version
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-367'>ACT-367</a>] -         Release a new Maven version of the Signavio core components and upload them to the alfresco repository
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-396'>ACT-396</a>] -         activiti.cfg.jar should go in webapps\activiti-rest\WEB-INF\lib as well
+    </li>
 </ul>
-    
+
 <h4>        Task
 </h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-123'>ACT-123</a>] -         Review the user guide for experimental features
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-163'>ACT-163</a>] -         Investigate if smaller groovy jar is sufficient
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-171'>ACT-171</a>] -         Remove model repository workaround in demo.setup
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-180'>ACT-180</a>] -         Fix forced downloads in mule build
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-205'>ACT-205</a>] -         Create Ant script to assemble update site
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-256'>ACT-256</a>] -         Changed config param dbSchemaStrategy to databaseSchemaUpdate
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-296'>ACT-296</a>] -         Fix date picker in safari
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-299'>ACT-299</a>] -         Fix JobQuery test
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-311'>ACT-311</a>] -         Rename JavaDelegation to JavaDelegate
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-315'>ACT-315</a>] -         fix wsdl importer parsing
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-317'>ACT-317</a>] -         Improve lib dependency management in distribution
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-321'>ACT-321</a>] -         Add orderByCreateTime() to TaskQuery
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-332'>ACT-332</a>] -         Make variable types configurable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-335'>ACT-335</a>] -         Move modeler patching from demo setup to a dedicated build
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-337'>ACT-337</a>] -         Refactor distribution to remove maven and include the libs in the distro
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-340'>ACT-340</a>] -         Add process definition diagram resource property
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-342'>ACT-342</a>] -         Make sessions configurable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-348'>ACT-348</a>] -         Make handling of process definition resource name and other resource names consistent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-349'>ACT-349</a>] -         Delete rest 2 webapp
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-355'>ACT-355</a>] -         Test java delegations in demo setup after distro refactoring
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-358'>ACT-358</a>] -         Lazy initialization of delegation classes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-378'>ACT-378</a>] -         Unify and simplify configuration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-381'>ACT-381</a>] -         Verify history level configuration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-383'>ACT-383</a>] -         Fix exception message
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-393'>ACT-393</a>] -         Create build file for example projects to deploy business archives and classes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-394'>ACT-394</a>] -         Review setup target cfg.create
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-395'>ACT-395</a>] -         Doc URIEncoding for Activiti Modeler
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-399'>ACT-399</a>] -         Check driver jars and setup demo.start with other dbs
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-400'>ACT-400</a>] -         Add release notes to the readme.html
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-401'>ACT-401</a>] -         Add cxf module to the checkmule profile
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-402'>ACT-402</a>] -         Add version number to userguide title
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-123'>ACT-123</a>] -         Review the user guide for experimental features
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-163'>ACT-163</a>] -         Investigate if smaller groovy jar is sufficient
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-171'>ACT-171</a>] -         Remove model repository workaround in demo.setup
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-180'>ACT-180</a>] -         Fix forced downloads in mule build
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-205'>ACT-205</a>] -         Create Ant script to assemble update site
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-256'>ACT-256</a>] -         Changed config param dbSchemaStrategy to databaseSchemaUpdate
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-296'>ACT-296</a>] -         Fix date picker in safari
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-299'>ACT-299</a>] -         Fix JobQuery test
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-311'>ACT-311</a>] -         Rename JavaDelegation to JavaDelegate
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-315'>ACT-315</a>] -         fix wsdl importer parsing
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-317'>ACT-317</a>] -         Improve lib dependency management in distribution
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-321'>ACT-321</a>] -         Add orderByCreateTime() to TaskQuery
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-332'>ACT-332</a>] -         Make variable types configurable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-335'>ACT-335</a>] -         Move modeler patching from demo setup to a dedicated build
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-337'>ACT-337</a>] -         Refactor distribution to remove maven and include the libs in the distro
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-340'>ACT-340</a>] -         Add process definition diagram resource property
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-342'>ACT-342</a>] -         Make sessions configurable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-348'>ACT-348</a>] -         Make handling of process definition resource name and other resource names consistent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-349'>ACT-349</a>] -         Delete rest 2 webapp
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-355'>ACT-355</a>] -         Test java delegations in demo setup after distro refactoring
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-358'>ACT-358</a>] -         Lazy initialization of delegation classes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-378'>ACT-378</a>] -         Unify and simplify configuration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-381'>ACT-381</a>] -         Verify history level configuration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-383'>ACT-383</a>] -         Fix exception message
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-393'>ACT-393</a>] -         Create build file for example projects to deploy business archives and classes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-394'>ACT-394</a>] -         Review setup target cfg.create
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-395'>ACT-395</a>] -         Doc URIEncoding for Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-399'>ACT-399</a>] -         Check driver jars and setup demo.start with other dbs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-400'>ACT-400</a>] -         Add release notes to the readme.html
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-401'>ACT-401</a>] -         Add cxf module to the checkmule profile
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-402'>ACT-402</a>] -         Add version number to userguide title
+    </li>
 </ul>
-        
-            <h3>5.0.rc1 (November 1, 2010)</h3>
 
-    <h4>Highlights</h4>
-    
-    <ul>
+<h3>5.0.rc1 (November 1, 2010)</h3>
+
+<h4>Highlights</h4>
+
+<ul>
     <li>Activiti Probe added Job and Deployment management</li>
     <li>Event listeners</li>
     <li>Query for process instances based on variable values</li>
@@ -2868,185 +2868,185 @@
     <li>Activiti config file from properties to xml</li>
     <li>PostgreSQL en Oracle support</li>
     <li>Improved DB performance by fine tuning indexes</li>
-    </ul>
-    
+</ul>
+
 <h4>Known limitations</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-294'>ACT-294</a>] - Currently the forms as worked out in Activiti Explorer
-    do not yet use the submitStartFormData and submitTaskFormData.
-    So the form properties are not yet archived when using the forms in Activity Explorer.
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-294'>ACT-294</a>] - Currently the forms as worked out in Activiti Explorer
+        do not yet use the submitStartFormData and submitTaskFormData.
+        So the form properties are not yet archived when using the forms in Activity Explorer.
+    </li>
 </ul>
-    
+
 <h4>Sub-tasks</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-191'>ACT-191</a>] -         Documentation Mistake in ProcessEngineFactoryBean section of User Guide
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-191'>ACT-191</a>] -         Documentation Mistake in ProcessEngineFactoryBean section of User Guide
+    </li>
 </ul>
-    
+
 <h4>Bug</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-144'>ACT-144</a>] -         Canot start process instance when sorted on version first
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-192'>ACT-192</a>] -         Table &quot;ACT_ID_GROUP&quot; not found for dbSchemaStrategy = &quot;create-drop&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-194'>ACT-194</a>] -         Business model is not persisted when reconnecting SequenceFlow
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-195'>ACT-195</a>] -         UpdateConnectionFlowElementFeature is not invoked for SequenceFlows
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-206'>ACT-206</a>] -         Cannot unclaim a task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-233'>ACT-233</a>] -         Connection pool of Ibatis is not used in standalone usage
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-287'>ACT-287</a>] -         Starting process instance in explorer doesn&#39;t show &#39;Start form&#39; anymore when the process has a startform
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-144'>ACT-144</a>] -         Canot start process instance when sorted on version first
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-192'>ACT-192</a>] -         Table &quot;ACT_ID_GROUP&quot; not found for dbSchemaStrategy = &quot;create-drop&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-194'>ACT-194</a>] -         Business model is not persisted when reconnecting SequenceFlow
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-195'>ACT-195</a>] -         UpdateConnectionFlowElementFeature is not invoked for SequenceFlows
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-206'>ACT-206</a>] -         Cannot unclaim a task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-233'>ACT-233</a>] -         Connection pool of Ibatis is not used in standalone usage
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-287'>ACT-287</a>] -         Starting process instance in explorer doesn&#39;t show &#39;Start form&#39; anymore when the process has a startform
+    </li>
 </ul>
-    
+
 <h4>Improvement</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-21'>ACT-21</a>] -         Manage list of deployments
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-22'>ACT-22</a>] -         Manage list of jobs
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-23'>ACT-23</a>] -         Add no-wrap to task list menu navigation
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-129'>ACT-129</a>] -         Make connection pool of MyBatis configurable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-138'>ACT-138</a>] -         Create REST API for Manage list of jobs
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-139'>ACT-139</a>] -         REST API for Manage list of deployments
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-179'>ACT-179</a>] -         Fix css code so its consistent with the rest of the app
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-189'>ACT-189</a>] -         Engine should be able to resolve parameterised method expressions  
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-196'>ACT-196</a>] -         Process and subprocess diagram should have default content
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-197'>ACT-197</a>] -         SequenceFlow arrowheads are mispositioned and too large
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-209'>ACT-209</a>] -         Expose Task start time in interface and query API
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-210'>ACT-210</a>] -         Rename ActivitiRule.getHistoricDataService() to ActivitiRule.getHistoryService() 
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-213'>ACT-213</a>] -         Verify all basic indices exist on supported databases
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-214'>ACT-214</a>] -         Clarify documentation demo setup
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-216'>ACT-216</a>] -         ServiceTaskMethodExpressionActivityBehavior / ServiceTaskValueExpressionActivityBehavior should support storing service task return value in process variable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-219'>ACT-219</a>] -         Update Userguide with latest UI changes
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-224'>ACT-224</a>] -         Allow parsing of document element for all activity types
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-230'>ACT-230</a>] -         Change BpmnParse: instead of throwing an exception, use the addProblem() method
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-238'>ACT-238</a>] -         Extract common methods from Query API to single Interface
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-241'>ACT-241</a>] -         Handle closing of inputstreams in a consistent way
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-246'>ACT-246</a>] -         Missing warning when process has a construct which is unsupported.
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-257'>ACT-257</a>] -         Define a order for group list (left panel)
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-259'>ACT-259</a>] -         Make method naming in Query API consistent
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-260'>ACT-260</a>] -         Make namespace prefix consistent activiti:
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-261'>ACT-261</a>] -         Change dashes in xml-entities to camelCase
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-265'>ACT-265</a>] -         Always use ReflectUtil to do classloader-related operations
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-272'>ACT-272</a>] -         Only use &#39;Expression&#39; instead of making distinction between value/method
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-21'>ACT-21</a>] -         Manage list of deployments
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-22'>ACT-22</a>] -         Manage list of jobs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-23'>ACT-23</a>] -         Add no-wrap to task list menu navigation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-129'>ACT-129</a>] -         Make connection pool of MyBatis configurable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-138'>ACT-138</a>] -         Create REST API for Manage list of jobs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-139'>ACT-139</a>] -         REST API for Manage list of deployments
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-179'>ACT-179</a>] -         Fix css code so its consistent with the rest of the app
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-189'>ACT-189</a>] -         Engine should be able to resolve parameterised method expressions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-196'>ACT-196</a>] -         Process and subprocess diagram should have default content
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-197'>ACT-197</a>] -         SequenceFlow arrowheads are mispositioned and too large
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-209'>ACT-209</a>] -         Expose Task start time in interface and query API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-210'>ACT-210</a>] -         Rename ActivitiRule.getHistoricDataService() to ActivitiRule.getHistoryService()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-213'>ACT-213</a>] -         Verify all basic indices exist on supported databases
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-214'>ACT-214</a>] -         Clarify documentation demo setup
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-216'>ACT-216</a>] -         ServiceTaskMethodExpressionActivityBehavior / ServiceTaskValueExpressionActivityBehavior should support storing service task return value in process variable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-219'>ACT-219</a>] -         Update Userguide with latest UI changes
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-224'>ACT-224</a>] -         Allow parsing of document element for all activity types
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-230'>ACT-230</a>] -         Change BpmnParse: instead of throwing an exception, use the addProblem() method
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-238'>ACT-238</a>] -         Extract common methods from Query API to single Interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-241'>ACT-241</a>] -         Handle closing of inputstreams in a consistent way
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-246'>ACT-246</a>] -         Missing warning when process has a construct which is unsupported.
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-257'>ACT-257</a>] -         Define a order for group list (left panel)
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-259'>ACT-259</a>] -         Make method naming in Query API consistent
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-260'>ACT-260</a>] -         Make namespace prefix consistent activiti:
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-261'>ACT-261</a>] -         Change dashes in xml-entities to camelCase
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-265'>ACT-265</a>] -         Always use ReflectUtil to do classloader-related operations
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-272'>ACT-272</a>] -         Only use &#39;Expression&#39; instead of making distinction between value/method
+    </li>
 </ul>
-    
+
 <h4>New Feature</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-120'>ACT-120</a>] -         Audit tracking
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-125'>ACT-125</a>] -         BPMN: add event listeners
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-145'>ACT-145</a>] -         Add Task.getTaskDefinitionKey()
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-148'>ACT-148</a>] -         Make Activiti &quot;offline runnable&quot;
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-152'>ACT-152</a>] -         Introduce business key
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-190'>ACT-190</a>] -         Query for process instances based on variable values
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-208'>ACT-208</a>] -         Cannot remove a variable
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-220'>ACT-220</a>] -         Allow for parameter injection in method-expr on service-task
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-242'>ACT-242</a>] -         Expose process definition model for introspection
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-258'>ACT-258</a>] -         Introduce form instances
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-273'>ACT-273</a>] -         Allow user to customize preference of automatically adding labels to sequence flows
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-120'>ACT-120</a>] -         Audit tracking
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-125'>ACT-125</a>] -         BPMN: add event listeners
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-145'>ACT-145</a>] -         Add Task.getTaskDefinitionKey()
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-148'>ACT-148</a>] -         Make Activiti &quot;offline runnable&quot;
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-152'>ACT-152</a>] -         Introduce business key
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-190'>ACT-190</a>] -         Query for process instances based on variable values
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-208'>ACT-208</a>] -         Cannot remove a variable
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-220'>ACT-220</a>] -         Allow for parameter injection in method-expr on service-task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-242'>ACT-242</a>] -         Expose process definition model for introspection
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-258'>ACT-258</a>] -         Introduce form instances
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-273'>ACT-273</a>] -         Allow user to customize preference of automatically adding labels to sequence flows
+    </li>
 </ul>
-    
+
 <h4>Task</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-134'>ACT-134</a>] -         Revisit configuration
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-137'>ACT-137</a>] -         Add oracle support
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-174'>ACT-174</a>] -         Document link to Signavio community in our wiki
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-183'>ACT-183</a>] -         Remove &#39;about&#39; tabs in the webapps
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-186'>ACT-186</a>] -         Improve exception analysis when no tables are present
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-193'>ACT-193</a>] -         Bring CYCLE_CONFIG in sync with rest of table naming conventions
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-243'>ACT-243</a>] -         Expose Execution.getProcessInstanceId
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-245'>ACT-245</a>] -         review variable in ByteArrayEntity
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-247'>ACT-247</a>] -         Clean unused table columns
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-248'>ACT-248</a>] -         Verify HistoricProcessInstance query filtering
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-251'>ACT-251</a>] -         Add task audit to history
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-262'>ACT-262</a>] -         Check docs about bar file classloading
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-263'>ACT-263</a>] -         Use a correct versioning scheme for activiti-juel module
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-264'>ACT-264</a>] -         Remove eclipse/idea files from trunk
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-266'>ACT-266</a>] -         Make demo-setup run on Postgres
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-267'>ACT-267</a>] -         Merge pvm and juel modules into engine
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-282'>ACT-282</a>] -         Transform BpmnJavaDelegation class to JavaDelegation interface
-</li>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-283'>ACT-283</a>] -         rename activiti bpmn extensions namespace
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-134'>ACT-134</a>] -         Revisit configuration
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-137'>ACT-137</a>] -         Add oracle support
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-174'>ACT-174</a>] -         Document link to Signavio community in our wiki
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-183'>ACT-183</a>] -         Remove &#39;about&#39; tabs in the webapps
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-186'>ACT-186</a>] -         Improve exception analysis when no tables are present
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-193'>ACT-193</a>] -         Bring CYCLE_CONFIG in sync with rest of table naming conventions
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-243'>ACT-243</a>] -         Expose Execution.getProcessInstanceId
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-245'>ACT-245</a>] -         review variable in ByteArrayEntity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-247'>ACT-247</a>] -         Clean unused table columns
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-248'>ACT-248</a>] -         Verify HistoricProcessInstance query filtering
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-251'>ACT-251</a>] -         Add task audit to history
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-262'>ACT-262</a>] -         Check docs about bar file classloading
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-263'>ACT-263</a>] -         Use a correct versioning scheme for activiti-juel module
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-264'>ACT-264</a>] -         Remove eclipse/idea files from trunk
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-266'>ACT-266</a>] -         Make demo-setup run on Postgres
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-267'>ACT-267</a>] -         Merge pvm and juel modules into engine
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-282'>ACT-282</a>] -         Transform BpmnJavaDelegation class to JavaDelegation interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-283'>ACT-283</a>] -         rename activiti bpmn extensions namespace
+    </li>
 </ul>
-    
+
 <h4>Test</h4>
 <ul>
-<li>[<a href='http://jira.codehaus.org/browse/ACT-221'>ACT-221</a>] -         Add an integration test for the webservice task solely based on CXF
-</li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-221'>ACT-221</a>] -         Add an integration test for the webservice task solely based on CXF
+    </li>
 </ul>
-    
 
-    <h3>5.0.beta2 (October 1, 2010)</h3>
 
-    <h4>Highlights</h4>
-    
-    <ul>
+<h3>5.0.beta2 (October 1, 2010)</h3>
+
+<h4>Highlights</h4>
+
+<ul>
     <li>Added Activiti Designer, an eclipse plugin for process authoring targetted for developers
-      <ul>
-        <li>Design BPMN processes grafically: start event, end event, sequence flow, parallel gateway, exclusive gateway, embedded subprocess, script task, user task and service task.</li>
-        <li>Generate JUnit test case by right click on the process in the package explorer</li>
-        <li>Run the JUnit test with an embedded h2 database</li>
-        <li>Configure Java class for a service task</li>
-        <li>Configure assignee or candidate for a user task</li>
-        <li>Configure script with a script task</li>
-      </ul>
+        <ul>
+            <li>Design BPMN processes grafically: start event, end event, sequence flow, parallel gateway, exclusive gateway, embedded subprocess, script task, user task and service task.</li>
+            <li>Generate JUnit test case by right click on the process in the package explorer</li>
+            <li>Run the JUnit test with an embedded h2 database</li>
+            <li>Configure Java class for a service task</li>
+            <li>Configure assignee or candidate for a user task</li>
+            <li>Configure script with a script task</li>
+        </ul>
     </li>
     <li>Added DB support for MySQL and PostgreSQL</li>
     <li>Activiti Modeler and Activiti Engine are now synced on the final BPMN 2.0 specification</li>
@@ -3059,265 +3059,265 @@
     <li>Added optimistic locking for out-of-the-box clustering support</li>
     <li>Added more query APIs</li>
     <li>Minor API cleanup</li>
-    </ul>
-    
-    <h4>Bug</h4>
-    
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-1'>ACT-1</a>] -         Change init servlet into context listener
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-56'>ACT-56</a>] -         Activiti Modeler is bound to localhost instead of the actual servername
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-57'>ACT-57</a>] -         Condition on sequence flow is not saved to bpmn20.xml file after reopening an existing process
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-71'>ACT-71</a>] -         Activiti Modeler doesn&#39;t work if not installed by demo setup
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-76'>ACT-76</a>] -         JSON Response contains unescaped control caharcters
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-94'>ACT-94</a>] -         java.util.logging.ErrorManager/ NullPointerException in catalina.out at startup of tomcat
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-113'>ACT-113</a>] -         Modeler &quot;Save&quot; does not regenerate bpmn20.xml file
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-114'>ACT-114</a>] -         Unable to save newly created diagram twice
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-115'>ACT-115</a>] -         Table ACT_GE_PROPERTY cannot be created on MySQL with UTF-8 encoding due to limitation of key index length
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-142'>ACT-142</a>] -         Logo is linked to Signavio jBpm page
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-181'>ACT-181</a>] -         Automatic deployment on resource change doesn&#39;t work
-    </li>
-    </ul>
-        
-    <h4>Improvement</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-7'>ACT-7</a>] -         Move logging.properties process activiti-engines-init to tomcat installation
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-23'>ACT-23</a>] -         Add no-wrap to task list menu navigation
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-64'>ACT-64</a>] -         Configure Tomcat in demo setup to have more memory
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-66'>ACT-66</a>] -         Make task form rendering consistent in API
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-68'>ACT-68</a>] -         Make demo.setup run on MySQL
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-69'>ACT-69</a>] -         Add ant target to start up h4 console 
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-70'>ACT-70</a>] -         Review API and build systematic test coverage
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-73'>ACT-73</a>] -         Document usage of activiti prefix 
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-104'>ACT-104</a>] -         Replace findXxx methods returning lists with query API
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-140'>ACT-140</a>] -         REST API for Show process definition diagram
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-158'>ACT-158</a>] -         ScriptTaskActivity should support storing script execution result in a process variable with configurable name
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-182'>ACT-182</a>] -         Add internal support for create-if-necessary db schema stragegy
-    </li>
-    </ul>
-        
-    <h4>New Feature</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-35'>ACT-35</a>] -         Provide external URL for navigating task forms
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-83'>ACT-83</a>] -         Capture the initiator
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-109'>ACT-109</a>] -         BPMN: document receive task
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-146'>ACT-146</a>] -         Add Activiti FavIcon to webapp
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-168'>ACT-168</a>] -         Introduce identityLink in API
-    </li>
-    </ul>
-        
-    <h4>Task</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-30'>ACT-30</a>] -         Finish the basic history data model
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-44'>ACT-44</a>] -         Verify exception and rollback behavior in Spring context
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-49'>ACT-49</a>] -         make activiti compatible with jdk 5
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-52'>ACT-52</a>] -         Remove BPMN 2.0 Beta compatibility
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-67'>ACT-67</a>] -         Rename modules activiti-probe to activiti-webapp-probe, similar for activiti-explorer
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-78'>ACT-78</a>] -         move sortorder out of the interface package
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-84'>ACT-84</a>] -         move parsing of value expression to bpmn parser
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-87'>ACT-87</a>] -         Fill exception field when job fails
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-89'>ACT-89</a>] -         Review test support
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-95'>ACT-95</a>] -         fix testTwoNestedSubProcessesInParallelWithTimer
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-103'>ACT-103</a>] -         Consider removing Page from engine interface
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-105'>ACT-105</a>] -         Add auto redirect to Activiti Modeler
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-106'>ACT-106</a>] -         Add testing for optimistic locking
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-110'>ACT-110</a>] -         Move Chapter 11. Running QA tests to wiki
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-124'>ACT-124</a>] -         Document library dependencies
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-127'>ACT-127</a>] -         Restructure modules
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-130'>ACT-130</a>] -         Reupload Maven artifacts due to checksum error
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-131'>ACT-131</a>] -         Switch to new repository/build for Ativiti Modeler
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-133'>ACT-133</a>] -         Refactor start process instance
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-135'>ACT-135</a>] -         Cleanup unused task properties
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-136'>ACT-136</a>] -         Verify MySQL
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-153'>ACT-153</a>] -         Replace DbSchemaStrategy enum with String
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-155'>ACT-155</a>] -         Create Junit @Rule test with ActivitiRule and document it
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-156'>ACT-156</a>] -         Revise Java service task: introduce BpmnJavaDelegation and field injection
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-157'>ACT-157</a>] -         Create mail activity
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-159'>ACT-159</a>] -         Remove expressionLanguage and typeLanguage in examples
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-167'>ACT-167</a>] -         fix excluded test RepositoryConnectorConfigurationManagerImplTest
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-177'>ACT-177</a>] -         Document configuration file properties
-    </li>
-    </ul>
-        
+</ul>
 
-    <h3>5.0.beta1 (September 1, 2010)</h3>
+<h4>Bug</h4>
 
-    <h4>Known limitations</h4>
-    <ul>
-    <li>Optimistic locking isn't tested yet [<a href='http://jira.codehaus.org/browse/ACT-106'>ACT-106</a>]</li>
-    <li>History only contains HistoricProcessInstances, no HistoricActivityInstances yet [<a href='http://jira.codehaus.org/browse/ACT-30'>ACT-30</a>]</li>
-    <li>Some API changes are still expected [<a href='http://jira.codehaus.org/browse/ACT-104'>ACT-104</a>]</li>
-    </ul>
-    <h4>New Features</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-55'>ACT-55</a>] -         Introduce first version of Activiti-Cycle
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-91'>ACT-91</a>] -         Expand serviceTask with method and value expressions
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-1'>ACT-1</a>] -         Change init servlet into context listener
     </li>
-    </ul>
-    <h4>Bugs</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-39'>ACT-39</a>] -         fix ProcessEngineInitializationTest
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-56'>ACT-56</a>] -         Activiti Modeler is bound to localhost instead of the actual servername
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-98'>ACT-98</a>] -         REST API errors
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-57'>ACT-57</a>] -         Condition on sequence flow is not saved to bpmn20.xml file after reopening an existing process
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-99'>ACT-99</a>] -         Table records don&#39;t show
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-71'>ACT-71</a>] -         Activiti Modeler doesn&#39;t work if not installed by demo setup
     </li>
-    </ul>
-    <h4>Improvements</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-2'>ACT-2</a>] -         Clean up API
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-76'>ACT-76</a>] -         JSON Response contains unescaped control caharcters
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-6'>ACT-6</a>] -         Rename DbProcessEngineBuilder to ProcessEngineBuilder
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-94'>ACT-94</a>] -         java.util.logging.ErrorManager/ NullPointerException in catalina.out at startup of tomcat
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-60'>ACT-60</a>] -         pvm refactoring
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-113'>ACT-113</a>] -         Modeler &quot;Save&quot; does not regenerate bpmn20.xml file
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-79'>ACT-79</a>] -         Please add a ELResolver that automatically resolves any bean in the Spring BeanFactory in which the ELResolver resides
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-114'>ACT-114</a>] -         Unable to save newly created diagram twice
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-80'>ACT-80</a>] -         Extend service task to SignallableActivityBehavior
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-115'>ACT-115</a>] -         Table ACT_GE_PROPERTY cannot be created on MySQL with UTF-8 encoding due to limitation of key index length
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-82'>ACT-82</a>] -         Expose form attribute from Task object
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-142'>ACT-142</a>] -         Logo is linked to Signavio jBpm page
     </li>
-    </ul>
-    <h4>Tasks</h4>
-    <ul>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-48'>ACT-48</a>] -         Add Grails plugin link to docs or website
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-181'>ACT-181</a>] -         Automatic deployment on resource change doesn&#39;t work
     </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-59'>ACT-59</a>] -         define table/column naming strategy
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-61'>ACT-61</a>] -         Introduce query API for deployments and resources
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-75'>ACT-75</a>] -         document maven repo in the website community page
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-85'>ACT-85</a>] -         Improve error message when db driver is not found
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-86'>ACT-86</a>] -         Fix classpath in setup script for other dbs
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-90'>ACT-90</a>] -         Add Spring integration examples and documentation
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-96'>ACT-96</a>] -         Cycle demo build creates 2 files in codebase
-    </li>
-    <li>[<a href='http://jira.codehaus.org/browse/ACT-101'>ACT-101</a>] -         Add sorting of the table names in Probe
-    </li>
-    </ul>
+</ul>
 
-    <h3>5.0.alpha4 (August 1, 2010)</h3>
-    <h4>Improvements</h4>
-    <ul>
-      <li>MySQL support</li>
-      <li>Support for method expressions on sequence flow</li>
-      <li>Revised ActivityExecution API</li>
-      <li>Added ConcurrencyController API</li>
-      <li>Process Event Bus</li>
-      <li>Taskforms: added date and date picker support</li>
-      <li>Explorer: changed process definition drop down list to a separate page</li>
-    </ul>
-    
-     <h4>New features</h4>
-    <ul>
-      <li>BPMN parallel gateway</li>
-      <li>BPMN manual task</li>
-      <li>BPMN (embedded) subprocess</li>
-      <li>BPMN call activity (subprocess)</li>
-      <li>BPMN Java service task</li>
-      <li>Spring integration (experimental, no docs yet)</li>
-    </ul>
-    
-     <h4>Bugfixes</h4>
-    <ul>
-      <li>Made engine compatible with BPMN 2.0 beta process models</li>
-      <li>Fixed exception on windows and linux when using boundary timer event</li>
-      <li>Expression cannot have whitespaces</li>
-    </ul>
+<h4>Improvement</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-7'>ACT-7</a>] -         Move logging.properties process activiti-engines-init to tomcat installation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-23'>ACT-23</a>] -         Add no-wrap to task list menu navigation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-64'>ACT-64</a>] -         Configure Tomcat in demo setup to have more memory
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-66'>ACT-66</a>] -         Make task form rendering consistent in API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-68'>ACT-68</a>] -         Make demo.setup run on MySQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-69'>ACT-69</a>] -         Add ant target to start up h4 console
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-70'>ACT-70</a>] -         Review API and build systematic test coverage
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-73'>ACT-73</a>] -         Document usage of activiti prefix
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-104'>ACT-104</a>] -         Replace findXxx methods returning lists with query API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-140'>ACT-140</a>] -         REST API for Show process definition diagram
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-158'>ACT-158</a>] -         ScriptTaskActivity should support storing script execution result in a process variable with configurable name
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-182'>ACT-182</a>] -         Add internal support for create-if-necessary db schema stragegy
+    </li>
+</ul>
 
-    <h3>5.0.alpha3 (July 1, 2010)</h3>
-    <h4>Improvements</h4>
-    <ul>
-      <li>Switch from iBatis to MyBatis</li>
-      <li>JobExecutor</li>
-      <li>BPMN Timers</li>
-      <li>BPMN JSR 223 script support.</li>
-      <li>Updated to a newer version of BPMN xsd</li>
-      <li>Query API</li>
-      <li>Switched JUnit usage from 3-style inheritance to 4-style annotations</li>
-    </ul>
+<h4>New Feature</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-35'>ACT-35</a>] -         Provide external URL for navigating task forms
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-83'>ACT-83</a>] -         Capture the initiator
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-109'>ACT-109</a>] -         BPMN: document receive task
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-146'>ACT-146</a>] -         Add Activiti FavIcon to webapp
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-168'>ACT-168</a>] -         Introduce identityLink in API
+    </li>
+</ul>
 
-    <h3>5.0.alpha2 (June 1, 2010)</h3>
-    <h4>Improvements</h4>
-    <ul>
-      <li>Task forms in Activiti Explorer</li>
-      <li>Database table content viewer in Activiti Probe</li>
-      <li>Exclusive gateway</li>
-      <li>Unified Expression Language support</li>
-      <li>Reduced download size</li>
-    </ul>
-    <h4>Known limitations</h4>
-    <ul>
-      <li>No history in Activiti Engine</li>
-      <li>Only single DB: H2</li>
-      <li>Only one tx demarcation tech: standalone JDBC</li>
-      <li>No process concurrency</li>
-    </ul>
-    <h3>5.0.alpha1 (May 17, 2010)</h3>
-    <h4>Known limitations</h4>
-    <ul>
-      <li>No history in Activiti Engine</li>
-      <li>Only single DB: H2</li>
-      <li>Only one tx demarcation tech: standalone JDBC</li>
-      <li>No task forms</li>
-      <li>No process concurrency</li>
-      <li>No Activiti Cycle</li>
-    </ul>
-  
-  </body>
+<h4>Task</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-30'>ACT-30</a>] -         Finish the basic history data model
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-44'>ACT-44</a>] -         Verify exception and rollback behavior in Spring context
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-49'>ACT-49</a>] -         make activiti compatible with jdk 5
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-52'>ACT-52</a>] -         Remove BPMN 2.0 Beta compatibility
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-67'>ACT-67</a>] -         Rename modules activiti-probe to activiti-webapp-probe, similar for activiti-explorer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-78'>ACT-78</a>] -         move sortorder out of the interface package
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-84'>ACT-84</a>] -         move parsing of value expression to bpmn parser
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-87'>ACT-87</a>] -         Fill exception field when job fails
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-89'>ACT-89</a>] -         Review test support
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-95'>ACT-95</a>] -         fix testTwoNestedSubProcessesInParallelWithTimer
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-103'>ACT-103</a>] -         Consider removing Page from engine interface
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-105'>ACT-105</a>] -         Add auto redirect to Activiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-106'>ACT-106</a>] -         Add testing for optimistic locking
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-110'>ACT-110</a>] -         Move Chapter 11. Running QA tests to wiki
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-124'>ACT-124</a>] -         Document library dependencies
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-127'>ACT-127</a>] -         Restructure modules
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-130'>ACT-130</a>] -         Reupload Maven artifacts due to checksum error
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-131'>ACT-131</a>] -         Switch to new repository/build for Ativiti Modeler
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-133'>ACT-133</a>] -         Refactor start process instance
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-135'>ACT-135</a>] -         Cleanup unused task properties
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-136'>ACT-136</a>] -         Verify MySQL
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-153'>ACT-153</a>] -         Replace DbSchemaStrategy enum with String
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-155'>ACT-155</a>] -         Create Junit @Rule test with ActivitiRule and document it
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-156'>ACT-156</a>] -         Revise Java service task: introduce BpmnJavaDelegation and field injection
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-157'>ACT-157</a>] -         Create mail activity
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-159'>ACT-159</a>] -         Remove expressionLanguage and typeLanguage in examples
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-167'>ACT-167</a>] -         fix excluded test RepositoryConnectorConfigurationManagerImplTest
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-177'>ACT-177</a>] -         Document configuration file properties
+    </li>
+</ul>
+
+
+<h3>5.0.beta1 (September 1, 2010)</h3>
+
+<h4>Known limitations</h4>
+<ul>
+    <li>Optimistic locking isn't tested yet [<a href='https://activiti.atlassian.net/browse/ACT-106'>ACT-106</a>]</li>
+    <li>History only contains HistoricProcessInstances, no HistoricActivityInstances yet [<a href='https://activiti.atlassian.net/browse/ACT-30'>ACT-30</a>]</li>
+    <li>Some API changes are still expected [<a href='https://activiti.atlassian.net/browse/ACT-104'>ACT-104</a>]</li>
+</ul>
+<h4>New Features</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-55'>ACT-55</a>] -         Introduce first version of Activiti-Cycle
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-91'>ACT-91</a>] -         Expand serviceTask with method and value expressions
+    </li>
+</ul>
+<h4>Bugs</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-39'>ACT-39</a>] -         fix ProcessEngineInitializationTest
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-98'>ACT-98</a>] -         REST API errors
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-99'>ACT-99</a>] -         Table records don&#39;t show
+    </li>
+</ul>
+<h4>Improvements</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-2'>ACT-2</a>] -         Clean up API
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-6'>ACT-6</a>] -         Rename DbProcessEngineBuilder to ProcessEngineBuilder
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-60'>ACT-60</a>] -         pvm refactoring
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-79'>ACT-79</a>] -         Please add a ELResolver that automatically resolves any bean in the Spring BeanFactory in which the ELResolver resides
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-80'>ACT-80</a>] -         Extend service task to SignallableActivityBehavior
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-82'>ACT-82</a>] -         Expose form attribute from Task object
+    </li>
+</ul>
+<h4>Tasks</h4>
+<ul>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-48'>ACT-48</a>] -         Add Grails plugin link to docs or website
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-59'>ACT-59</a>] -         define table/column naming strategy
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-61'>ACT-61</a>] -         Introduce query API for deployments and resources
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-75'>ACT-75</a>] -         document maven repo in the website community page
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-85'>ACT-85</a>] -         Improve error message when db driver is not found
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-86'>ACT-86</a>] -         Fix classpath in setup script for other dbs
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-90'>ACT-90</a>] -         Add Spring integration examples and documentation
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-96'>ACT-96</a>] -         Cycle demo build creates 2 files in codebase
+    </li>
+    <li>[<a href='https://activiti.atlassian.net/browse/ACT-101'>ACT-101</a>] -         Add sorting of the table names in Probe
+    </li>
+</ul>
+
+<h3>5.0.alpha4 (August 1, 2010)</h3>
+<h4>Improvements</h4>
+<ul>
+    <li>MySQL support</li>
+    <li>Support for method expressions on sequence flow</li>
+    <li>Revised ActivityExecution API</li>
+    <li>Added ConcurrencyController API</li>
+    <li>Process Event Bus</li>
+    <li>Taskforms: added date and date picker support</li>
+    <li>Explorer: changed process definition drop down list to a separate page</li>
+</ul>
+
+<h4>New features</h4>
+<ul>
+    <li>BPMN parallel gateway</li>
+    <li>BPMN manual task</li>
+    <li>BPMN (embedded) subprocess</li>
+    <li>BPMN call activity (subprocess)</li>
+    <li>BPMN Java service task</li>
+    <li>Spring integration (experimental, no docs yet)</li>
+</ul>
+
+<h4>Bugfixes</h4>
+<ul>
+    <li>Made engine compatible with BPMN 2.0 beta process models</li>
+    <li>Fixed exception on windows and linux when using boundary timer event</li>
+    <li>Expression cannot have whitespaces</li>
+</ul>
+
+<h3>5.0.alpha3 (July 1, 2010)</h3>
+<h4>Improvements</h4>
+<ul>
+    <li>Switch from iBatis to MyBatis</li>
+    <li>JobExecutor</li>
+    <li>BPMN Timers</li>
+    <li>BPMN JSR 223 script support.</li>
+    <li>Updated to a newer version of BPMN xsd</li>
+    <li>Query API</li>
+    <li>Switched JUnit usage from 3-style inheritance to 4-style annotations</li>
+</ul>
+
+<h3>5.0.alpha2 (June 1, 2010)</h3>
+<h4>Improvements</h4>
+<ul>
+    <li>Task forms in Activiti Explorer</li>
+    <li>Database table content viewer in Activiti Probe</li>
+    <li>Exclusive gateway</li>
+    <li>Unified Expression Language support</li>
+    <li>Reduced download size</li>
+</ul>
+<h4>Known limitations</h4>
+<ul>
+    <li>No history in Activiti Engine</li>
+    <li>Only single DB: H2</li>
+    <li>Only one tx demarcation tech: standalone JDBC</li>
+    <li>No process concurrency</li>
+</ul>
+<h3>5.0.alpha1 (May 17, 2010)</h3>
+<h4>Known limitations</h4>
+<ul>
+    <li>No history in Activiti Engine</li>
+    <li>Only single DB: H2</li>
+    <li>Only one tx demarcation tech: standalone JDBC</li>
+    <li>No task forms</li>
+    <li>No process concurrency</li>
+    <li>No Activiti Cycle</li>
+</ul>
+
+</body>
 </html>


### PR DESCRIPTION
Now that `codehaus.org` is no more, update the JIRA references from: `http://jira.codehaus.org` to `https://activiti.atlassian.net`.

There is still one `codehous.org` reference as I could not find the location of the Wiki.