### PR TITLE
ACT-4012: IllegalArgumentException when invoking a service task requiring a date

### DIFF
--- a/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/CxfWSDLImporter.java
+++ b/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/CxfWSDLImporter.java
@@ -61,7 +61,7 @@ import com.sun.tools.xjc.api.XJC;
  */
 public class CxfWSDLImporter implements XMLImporter {
     
-  private static final String JAXB_BINDINGS_RESOURCE = "activiti-bindings.xjc";
+    protected static final String JAXB_BINDINGS_RESOURCE = "activiti-bindings.xjc";
 
   protected Map<String, WSService> wsServices = new HashMap<String, WSService>();
   protected Map<String, WSOperation> wsOperations = new HashMap<String, WSOperation>();


### PR DESCRIPTION
The previous pull request #585 about [ACT-4012](https://activiti.atlassian.net/browse/ACT-4012) must be completed: JaxB custom bindings must be used not only when importing the WSDL, but also when creating web-service clients