### PR TITLE
Change in Exchange creation

### DIFF
--- a/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
+++ b/modules/activiti-camel/src/main/java/org/activiti/camel/CamelBehavior.java
@@ -132,7 +132,7 @@ public abstract class CamelBehavior extends AbstractBpmnActivityBehavior impleme
   }
 
   protected Exchange createExchange(ActivityExecution activityExecution, ActivitiEndpoint endpoint) {
-    Exchange ex = new DefaultExchange(camelContextObj);
+    Exchange ex = endpoint.createExchange();
     ex.setProperty(ActivitiProducer.PROCESS_ID_PROPERTY, activityExecution.getProcessInstanceId());
     ex.setProperty(ActivitiProducer.EXECUTION_ID_PROPERTY, activityExecution.getId());
     Map<String, Object> variables = activityExecution.getVariables();


### PR DESCRIPTION
In camel 2.16.0-SNAPSHOT... The use of "Exchange ex = new DefaultExchange(camelContextObj);" seems to generate an NPE, because it doesn't set the necessary properties on the exchange for the event to be notified correctly.