### PR TITLE
ACT 4025 Sequence Flow bug fix

### DIFF
--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SequenceFlowJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SequenceFlowJsonConverter.java
@@ -100,6 +100,10 @@ public class SequenceFlowJsonConverter extends BaseBpmnJsonConverter {
       propertiesNode.put(PROPERTY_SEQUENCEFLOW_CONDITION, sequenceFlow.getConditionExpression());
     }
 
+    if (sequenceFlow.getExecutionListeners().size() > 0) {
+      BpmnJsonConverterUtil.convertListenersToJson(sequenceFlow.getExecutionListeners(), true, propertiesNode);
+    }
+
     flowNode.put(EDITOR_SHAPE_PROPERTIES, propertiesNode);
     shapesArrayNode.add(flowNode);
   }


### PR DESCRIPTION
This fix is for ACT 4025: execution listeners on sequence flows not
being imported into Explorer from a Designer file.

Added a check to SequenceFlowJsonConverter class to add execution
listeners to the properties node on XML —> JSON conversion inside
convertToJson method. Was unable to consistently reproduce the issue in
which execution listeners were not converted to XML on export.