### PR TITLE
ACT-4029: allow tasks, historic task instances and executions to be queried by a list of process definition keys

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
@@ -98,6 +98,14 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
     return this;
   }
 
+  public ExecutionQuery processDefinitionKeys(Set<String> processDefinitionKeys) {
+    if (processDefinitionKeys == null) {
+      throw new ActivitiIllegalArgumentException("Process definition keys is null");
+    }
+    this.processDefinitionKeys = processDefinitionKeys;
+    return this;
+  }
+  
   @Override
   public ExecutionQuery processDefinitionName(String processDefinitionName) {
     if (processDefinitionName == null) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -36,6 +36,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   private static final long serialVersionUID = 1L;
   protected String processDefinitionId;
   protected String processDefinitionKey;
+  protected List<String> processKeyIn;
   protected String processDefinitionKeyLike;
   protected String processDefinitionKeyLikeIgnoreCase;
   protected String processDefinitionName;
@@ -218,6 +219,15 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
       this.orQueryObject.processDefinitionKey = processDefinitionKey;
     } else {
       this.processDefinitionKey = processDefinitionKey;
+    }
+    return this;
+  }
+  
+  public HistoricTaskInstanceQuery processDefinitionKeyIn(List<String> processDefinitionKeys) {
+    if (inOrStatement) {
+      this.orQueryObject.processKeyIn = processDefinitionKeys;
+    } else {
+      this.processKeyIn = processDefinitionKeys;
     }
     return this;
   }
@@ -1223,6 +1233,9 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   }
   public String getProcessDefinitionId() {
     return processDefinitionId;
+  }
+  public List<String> getProcessKeyIn() {
+    return processKeyIn;
   }
   public String getProcessDefinitionKey() {
     return processDefinitionKey;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -76,6 +76,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String key;
   protected String keyLike;
   protected String processDefinitionKey;
+  protected List<String> processKeyIn;
   protected String processDefinitionKeyLike;
   protected String processDefinitionKeyLikeIgnoreCase;
   protected String processDefinitionId;
@@ -861,6 +862,15 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     return this;
   }
   
