### PR TITLE
Add a ClassDelegateFactory interface.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ClassDelegateFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ClassDelegateFactory.java
@@ -1,0 +1,28 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.helper;
+
+import java.util.List;
+
+import org.activiti.bpmn.model.MapExceptionEntry;
+import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.impl.bpmn.helper.ClassDelegate;
+import org.activiti.engine.impl.bpmn.parser.FieldDeclaration;
+
+/** Constructs {@link ClassDelegate}s. */
+public interface ClassDelegateFactory {
+  public ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
+      Expression skipExpression, List<MapExceptionEntry> mapExceptions);
+
+  public ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations);
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/DefaultClassDelegateFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/DefaultClassDelegateFactory.java
@@ -1,0 +1,31 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.helper;
+
+import java.util.List;
+
+import org.activiti.bpmn.model.MapExceptionEntry;
+import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.impl.bpmn.helper.ClassDelegate;
+import org.activiti.engine.impl.bpmn.parser.FieldDeclaration;
+
+public class DefaultClassDelegateFactory implements ClassDelegateFactory {
+  public ClassDelegate create(String id, String className, List<FieldDeclaration> fieldDeclarations,
+      Expression skipExpression, List<MapExceptionEntry> mapExceptions) {
+    return new ClassDelegate(id, className, fieldDeclarations, skipExpression, mapExceptions);
+  }
+
+  public ClassDelegate create(String className, List<FieldDeclaration> fieldDeclarations) {
+    return new ClassDelegate(className, fieldDeclarations);
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultListenerFactory.java
@@ -23,7 +23,8 @@ import org.activiti.engine.delegate.ExecutionListener;
 import org.activiti.engine.delegate.TaskListener;
 import org.activiti.engine.delegate.event.ActivitiEventListener;
 import org.activiti.engine.impl.bpmn.helper.BaseDelegateEventListener;
-import org.activiti.engine.impl.bpmn.helper.ClassDelegate;
+import org.activiti.engine.impl.bpmn.helper.ClassDelegateFactory;
+import org.activiti.engine.impl.bpmn.helper.DefaultClassDelegateFactory;
 import org.activiti.engine.impl.bpmn.helper.DelegateActivitiEventListener;
 import org.activiti.engine.impl.bpmn.helper.DelegateExpressionActivitiEventListener;
 import org.activiti.engine.impl.bpmn.helper.ErrorThrowingEventListener;
@@ -49,6 +50,15 @@ import org.activiti.engine.task.Task;
  * @author Joram Barrez
  */
 public class DefaultListenerFactory extends AbstractBehaviorFactory implements ListenerFactory {
+  private final ClassDelegateFactory classDelegateFactory;
+
+  public DefaultListenerFactory(ClassDelegateFactory classDelegateFactory) {
+    this.classDelegateFactory = classDelegateFactory;
+  }
+
+  public DefaultListenerFactory() {
+    this(new DefaultClassDelegateFactory());
+  }
 
   public static final Map<String, Class<?>> ENTITY_MAPPING = new HashMap<String, Class<?>>();
   static {
@@ -63,7 +73,8 @@ public class DefaultListenerFactory extends AbstractBehaviorFactory implements L
   }
 
   public TaskListener createClassDelegateTaskListener(ActivitiListener activitiListener) {
-    return new ClassDelegate(activitiListener.getImplementation(), createFieldDeclarations(activitiListener.getFieldExtensions()));
+    return classDelegateFactory.create(activitiListener.getImplementation(),
+        createFieldDeclarations(activitiListener.getFieldExtensions()));
   }
 
   public TaskListener createExpressionTaskListener(ActivitiListener activitiListener) {
@@ -75,7 +86,7 @@ public class DefaultListenerFactory extends AbstractBehaviorFactory implements L
   }
 
   public ExecutionListener createClassDelegateExecutionListener(ActivitiListener activitiListener) {
-    return new ClassDelegate(activitiListener.getImplementation(), createFieldDeclarations(activitiListener.getFieldExtensions()));
+    return classDelegateFactory.create(activitiListener.getImplementation(), createFieldDeclarations(activitiListener.getFieldExtensions()));
   }
 
   public ExecutionListener createExpressionExecutionListener(ActivitiListener activitiListener) {


### PR DESCRIPTION
This change adds a ClassDelegateFactory interface along with an implementation that calls new ClassDelegate(...). DefaultActivityBehaviorFactory and TaskListenerFactory are updated to accept a ClassDelegateFactory and use it instead of calling new directly. By default they are constructed with the DefaultClassDelegateFactory so no additional configuration is required.

Also factored out getSkipExpressionFromServiceTask in DefaultActivityBehaviorFactory.

This change should be completely safe. It doesn't change any existing interfaces.