### PR TITLE
Weblogic 12c -solve problem with ProcessEngineLookup 

### DIFF
--- a/modules/activiti-cdi/pom.xml
+++ b/modules/activiti-cdi/pom.xml
@@ -10,8 +10,7 @@
   <parent>
     <groupId>org.activiti</groupId>
     <artifactId>activiti-root</artifactId>
-    <relativePath>../..</relativePath>
-    <version>5.18.1-SNAPSHOT</version>
+    <version>5.18.0</version>
   </parent>
 
 

--- a/modules/activiti-cdi/pom.xml
+++ b/modules/activiti-cdi/pom.xml
@@ -10,7 +10,8 @@
   <parent>
     <groupId>org.activiti</groupId>
     <artifactId>activiti-root</artifactId>
-    <version>5.18.0</version>
+    <relativePath>../..</relativePath>
+    <version>5.18.1-SNAPSHOT</version>
   </parent>
 
 

--- a/modules/activiti-cdi/src/main/resources/META-INF/services/org.activiti.cdi.spi.ProcessEngineLookup
+++ b/modules/activiti-cdi/src/main/resources/META-INF/services/org.activiti.cdi.spi.ProcessEngineLookup
@@ -1,2 +1,0 @@
-# The LocalProcessEngineLookup implementation is enabled by default 
-org.activiti.cdi.impl.LocalProcessEngineLookup


### PR DESCRIPTION
Activiti-cdi not work on Weblogic 12c because Weblogic ClassLoader on CDI Extension don´t localize META-INF/services necessary to load ProcessEngine.
Change on ActivitiExtension for not call ClassLoader and call ProgrammaticBeanLookup for find implementation of ProcessEngineLookup.
It´s work fine on time of deploy, but not localize activiti.cfg.xml because again ClassLoader not access resources at this time.
For create ProcessEngine i add a ServletContextListener and call ProgrammaticBeanLookup.lookup(ProcessEngineLookup.class).getProcessEngine();
At this time all resources are disponible by ClassLoader.
If need create another ProcessEngineLookup eg for TestCase, we have that extend LocalProcessEngineLookup and put @Specializes annotation.
This work well for me on Weblogic 12c