+  public TaskQuery processDefinitionKeyIn(List<String> processDefinitionKeys) {
+    if (orActive) {
+      orQueryObject.processKeyIn = processDefinitionKeys;
+    } else {
+      this.processKeyIn = processDefinitionKeys;
+    }
+    return this;
+  }
+  
   public TaskQuery processDefinitionKeyLikeIgnoreCase(String processDefinitionKeyLikeIgnoreCase) {
   	if(orActive) {
       orQueryObject.processDefinitionKeyLikeIgnoreCase = processDefinitionKeyLikeIgnoreCase.toLowerCase();
@@ -1296,6 +1306,9 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   }
   public String getProcessDefinitionKey() {
     return processDefinitionKey;
+  }
+  public List<String> getProcessKeyIn() {
+    return processKeyIn;
   }
   public String getProcessDefinitionId() {
     return processDefinitionId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ExecutionQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ExecutionQuery.java
@@ -13,6 +13,8 @@
 package org.activiti.engine.runtime;
 
 import java.io.Serializable;
+import java.util.List;
+import java.util.Set;
 
 import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.query.Query;
@@ -28,6 +30,9 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   
   /** Only select executions which have the given process definition key. **/
   ExecutionQuery processDefinitionKey(String processDefinitionKey);
+  
+  /** Only select executions which have process definitions with the given keys. **/
+  ExecutionQuery processDefinitionKeys(Set<String> processDefinitionKeys);
   
   /** Only select executions which have the given process definition id. **/
   ExecutionQuery processDefinitionId(String processDefinitionId);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
@@ -275,6 +275,9 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
    */
   T processDefinitionKey(String processDefinitionKey);
   
+  /** Only select tasks that have a process definition for which the key is present in the given list **/
+  T processDefinitionKeyIn(List<String> processDefinitionKeys);
+  
   /**
    * Only select tasks which are part of a process instance which has a
    * process definition key like the given value.

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
@@ -262,7 +262,7 @@
     <if test="processFinished || processUnfinished || processInstanceBusinessKey != null || processInstanceBusinessKeyLike != null || processInstanceBusinessKeyLikeIgnoreCase != null || (orQueryObject != null &amp;&amp; (orQueryObject.processFinished || orQueryObject.processUnfinished || orQueryObject.processInstanceBusinessKey != null || orQueryObject.processInstanceBusinessKeyLike != null || orQueryObject.processInstanceBusinessKeyLikeIgnoreCase != null))">
       inner join ${prefix}ACT_HI_PROCINST HPI ON RES.PROC_INST_ID_ = HPI.ID_
     </if>
-    <if test="processDefinitionKey != null || processDefinitionKeyLike != null || processDefinitionKeyLikeIgnoreCase != null || processDefinitionName != null || processDefinitionNameLike != null || (processCategoryInList != null &amp;&amp; processCategoryInList.size() &gt; 0) || (processCategoryNotInList != null &amp;&amp; processCategoryNotInList.size() &gt; 0) || (orQueryObject != null &amp;&amp; (orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionKeyLike != null || orQueryObject.processDefinitionKeyLikeIgnoreCase != null || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionNameLike != null || (orQueryObject.processCategoryInList != null &amp;&amp; orQueryObject.processCategoryInList.size() &gt; 0) || (orQueryObject.processCategoryNotInList != null &amp;&amp; orQueryObject.processCategoryNotInList.size() &gt; 0)))">
+    <if test="processDefinitionKey != null || processDefinitionKeyLike != null || processDefinitionKeyLikeIgnoreCase != null || (processKeyIn != null &amp;&amp; processKeyIn.size() &gt; 0) || processDefinitionName != null || processDefinitionNameLike != null || (processCategoryInList != null &amp;&amp; processCategoryInList.size() &gt; 0) || (processCategoryNotInList != null &amp;&amp; processCategoryNotInList.size() &gt; 0) || (orQueryObject != null &amp;&amp; (orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionKeyLike != null || orQueryObject.processDefinitionKeyLikeIgnoreCase != null || (orQueryObject.processKeyIn != null &amp;&amp; orQueryObject.processKeyIn.size() &gt; 0) || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionNameLike != null || (orQueryObject.processCategoryInList != null &amp;&amp; orQueryObject.processCategoryInList.size() &gt; 0) || (orQueryObject.processCategoryNotInList != null &amp;&amp; orQueryObject.processCategoryNotInList.size() &gt; 0)))">
       inner join ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
     </if>
     <if test="deploymentId != null || (deploymentIds != null &amp;&amp; deploymentIds.size() &gt; 0) || (orQueryObject != null &amp;&amp; (orQueryObject.deploymentId != null || (orQueryObject.deploymentIds != null &amp;&amp; orQueryObject.deploymentIds.size() &gt; 0)))">
@@ -302,6 +302,12 @@
       </if>
       <if test="processDefinitionKeyLike != null">
         and D.KEY_ like #{processDefinitionKeyLike}
+      </if>
+      <if test="processKeyIn != null &amp;&amp; processKeyIn.size() &gt; 0">
+        and D.KEY_ in
+        <foreach item="item" index="index" collection="processKeyIn" open="(" separator="," close=")">
+          #{item}
+        </foreach>
       </if>
        <if test="processDefinitionKeyLikeIgnoreCase != null">
         and lower(D.KEY_) like #{processDefinitionKeyLikeIgnoreCase}
@@ -588,6 +594,12 @@
           </if>
           <if test="orQueryObject.processDefinitionKeyLikeIgnoreCase != null">
             or lower(D.KEY_) like #{orQueryObject.processDefinitionKeyLikeIgnoreCase}
+          </if>
+          <if test="orQueryObject.processKeyIn != null &amp;&amp; orQueryObject.processKeyIn.size() &gt; 0">
+            or D.KEY_ in
+            <foreach item="item" index="index" collection="orQueryObject.processKeyIn" open="(" separator="," close=")">
+              #{item}
+            </foreach>
           </if>
           <if test="orQueryObject.processDefinitionName != null">
             or D.NAME_ = #{orQueryObject.processDefinitionName}

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -309,7 +309,7 @@
       </foreach>
       </if>
     
-    <if test="processDefinitionKey != null || processDefinitionKeyLike != null ||  processDefinitionKeyLikeIgnoreCase != null || processDefinitionName != null || processDefinitionNameLike != null || (processCategoryInList != null &amp;&amp; processCategoryInList.size() &gt; 0) || (processCategoryNotInList != null &amp;&amp; processCategoryNotInList.size() &gt; 0) || (orQueryObject != null &amp;&amp; (orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionKeyLike != null || orQueryObject.processDefinitionKeyLikeIgnoreCase != null || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionNameLike != null || (orQueryObject.processCategoryInList != null &amp;&amp; orQueryObject.processCategoryInList.size() &gt; 0) || (orQueryObject.processCategoryNotInList != null &amp;&amp; orQueryObject.processCategoryNotInList.size() &gt; 0)))">
+    <if test="processDefinitionKey != null || processDefinitionKeyLike != null ||  processDefinitionKeyLikeIgnoreCase != null || (processKeyIn != null &amp;&amp; processKeyIn.size() &gt; 0) || processDefinitionName != null || processDefinitionNameLike != null || (processCategoryInList != null &amp;&amp; processCategoryInList.size() &gt; 0) || (processCategoryNotInList != null &amp;&amp; processCategoryNotInList.size() &gt; 0) || (orQueryObject != null &amp;&amp; (orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionKeyLike != null || orQueryObject.processDefinitionKeyLikeIgnoreCase != null || (orQueryObject.processKeyIn != null &amp;&amp; orQueryObject.processKeyIn.size() &gt; 0) || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionNameLike != null || (orQueryObject.processCategoryInList != null &amp;&amp; orQueryObject.processCategoryInList.size() &gt; 0) || (orQueryObject.processCategoryNotInList != null &amp;&amp; orQueryObject.processCategoryNotInList.size() &gt; 0)))">
       inner join ${prefix}ACT_RE_PROCDEF D on RES.PROC_DEF_ID_ = D.ID_
     </if>
     <if test="processInstanceBusinessKey != null || processInstanceBusinessKeyLike != null  || processInstanceBusinessKeyLikeIgnoreCase != null || (orQueryObject != null &amp;&amp; (orQueryObject.processInstanceBusinessKey != null || orQueryObject.processInstanceBusinessKeyLike != null || orQueryObject.processInstanceBusinessKeyLikeIgnoreCase != null))">
@@ -438,6 +438,12 @@
       </if>
       <if test="processDefinitionKeyLikeIgnoreCase != null">
         and lower(D.KEY_) like #{processDefinitionKeyLikeIgnoreCase}
+      </if>
+      <if test="processKeyIn != null &amp;&amp; processKeyIn.size() &gt; 0">
+        and D.KEY_ in
+        <foreach item="item" index="index" collection="processKeyIn" open="(" separator="," close=")">
+          #{item}
+        </foreach>
       </if>
       <if test="processDefinitionName != null">
         and D.NAME_ = #{processDefinitionName}
@@ -743,6 +749,12 @@
             </if>
              <if test="orQueryObject.processDefinitionKeyLikeIgnoreCase != null">
               or lower(D.KEY_) like #{orQueryObject.processDefinitionKeyLikeIgnoreCase}
+            </if>
+            <if test="orQueryObject.processKeyIn != null &amp;&amp; orQueryObject.processKeyIn.size() &gt; 0">
+              or D.KEY_ in
+              <foreach item="item" index="index" collection="orQueryObject.processKeyIn" open="(" separator="," close=")">
+                #{item}
+              </foreach>
             </if>
             <if test="orQueryObject.processDefinitionName != null">
               or D.NAME_ = #{orQueryObject.processDefinitionName}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -32,8 +32,10 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
@@ -86,6 +88,17 @@ public class ExecutionQueryTest extends PluggableActivitiTestCase {
     // Concurrent process with 3 executions for each process instance
     assertEquals(12, runtimeService.createExecutionQuery().processDefinitionKey(CONCURRENT_PROCESS_KEY).list().size());
     assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(SEQUENTIAL_PROCESS_KEY).list().size());
+  }
+  
+  public void testQueryByProcessDefinitionKeyIn() {
+    Set<String> includeIds = new HashSet<String>();
+    assertEquals(13, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
+    includeIds.add(CONCURRENT_PROCESS_KEY);
+    assertEquals(12, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
+    includeIds.add(SEQUENTIAL_PROCESS_KEY);
+    assertEquals(13, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
+    includeIds.add("invalid");
+    assertEquals(13, runtimeService.createExecutionQuery().processDefinitionKeys(includeIds).list().size());
   }
   
   public void testQueryByInvalidProcessDefinitionKey() {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -1869,6 +1869,40 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
         .processDefinitionId("unexisting").count());
   }
   
+  @Deployment(resources={"org/activiti/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml"})
+  public void testProcessDefinitionKeyIn() throws Exception {
+    runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    List<String> includeIds = new ArrayList<String>();
+    
+    assertEquals(13, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+    includeIds.add("unexisting");
+    assertEquals(0, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+    includeIds.add("oneTaskProcess");
+    assertEquals(1, taskService.createTaskQuery().processDefinitionKeyIn(includeIds).count());
+  }
+  
+  @Deployment(resources={"org/activiti/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml"})
+  public void testProcessDefinitionKeyInOr() throws Exception {
+    runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    
+    List<String> includeIds = new ArrayList<String>();
+    assertEquals(0, taskService.createTaskQuery()
+        .or().taskId("invalid")
+        .processDefinitionKeyIn(includeIds)
+        .count());
+    
+    includeIds.add("unexisting");
+    assertEquals(0, taskService.createTaskQuery()
+        .or().taskId("invalid")
+        .processDefinitionKeyIn(includeIds)
+        .count());
+    
+    includeIds.add("oneTaskProcess");
+    assertEquals(1, taskService.createTaskQuery()
+        .or().taskId("invalid")
+        .processDefinitionKeyIn(includeIds)
+        .count());
+  }
   
   @Deployment(resources={"org/activiti/engine/test/api/task/TaskQueryTest.testProcessDefinition.bpmn20.xml"})
   public void testProcessDefinitionKey() throws Exception {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricTaskInstanceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricTaskInstanceTest.java
@@ -181,6 +181,14 @@ public class HistoricTaskInstanceTest extends PluggableActivitiTestCase {
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionKey("HistoricTaskQueryTest").count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionKey("unexistingdefinitionkey").count());
     
+    // Process definition key in
+    List<String> includeIds = new ArrayList<String>();
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count());
+    includeIds.add("unexistingProcessDefinition");    
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().processDefinitionKeyIn(includeIds).count());    
+    includeIds.add("HistoricTaskQueryTest");
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKeyIn(includeIds).count()); 
+    
     // Form key
     HistoricTaskInstance historicTask = historyService.createHistoricTaskInstanceQuery()
         .processInstanceId(finishedInstance.getId()).singleResult();
@@ -355,6 +363,16 @@ public class HistoricTaskInstanceTest extends PluggableActivitiTestCase {
     // Process definition key
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").endOr().count());
     assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").endOr().count());
+    
+    // Process definition key in
+    List<String> includeIds = new ArrayList<String>();
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());
+    includeIds.add("unexistingProcessDefinition");
+    assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());    
+    includeIds.add("unexistingProcessDefinition");    
+    assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().processDefinitionKey("HistoricTaskQueryTest").processDefinitionKeyIn(includeIds).endOr().count());
+    includeIds.add("HistoricTaskQueryTest");
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionKey("unexistingdefinitionkey").processDefinitionKeyIn(includeIds).endOr().count());
     
     // Assignee
     assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskAssignee("kermit").endOr().count());


### PR DESCRIPTION
Executions are queried using processDefinitionKeys as is currently available in ProcessInstanceQuery, tasks and historic task instances are queried using processDefinitionKeyIn as currently used in HistoricProcessInstanceQuery.