### PR TITLE
Activiti Spring Boot configuration extended for custom Mybatis mappers 

### DIFF
--- a/modules/activiti-spring-boot/spring-boot-samples/pom.xml
+++ b/modules/activiti-spring-boot/spring-boot-samples/pom.xml
@@ -20,6 +20,7 @@
 		  <module>spring-boot-sample-rest-api-security</module>
         <module>spring-boot-sample-actuator</module>
         <module>spring-boot-sample-integration</module>
+        <module>spring-boot-sample-custom-mybatis-mapper</module>
     </modules>
     <dependencies>
         <dependency>

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/pom.xml
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/pom.xml
@@ -1,0 +1,25 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.activiti</groupId>
+        <artifactId>activiti-spring-boot-samples</artifactId>
+        <version>5.18.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>spring-boot-sample-custom-mybatis-mapper</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.activiti</groupId>
+            <artifactId>activiti-spring-boot-starter-basic</artifactId>
+            <version>5.18.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/java/activiti/Application.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/java/activiti/Application.java
@@ -1,0 +1,65 @@
+package activiti;
+
+import activiti.mappers.CustomMybatisMapper;
+import org.activiti.engine.ManagementService;
+import org.activiti.engine.impl.cmd.AbstractCustomSqlExecution;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ *  @author Dominik Bartos
+ */
+@SpringBootApplication
+public class Application {
+
+    private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
+    @Bean
+    CommandLineRunner customMybatisMapper(final ManagementService managementService) {
+        return new CommandLineRunner() {
+            @Override
+            public void run(String... args) throws Exception {
+                String processDefinitionId = managementService.executeCustomSql(new AbstractCustomSqlExecution<CustomMybatisMapper, String>(CustomMybatisMapper.class) {
+                    @Override
+                    public String execute(CustomMybatisMapper customMybatisMapper) {
+                        return customMybatisMapper.loadProcessDefinitionIdByKey("waiter");
+                    }
+                });
+
+                logger.info("Process definition id = {}", processDefinitionId);
+            }
+        };
+    }
+
+    @Bean
+    CommandLineRunner customMybatisXmlMapper(final ManagementService managementService) {
+        return new CommandLineRunner() {
+            @Override
+            public void run(String... args) throws Exception {
+                String processDefinitionDeploymentId = managementService.executeCommand(new Command<String>() {
+                    @Override
+                    public String execute(CommandContext commandContext) {
+                        return (String) commandContext
+                                .getDbSqlSession()
+                                .selectOne("selectProcessDefinitionDeploymentIdByKey", "waiter");
+                    }
+                });
+
+                logger.info("Process definition deployment id = {}", processDefinitionDeploymentId);
+            }
+        };
+    }
+
+
+    public static void main(String args[]) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/java/activiti/mappers/CustomMybatisMapper.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/java/activiti/mappers/CustomMybatisMapper.java
@@ -1,0 +1,14 @@
+package activiti.mappers;
+
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+/**
+ * @author Dominik Bartos
+ */
+public interface CustomMybatisMapper {
+
+    @Select("SELECT ID_ FROM ACT_RE_PROCDEF WHERE KEY_ = #{key}")
+    String loadProcessDefinitionIdByKey(String key);
+}

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/config/application.yml
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/config/application.yml
@@ -1,0 +1,6 @@
+spring:
+  activiti:
+    customMybatisXMLMappers:
+      - mappers/CustomMybatisXmlMapper.xml
+    customMybatisMappers:
+      - activiti.mappers.CustomMybatisMapper

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/mappers/CustomMybatisXmlMapper.xml
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/mappers/CustomMybatisXmlMapper.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.activiti.CustomMybatisMapper">
+
+    <!-- SELECT ALL PROCESS DEFINITION ID -->
+    <select id="selectProcessDefinitionDeploymentIdByKey" parameterType="String" resultType="String">
+        SELECT DEPLOYMENT_ID_ FROM ACT_RE_PROCDEF WHERE KEY_ = #{value}
+    </select>
+
+</mapper>

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/processes/basic.bpmn20.xml
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/main/resources/processes/basic.bpmn20.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* Copyright 2012-2014 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->
+<definitions id="processDefinitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="processDefinitions">
+
+    <process id="waiter">
+
+        <startEvent id="start"/>
+
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="service1"/>
+
+        <scriptTask id="service1" scriptFormat="groovy">
+            <script>
+               println 'customerId=' + customerId
+            </script>
+        </scriptTask>
+
+        <sequenceFlow id="flow2" sourceRef="service1" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+    </process>
+
+</definitions>

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/test/java/org/activiti/test/spring/boot/CustomMybatisMapperConfigurationTest.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/test/java/org/activiti/test/spring/boot/CustomMybatisMapperConfigurationTest.java
@@ -1,0 +1,77 @@
+package org.activiti.test.spring.boot;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import activiti.Application;
+import activiti.mappers.CustomMybatisMapper;
+import org.activiti.engine.ManagementService;
+import org.activiti.engine.ProcessEngine;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.impl.cmd.AbstractCustomSqlExecution;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.spring.boot.DataSourceProcessEngineAutoConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.PropertiesPropertySource;
+
+/**
+ * @author Dominik Bartos
+ */
+public class CustomMybatisMapperConfigurationTest {
+
+
+    @Test
+    public void executeCustomMybatisMapperQuery() throws Exception {
+        AnnotationConfigApplicationContext applicationContext = this.context(Application.class);
+        ManagementService managementService = applicationContext.getBean(ManagementService.class);
+        String processDefinitionId = managementService.executeCustomSql(new AbstractCustomSqlExecution<CustomMybatisMapper, String>(CustomMybatisMapper.class) {
+            @Override
+            public String execute(CustomMybatisMapper customMybatisMapper) {
+                return customMybatisMapper.loadProcessDefinitionIdByKey("waiter");
+            }
+        });
+        Assert.assertNotNull("the processDefinitionId should not be null!", processDefinitionId);
+    }
+
+    @Test
+    public void executeCustomMybatisXmlQuery() throws Exception {
+        AnnotationConfigApplicationContext applicationContext = this.context(Application.class);
+        ManagementService managementService = applicationContext.getBean(ManagementService.class);
+        String processDefinitionDeploymentId = managementService.executeCommand(new Command<String>() {
+            @Override
+            public String execute(CommandContext commandContext) {
+                return (String) commandContext.getDbSqlSession().selectOne("selectProcessDefinitionDeploymentIdByKey", "waiter");
+            }
+        });
+        Assert.assertNotNull("the processDefinitionDeploymentId should not be null!", processDefinitionDeploymentId);
+    }
+
+    private AnnotationConfigApplicationContext context(Class<?>... clzz) throws IOException {
+        AnnotationConfigApplicationContext annotationConfigApplicationContext
+                = new AnnotationConfigApplicationContext();
+        annotationConfigApplicationContext.register(clzz);
+
+        File springBootPropertiesFile = new File("src/test/resources/config/application.properties");
+        Properties springBootProperties = new Properties();
+        springBootProperties.load(new FileInputStream(springBootPropertiesFile));
+
+        annotationConfigApplicationContext
+                .getEnvironment()
+                .getPropertySources()
+                .addFirst(new PropertiesPropertySource("testProperties", springBootProperties));
+
+        annotationConfigApplicationContext.refresh();
+        return annotationConfigApplicationContext;
+    }
+}

--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/test/resources/config/application.properties
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-custom-mybatis-mapper/src/test/resources/config/application.properties
@@ -1,0 +1,2 @@
+spring.activiti.customMybatisXMLMappers[0] = mappers/CustomMybatisXmlMapper.xml
+spring.activiti.customMybatisMappers[0] = activiti.mappers.CustomMybatisMapper

--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
@@ -1,7 +1,9 @@
 package org.activiti.spring.boot;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.sql.DataSource;
 
@@ -79,8 +81,28 @@ public abstract class AbstractProcessEngineAutoConfiguration
     conf.setMailServerUseSSL(activitiProperties.isMailServerUseSsl());
     conf.setMailServerUseTLS(activitiProperties.isMailServerUseTls());
 
+    if (activitiProperties.getCustomMybatisMappers() != null) {
+      conf.setCustomMybatisMappers(getCustomMybatisMapperClasses(activitiProperties.getCustomMybatisMappers()));
+    }
+
+    if (activitiProperties.getCustomMybatisXMLMappers() != null) {
+      conf.setCustomMybatisXMLMappers(new HashSet<String>(activitiProperties.getCustomMybatisXMLMappers()));
+    }
 
     return conf;
+  }
+
+  private Set<Class<?>> getCustomMybatisMapperClasses(List<String> customMyBatisMappers) {
+    Set<Class<?>> mybatisMappers = new HashSet<Class<?>>();
+    for (String customMybatisMapperClassName : customMyBatisMappers) {
+      try {
+        Class customMybatisClass = Class.forName(customMybatisMapperClassName);
+        mybatisMappers.add(customMybatisClass);
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException("Class " + customMybatisMapperClassName + " has not been found.", e);
+      }
+    }
+    return mybatisMappers;
   }
 
 

