### PR TITLE
Refactor Spring Boot RestApiAutoConfiguration to rely on ObjectMapper…

### DIFF
--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/test/java/org/activiti/test/spring/boot/RestApiAutoConfigurationTest.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/test/java/org/activiti/test/spring/boot/RestApiAutoConfigurationTest.java
@@ -7,6 +7,7 @@ import org.activiti.spring.boot.DataSourceProcessEngineAutoConfiguration;
 import org.activiti.spring.boot.RestApiAutoConfiguration;
 import org.junit.After;
 import org.junit.Test;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.EmbeddedServletContainerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.MultipartAutoConfiguration;
@@ -24,6 +25,7 @@ import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Josh Long
+ * @author Vedran Pavic
  */
 public class RestApiAutoConfigurationTest {
 
@@ -33,7 +35,8 @@ public class RestApiAutoConfigurationTest {
           ServerPropertiesAutoConfiguration.class,
           DataSourceAutoConfiguration.class,
           DataSourceProcessEngineAutoConfiguration.DataSourceProcessEngineConfiguration.class,
-          RestApiAutoConfiguration.class
+          RestApiAutoConfiguration.class,
+          JacksonAutoConfiguration.class
   })
   protected static class BaseConfiguration {
     

--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
@@ -30,13 +30,12 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
  * Auto-configuration and starter for the Activiti REST APIs.
  *
  * @author Joram Barrez
  * @author Josh Long
+ * @author Vedran Pavic
  */
 @Configuration
 @AutoConfigureAfter(SecurityAutoConfiguration.class)
@@ -53,13 +52,6 @@ public class RestApiAutoConfiguration {
   public ContentTypeResolver contentTypeResolver() {
     ContentTypeResolver resolver = new DefaultContentTypeResolver();
     return resolver;
-  }
-  
-  @Bean
-  public ObjectMapper objectMapper() {
-    // To avoid instantiating and configuring the mapper everywhere
-    ObjectMapper mapper = new ObjectMapper();
-    return mapper;
   }
   
   @Configuration


### PR DESCRIPTION
… provided by JacksonAutoConfiguration instead of explicitly defined instance.

This is a proposed solution for [ACT-4069](https://activiti.atlassian.net/browse/ACT-4069).
