### PR TITLE
Business calendar extension of TimerEventDefinition

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
@@ -229,6 +229,7 @@ public interface BpmnXMLConstants {
   public static final String ATTRIBUTE_SIGNAL_REF = "signalRef";
   public static final String ATTRIBUTE_SCOPE = "scope";
   public static final String ELEMENT_EVENT_TIMERDEFINITION = "timerEventDefinition";
+  public static final String ATTRIBUTE_CALENDAR_NAME = "businessCalendarName";
   public static final String ATTRIBUTE_TIMER_DATE = "timeDate";
   public static final String ATTRIBUTE_TIMER_CYCLE = "timeCycle";
   public static final String ATTRIBUTE_END_DATE = "endDate";

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
@@ -176,6 +176,7 @@ public interface BpmnXMLConstants {
   public static final String ATTRIBUTE_TASK_USER_CANDIDATEUSERS = "candidateUsers";
   public static final String ATTRIBUTE_TASK_USER_CANDIDATEGROUPS = "candidateGroups";
   public static final String ATTRIBUTE_TASK_USER_DUEDATE = "dueDate";
+  public static final String ATTRIBUTE_TASK_USER_BUSINESS_CALENDAR_NAME = "businessCalendarName";
   public static final String ATTRIBUTE_TASK_USER_CATEGORY = "category";
   public static final String ATTRIBUTE_TASK_USER_PRIORITY = "priority";
   public static final String ATTRIBUTE_TASK_USER_SKIP_EXPRESSION = "skipExpression";

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
@@ -410,6 +410,9 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
   
   protected void writeTimerDefinition(Event parentEvent, TimerEventDefinition timerDefinition, XMLStreamWriter xtw) throws Exception {
     xtw.writeStartElement(ELEMENT_EVENT_TIMERDEFINITION);
+    if (StringUtils.isNotEmpty(timerDefinition.getCalendarName())) {
+      writeQualifiedAttribute(ATTRIBUTE_CALENDAR_NAME, timerDefinition.getCalendarName(), xtw);
+    }
     boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(timerDefinition, false, xtw);
     if (didWriteExtensionStartElement) {
       xtw.writeEndElement();

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/UserTaskXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/UserTaskXMLConverter.java
@@ -39,14 +39,15 @@ import org.apache.commons.lang3.StringUtils;
  * @author Tijs Rademakers, Saeid Mirzaei
  */
 public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
-  
+
   protected Map<String, BaseChildElementParser> childParserMap = new HashMap<String, BaseChildElementParser>();
 
   /** default attributes taken from bpmn spec and from activiti extension */
   protected static final List<ExtensionAttribute> defaultUserTaskAttributes = Arrays.asList(
       new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_FORM_FORMKEY), 
       new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_DUEDATE), 
-      new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_ASSIGNEE), 
+      new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_BUSINESS_CALENDAR_NAME),
+      new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_ASSIGNEE),
       new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_PRIORITY), 
       new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_CANDIDATEUSERS), 
       new ExtensionAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_CANDIDATEGROUPS),
@@ -88,6 +89,7 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
     }
     BpmnXMLUtil.addXMLLocation(userTask, xtr);
     userTask.setDueDate(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_DUEDATE));
+    userTask.setBusinessCalendarName(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_BUSINESS_CALENDAR_NAME));
     userTask.setCategory(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_CATEGORY));
     userTask.setFormKey(formKey);
     userTask.setAssignee(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_TASK_USER_ASSIGNEE)); 
