### PR TITLE
Fix string concatenation when used as argument of append() call

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoExecutionCreated.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoExecutionCreated.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,11 +30,11 @@ public class DebugInfoExecutionCreated extends AbstractDebugInfo {
 
   @Override
   public void printOut(Logger logger) {
-    StringBuilder strb = new StringBuilder();
-    strb.append("Execution " + executionEntity.getId() + " created");
+    StringBuilder strb = new StringBuilder(25);
+    strb.append("Execution ").append(executionEntity.getId()).append(" created");
 
     if (flowElementId != null) {
-      strb.append(" at flow element " + flowElementId);
+      strb.append(" at flow element ").append(flowElementId);
     }
 
     logger.info(strb.toString());

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoExecutionTree.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoExecutionTree.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,18 +62,18 @@ public class DebugInfoExecutionTree {
     }
 
     protected String getCurrentFlowElementInfo() {
-      StringBuilder strb = new StringBuilder();
+      StringBuilder strb = new StringBuilder(30);
       strb.append(id);
 
       if (activityId != null || activityName != null) {
         strb.append(" in flow element ");
 
         if (activityId != null) {
-          strb.append("'" + activityId + "'");
+          strb.append("'").append(activityId).append("'");
         }
 
         if (activityName != null) {
-          strb.append(" with name " + activityName);
+          strb.append(" with name ").append(activityName);
         }
 
       }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoOperationExecuted.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/test/impl/logger/DebugInfoOperationExecuted.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -58,21 +58,22 @@ public class DebugInfoOperationExecuted extends AbstractDebugInfo {
   }
 
   protected void printOperationInfo(Logger logger) {
-    StringBuilder strb = new StringBuilder();
+    StringBuilder strb = new StringBuilder(35);
 
     // Timing info
-    strb.append("[" + dateFormat.format(new Date(getPreExecutionTime())) + " - " + dateFormat.format(new Date(getPostExecutionTime())) + " (" + (getPostExecutionTime() - getPreExecutionTime())
-        + "ms)]");
+    strb.append("[").append(dateFormat.format(new Date(getPreExecutionTime()))).append(" - ")
+            .append(dateFormat.format(new Date(getPostExecutionTime()))).append(" (")
+            .append(getPostExecutionTime() - getPreExecutionTime()).append("ms)]");
 
     // Operation info
-    strb.append(" " + getOperation().getClass().getSimpleName() + " ");
+    strb.append(" ").append(getOperation().getClass().getSimpleName()).append(" ");
 
     // Execution info
     if (getExecutionId() != null) {
-      strb.append("with execution " + getExecutionId());
+      strb.append("with execution ").append(getExecutionId());
 
       if (getFlowElementId() != null) {
-        strb.append(" at flow element " + getFlowElementId() + " (" + getFlowElementClass().getSimpleName() + ")");
+        strb.append(" at flow element ").append(getFlowElementId()).append(" (").append(getFlowElementClass().getSimpleName()).append(")");
       }
     }
 


### PR DESCRIPTION
Fix string concatenation when used as argument of append() call and set initial size of StringBuffer to be a little large than the default to reduce reallocation.