--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
@@ -2,6 +2,9 @@ package org.activiti.spring.boot;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.List;
+import java.util.Set;
+
 /**
  * @author Josh Long
  * @author Joram Barrez
@@ -29,6 +32,8 @@ public class ActivitiProperties {
   private String restApiMapping = "/api/*";
   private String restApiServletName = "activitiRestApi";
   private boolean jpaEnabled = true; // true by default
+  private List<String> customMybatisMappers;
+  private List<String> customMybatisXMLMappers;
 
   public boolean isJobExecutorActivate() {
     return jobExecutorActivate;
@@ -191,5 +196,20 @@ public class ActivitiProperties {
 	public void setMailServerUseTls(boolean mailServerUseTls) {
 		this.mailServerUseTls = mailServerUseTls;
 	}
-	
+
+  public List<String> getCustomMybatisMappers() {
+    return customMybatisMappers;
+  }
+
+  public void setCustomMybatisMappers(List<String> customMyBatisMappers) {
+    this.customMybatisMappers = customMyBatisMappers;
+  }
+
+  public List<String> getCustomMybatisXMLMappers() {
+    return customMybatisXMLMappers;
+  }
+
+  public void setCustomMybatisXMLMappers(List<String> customMybatisXMLMappers) {
+    this.customMybatisXMLMappers = customMybatisXMLMappers;
+  }
 }


### PR DESCRIPTION
Recently I had a problem with defining custom Mybatis mappers. I like clean solutions so I have added to activiti-spring-boot project possibility to define these mappers in spring boot configuration file. Additionally I have created sample project with two simple test cases.