### PR TITLE
Activiti6 Modify ClassDelegate to so that the way it instantiates classes can be overridden.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ClassDelegate.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ClassDelegate.java
@@ -209,14 +209,18 @@ public class ClassDelegate extends AbstractBpmnActivityBehavior implements TaskL
     return delegateInstance;
   }
 
+  protected Object instantiateDelegate(String className, List<FieldDeclaration> fieldDeclarations) {
+    return ClassDelegate.defaultInstantiateDelegate(className, fieldDeclarations);
+  }
+
   // --HELPER METHODS (also usable by external classes)
   // ----------------------------------------
 
-  public static Object instantiateDelegate(Class<?> clazz, List<FieldDeclaration> fieldDeclarations) {
-    return instantiateDelegate(clazz.getName(), fieldDeclarations);
+  public static Object defaultInstantiateDelegate(Class<?> clazz, List<FieldDeclaration> fieldDeclarations) {
+    return defaultInstantiateDelegate(clazz.getName(), fieldDeclarations);
   }
 
-  public static Object instantiateDelegate(String className, List<FieldDeclaration> fieldDeclarations) {
+  public static Object defaultInstantiateDelegate(String className, List<FieldDeclaration> fieldDeclarations) {
     Object object = ReflectUtil.instantiate(className);
     applyFieldDeclaration(fieldDeclarations, object);
     return object;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -180,7 +180,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 
   protected MailActivityBehavior createMailActivityBehavior(String taskId, List<FieldExtension> fields) {
     List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(fields);
-    return (MailActivityBehavior) ClassDelegate.instantiateDelegate(MailActivityBehavior.class, fieldDeclarations);
+    return (MailActivityBehavior) ClassDelegate.defaultInstantiateDelegate(
+        MailActivityBehavior.class, fieldDeclarations);
   }
 
   // We do not want a hard dependency on Mule, hence we return
@@ -199,7 +200,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 
       Class<?> theClass = Class.forName("org.activiti.mule.MuleSendActivitiBehavior");
       List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(fieldExtensions);
-      return (ActivityBehavior) ClassDelegate.instantiateDelegate(theClass, fieldDeclarations);
+      return (ActivityBehavior) ClassDelegate.defaultInstantiateDelegate(
+          theClass, fieldDeclarations);
 
     } catch (ClassNotFoundException e) {
       throw new ActivitiException("Could not find org.activiti.mule.MuleSendActivitiBehavior: ", e);
@@ -239,7 +241,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 
       List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(fieldExtensions);
       addExceptionMapAsFieldDeclaration(fieldDeclarations, task.getMapExceptions());
-      return (ActivityBehavior) ClassDelegate.instantiateDelegate(theClass, fieldDeclarations);
+      return (ActivityBehavior) ClassDelegate.defaultInstantiateDelegate(
+          theClass, fieldDeclarations);
 
     } catch (ClassNotFoundException e) {
       throw new ActivitiException("Could not find org.activiti.camel.CamelBehavior: ", e);
@@ -254,7 +257,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 
   public ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask) {
     List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(serviceTask.getFieldExtensions());
-    return (ShellActivityBehavior) ClassDelegate.instantiateDelegate(ShellActivityBehavior.class, fieldDeclarations);
+    return (ShellActivityBehavior) ClassDelegate.defaultInstantiateDelegate(
+        ShellActivityBehavior.class, fieldDeclarations);
   }
 
   public BusinessRuleTaskActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask) {


### PR DESCRIPTION
This is a functional no-op change that allows us to add children of ClassDelegate that override the instantiateDelegate method.

This does change two public method names. I've updated the call sites in Activiti, but it is possible that external users are calling these methods.