### PR TITLE
fire process and task cancelled events for sub processes and tasks in…

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteProcessInstanceCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeleteProcessInstanceCmd.java
@@ -37,17 +37,6 @@ public class DeleteProcessInstanceCmd implements Command<Void>, Serializable {
     if (processInstanceId == null) {
       throw new ActivitiIllegalArgumentException("processInstanceId is null");
     }
-    
-    // fill default reason if none provided
-    if (deleteReason == null) {
-      deleteReason = "ACTIVITI_DELETED";
-    }
-
-    if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
-      commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-        ActivitiEventBuilder.createCancelledEvent(this.processInstanceId
-        , this.processInstanceId, null, deleteReason));
-    }
 
     commandContext
       .getExecutionEntityManager()

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.ActivitiOptimisticLockingException;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.ExecutionQueryImpl;
 import org.activiti.engine.impl.Page;
 import org.activiti.engine.impl.ProcessInstanceQueryImpl;
@@ -70,16 +71,26 @@ public class ExecutionEntityManager extends AbstractManager {
   }
 
   private void deleteProcessInstanceCascade(ExecutionEntity execution, String deleteReason, boolean deleteHistory) {
-    for (ExecutionEntity subExecutionEntity : execution.getExecutions()) {
-      if (subExecutionEntity.getSubProcessInstance() != null) {
-        deleteProcessInstanceCascade(subExecutionEntity.getSubProcessInstance(), deleteReason, deleteHistory);
-      }
+    List<ProcessInstance> subProcesses = execution.getEngineServices().getRuntimeService().createProcessInstanceQuery().superProcessInstanceId(execution.processInstanceId).list();
+    for (ProcessInstance subProcess : subProcesses) {
+      deleteProcessInstanceCascade((ExecutionEntity) subProcess, deleteReason, deleteHistory);
     }
 
     CommandContext commandContext = Context.getCommandContext();
     commandContext
       .getTaskEntityManager()
       .deleteTasksByProcessInstanceId(execution.getId(), deleteReason, deleteHistory);
+
+    // fill default reason if none provided
+    if (deleteReason == null) {
+      deleteReason = "ACTIVITI_DELETED";
+    }
+
+    if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled() && execution.isProcessInstanceType()) {
+      commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
+              ActivitiEventBuilder.createCancelledEvent(execution.processInstanceId
+                      , execution.processInstanceId, execution.processDefinitionId, deleteReason));
+    }
 
     // delete the execution BEFORE we delete the history, otherwise we will produce orphan HistoricVariableInstance instances
     execution.deleteCascade(deleteReason);
@@ -106,7 +117,7 @@ public class ExecutionEntityManager extends AbstractManager {
   }
 
   public ExecutionEntity findExecutionById(String executionId) {
-    return (ExecutionEntity) getDbSqlSession().selectById(ExecutionEntity.class, executionId);
+    return getDbSqlSession().selectById(ExecutionEntity.class, executionId);
   }
   
   public long findExecutionCountByQueryCriteria(ExecutionQueryImpl executionQuery) {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -307,8 +307,14 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     runtimeService.deleteProcessInstance(processInstance.getId(), "delete_test");
 
     List<ActivitiEvent> processCancelledEvents = listener.filterEvents(ActivitiEventType.PROCESS_CANCELLED);
-    assertEquals("ActivitiEventType.PROCESS_CANCELLED was expected 1 time.", 1, processCancelledEvents.size());
+    assertEquals("ActivitiEventType.PROCESS_CANCELLED was expected 2 times.", 2, processCancelledEvents.size());
     ActivitiCancelledEvent processCancelledEvent = (ActivitiCancelledEvent) processCancelledEvents.get(0);
+    assertTrue("The cause has to be the same as deleteProcessInstance method call", ActivitiCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()));
+    assertEquals("The process instance has to be the same as in deleteProcessInstance method call", subProcess.getId(), processCancelledEvent.getProcessInstanceId());
+    assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", subProcess.getId(), processCancelledEvent.getExecutionId());
+    assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", processCancelledEvent.getCause());
+
+    processCancelledEvent = (ActivitiCancelledEvent) processCancelledEvents.get(1);
     assertTrue("The cause has to be the same as deleteProcessInstance method call", ActivitiCancelledEvent.class.isAssignableFrom(processCancelledEvent.getClass()));
     assertEquals("The process instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getProcessInstanceId());
     assertEquals("The execution instance has to be the same as in deleteProcessInstance method call", processInstance.getId(), processCancelledEvent.getExecutionId());
@@ -324,8 +330,7 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     assertEquals("The process instance has to point to the subprocess", subProcess.getId(), activityCancelledEvent.getProcessInstanceId());
     assertEquals("The execution instance has to point to the subprocess", subProcess.getId(), activityCancelledEvent.getExecutionId());
     assertEquals("The cause has to be the same as in deleteProcessInstance method call", "delete_test", activityCancelledEvent.getCause());
-
-
+  
     listener.clearEventsReceived();
   }
 
@@ -465,6 +470,24 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     // Completing the task will end the process instance
     taskService.complete(task.getId());
     assertProcessEnded(pi.getId());
+  }
+
+  @Deployment(resources = {
+          "org/activiti/engine/test/bpmn/multiinstance/MultiInstanceTest.testParallelCallActivity.bpmn20.xml",
+          "org/activiti/engine/test/bpmn/multiinstance/MultiInstanceTest.externalSubProcess.bpmn20.xml"})
+  public void testDeleteMultiInstanceCallActivityProcessInstance() {
+    assertEquals(0, taskService.createTaskQuery().count());
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("miParallelCallActivity");
+    assertEquals(7, runtimeService.createProcessInstanceQuery().count());
+    assertEquals(12, taskService.createTaskQuery().count());
+    this.listener.clearEventsReceived();
+
+    runtimeService.deleteProcessInstance(processInstance.getId(), "testing instance deletion");
+
+    assertThat("Task cancelled event has to be fired.", this.listener.getEventsReceived().get(0).getType(), is(ActivitiEventType.ACTIVITY_CANCELLED));
+    assertThat("SubProcess cancelled event has to be fired.", this.listener.getEventsReceived().get(2).getType(), is(ActivitiEventType.PROCESS_CANCELLED));
+    assertEquals(0, runtimeService.createProcessInstanceQuery().count());
+    assertEquals(0, taskService.createTaskQuery().count());
   }
 
   @Override


### PR DESCRIPTION
When process instance is deleted, process cancelled event is not fired for sub processes and ENTITY_DELETED event is not thrown for the tasks.