### PR TITLE
[activiti-webapp-explorer] disable post event when no task is active

### DIFF
--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/TaskEventsPanel.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/TaskEventsPanel.java
@@ -66,6 +66,7 @@ public class TaskEventsPanel extends Panel {
   protected String taskId;
   protected List<org.activiti.engine.task.Event> taskEvents;
   protected TextField commentInputField;
+  protected Button addCommentButton;
   protected GridLayout eventGrid;
 
   public TaskEventsPanel() {
@@ -128,6 +129,8 @@ public class TaskEventsPanel extends Panel {
         addTaskEventText(event, eventGrid);
       }
     }
+    addCommentButton.setEnabled(taskId != null);
+    commentInputField.setEnabled(taskId != null);
   }
 
   protected void addTaskEventPicture(final org.activiti.engine.task.Event taskEvent, GridLayout eventGrid) {
@@ -199,7 +202,7 @@ public class TaskEventsPanel extends Panel {
       }
     });
     
-    Button addCommentButton = new Button(i18nManager.getMessage(Messages.TASK_ADD_COMMENT));
+    addCommentButton = new Button(i18nManager.getMessage(Messages.TASK_ADD_COMMENT));
     layout.addComponent(addCommentButton);
     layout.setComponentAlignment(addCommentButton, Alignment.MIDDLE_LEFT);
     addCommentButton.addListener(new ClickListener() {

--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/TaskPage.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/task/TaskPage.java
@@ -121,6 +121,7 @@ public abstract class TaskPage extends AbstractTablePage {
         } else {
           // Nothing is selected
           setDetailComponent(null);
+          taskEventPanel.setTaskId(null);          
           ExplorerApp.get().setCurrentUriFragment(getUriFragment(null));
         }
       }


### PR DESCRIPTION
If 
- I create a New Task in the explorer 
- complete it 
- post an event

Then an error message is shown with a stack trace in the log (task with a given id does not exist)

The Post Event should be enabled only when there is an active task.