### PR TITLE
Delete byte array only if there is one

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -498,7 +498,7 @@ public class ExecutionEntityManager extends AbstractEntityManager<ExecutionEntit
     Collection<VariableInstanceEntity> executionVariables = variableInstanceEntityManager.findVariableInstancesByExecutionId(executionEntity.getId());
     for (VariableInstanceEntity variableInstanceEntity : executionVariables) {
       variableInstanceEntityManager.delete(variableInstanceEntity);
-      if (variableInstanceEntity.getByteArrayRef() != null) {
+      if (variableInstanceEntity.getByteArrayRef() != null && variableInstanceEntity.getByteArrayRef().getId() != null) {
         commandContext.getByteArrayEntityManager().deleteByteArrayById(variableInstanceEntity.getByteArrayRef().getId());
       }
     }


### PR DESCRIPTION
Seems like VariableInstanceEntity.getByteArrayRef is never null. Not sure what to do here, but I get a SQL exception from oracle, because "deleteByteArrayNoRevisionCheck" tries to delete with 'where ID_ = null'. Maybe this works for other databases, but it sure isn't good?