### PR TITLE
Improved logging at gateway transition

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/GatewayActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/GatewayActivityBehavior.java
@@ -12,8 +12,13 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
+import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.pvm.PvmTransition;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
+import org.slf4j.Logger;
+
+import java.util.Map;
 
 
 /**
@@ -31,6 +36,45 @@ public abstract class GatewayActivityBehavior extends FlowNodeActivityBehavior {
       concurrentRoot = execution;
     }
     ((ExecutionEntity)concurrentRoot).forceUpdate();
+  }
+
+  protected static void logExecutionVariables(Logger log, ActivityExecution execution) {
+    if (log.isTraceEnabled()) {
+      Map<String, Object> variables = execution.getVariables();
+      log.trace("Sequence decision based on following variables: ");
+      if (!(variables == null || variables.isEmpty())) {
+        for (String key : variables.keySet()) {
+          Object value = variables.get(key);
+          log.trace(
+                   "  {} -> '{}' ({})",
+                   key,
+                   value,
+                   value.getClass().getSimpleName()
+          );
+        }
+      }
+    }
+  }
+
+  protected static void logSequenceSelection(Logger log, PvmTransition transition, boolean selected) {
+    if (log.isDebugEnabled()) {
+      String reasoning = "";
+      if (log.isTraceEnabled()) {
+        reasoning = "since expression [" + transition.getProperty(BpmnParse.PROPERTYNAME_CONDITION_TEXT) + "] evaluated to " + selected;
+      }
+
+      if (selected) {
+        log.debug("Sequence flow '{}' selected as outgoing sequence flow {}.",
+                 transition.getId(),
+                 reasoning
+        );
+      } else {
+        log.trace("Sequence flow '{}' not selected as outgoing sequence flow {}.",
+                 transition.getId(),
+                 reasoning
+        );
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Having a workflow transitioning different paths after certain conditions are met is one of the most powerful features of any workflow engine. 
Unfortunately, Activiti's execution engine currently does not reveal any information about why a certain path was chosen. This might not be of much concern to savvy BPMN model experts, but a developer could save quite some time debugging erogenous gateway decisions (caused for example by wrong types passed to ``formVariables``) if Activiti would log them.

This small PR opens the previous "black box" of gateway execution and offers more insight for developers. I hope the community follows my reasoning and accepts my PR.