@@ -128,6 +130,7 @@ public class UserTaskXMLConverter extends BaseBpmnXMLConverter {
     writeQualifiedAttribute(ATTRIBUTE_TASK_USER_CANDIDATEUSERS, convertToDelimitedString(userTask.getCandidateUsers()), xtw);
     writeQualifiedAttribute(ATTRIBUTE_TASK_USER_CANDIDATEGROUPS, convertToDelimitedString(userTask.getCandidateGroups()), xtw);
     writeQualifiedAttribute(ATTRIBUTE_TASK_USER_DUEDATE, userTask.getDueDate(), xtw);
+    writeQualifiedAttribute(ATTRIBUTE_TASK_USER_BUSINESS_CALENDAR_NAME, userTask.getBusinessCalendarName(), xtw);
     writeQualifiedAttribute(ATTRIBUTE_TASK_USER_CATEGORY, userTask.getCategory(), xtw);
     writeQualifiedAttribute(ATTRIBUTE_FORM_FORMKEY, userTask.getFormKey(), xtw);
     if (userTask.getPriority() != null) {

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/TimerEventDefinitionParser.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/TimerEventDefinitionParser.java
@@ -19,6 +19,7 @@ import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.Event;
 import org.activiti.bpmn.model.TimerEventDefinition;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author Tijs Rademakers
@@ -33,6 +34,10 @@ public class TimerEventDefinitionParser extends BaseChildElementParser {
     if (parentElement instanceof Event == false) return;
     
     TimerEventDefinition eventDefinition = new TimerEventDefinition();
+    String calendarName = xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_CALENDAR_NAME);
+    if (StringUtils.isNotEmpty(calendarName)) {
+      eventDefinition.setCalendarName(calendarName);
+    }
     BpmnXMLUtil.addXMLLocation(eventDefinition, xtr);
     BpmnXMLUtil.parseChildElements(ELEMENT_EVENT_TIMERDEFINITION, eventDefinition, xtr, model);
     

--- a/modules/activiti-bpmn-converter/src/main/resources/org/activiti/impl/bpmn/parser/activiti-bpmn-extensions-5.18.xsd
+++ b/modules/activiti-bpmn-converter/src/main/resources/org/activiti/impl/bpmn/parser/activiti-bpmn-extensions-5.18.xsd
@@ -322,7 +322,16 @@
       </documentation>
     </annotation>
   </attribute>
-  
+
+  <attribute name="businessCalendarName" type="tns:tExpression">
+    <annotation>
+      <documentation>
+        User Task attribute specifies business calendar to use to resolve dueDate expression.
+        Business calendar with the given name has to be configured in process engine configuration.
+      </documentation>
+    </annotation>
+  </attribute>
+
   <attribute name="candidateUsers">
     <annotation>
       <documentation>

--- a/modules/activiti-bpmn-converter/src/main/resources/org/activiti/impl/bpmn/parser/activiti-bpmn-extensions-5.18.xsd
+++ b/modules/activiti-bpmn-converter/src/main/resources/org/activiti/impl/bpmn/parser/activiti-bpmn-extensions-5.18.xsd
@@ -384,7 +384,9 @@
   </complexType>
   
   <element name="potentialStarter" type="string" />
-  
+
+  <element name="businessCalendarName" type="string" />
+
   <element name="taskListener">
     <annotation>
       <documentation>

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/TimerDefinitionConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/TimerDefinitionConverterTest.java
@@ -1,0 +1,47 @@
+package org.activiti.editor.language.xml;
+
+import org.activiti.bpmn.model.*;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class TimerDefinitionConverterTest extends AbstractConverterTest {
+  
+  @Test
+  public void connvertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+  
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+  
+  protected String getResource() {
+    return "timerCalendarDefinition.bpmn";
+  }
+  
+  private void validateModel(BpmnModel model) {
+    IntermediateCatchEvent timer = (IntermediateCatchEvent) model.getMainProcess().getFlowElement("timer");
+    assertNotNull(timer);
+    TimerEventDefinition timerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
+    assertThat(timerEvent.getCalendarName(), is("custom"));
+
+    StartEvent start = (StartEvent) model.getMainProcess().getFlowElement("theStart");
+    assertNotNull(start);
+    TimerEventDefinition startTimerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
+    assertThat(startTimerEvent.getCalendarName(), is("custom"));
+
+    BoundaryEvent boundaryTimer = (BoundaryEvent) model.getMainProcess().getFlowElement("boundaryTimer");
+    assertNotNull(boundaryTimer);
+    TimerEventDefinition boundaryTimerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
+    assertThat(boundaryTimerEvent.getCalendarName(), is("custom"));
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/UserTaskConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/UserTaskConverterTest.java
@@ -47,7 +47,8 @@ public class UserTaskConverterTest extends AbstractConverterTest {
     assertEquals("testKey", userTask.getFormKey());
     assertEquals("40", userTask.getPriority());
     assertEquals("2012-11-01", userTask.getDueDate());
-    
+    assertEquals("customCalendarName", userTask.getBusinessCalendarName());
+
     assertEquals("kermit", userTask.getAssignee());
     assertEquals(2, userTask.getCandidateUsers().size());
     assertTrue(userTask.getCandidateUsers().contains("kermit"));

--- a/modules/activiti-bpmn-converter/src/test/resources/timerCalendarDefinition.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/timerCalendarDefinition.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+  <process id="startTimerEventExampleCycle" name="Timer start event example">
+
+    <startEvent id="theStart">
+      <timerEventDefinition activiti:businessCalendarName="custom">
+        <timeCycle>R2/PT5S</timeCycle>
+      </timerEventDefinition>
+    </startEvent>
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer"/>
+
+    <intermediateCatchEvent id="timer">
+      <timerEventDefinition activiti:businessCalendarName="custom">
+        <timeDuration>PT5M</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <sequenceFlow id="flow2" sourceRef="timer" targetRef="task"/>
+
+    <userTask id="task" name="Task rigged with timer"/>
+    <sequenceFlow id="flow3" sourceRef="task" targetRef="theEnd"/>
+
+
+    <boundaryEvent id="boundaryTimer" cancelActivity="true" attachedToRef="task">
+      <timerEventDefinition activiti:businessCalendarName="custom">
+        <timeDuration>PT10S</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="flow4" sourceRef="boundaryTimer" targetRef="theEnd"/>
+
+    <endEvent id="theEnd"/>
+
+  </process>
+
+</definitions>

--- a/modules/activiti-bpmn-converter/src/test/resources/usertaskmodel.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/usertaskmodel.bpmn
@@ -5,7 +5,7 @@
     <sequenceFlow id="sid-10FF0337-D8FC-495E-92C4-82C2FD5F44F8" sourceRef="sid-12DAA756-C12D-42B6-9AB7-D08C7C8283C1" targetRef="usertask"></sequenceFlow>
     <startEvent id="sid-12DAA756-C12D-42B6-9AB7-D08C7C8283C1"></startEvent>
     <sequenceFlow id="sid-AA1205FD-63BD-47BA-9FB3-AA9F7C1E31F0" sourceRef="usertask" targetRef="endEvent"></sequenceFlow>
-    <userTask id="usertask" name="User task" activiti:category="Test Category" activiti:async="true" activiti:exclusive="false" activiti:assignee="kermit" activiti:candidateUsers="kermit,fozzie" activiti:candidateGroups="management,sales" activiti:dueDate="2012-11-01" activiti:formKey="testKey" activiti:priority="40">
+    <userTask id="usertask" name="User task" activiti:category="Test Category" activiti:async="true" activiti:exclusive="false" activiti:assignee="kermit" activiti:candidateUsers="kermit,fozzie" activiti:candidateGroups="management,sales" activiti:dueDate="2012-11-01" activiti:businessCalendarName="customCalendarName" activiti:formKey="testKey" activiti:priority="40">
       <extensionElements>
         <activiti:customResource name="businessAdministrator">
          <resourceAssignmentExpression>

--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/TimerEventDefinition.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/TimerEventDefinition.java
@@ -21,6 +21,7 @@ public class TimerEventDefinition extends EventDefinition {
   protected String timeDuration;
   protected String timeCycle;
   protected String endDate;
+  protected String calendarName;
 
   public String getTimeDate() {
     return timeDate;
@@ -48,18 +49,29 @@ public class TimerEventDefinition extends EventDefinition {
   public String getEndDate() {
     return endDate;
   }
-  
+
+
+  public void setCalendarName(String calendarName) {
+    this.calendarName = calendarName;
+  }
+
+  public String getCalendarName() {
+    return this.calendarName;
+  }
+
   public TimerEventDefinition clone() {
     TimerEventDefinition clone = new TimerEventDefinition();
     clone.setValues(this);
     return clone;
   }
-  
+
   public void setValues(TimerEventDefinition otherDefinition) {
     super.setValues(otherDefinition);
     setTimeDate(otherDefinition.getTimeDate());
     setTimeDuration(otherDefinition.getTimeDuration());
     setTimeCycle(otherDefinition.getTimeCycle());
     setEndDate(otherDefinition.getEndDate());
+    setCalendarName(otherDefinition.getCalendarName());
   }
+
 }

--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/UserTask.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/UserTask.java
@@ -29,6 +29,7 @@ public class UserTask extends Task {
   protected String priority;
   protected String formKey;
   protected String dueDate;
+  protected String businessCalendarName;
   protected String category;
   protected String extensionId;
   protected List<String> candidateUsers = new ArrayList<String>();
@@ -72,6 +73,15 @@ public class UserTask extends Task {
   public void setDueDate(String dueDate) {
     this.dueDate = dueDate;
   }
+
+  public String getBusinessCalendarName() {
+    return businessCalendarName;
+  }
+
+  public void setBusinessCalendarName(String businessCalendarName) {
+    this.businessCalendarName = businessCalendarName;
+  }
+
   public String getCategory() {
 		return category;
 	}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -90,7 +90,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
           BusinessCalendar businessCalendar = Context
             .getProcessEngineConfiguration()
             .getBusinessCalendarManager()
-            .getBusinessCalendar(DueDateBusinessCalendar.NAME);
+            .getBusinessCalendar(taskDefinition.getBusinessCalendarNameExpression().getValue(execution).toString());
           task.setDueDate(businessCalendar.resolveDuedate((String) dueDate));
         } else {
           throw new ActivitiIllegalArgumentException("Due date expression does not resolve to a Date or Date string: " + 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
@@ -42,7 +42,6 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
 	private static final Logger logger = LoggerFactory.getLogger(TimerEventDefinitionParseHandler.class);
 
   public static final String PROPERTYNAME_START_TIMER = "timerStart";
-  public static final String PROPERTYNAME_CALENDAR_NAME = "businessCalendarName";
 
   public Class< ? extends BaseElement> getHandledType() {
     return TimerEventDefinition.class;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/TimerEventDefinitionParseHandler.java
@@ -42,6 +42,7 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
 	private static final Logger logger = LoggerFactory.getLogger(TimerEventDefinitionParseHandler.class);
 
   public static final String PROPERTYNAME_START_TIMER = "timerStart";
+  public static final String PROPERTYNAME_CALENDAR_NAME = "businessCalendarName";
 
   public Class< ? extends BaseElement> getHandledType() {
     return TimerEventDefinition.class;
@@ -109,6 +110,7 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
     TimerDeclarationType type = null;
     Expression expression = null;
     Expression endDate = null;
+    Expression calendarName = null;
     ExpressionManager expressionManager = bpmnParse.getExpressionManager();
     if (StringUtils.isNotEmpty(timerEventDefinition.getTimeDate())) {
       // TimeDate
@@ -127,6 +129,9 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
       type = TimerDeclarationType.DURATION;
       expression = expressionManager.createExpression(timerEventDefinition.getTimeDuration());
     }
+    if (StringUtils.isNotEmpty(timerEventDefinition.getCalendarName())) {
+      calendarName = expressionManager.createExpression(timerEventDefinition.getCalendarName());
+    }
 
     // neither date, cycle or duration configured!
     if (expression == null) {
@@ -139,13 +144,13 @@ public class TimerEventDefinitionParseHandler extends AbstractBpmnParseHandler<T
     if (jobHandlerType.equalsIgnoreCase(TimerExecuteNestedActivityJobHandler.TYPE) ||
             jobHandlerType.equalsIgnoreCase(TimerCatchIntermediateEventJobHandler.TYPE) ||
             jobHandlerType.equalsIgnoreCase(TimerStartEventJobHandler.TYPE)) {
-      jobHandlerConfiguration = TimerStartEventJobHandler.createConfiguration(timerActivity.getId(), endDate);
+      jobHandlerConfiguration = TimerStartEventJobHandler.createConfiguration(timerActivity.getId(), endDate, calendarName);
     }
 
     // Parse the timer declaration
     // TODO move the timer declaration into the bpmn activity or next to the
     // TimerSession
-    TimerDeclarationImpl timerDeclaration = new TimerDeclarationImpl(expression, type, jobHandlerType , endDate);
+    TimerDeclarationImpl timerDeclaration = new TimerDeclarationImpl(expression, type, jobHandlerType , endDate, calendarName);
     timerDeclaration.setJobHandlerConfiguration(jobHandlerConfiguration);
 
     timerDeclaration.setExclusive(true);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/UserTaskParseHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/handler/UserTaskParseHandler.java
@@ -23,6 +23,7 @@ import org.activiti.bpmn.model.UserTask;
 import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.delegate.TaskListener;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
+import org.activiti.engine.impl.calendar.DueDateBusinessCalendar;
 import org.activiti.engine.impl.el.ExpressionManager;
 import org.activiti.engine.impl.form.DefaultTaskFormHandler;
 import org.activiti.engine.impl.form.TaskFormHandler;
@@ -96,7 +97,14 @@ public class UserTaskParseHandler extends AbstractActivityBpmnParseHandler<UserT
     if (StringUtils.isNotEmpty(userTask.getDueDate())) {
       taskDefinition.setDueDateExpression(expressionManager.createExpression(userTask.getDueDate()));
     }
-    
+
+    // Business calendar name
+    if (StringUtils.isNotEmpty(userTask.getBusinessCalendarName())) {
+      taskDefinition.setBusinessCalendarNameExpression(expressionManager.createExpression(userTask.getBusinessCalendarName()));
+    } else {
+      taskDefinition.setBusinessCalendarNameExpression(expressionManager.createExpression(DueDateBusinessCalendar.NAME));
+    }
+
     // Category
     if (StringUtils.isNotEmpty(userTask.getCategory())) {
     	taskDefinition.setCategoryExpression(expressionManager.createExpression(userTask.getCategory()));

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManager.java
@@ -12,6 +12,8 @@
  */
 package org.activiti.engine.impl.calendar;
 
+import org.activiti.engine.ActivitiException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,10 +23,25 @@ import java.util.Map;
  */
 public class MapBusinessCalendarManager implements BusinessCalendarManager {
   
-  private Map<String, BusinessCalendar> businessCalendars = new HashMap<String, BusinessCalendar>();
+  private final Map<String, BusinessCalendar> businessCalendars;
+
+  public MapBusinessCalendarManager(){
+    this.businessCalendars = new HashMap<String, BusinessCalendar>();
+  }
+
+  public MapBusinessCalendarManager(Map<String, BusinessCalendar> businessCalendars) {
+    assert(businessCalendars != null);
+
+    this.businessCalendars = new HashMap<String, BusinessCalendar>(businessCalendars);
+  }
 
   public BusinessCalendar getBusinessCalendar(String businessCalendarRef) {
-    return businessCalendars.get(businessCalendarRef);
+    BusinessCalendar businessCalendar = businessCalendars.get(businessCalendarRef);
+    if (businessCalendar == null) {
+      throw new ActivitiException("Requested business calendar "+ businessCalendarRef +
+              " does not exist. Allowed calendars are "+ this.businessCalendars.keySet()+".");
+    }
+    return businessCalendar;
   }
   
   public BusinessCalendarManager addBusinessCalendar(String businessCalendarRef, BusinessCalendar businessCalendar) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManager.java
@@ -19,7 +19,7 @@ import java.util.Map;
 
 
 /**
- * @author Tom Baeyens
+ * @author martin.grofcik
  */
 public class MapBusinessCalendarManager implements BusinessCalendarManager {
   
@@ -30,7 +30,9 @@ public class MapBusinessCalendarManager implements BusinessCalendarManager {
   }
 
   public MapBusinessCalendarManager(Map<String, BusinessCalendar> businessCalendars) {
-    assert(businessCalendars != null);
+    if (businessCalendars != null) {
+      throw new IllegalArgumentException("businessCalendars can not be null");
+    }
 
     this.businessCalendars = new HashMap<String, BusinessCalendar>(businessCalendars);
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/jobexecutor/TimerEventHandler.java
@@ -20,12 +20,16 @@ public class TimerEventHandler {
 
   public static final String PROPERTYNAME_TIMER_ACTIVITY_ID = "activityId";
   public static final String PROPERTYNAME_END_DATE_EXPRESSION = "timerEndDate";
+  public static final String PROPERTYNAME_CALENDAR_NAME_EXPRESSION = "calendarName";
 
-  public static String createConfiguration(String id, Expression endDate) {
+  public static String createConfiguration(String id, Expression endDate, Expression calendarName) {
     JSONObject cfgJson = new JSONObject();
     cfgJson.put(PROPERTYNAME_TIMER_ACTIVITY_ID, id);
     if (endDate!=null) {
       cfgJson.put(PROPERTYNAME_END_DATE_EXPRESSION, endDate.getExpressionText());
+    }
+    if (calendarName != null) {
+      cfgJson.put(PROPERTYNAME_CALENDAR_NAME_EXPRESSION, calendarName);
     }
     return cfgJson.toString();
   }
@@ -47,6 +51,16 @@ public class TimerEventHandler {
    }catch (JSONException ex){
     return jobHandlerConfiguration;
    }
+  }
+
+  public static String geCalendarNameFromConfiguration(String jobHandlerConfiguration) {
+    try {
+      JSONObject cfgJson = new JSONObject(jobHandlerConfiguration);
+      return cfgJson.get(PROPERTYNAME_CALENDAR_NAME_EXPRESSION).toString();
+    } catch (JSONException ex) {
+      // calendar name is not specified
+      return "";
+    }
   }
 
   public String setEndDateToConfiguration(String jobHandlerConfiguration, String endDate) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/task/TaskDefinition.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/task/TaskDefinition.java
@@ -43,6 +43,7 @@ public class TaskDefinition implements Serializable {
   protected Set<Expression> candidateUserIdExpressions = new HashSet<Expression>();
   protected Set<Expression> candidateGroupIdExpressions = new HashSet<Expression>();
   protected Expression dueDateExpression;
+  protected Expression businessCalendarNameExpression;
   protected Expression priorityExpression;
   protected Expression categoryExpression;
   protected Map<String, Set<Expression>> customUserIdentityLinkExpressions = new HashMap<String, Set<Expression>>(); 
@@ -165,7 +166,15 @@ public class TaskDefinition implements Serializable {
   public void setDueDateExpression(Expression dueDateExpression) {
     this.dueDateExpression = dueDateExpression;
   }
-  
+
+  public Expression getBusinessCalendarNameExpression() {
+    return businessCalendarNameExpression;
+  }
+
+  public void setBusinessCalendarNameExpression(Expression businessCalendarNameExpression) {
+    this.businessCalendarNameExpression = businessCalendarNameExpression;
+  }
+
   public Expression getCategoryExpression() {
 		return categoryExpression;
 	}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManagerTest.java
@@ -27,7 +27,7 @@ public class MapBusinessCalendarManagerTest extends TestCase {
     }
 
     public void testInvalidCalendarNameRequest() {
-        MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(Collections.EMPTY_MAP);
+        @SuppressWarnings("unchecked") MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(Collections.EMPTY_MAP);
 
         try {
             businessCalendarManager.getBusinessCalendar("INVALID");
@@ -41,7 +41,7 @@ public class MapBusinessCalendarManagerTest extends TestCase {
         try {
             new MapBusinessCalendarManager(null);
             fail("AssertionError expected");
-        } catch(AssertionError e) {
+        } catch(IllegalArgumentException e) {
             // Expected error
         }
     }

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/impl/calendar/MapBusinessCalendarManagerTest.java
@@ -1,0 +1,49 @@
+package org.activiti.engine.impl.calendar;
+
+import junit.framework.TestCase;
+import org.activiti.engine.ActivitiException;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * Created by martin.grofcik
+ */
+public class MapBusinessCalendarManagerTest extends TestCase {
+
+    public void testMapConstructor() {
+        Map<String, BusinessCalendar> calendars = new HashMap<String, BusinessCalendar>(1);
+        CycleBusinessCalendar calendar = new CycleBusinessCalendar(null);
+        calendars.put("someKey", calendar);
+        MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(calendars);
+
+        assertTrue(businessCalendarManager.getBusinessCalendar("someKey").equals(calendar));
+    }
+
+    public void testInvalidCalendarNameRequest() {
+        MapBusinessCalendarManager businessCalendarManager = new MapBusinessCalendarManager(Collections.EMPTY_MAP);
+
+        try {
+            businessCalendarManager.getBusinessCalendar("INVALID");
+            fail("ActivitiException expected");
+        } catch (ActivitiException e) {
+            assertThat(e.getMessage(), containsString("INVALID does not exist"));
+        }
+    }
+
+    public void testNullCalendars() {
+        try {
+            new MapBusinessCalendarManager(null);
+            fail("AssertionError expected");
+        } catch(AssertionError e) {
+            // Expected error
+        }
+    }
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/ManagementServiceTest.java
@@ -135,7 +135,9 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     Job timerJob = managementService.createJobQuery()
       .processInstanceId(processInstance.getId())
       .singleResult();
-    
+
+    Date duedate = timerJob.getDuedate();
+
     assertNotNull("No job found for process instance", timerJob);
     assertEquals(JobEntity.DEFAULT_RETRIES, timerJob.getRetries());
 
@@ -145,6 +147,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       .processInstanceId(processInstance.getId())
       .singleResult();
     assertEquals(5, timerJob.getRetries());
+    assertEquals(duedate, timerJob.getDuedate());
   }
   
   public void testSetJobRetriesUnexistingJobId() {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/IntermediateTimerEventTest.java
@@ -43,7 +43,6 @@ public class IntermediateTimerEventTest extends PluggableActivitiTestCase {
 
     assertEquals(0, jobQuery.count());
     assertProcessEnded(pi.getProcessInstanceId());
-
   }
 
   @Deployment

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.java
@@ -1,0 +1,108 @@
+package org.activiti.engine.test.bpmn.event.timer;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.impl.calendar.BusinessCalendar;
+import org.activiti.engine.impl.test.ResourceActivitiTestCase;
+import org.activiti.engine.runtime.Job;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.test.Deployment;
+
+import java.util.Date;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * testing custom calendar for timer definitions
+ * Created by martin.grofcik
+ */
+public class TimerCustomCalendarTest extends ResourceActivitiTestCase {
+
+    public TimerCustomCalendarTest() {
+        super("org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.activiti.cfg.xml");
+    }
+
+    @Deployment
+    public void testCycleTimer() {
+        List<Job> jobs = this.managementService.createJobQuery().list();
+
+        assertThat("One job is scheduled", jobs.size(), is(1));
+        assertThat("Job must be scheduled by custom business calendar to Date(0)", jobs.get(0).getDuedate(), is(new Date(0)));
+
+        this.managementService.executeJob(jobs.get(0).getId());
+
+        jobs = this.managementService.createJobQuery().list();
+
+        assertThat("One job is scheduled (repetition is 2x)", jobs.size(), is(1));
+        assertThat("Job must be scheduled by custom business calendar to Date(0)", jobs.get(0).getDuedate(), is(new Date(0)));
+
+        this.managementService.executeJob(jobs.get(0).getId());
+
+        jobs = this.managementService.createJobQuery().list();
+        assertThat("There must be no job.", jobs.isEmpty());
+    }
+
+    @Deployment
+    public void testCustomDurationTimerCalendar() {
+        ProcessInstance processInstance = this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar");
+
+        List<Job> jobs = this.managementService.createJobQuery().list();
+
+        assertThat("One job is scheduled", jobs.size(), is(1));
+        assertThat("Job must be scheduled by custom business calendar to Date(0)", jobs.get(0).getDuedate(), is(new Date(0)));
+
+        this.managementService.executeJob(jobs.get(0).getId());
+        waitForJobExecutorToProcessAllJobs(10000, 100);
+
+        this.runtimeService.signal(processInstance.getId());
+    }
+
+    @Deployment
+    public void testInvalidDurationTimerCalendar() {
+        try {
+            this.runtimeService.startProcessInstanceByKey("testCustomDurationCalendar");
+            fail("Activiti exception expected - calendar not found");
+        } catch (ActivitiException e) {
+            assertThat(e.getMessage(), containsString("INVALID does not exist"));
+        }
+    }
+
+    @Deployment
+    public void testBoundaryTimer() {
+        this.runtimeService.startProcessInstanceByKey("testBoundaryTimer");
+
+        List<Job> jobs = this.managementService.createJobQuery().list();
+        assertThat("One job is scheduled", jobs.size(), is(1));
+        assertThat("Job must be scheduled by custom business calendar to Date(0)", jobs.get(0).getDuedate(), is(new Date(0)));
+
+        this.managementService.executeJob(jobs.get(0).getId());
+        waitForJobExecutorToProcessAllJobs(10000, 100);
+    }
+
+    public static class CustomBusinessCalendar implements BusinessCalendar {
+
+        @Override
+        public Date resolveDuedate(String duedateDescription) {
+            return new Date(0);
+        }
+
+        @Override
+        public Date resolveDuedate(String duedateDescription, int maxIterations) {
+            return new Date(0);
+        }
+
+        @Override
+        public Boolean validateDuedate(String duedateDescription, int maxIterations, Date endDate, Date newTimer) {
+            return true;
+        }
+
+        @Override
+        public Date resolveEndDate(String endDateString) {
+            return new Date(0);
+        }
+
+    }
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.java
@@ -18,17 +18,26 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.activiti.engine.impl.calendar.BusinessCalendar;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.impl.test.ResourceActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
 import org.joda.time.Period;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 
 /**
  * @author Frederik Heremans
  */
-public class TaskDueDateExtensionsTest extends PluggableActivitiTestCase {
+public class TaskDueDateExtensionsTest extends ResourceActivitiTestCase {
+
+  public TaskDueDateExtensionsTest() {
+    super("org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.activiti.cfg.xml");
+  }
 
   @Deployment
   public void testDueDateExtension() throws Exception {
@@ -79,4 +88,44 @@ public class TaskDueDateExtensionsTest extends PluggableActivitiTestCase {
     assertEquals(5, period.getHours());
     assertEquals(40, period.getMinutes());
   }
+
+  @Deployment
+  public void testRelativeDueDateStringWithCalendarNameExtension() throws Exception {
+
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("dateVariable", "P2DT5H40M");
+
+    // Start process-instance, passing ISO8601 duration formatted String that should be used to calculate dueDate
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("dueDateExtension", variables);
+
+    Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+    assertNotNull(task.getDueDate());
+    assertThat(task.getDueDate(), is(new Date(0)));
+  }
+
+  public static class CustomBusinessCalendar implements BusinessCalendar {
+
+    @Override
+    public Date resolveDuedate(String duedateDescription) {
+      return new Date(0);
+    }
+
+    @Override
+    public Date resolveDuedate(String duedateDescription, int maxIterations) {
+      return new Date(0);
+    }
+
+    @Override
+    public Boolean validateDuedate(String duedateDescription, int maxIterations, Date endDate, Date newTimer) {
+      return true;
+    }
+
+    @Override
+    public Date resolveEndDate(String endDateString) {
+      return new Date(0);
+    }
+
+  }
+
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/JobExecutorFailRetryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/JobExecutorFailRetryTest.java
@@ -13,7 +13,13 @@
 package org.activiti.engine.test.jobexecutor;
 
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.Job;
 import org.activiti.engine.test.Deployment;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Saeid Mirzaei
@@ -41,5 +47,5 @@ public class JobExecutorFailRetryTest extends PluggableActivitiTestCase {
   	assertEquals(2, RetryFailingDelegate.times.size());  // check number of calls of delegate
   	long timeDiff = RetryFailingDelegate.times.get(1) - RetryFailingDelegate.times.get(0) ; 
   	assertTrue(timeDiff > 6000 && timeDiff < 12000);  // check time difference between calls. Just roughly
-  }
+	}
 }

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventTest.testSignalWithGlobalScope.bpmn20.xml
@@ -11,6 +11,7 @@
 
    <intermediateThrowEvent id="signalThrow">
     <signalEventDefinition signalRef="theSignal" />
+       <
    </intermediateThrowEvent>
     <sequenceFlow id="flow3" sourceRef="signalThrow" targetRef="theEnd" />
     

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.activiti.cfg.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.activiti.cfg.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration"
+    class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
+
+   <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
+   <property name="jdbcDriver" value="org.h2.Driver" />
+   <property name="jdbcUsername" value="sa" />
+   <property name="jdbcPassword" value="" />
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="drop-create" />
+
+    <!-- job executor configurations -->
+    <property name="jobExecutorActivate" value="false" />
+    <property name="asyncExecutor" ref="asyncExecutor" />
+    <property name="asyncExecutorEnabled" value="true" />
+    <property name="asyncExecutorActivate" value="false" />
+    
+    <property name="defaultFailedJobWaitTime" value="1" />
+    <property name="asyncFailedJobWaitTime" value="1" />
+
+    <!-- mail server configurations -->
+    <property name="mailServerPort" value="5025" />
+    
+    <property name="mailServers">
+      <map>
+        <entry key="myEmailTenant">
+          <bean class="org.activiti.engine.cfg.MailServerInfo">
+            <property name="mailServerHost" value="localhost" />
+            <property name="mailServerPort" value="5025" />
+            <property name="mailServerUseSSL" value="false" />
+            <property name="mailServerUseTLS" value="false" />
+            <property name="mailServerDefaultFrom" value="activiti@myTenant.com" />
+            <property name="mailServerUsername" value="activiti@myTenant.com" />
+            <property name="mailServerPassword" value="password" />
+          </bean>
+        </entry>
+      </map>
+    </property>
+
+    <property name="clock" ref="clock"/>
+
+    <property name="businessCalendarManager">
+      <bean class="org.activiti.engine.impl.calendar.MapBusinessCalendarManager">
+        <constructor-arg name="businessCalendars">
+           <map>
+             <entry key="custom">
+               <bean class="org.activiti.engine.test.bpmn.event.timer.TimerCustomCalendarTest$CustomBusinessCalendar"/>
+             </entry>
+             <entry key="cycle">
+               <bean class="org.activiti.engine.impl.calendar.CycleBusinessCalendar">
+                   <constructor-arg name="clockReader" ref="clock"/>
+               </bean>
+             </entry>
+             <entry key="duration">
+               <bean class="org.activiti.engine.impl.calendar.DurationBusinessCalendar">
+                 <constructor-arg name="clockReader" ref="clock"/>
+               </bean>
+             </entry>
+             <entry key="dueDate">
+               <bean class="org.activiti.engine.impl.calendar.DueDateBusinessCalendar">
+                 <constructor-arg name="clockReader" ref="clock"/>
+               </bean>
+             </entry>
+           </map>
+        </constructor-arg>
+      </bean>
+      </property>
+
+    <property name="history" value="full" />
+  </bean>
+  
+  <bean id="asyncExecutor" class="org.activiti.engine.impl.asyncexecutor.DefaultAsyncJobExecutor">
+    <property name="defaultAsyncJobAcquireWaitTimeInMillis" value="1000" />
+    <property name="defaultTimerJobAcquireWaitTimeInMillis" value="1000" />
+  </bean>
+
+  <bean id="clock" class="org.activiti.engine.impl.util.DefaultClockImpl"/>
+
+</beans>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testCustomDurationTimerCalendar.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testCustomDurationTimerCalendar.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:activiti="http://activiti.org/bpmn"
+	targetNamespace="Examples">
+
+	<process id="testCustomDurationCalendar">
+
+		<startEvent id="theStart" />
+		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer" />
+
+		<intermediateCatchEvent id="timer">
+			<timerEventDefinition activiti:businessCalendarName="custom">
+				<timeDuration>PT5M</timeDuration>
+			</timerEventDefinition>
+		</intermediateCatchEvent>
+		
+		<sequenceFlow id="flow2" sourceRef="timer" targetRef="receive" />
+
+		<receiveTask id="receive"/>
+
+		<sequenceFlow id="flow3" sourceRef="receive" targetRef="theEnd"/>
+
+		<endEvent id="theEnd"/>
+	</process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testCycleTimer.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testCycleTimer.bpmn20.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="startTimerEventExampleCycle" name="Timer start event example">
+
+        <startEvent id="theStart">
+            <timerEventDefinition activiti:businessCalendarName="custom">
+                <timeCycle>R2/PT5S</timeCycle>
+            </timerEventDefinition>
+        </startEvent>    
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="receive"/>
+
+        <receiveTask id="receive"/>
+
+        <sequenceFlow id="flow2" sourceRef="receive" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testInvalidDurationTimerCalendar.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomCalendarTest.testInvalidDurationTimerCalendar.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" 
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:activiti="http://activiti.org/bpmn"
+	targetNamespace="Examples">
+
+	<process id="testCustomDurationCalendar">
+
+		<startEvent id="theStart" />
+		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer" />
+
+		<intermediateCatchEvent id="timer">
+			<timerEventDefinition activiti:businessCalendarName="INVALID">
+				<timeDuration>PT5M</timeDuration>
+			</timerEventDefinition>
+		</intermediateCatchEvent>
+		
+		<sequenceFlow id="flow2" sourceRef="timer" targetRef="receive" />
+
+		<receiveTask id="receive"/>
+
+		<sequenceFlow id="flow3" sourceRef="receive" targetRef="theEnd"/>
+
+		<endEvent id="theEnd"/>
+	</process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomcalendarTest.testBoundaryTimer.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/TimerCustomcalendarTest.testBoundaryTimer.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:activiti="http://activiti.org/bpmn" 
+	targetNamespace="Examples">
+
+	<process id="testBoundaryTimer">
+
+		<startEvent id="theStart" />
+		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="task" />
+        
+        <userTask id="task" name="Task rigged with timer" />
+		<sequenceFlow id="flow2" sourceRef="task" targetRef="theEnd" />
+   
+
+		<boundaryEvent id="boundaryTimer" cancelActivity="true" attachedToRef="task">
+			<timerEventDefinition activiti:businessCalendarName="custom">
+			  <timeDuration>PT10S</timeDuration>
+			</timerEventDefinition>
+		</boundaryEvent>
+    
+		<sequenceFlow id="flow3" sourceRef="boundaryTimer" targetRef="theEnd" />
+		
+		<endEvent id="theEnd" />
+
+	</process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.activiti.cfg.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.activiti.cfg.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="processEngineConfiguration"
+          class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
+
+        <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000"/>
+        <property name="jdbcDriver" value="org.h2.Driver"/>
+        <property name="jdbcUsername" value="sa"/>
+        <property name="jdbcPassword" value=""/>
+
+        <!-- Database configurations -->
+        <property name="databaseSchemaUpdate" value="drop-create"/>
+
+        <!-- job executor configurations -->
+        <property name="jobExecutorActivate" value="false"/>
+        <property name="asyncExecutor" ref="asyncExecutor"/>
+        <property name="asyncExecutorEnabled" value="true"/>
+        <property name="asyncExecutorActivate" value="false"/>
+
+        <property name="defaultFailedJobWaitTime" value="1"/>
+        <property name="asyncFailedJobWaitTime" value="1"/>
+
+        <!-- mail server configurations -->
+        <property name="mailServerPort" value="5025"/>
+
+        <property name="mailServers">
+            <map>
+                <entry key="myEmailTenant">
+                    <bean class="org.activiti.engine.cfg.MailServerInfo">
+                        <property name="mailServerHost" value="localhost"/>
+                        <property name="mailServerPort" value="5025"/>
+                        <property name="mailServerUseSSL" value="false"/>
+                        <property name="mailServerUseTLS" value="false"/>
+                        <property name="mailServerDefaultFrom" value="activiti@myTenant.com"/>
+                        <property name="mailServerUsername" value="activiti@myTenant.com"/>
+                        <property name="mailServerPassword" value="password"/>
+                    </bean>
+                </entry>
+            </map>
+        </property>
+
+        <property name="clock" ref="clock"/>
+
+        <property name="businessCalendarManager">
+            <bean class="org.activiti.engine.impl.calendar.MapBusinessCalendarManager">
+                <constructor-arg name="businessCalendars">
+                    <map>
+                        <entry key="custom">
+                            <bean class="org.activiti.engine.test.bpmn.usertask.TaskDueDateExtensionsTest.CustomBusinessCalendar"/>
+                        </entry>
+                        <entry key="cycle">
+                            <bean class="org.activiti.engine.impl.calendar.CycleBusinessCalendar">
+                                <constructor-arg name="clockReader" ref="clock"/>
+                            </bean>
+                        </entry>
+                        <entry key="duration">
+                            <bean class="org.activiti.engine.impl.calendar.DurationBusinessCalendar">
+                                <constructor-arg name="clockReader" ref="clock"/>
+                            </bean>
+                        </entry>
+                        <entry key="dueDate">
+                            <bean class="org.activiti.engine.impl.calendar.DueDateBusinessCalendar">
+                                <constructor-arg name="clockReader" ref="clock"/>
+                            </bean>
+                        </entry>
+                    </map>
+                </constructor-arg>
+            </bean>
+        </property>
+
+        <property name="history" value="full"/>
+    </bean>
+
+    <bean id="asyncExecutor" class="org.activiti.engine.impl.asyncexecutor.DefaultAsyncJobExecutor">
+        <property name="defaultAsyncJobAcquireWaitTimeInMillis" value="1000"/>
+        <property name="defaultTimerJobAcquireWaitTimeInMillis" value="1000"/>
+    </bean>
+
+    <bean id="clock" class="org.activiti.engine.impl.util.DefaultClockImpl"/>
+
+</beans>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testRelativeDueDateStringWithCalendarNameExtension.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/usertask/TaskDueDateExtensionsTest.testRelativeDueDateStringWithCalendarNameExtension.bpmn20.xml
@@ -10,8 +10,8 @@
     
     <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
 
-    <userTask id="theTask" name="my task" activiti:dueDate="${dateVariable}"/>
-    
+    <userTask id="theTask" name="my task" activiti:dueDate="${dateVariable}" activiti:businessCalendarName="custom"/>
+
     <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
     
     <endEvent id="theEnd" />

--- a/userguide/src/en/ch07b-BPMN-Constructs.adoc
+++ b/userguide/src/en/ch07b-BPMN-Constructs.adoc
@@ -44,7 +44,15 @@ Event definitions define the semantics of an event. Without an event definition,
 
 ==== Timer Event Definitions
 
-Timer events are events which are triggered by defined timer. They can be used as <<bpmnTimerStartEvent,start event>>, <<bpmnIntermediateCatchingEvent,intermediate event>> or <<bpmnTimerBoundaryEvent,boundary event>>
+Timer events are events which are triggered by defined timer. They can be used as <<bpmnTimerStartEvent,start event>>, <<bpmnIntermediateCatchingEvent,intermediate event>> or <<bpmnTimerBoundaryEvent,boundary event>>. Timer event highly depends on used business calendar. Business calendar dependency is specified by activiti bpmn extension
+
+[source,xml,linenums]
+----
+<timerEventDefinition activiti:businessCalendarName="custom">
+    ...
+</timerEventDefinition>
+----
+Where businessCalendarName points to business calendar in process engine configuration. When business calendar is omitted default business calendars are used.
 
 Timer definition must have exactly one element from the following:
 


### PR DESCRIPTION
Allows to extend timerEventDefinition with businessCalendar. Business calendar extension can take into account business days and local calendars for timer calculation
