### PR TITLE
resolve use mybatis startup error

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/mappings.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/mappings.xml
@@ -8,10 +8,14 @@
   </settings>
   <typeAliases>
     <typeAlias type="org.activiti.engine.impl.persistence.ByteArrayRefTypeHandler" alias="ByteArrayRefTypeHandler"/>
+    <typeAlias type="org.activiti.engine.impl.db.IbatisVariableTypeHandler" alias="IbatisVariableTypeHandler"/>
   </typeAliases>
   <typeHandlers>
     <typeHandler handler="ByteArrayRefTypeHandler" 
                  javaType="org.activiti.engine.impl.persistence.entity.ByteArrayRef"
+                 jdbcType="VARCHAR"/>
+    <typeHandler handler="IbatisVariableTypeHandler" 
+                 javaType="org.activiti.engine.impl.variable.VariableType" 
                  jdbcType="VARCHAR"/>
   </typeHandlers>
   <mappers>


### PR DESCRIPTION
add IbatisVariableTypeHandler to handler VariableType, some mapper.xml use VariableType , but don't use IbatisVariableTypeHandler  to mapper this type. So if you use mybatis, you'll startup with error. 