### PR TITLE
Refactor BpmnDeployer into multiple classes

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -12,69 +12,23 @@
  */
 package org.activiti.engine.impl.bpmn.deployer;
 
-import java.io.ByteArrayInputStream;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.activiti.bpmn.model.BpmnModel;
-import org.activiti.bpmn.model.EventDefinition;
-import org.activiti.bpmn.model.FlowElement;
-import org.activiti.bpmn.model.Message;
-import org.activiti.bpmn.model.MessageEventDefinition;
-import org.activiti.bpmn.model.Process;
-import org.activiti.bpmn.model.Signal;
-import org.activiti.bpmn.model.SignalEventDefinition;
-import org.activiti.bpmn.model.StartEvent;
-import org.activiti.bpmn.model.TimerEventDefinition;
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.ProcessEngineConfiguration;
-import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
-import org.activiti.engine.impl.bpmn.parser.BpmnParse;
-import org.activiti.engine.impl.bpmn.parser.BpmnParser;
 import org.activiti.engine.impl.cfg.IdGenerator;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.activiti.engine.impl.cmd.CancelJobsCmd;
-import org.activiti.engine.impl.cmd.DeploymentSettings;
 import org.activiti.engine.impl.context.Context;
-import org.activiti.engine.impl.el.ExpressionManager;
-import org.activiti.engine.impl.event.MessageEventHandler;
-import org.activiti.engine.impl.event.SignalEventHandler;
 import org.activiti.engine.impl.interceptor.CommandContext;
-import org.activiti.engine.impl.jobexecutor.TimerEventHandler;
-import org.activiti.engine.impl.jobexecutor.TimerStartEventJobHandler;
 import org.activiti.engine.impl.persistence.deploy.Deployer;
-import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
-import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
-import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionInfoCacheObject;
 import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
-import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
-import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManager;
-import org.activiti.engine.impl.persistence.entity.IdentityLinkEntity;
-import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntityManager;
-import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntity;
-import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntityManager;
 import org.activiti.engine.impl.persistence.entity.ResourceEntity;
 import org.activiti.engine.impl.persistence.entity.ResourceEntityManager;
-import org.activiti.engine.impl.persistence.entity.SignalEventSubscriptionEntity;
-import org.activiti.engine.impl.persistence.entity.TimerEntity;
-import org.activiti.engine.impl.util.IoUtil;
-import org.activiti.engine.impl.util.TimerUtil;
-import org.activiti.engine.runtime.Job;
-import org.activiti.engine.task.IdentityLinkType;
-import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  * @author Joram Barrez
@@ -84,503 +38,192 @@ public class BpmnDeployer implements Deployer {
 
   private static final Logger log = LoggerFactory.getLogger(BpmnDeployer.class);
 
-  public static final String[] BPMN_RESOURCE_SUFFIXES = new String[] { "bpmn20.xml", "bpmn" };
-  public static final String[] DIAGRAM_SUFFIXES = new String[] { "png", "jpg", "gif", "svg" };
-
-  protected ExpressionManager expressionManager;
-  protected BpmnParser bpmnParser;
   protected IdGenerator idGenerator;
+  protected ExpandedDeployment.BuilderFactory expandedDeploymentBuilderFactory;
+  protected BpmnDeploymentUtilities deploymentUtility;
+  protected CachingAndArtifactsManager cachingAndArtifactsManager;
+  protected ProcessDefinitionDiagrammer processDefinitionDiagrammer;
 
+  @Override
   public void deploy(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
     log.debug("Processing deployment {}", deployment.getName());
 
-    List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
-    Map<String, org.activiti.bpmn.model.Process> processModels = new HashMap<String, org.activiti.bpmn.model.Process>();
-    Map<String, BpmnModel> bpmnModels = new HashMap<String, BpmnModel>();
-    Map<String, ResourceEntity> resources = deployment.getResources();
+    // The ExpandedDeployment represents the deployment, the process definitions, and the BPMN 
+    // resource, parse, and model associated with each process definition.
+    ExpandedDeployment expandedDeployment = 
+        expandedDeploymentBuilderFactory.getBuilderForDeploymentAndSettings(deployment, deploymentSettings)
+        .build();
+    
+    deploymentUtility.verifyProcessDefinitionsDoNotShareKeys(expandedDeployment.getAllProcessDefinitions());
 
+    deploymentUtility.copyDeploymentValuesToProcessDefinitions(
+        expandedDeployment.getDeployment(), expandedDeployment.getAllProcessDefinitions());
+    deploymentUtility.setResourceNamesOnProcessDefinitions(expandedDeployment);
+    
+    createAndPersistNewDiagramsAsNeeded(expandedDeployment);
+    setProcessDefinitionDiagramNames(expandedDeployment);
+    
+    if (deployment.isNew()) {
+      Map<ProcessDefinitionEntity, ProcessDefinitionEntity> mapOfNewProcessDefinitionToPreviousVersion =
+          getPreviousVersionsOfProcessDefinitions(expandedDeployment);
+      setProcessDefinitionVersionsAndIds(expandedDeployment, mapOfNewProcessDefinitionToPreviousVersion);
+      persistProcessDefinitionsAndAuthorizations(expandedDeployment);
+
+      updateTimersAndEvents(expandedDeployment, mapOfNewProcessDefinitionToPreviousVersion);
+    } else {
+      makeProcessDefinitionsConsistentWithPersistedVersions(expandedDeployment);
+    }
+    
+    cachingAndArtifactsManager.updateCachingAndArtifacts(expandedDeployment);
+  }
+
+  /**
+   * Creates new diagrams for process definitions if the deployment is new, the process definition in
+   * question supports it, and the engine is configured to make new diagrams.  When this method
+   * creates a new diagram, it also persists it via the ResourceEntityManager and adds it to the
+   * resources of the deployment.
+   */
+  protected void createAndPersistNewDiagramsAsNeeded(ExpandedDeployment expandedDeployment) {
     final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-    for (String resourceName : resources.keySet()) {
-
-      log.info("Processing resource {}", resourceName);
-      if (isBpmnResource(resourceName)) {
-        ResourceEntity resource = resources.get(resourceName);
-        byte[] bytes = resource.getBytes();
-        ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
-
-        BpmnParse bpmnParse = bpmnParser.createParse()
-            .sourceInputStream(inputStream)
-            .setSourceSystemId(resourceName)
-            .deployment(deployment)
-            .name(resourceName);
-
-        if (deploymentSettings != null) {
-
-          // Schema validation if needed
-          if (deploymentSettings.containsKey(DeploymentSettings.IS_BPMN20_XSD_VALIDATION_ENABLED)) {
-            bpmnParse.setValidateSchema((Boolean) deploymentSettings.get(DeploymentSettings.IS_BPMN20_XSD_VALIDATION_ENABLED));
-          }
-
-          // Process validation if needed
-          if (deploymentSettings.containsKey(DeploymentSettings.IS_PROCESS_VALIDATION_ENABLED)) {
-            bpmnParse.setValidateProcess((Boolean) deploymentSettings.get(DeploymentSettings.IS_PROCESS_VALIDATION_ENABLED));
-          }
-
-        } else {
-          // On redeploy, we assume it is validated at the first
-          // deploy
-          bpmnParse.setValidateSchema(false);
-          bpmnParse.setValidateProcess(false);
-        }
-
-        bpmnParse.execute();
-
-        for (ProcessDefinitionEntity processDefinition : bpmnParse.getProcessDefinitions()) {
-          processDefinition.setResourceName(resourceName);
-
-          // Backwards compatibility
-          if (deployment.getEngineVersion() != null) {
-            processDefinition.setEngineVersion(deployment.getEngineVersion());
-          }
-
-          if (deployment.getTenantId() != null) {
-            processDefinition.setTenantId(deployment.getTenantId()); // process definition inherits the tenant id
-          }
-
-          String diagramResourceName = getDiagramResourceForProcess(resourceName, processDefinition.getKey(), resources);
-
-          // Only generate the resource when deployment is new to prevent modification of deployment resources
-          // after the process-definition is actually deployed. Also to prevent resource-generation failure every
-          // time the process definition is added to the deployment-cache when diagram-generation has failed the first time.
-          if (deployment.isNew()) {
-            if (processEngineConfiguration.isCreateDiagramOnDeploy() && diagramResourceName == null && processDefinition.isGraphicalNotationDefined()) {
-              try {
-                byte[] diagramBytes = IoUtil.readInputStream(
-                    processEngineConfiguration.getProcessDiagramGenerator().generateDiagram(bpmnParse.getBpmnModel(), "png", processEngineConfiguration.getActivityFontName(),
-                        processEngineConfiguration.getLabelFontName(), processEngineConfiguration.getClassLoader()), null);
-                diagramResourceName = getProcessImageResourceName(resourceName, processDefinition.getKey(), "png");
-                createResource(processEngineConfiguration.getResourceEntityManager(), diagramResourceName, diagramBytes, deployment);
-              } catch (Throwable t) { // if anything goes wrong, we don't store the image (the process will still be executable).
-                log.warn("Error while generating process diagram, image will not be stored in repository", t);
-              }
-            }
-          }
-
-          processDefinition.setDiagramResourceName(diagramResourceName);
-          processDefinitions.add(processDefinition);
-
-          processModels.put(processDefinition.getKey(), bpmnParse.getBpmnModel().getProcessById(processDefinition.getKey()));
-          bpmnModels.put(processDefinition.getKey(), bpmnParse.getBpmnModel());
-        }
-      }
-    }
-
-    // check if there are process definitions with the same process key to
-    // prevent database unique index violation
-    List<String> keyList = new ArrayList<String>();
-    for (ProcessDefinitionEntity processDefinition : processDefinitions) {
-      if (keyList.contains(processDefinition.getKey())) {
-        throw new ActivitiException("The deployment contains process definitions with the same key (process id attribute), this is not allowed");
-      }
-      keyList.add(processDefinition.getKey());
-    }
-
-    CommandContext commandContext = Context.getCommandContext();
-    ProcessDefinitionEntityManager processDefinitionManager = commandContext.getProcessDefinitionEntityManager();
-    for (ProcessDefinitionEntity processDefinition : processDefinitions) {
-      List<TimerEntity> timers = new ArrayList<TimerEntity>();
-      if (deployment.isNew()) {
-        int processDefinitionVersion;
-
-        ProcessDefinitionEntity latestProcessDefinition = null;
-        if (processDefinition.getTenantId() != null && !ProcessEngineConfiguration.NO_TENANT_ID.equals(processDefinition.getTenantId())) {
-          latestProcessDefinition = processDefinitionManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinition.getKey(), processDefinition.getTenantId());
-        } else {
-          latestProcessDefinition = processDefinitionManager.findLatestProcessDefinitionByKey(processDefinition.getKey());
-        }
-
-        if (latestProcessDefinition != null) {
-          processDefinitionVersion = latestProcessDefinition.getVersion() + 1;
-        } else {
-          processDefinitionVersion = 1;
-        }
-
-        processDefinition.setVersion(processDefinitionVersion);
-        processDefinition.setDeploymentId(deployment.getId());
-
-        String nextId = idGenerator.getNextId();
-        String processDefinitionId = processDefinition.getKey() + ":" + processDefinition.getVersion() + ":" + nextId; // ACT-505
-
-        // ACT-115: maximum id length is 64 characters
-        if (processDefinitionId.length() > 64) {
-          processDefinitionId = nextId;
-        }
-        processDefinition.setId(processDefinitionId);
-
-        if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
-          commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_CREATED, processDefinition));
-        }
-
-        org.activiti.bpmn.model.Process process = processModels.get(processDefinition.getKey());
-
-        removeObsoleteTimers(processDefinition);
-        addTimerDeclarations(processDefinition, process, timers);
-
-        removeObsoleteMessageEventSubscriptions(processDefinition, latestProcessDefinition);
-        addMessageEventSubscriptions(processDefinition, process, bpmnModels.get(processDefinition.getKey()));
-
-        removeObsoleteSignalEventSubScription(processDefinition, latestProcessDefinition);
-        addSignalEventSubscriptions(commandContext, processDefinition, process, bpmnModels.get(processDefinition.getKey()));
-
-        commandContext.getProcessDefinitionEntityManager().insert(processDefinition, false);
-        addAuthorizationsFromIterator(commandContext, processDefinition.getCandidateStarterUserIdExpressions(), processDefinition, ExprType.USER);
-        addAuthorizationsFromIterator(commandContext, processDefinition.getCandidateStarterGroupIdExpressions(), processDefinition, ExprType.GROUP);
-
-        if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
-          commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_INITIALIZED, processDefinition));
-        }
-
-        scheduleTimers(timers);
-
-      } else {
-        String deploymentId = deployment.getId();
-        processDefinition.setDeploymentId(deploymentId);
-
-        ProcessDefinitionEntity persistedProcessDefinition = null;
-        if (processDefinition.getTenantId() == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(processDefinition.getTenantId())) {
-          persistedProcessDefinition = processDefinitionManager.findProcessDefinitionByDeploymentAndKey(deploymentId, processDefinition.getKey());
-        } else {
-          persistedProcessDefinition = processDefinitionManager.findProcessDefinitionByDeploymentAndKeyAndTenantId(deploymentId, processDefinition.getKey(), processDefinition.getTenantId());
-        }
-
-        if (persistedProcessDefinition != null) {
-          processDefinition.setId(persistedProcessDefinition.getId());
-          processDefinition.setVersion(persistedProcessDefinition.getVersion());
-          processDefinition.setSuspensionState(persistedProcessDefinition.getSuspensionState());
-        }
-      }
-
-      // Add to cache
-      ProcessDefinitionCacheEntry cacheEntry = new ProcessDefinitionCacheEntry(processDefinition, bpmnModels.get(processDefinition.getKey()), processModels.get(processDefinition.getKey()));
-      processEngineConfiguration.getDeploymentManager().getProcessDefinitionCache().add(processDefinition.getId(), cacheEntry);
-      addDefinitionInfoToCache(processDefinition, processEngineConfiguration, commandContext);
+    DeploymentEntity deployment = expandedDeployment.getDeployment();
+    
+    if (expandedDeployment.getDeployment().isNew() && processEngineConfiguration.isCreateDiagramOnDeploy()) {
+      ResourceEntityManager resourceEntityManager = processEngineConfiguration.getResourceEntityManager();
       
-      // Add to deployment for further usage
-      deployment.addDeployedArtifact(processDefinition);
-    }
-  }
-  
-  protected void addDefinitionInfoToCache(ProcessDefinitionEntity processDefinition, 
-      ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
-    
-    if (processEngineConfiguration.isEnableProcessDefinitionInfoCache() == false) {
-      return;
-    }
-    
-    DeploymentManager deploymentManager = processEngineConfiguration.getDeploymentManager();
-    ProcessDefinitionInfoEntityManager definitionInfoEntityManager = commandContext.getProcessDefinitionInfoEntityManager();
-    ObjectMapper objectMapper = commandContext.getProcessEngineConfiguration().getObjectMapper();
-    ProcessDefinitionInfoEntity definitionInfoEntity = definitionInfoEntityManager.findProcessDefinitionInfoByProcessDefinitionId(processDefinition.getId());
-    
-    ObjectNode infoNode = null;
-    if (definitionInfoEntity != null && definitionInfoEntity.getInfoJsonId() != null) {
-      byte[] infoBytes = definitionInfoEntityManager.findInfoJsonById(definitionInfoEntity.getInfoJsonId());
-      if (infoBytes != null) {
-        try {
-          infoNode = (ObjectNode) objectMapper.readTree(infoBytes);
-        } catch (Exception e) {
-          throw new ActivitiException("Error deserializing json info for process definition " + processDefinition.getId());
-        }
-      }
-    }
-    
-    ProcessDefinitionInfoCacheObject definitionCacheObject = new ProcessDefinitionInfoCacheObject();
-    if (definitionInfoEntity == null) {
-      definitionCacheObject.setRevision(0);
-    } else {
-      definitionCacheObject.setId(definitionInfoEntity.getId());
-      definitionCacheObject.setRevision(definitionInfoEntity.getRevision());
-    }
-    
-    if (infoNode == null) {
-      infoNode = objectMapper.createObjectNode();
-    }
-    definitionCacheObject.setInfoNode(infoNode);
-    
-    deploymentManager.getProcessDefinitionInfoCache().add(processDefinition.getId(), definitionCacheObject);
-  }
-
-  protected void scheduleTimers(List<TimerEntity> timers) {
-    for (TimerEntity timer : timers) {
-      Context.getCommandContext().getJobEntityManager().schedule(timer);
-    }
-  }
-
-  protected void addTimerDeclarations(ProcessDefinitionEntity processDefinition, org.activiti.bpmn.model.Process process, List<TimerEntity> timers) {
-    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
-      for (FlowElement element : process.getFlowElements()) {
-        if (element instanceof StartEvent) {
-          StartEvent startEvent = (StartEvent) element;
-          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
-            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
-            if (eventDefinition instanceof TimerEventDefinition) {
-              TimerEventDefinition timerEventDefinition = (TimerEventDefinition) eventDefinition;
-              TimerEntity timer = TimerUtil.createTimerEntityForTimerEventDefinition(timerEventDefinition, false, null, TimerStartEventJobHandler.TYPE,
-                  TimerEventHandler.createConfiguration(startEvent.getId(), timerEventDefinition.getEndDate()));
-              
-              if (timer != null) {
-                timer.setProcessDefinitionId(processDefinition.getId());
-  
-                if (processDefinition.getTenantId() != null) {
-                  timer.setTenantId(processDefinition.getTenantId());
-                }
-                timers.add(timer);
-              }
-              
-            }
+      for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+        if (processDefinitionDiagrammer.shouldCreateDiagram(processDefinition, deployment)) {
+          ResourceEntity resource = processDefinitionDiagrammer.createDiagramForProcessDefinition(
+              processDefinition, expandedDeployment.getBpmnParseForProcessDefinition(processDefinition));
+          if (resource != null) {
+            resourceEntityManager.insert(resource, false);
+            deployment.addResource(resource);  // now we'll find it if we look for the diagram name later.
           }
         }
       }
     }
   }
-
- protected void removeObsoleteTimers(ProcessDefinitionEntity processDefinition) {
-    
-    List<Job> jobsToDelete = null;
-    
-    if (processDefinition.getTenantId() != null && !ProcessEngineConfiguration.NO_TENANT_ID.equals(processDefinition.getTenantId())) {
-      jobsToDelete = Context.getCommandContext().getJobEntityManager().findJobsByTypeAndProcessDefinitionKeyAndTenantId(
-          TimerStartEventJobHandler.TYPE, processDefinition.getKey(), processDefinition.getTenantId());
-    } else {
-      jobsToDelete = Context.getCommandContext().getJobEntityManager()
-          .findJobsByTypeAndProcessDefinitionKeyNoTenantId(TimerStartEventJobHandler.TYPE, processDefinition.getKey());
-    }
-
-    if (jobsToDelete != null) {
-      for (Job job :jobsToDelete) {
-          new CancelJobsCmd(job.getId()).execute(Context.getCommandContext());
-      }
-    }
-  }
-
-  protected void removeObsoleteMessageEventSubscriptions(ProcessDefinitionEntity processDefinition, ProcessDefinitionEntity latestProcessDefinition) {
-    // remove all subscriptions for the previous version
-    if (latestProcessDefinition != null) {
-      CommandContext commandContext = Context.getCommandContext();
-
-      EventSubscriptionEntityManager eventSubscriptionEntityManager = commandContext.getEventSubscriptionEntityManager();
-      List<EventSubscriptionEntity> subscriptionsToDelete = eventSubscriptionEntityManager.findEventSubscriptionsByConfiguration(MessageEventHandler.EVENT_HANDLER_TYPE,
-          latestProcessDefinition.getId(), latestProcessDefinition.getTenantId());
-
-      for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsToDelete) {
-        eventSubscriptionEntityManager.delete(eventSubscriptionEntity);
-      }
-
-    }
-  }
-
-  protected void addMessageEventSubscriptions(ProcessDefinitionEntity processDefinition, Process process, BpmnModel bpmnModel) {
-    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
-      for (FlowElement element : process.getFlowElements()) {
-        if (element instanceof StartEvent) {
-          StartEvent startEvent = (StartEvent) element;
-          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
-            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
-            if (eventDefinition instanceof MessageEventDefinition) {
-              MessageEventDefinition messageEventDefinition = (MessageEventDefinition) eventDefinition;
-              insertMessageEvent(messageEventDefinition, startEvent, processDefinition, bpmnModel);
-            }
-          }
-        } 
-      }
-    }
-  }
   
-  protected void insertMessageEvent(MessageEventDefinition messageEventDefinition, StartEvent startEvent, ProcessDefinitionEntity processDefinition, BpmnModel bpmnModel) {
-    
-    CommandContext commandContext = Context.getCommandContext();
-    if (bpmnModel.containsMessageId(messageEventDefinition.getMessageRef())) {
-      Message message = bpmnModel.getMessage(messageEventDefinition.getMessageRef());
-      messageEventDefinition.setMessageRef(message.getName());
-    }
+  /**
+   * Updates all the process definition entities to have the correct diagram resource name.  Must
+   * be called after createAndPersistNewDiagramsAsNeeded to ensure that any newly-created diagrams
+   * already have their resources attached to the deployment.
+   */
+  protected void setProcessDefinitionDiagramNames(ExpandedDeployment expandedDeployment) {
+    Map<String, ResourceEntity> resources = expandedDeployment.getDeployment().getResources();
 
-    // look for subscriptions for the same name in db:
-    List<EventSubscriptionEntity> subscriptionsForSameMessageName = commandContext.getEventSubscriptionEntityManager()
-        .findEventSubscriptionsByName(MessageEventHandler.EVENT_HANDLER_TYPE, messageEventDefinition.getMessageRef(), processDefinition.getTenantId());
-
-    
-    for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsForSameMessageName) {
-      // throw exception only if there's already a subscription as start event
-      if (eventSubscriptionEntity.getProcessInstanceId() == null || eventSubscriptionEntity.getProcessInstanceId().isEmpty()) { // processInstanceId != null or not empty -> it's a message related to an execution
-        // the event subscription has no instance-id, so it's a message start event
-        throw new ActivitiException("Cannot deploy process definition '" + processDefinition.getResourceName()
-            + "': there already is a message event subscription for the message with name '" + messageEventDefinition.getMessageRef() + "'.");
-      }
-    }
-
-    MessageEventSubscriptionEntity newSubscription = commandContext.getEventSubscriptionEntityManager().createMessageEventSubscription();
-    newSubscription.setEventName(messageEventDefinition.getMessageRef());
-    newSubscription.setActivityId(startEvent.getId());
-    newSubscription.setConfiguration(processDefinition.getId());
-    newSubscription.setProcessDefinitionId(processDefinition.getId());
-
-    if (processDefinition.getTenantId() != null) {
-      newSubscription.setTenantId(processDefinition.getTenantId());
-    }
-
-    commandContext.getEventSubscriptionEntityManager().insert(newSubscription);
-  }
-
-  protected void removeObsoleteSignalEventSubScription(ProcessDefinitionEntity processDefinition, ProcessDefinitionEntity latestProcessDefinition) {
-    // remove all subscriptions for the previous version
-    if (latestProcessDefinition != null) {
-      CommandContext commandContext = Context.getCommandContext();
-
-      EventSubscriptionEntityManager eventSubscriptionEntityManager = commandContext.getEventSubscriptionEntityManager();
-      List<EventSubscriptionEntity> subscriptionsToDelete = eventSubscriptionEntityManager.findEventSubscriptionsByConfiguration(SignalEventHandler.EVENT_HANDLER_TYPE,
-          latestProcessDefinition.getId(), latestProcessDefinition.getTenantId());
-
-      for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsToDelete) {
-        eventSubscriptionEntityManager.delete(eventSubscriptionEntity);
-      }
-
-    }
-  }
-
-  protected void addSignalEventSubscriptions(CommandContext commandContext, ProcessDefinitionEntity processDefinition, org.activiti.bpmn.model.Process process, BpmnModel bpmnModel) {
-    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
-      for (FlowElement element : process.getFlowElements()) {
-        if (element instanceof StartEvent) {
-          StartEvent startEvent = (StartEvent) element;
-          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
-            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
-            if (eventDefinition instanceof SignalEventDefinition) {
-              SignalEventDefinition signalEventDefinition = (SignalEventDefinition) eventDefinition;
-              SignalEventSubscriptionEntity subscriptionEntity = commandContext.getEventSubscriptionEntityManager().createSignalEventSubscription();
-              Signal signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
-              if (signal != null) {
-                subscriptionEntity.setEventName(signal.getName());
-              } else {
-                subscriptionEntity.setEventName(signalEventDefinition.getSignalRef());
-              }
-              subscriptionEntity.setActivityId(startEvent.getId());
-              subscriptionEntity.setProcessDefinitionId(processDefinition.getId());
-              if (processDefinition.getTenantId() != null) {
-                subscriptionEntity.setTenantId(processDefinition.getTenantId());
-              }
-              
-              Context.getCommandContext().getEventSubscriptionEntityManager().insert(subscriptionEntity);
-            }
-          }
-        }
-      }
-    }
-  }
-
-  enum ExprType {
-    USER, GROUP
-  }
-
-  private void addAuthorizationsFromIterator(CommandContext commandContext, Set<Expression> exprSet, ProcessDefinitionEntity processDefinition, ExprType exprType) {
-    if (exprSet != null) {
-      Iterator<Expression> iterator = exprSet.iterator();
-      while (iterator.hasNext()) {
-        Expression expr = (Expression) iterator.next();
-        IdentityLinkEntity identityLink = commandContext.getIdentityLinkEntityManager().create();
-        identityLink.setProcessDef(processDefinition);
-        if (exprType.equals(ExprType.USER)) {
-          identityLink.setUserId(expr.toString());
-        } else if (exprType.equals(ExprType.GROUP)) {
-          identityLink.setGroupId(expr.toString());
-        }
-        identityLink.setType(IdentityLinkType.CANDIDATE);
-        Context.getCommandContext().getIdentityLinkEntityManager().insert(identityLink);
-      }
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      String diagramResourceName = ResourceNameUtilities.getDiagramResourceName(processDefinition, resources);
+      processDefinition.setDiagramResourceName(diagramResourceName);
     }
   }
 
   /**
-   * Returns the default name of the image resource for a certain process.
-   * 
-   * It will first look for an image resource which matches the process specifically, before resorting to an image resource which matches the BPMN 2.0 xml file resource.
-   * 
-   * Example: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml' containing only one process with key 'myProcess', then this method will look for an image resources called
-   * 'abc.myProcess.png' (or .jpg, or .gif, etc.) or 'abc.png' if the previous one wasn't found.
-   * 
-   * Example 2: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml' containing three processes (with keys a, b and c), then this method will first look for an image resource
-   * called 'abc.a.png' before looking for 'abc.png' (likewise for b and c). Note that if abc.a.png, abc.b.png and abc.c.png don't exist, all processes will have the same image: abc.png.
-   * 
-   * @return null if no matching image resource is found.
+   * Constructs a map from new ProcessDefinitionEntities to the previous version by key and tenant.
+   * If no previous version exists, no map entry is created.
    */
-  protected String getDiagramResourceForProcess(String bpmnFileResource, String processKey, Map<String, ResourceEntity> resources) {
-    for (String diagramSuffix : DIAGRAM_SUFFIXES) {
-      String diagramForBpmnFileResource = getBpmnFileImageResourceName(bpmnFileResource, diagramSuffix);
-      String processDiagramResource = getProcessImageResourceName(bpmnFileResource, processKey, diagramSuffix);
-      if (resources.containsKey(processDiagramResource)) {
-        return processDiagramResource;
-      } else if (resources.containsKey(diagramForBpmnFileResource)) {
-        return diagramForBpmnFileResource;
+  protected Map<ProcessDefinitionEntity, ProcessDefinitionEntity> getPreviousVersionsOfProcessDefinitions(
+      ExpandedDeployment expandedDeployment) {
+    Map<ProcessDefinitionEntity, ProcessDefinitionEntity> result = new LinkedHashMap<ProcessDefinitionEntity, ProcessDefinitionEntity>();
+    
+    for (ProcessDefinitionEntity newDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      ProcessDefinitionEntity existingDefinition = deploymentUtility.getMostRecentVersionOfProcessDefinition(newDefinition);
+      
+      if (existingDefinition != null) {
+        result.put(newDefinition, existingDefinition);
       }
     }
-    return null;
+    
+    return result;
   }
+  
+  /**
+   * Sets the version on each process definition entity, and the identifier.  If the map contains
+   * an older version for a process definition, then the version is set to that older entity's
+   * version plus one; otherwise it is set to 1.  Also dispatches an ENTITY_CREATED event.
+   */
+  protected void setProcessDefinitionVersionsAndIds(ExpandedDeployment expandedDeployment,
+      Map<ProcessDefinitionEntity, ProcessDefinitionEntity> mapNewToOldProcessDefinitions) {
+    CommandContext commandContext = Context.getCommandContext();
 
-  protected String getBpmnFileImageResourceName(String bpmnFileResource, String diagramSuffix) {
-    String bpmnFileResourceBase = stripBpmnFileSuffix(bpmnFileResource);
-    return bpmnFileResourceBase + diagramSuffix;
-  }
-
-  protected String getProcessImageResourceName(String bpmnFileResource, String processKey, String diagramSuffix) {
-    String bpmnFileResourceBase = stripBpmnFileSuffix(bpmnFileResource);
-    return bpmnFileResourceBase + processKey + "." + diagramSuffix;
-  }
-
-  protected String stripBpmnFileSuffix(String bpmnFileResource) {
-    for (String suffix : BPMN_RESOURCE_SUFFIXES) {
-      if (bpmnFileResource.endsWith(suffix)) {
-        return bpmnFileResource.substring(0, bpmnFileResource.length() - suffix.length());
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      int version = 1;
+      
+      ProcessDefinitionEntity latest = mapNewToOldProcessDefinitions.get(processDefinition);
+      if (latest != null) {
+        version = latest.getVersion() + 1;
+      }
+      
+      processDefinition.setVersion(version);
+      processDefinition.setId(getIdForNewProcessDefinition(processDefinition));
+      
+      if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
+        commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_CREATED, processDefinition));
       }
     }
-    return bpmnFileResource;
   }
+  
+  /**
+   * Saves each process definition.  It is assumed that the deployment is new, the definitions
+   * have never been saved before, and that they have all their values properly set up.  Also
+   * dispatches an ENTITY_INITIALIZED event.
+   */
+  protected void persistProcessDefinitionsAndAuthorizations(ExpandedDeployment expandedDeployment) {
+    CommandContext commandContext = Context.getCommandContext();
+    ProcessDefinitionEntityManager processDefinitionManager = commandContext.getProcessDefinitionEntityManager();
+    
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      processDefinitionManager.insert(processDefinition, false);
+      
+      deploymentUtility.addAuthorizationsForNewProcessDefinition(processDefinition);
 
-  protected void createResource(ResourceEntityManager resourceEntityManager, String name, byte[] bytes, DeploymentEntity deploymentEntity) {
-    ResourceEntity resource = resourceEntityManager.create();
-    resource.setName(name);
-    resource.setBytes(bytes);
-    resource.setDeploymentId(deploymentEntity.getId());
-
-    // Mark the resource as 'generated'
-    resource.setGenerated(true);
-
-    resourceEntityManager.insert(resource, false);
-  }
-
-  protected boolean isBpmnResource(String resourceName) {
-    for (String suffix : BPMN_RESOURCE_SUFFIXES) {
-      if (resourceName.endsWith(suffix)) {
-        return true;
+      if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
+        commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_INITIALIZED, processDefinition));
       }
     }
-    return false;
   }
-
-  public ExpressionManager getExpressionManager() {
-    return expressionManager;
+  
+  protected void updateTimersAndEvents(ExpandedDeployment expandedDeployment, 
+      Map<ProcessDefinitionEntity, ProcessDefinitionEntity> mapNewToOldProcessDefinitions) {
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      deploymentUtility.updateTimersAndEvents(processDefinition,
+          mapNewToOldProcessDefinitions.get(processDefinition),
+          expandedDeployment);
+    }
   }
-
-  public void setExpressionManager(ExpressionManager expressionManager) {
-    this.expressionManager = expressionManager;
+  
+  /**
+   * Returns the ID to use for a new process definition; subclasses may override this to provide
+   * their own identification scheme.
+   */
+  protected String getIdForNewProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    String nextId = idGenerator.getNextId();
+    
+    String result = processDefinition.getKey() + ":" + processDefinition.getVersion() + ":" + nextId; // ACT-505
+    // ACT-115: maximum id length is 64 characters
+    if (result.length() > 64) {
+      result = nextId;
+    }
+    
+    return result;
   }
+  
+  /**
+   * Loads the persisted version of each process definition and set values on the in-memory
+   * version to be consistent.
+   */
+  protected void makeProcessDefinitionsConsistentWithPersistedVersions(ExpandedDeployment expandedDeployment) {
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      ProcessDefinitionEntity persistedProcessDefinition = 
+          deploymentUtility.getPersistedInstanceOfProcessDefinition(processDefinition);
 
-  public BpmnParser getBpmnParser() {
-    return bpmnParser;
+      if (persistedProcessDefinition != null) {
+        processDefinition.setId(persistedProcessDefinition.getId());
+        processDefinition.setVersion(persistedProcessDefinition.getVersion());
+        processDefinition.setSuspensionState(persistedProcessDefinition.getSuspensionState());
+      }
+    }
   }
-
-  public void setBpmnParser(BpmnParser bpmnParser) {
-    this.bpmnParser = bpmnParser;
-  }
-
+  
   public IdGenerator getIdGenerator() {
     return idGenerator;
   }
@@ -589,4 +232,35 @@ public class BpmnDeployer implements Deployer {
     this.idGenerator = idGenerator;
   }
 
+  public ExpandedDeployment.BuilderFactory getExpandedDeploymentBuilderFactory() {
+    return expandedDeploymentBuilderFactory;
+  }
+  
+  public void setExpandedDeploymentBuilderFactory(ExpandedDeployment.BuilderFactory factory) {
+    this.expandedDeploymentBuilderFactory = factory;
+  }
+  
+  public BpmnDeploymentUtilities getBpmnDeploymentUtilities() {
+    return deploymentUtility;
+  }
+  
+  public void setBpmnDeploymentUtilities(BpmnDeploymentUtilities bpmnDeploymentUtilities) {
+    this.deploymentUtility = bpmnDeploymentUtilities;
+  }
+  
+  public CachingAndArtifactsManager getCachingAndArtifcatsManager() {
+    return cachingAndArtifactsManager;
+  }
+  
+  public void setCachingAndArtifactsManager(CachingAndArtifactsManager manager) {
+    this.cachingAndArtifactsManager = manager;
+  }
+  
+  public ProcessDefinitionDiagrammer getProcessDefinitionDiagrammer() {
+    return processDefinitionDiagrammer;
+  }
+  
+  public void setProcessDefinitionDiagrammer(ProcessDefinitionDiagrammer processDefinitionDiagrammer) {
+    this.processDefinitionDiagrammer = processDefinitionDiagrammer;
+  }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeploymentUtilities.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeploymentUtilities.java
@@ -1,0 +1,210 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Process;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
+import org.activiti.engine.impl.persistence.entity.IdentityLinkEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntityManager;
+import org.activiti.engine.task.IdentityLinkType;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Methods for working with deployments.  Much of the actual work of {@link BpmnDeployer} is
+ * done by orchestrating the different pieces of work this class does; by having them here,
+ * we allow other deployers to make use of them.   
+ */
+public class BpmnDeploymentUtilities  {
+  protected TimerManager timerManager;
+  protected EventSubscriptionManager eventSubscriptionManager;
+  
+  /**
+   * Verifies that no two process definitions share the same key, to prevent database unique
+   * index violation.
+   * 
+   * @throws ActivitiException if any two processes have the same key
+   */
+  public void verifyProcessDefinitionsDoNotShareKeys(
+      Collection<ProcessDefinitionEntity> processDefinitions) {
+    Set<String> keySet = new LinkedHashSet<String>();
+    for (ProcessDefinitionEntity processDefinition : processDefinitions) {
+      if (keySet.contains(processDefinition.getKey())) {
+        throw new ActivitiException(
+            "The deployment contains process definitions with the same key (process id attribute), this is not allowed");
+      }
+      keySet.add(processDefinition.getKey());
+    }
+  }
+
+  /**
+   * Updates all the process definition entities to match the deployment's values for tenant,
+   * engine version, and deployment id.
+   */
+  public void copyDeploymentValuesToProcessDefinitions(DeploymentEntity deployment,
+      List<ProcessDefinitionEntity> processDefinitions) {
+    String engineVersion = deployment.getEngineVersion();
+    String tenantId = deployment.getTenantId();
+    String deploymentId = deployment.getId();
+
+    for (ProcessDefinitionEntity processDefinition : processDefinitions) {
+      // Backwards compatibility
+      if (engineVersion != null) {
+        processDefinition.setEngineVersion(engineVersion);
+      }
+
+      if (tenantId != null) {
+        processDefinition.setTenantId(tenantId); // process definition inherits the tenant id
+      }
+
+      processDefinition.setDeploymentId(deploymentId);
+    }
+  }
+
+  /**
+   * Updates all the process definition entities to have the correct resource names.
+   */
+  public void setResourceNamesOnProcessDefinitions(ExpandedDeployment expandedDeployment) {
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      String resourceName = expandedDeployment.getResourceForProcessDefinition(processDefinition).getName();
+      processDefinition.setResourceName(resourceName);
+    }
+  }
+
+  /**
+   * Gets the most recent persisted process definition that matches this one for tenant and key.
+   * If none is found, returns null.  This method assumes that the tenant and key are properly
+   * set on the process definition entity.
+   */
+  public ProcessDefinitionEntity getMostRecentVersionOfProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    String key = processDefinition.getKey();
+    String tenantId = processDefinition.getTenantId();
+    ProcessDefinitionEntityManager processDefinitionManager = Context.getCommandContext().getProcessEngineConfiguration().getProcessDefinitionEntityManager();
+
+    ProcessDefinitionEntity existingDefinition = null;
+
+    if (tenantId != null && !tenantId.equals(ProcessEngineConfiguration.NO_TENANT_ID)) {
+      existingDefinition = processDefinitionManager.findLatestProcessDefinitionByKeyAndTenantId(key, tenantId);
+    } else {
+      existingDefinition = processDefinitionManager.findLatestProcessDefinitionByKey(key);
+    }
+
+    return existingDefinition;
+  }
+
+  /**
+   * Gets the persisted version of the already-deployed process definition.  Note that this is
+   * different from {@link #getMostRecentVersionOfProcessDefinition} as it looks specifically for
+   * a process definition that is already persisted and attached to a particular deployment,
+   * rather than the latest version across all deployments.
+   */
+  public ProcessDefinitionEntity getPersistedInstanceOfProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    String deploymentId = processDefinition.getDeploymentId();
+    if (StringUtils.isEmpty(processDefinition.getDeploymentId())) {
+      throw new IllegalStateException("Provided process definition must have a deployment id.");
+    }
+
+    ProcessDefinitionEntityManager processDefinitionManager = Context.getCommandContext().getProcessEngineConfiguration().getProcessDefinitionEntityManager();
+    ProcessDefinitionEntity persistedProcessDefinition = null;
+    if (processDefinition.getTenantId() == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(processDefinition.getTenantId())) {
+      persistedProcessDefinition = processDefinitionManager.findProcessDefinitionByDeploymentAndKey(deploymentId, processDefinition.getKey());
+    } else {
+      persistedProcessDefinition = processDefinitionManager.findProcessDefinitionByDeploymentAndKeyAndTenantId(deploymentId, processDefinition.getKey(), processDefinition.getTenantId());
+    }
+
+    return persistedProcessDefinition;
+  }
+
+  /**
+   * Updates all timers and events for the process definition.  This removes obsolete message and signal
+   * subscriptions and timers, and adds new ones.
+   */
+  public void updateTimersAndEvents(ProcessDefinitionEntity processDefinition, 
+      ProcessDefinitionEntity previousProcessDefinition, ExpandedDeployment expandedDeployment) {
+    Process process = expandedDeployment.getProcessModelForProcessDefinition(processDefinition);
+    BpmnModel bpmnModel = expandedDeployment.getBpmnModelForProcessDefinition(processDefinition);
+
+    eventSubscriptionManager.removeObsoleteMessageEventSubscriptions(previousProcessDefinition);
+    eventSubscriptionManager.addMessageEventSubscriptions(processDefinition, process, bpmnModel);
+
+    eventSubscriptionManager.removeObsoleteSignalEventSubScription(previousProcessDefinition);
+    eventSubscriptionManager.addSignalEventSubscriptions(Context.getCommandContext(), processDefinition, process, bpmnModel);
+
+    timerManager.removeObsoleteTimers(processDefinition);
+    timerManager.scheduleTimers(processDefinition, process);
+  }
+
+  enum ExprType {
+    USER, GROUP
+  }
+
+  /**
+   * @param processDefinition
+   */
+  public void addAuthorizationsForNewProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    CommandContext commandContext = Context.getCommandContext();
+    addAuthorizationsFromIterator(commandContext, processDefinition.getCandidateStarterUserIdExpressions(), processDefinition, ExprType.USER);
+    addAuthorizationsFromIterator(commandContext, processDefinition.getCandidateStarterGroupIdExpressions(), processDefinition, ExprType.GROUP);
+  }
+  
+  private void addAuthorizationsFromIterator(CommandContext commandContext, 
+      Set<Expression> exprSet, 
+      ProcessDefinitionEntity processDefinition, 
+      ExprType exprType) {
+    if (exprSet != null) {
+      Iterator<Expression> iterator = exprSet.iterator();
+      while (iterator.hasNext()) {
+        @SuppressWarnings("cast")
+        Expression expr = (Expression) iterator.next();
+        IdentityLinkEntity identityLink = commandContext.getIdentityLinkEntityManager().create();
+        identityLink.setProcessDef(processDefinition);
+        if (exprType.equals(ExprType.USER)) {
+          identityLink.setUserId(expr.toString());
+        } else if (exprType.equals(ExprType.GROUP)) {
+          identityLink.setGroupId(expr.toString());
+        }
+        identityLink.setType(IdentityLinkType.CANDIDATE);
+        commandContext.getIdentityLinkEntityManager().insert(identityLink);
+      }
+    }
+  }
+
+  public TimerManager getTimerManager() {
+    return timerManager;
+  }
+
+  public void setTimerManager(TimerManager timerManager) {
+    this.timerManager = timerManager;
+  }
+
+  public EventSubscriptionManager getEventSubscriptionManager() {
+    return eventSubscriptionManager;
+  }
+
+  public void setEventSubscriptionManager(EventSubscriptionManager eventSubscriptionManager) {
+    this.eventSubscriptionManager = eventSubscriptionManager;
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/CachingAndArtifactsManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/CachingAndArtifactsManager.java
@@ -1,0 +1,101 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Process;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.deploy.DeploymentCache;
+import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
+import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
+import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionInfoCacheObject;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntityManager;
+
+/**
+ * Updates caches and artifacts for a deployment, its process definitions, and its process definition
+ * infos.
+ */
+public class CachingAndArtifactsManager {
+  /**
+   * Ensures that the process definition is cached in the appropriate places, including the
+   * deployment's collection of deployed artifacts and the deployment manager's cache, as well
+   * as caching any ProcessDefinitionInfos.
+   */
+  public void updateCachingAndArtifacts(ExpandedDeployment expandedDeployment) {
+    CommandContext commandContext = Context.getCommandContext();
+    final ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
+    DeploymentCache<ProcessDefinitionCacheEntry> processDefinitionCache = processEngineConfiguration.getDeploymentManager().getProcessDefinitionCache();
+    DeploymentEntity deployment = expandedDeployment.getDeployment();
+
+    for (ProcessDefinitionEntity processDefinition : expandedDeployment.getAllProcessDefinitions()) {
+      BpmnModel bpmnModel = expandedDeployment.getBpmnModelForProcessDefinition(processDefinition);
+      Process process = expandedDeployment.getProcessModelForProcessDefinition(processDefinition);
+      ProcessDefinitionCacheEntry cacheEntry = new ProcessDefinitionCacheEntry(processDefinition, bpmnModel, process);
+      processDefinitionCache.add(processDefinition.getId(), cacheEntry);
+      addDefinitionInfoToCache(processDefinition, processEngineConfiguration, commandContext);
+    
+      // Add to deployment for further usage
+      deployment.addDeployedArtifact(processDefinition);
+    }
+  }
+
+  protected void addDefinitionInfoToCache(ProcessDefinitionEntity processDefinition, 
+      ProcessEngineConfigurationImpl processEngineConfiguration, CommandContext commandContext) {
+    
+    if (processEngineConfiguration.isEnableProcessDefinitionInfoCache() == false) {
+      return;
+    }
+    
+    DeploymentManager deploymentManager = processEngineConfiguration.getDeploymentManager();
+    ProcessDefinitionInfoEntityManager definitionInfoEntityManager = commandContext.getProcessDefinitionInfoEntityManager();
+    ObjectMapper objectMapper = commandContext.getProcessEngineConfiguration().getObjectMapper();
+    ProcessDefinitionInfoEntity definitionInfoEntity = definitionInfoEntityManager.findProcessDefinitionInfoByProcessDefinitionId(processDefinition.getId());
+    
+    ObjectNode infoNode = null;
+    if (definitionInfoEntity != null && definitionInfoEntity.getInfoJsonId() != null) {
+      byte[] infoBytes = definitionInfoEntityManager.findInfoJsonById(definitionInfoEntity.getInfoJsonId());
+      if (infoBytes != null) {
+        try {
+          infoNode = (ObjectNode) objectMapper.readTree(infoBytes);
+        } catch (Exception e) {
+          throw new ActivitiException("Error deserializing json info for process definition " + processDefinition.getId());
+        }
+      }
+    }
+    
+    ProcessDefinitionInfoCacheObject definitionCacheObject = new ProcessDefinitionInfoCacheObject();
+    if (definitionInfoEntity == null) {
+      definitionCacheObject.setRevision(0);
+    } else {
+      definitionCacheObject.setId(definitionInfoEntity.getId());
+      definitionCacheObject.setRevision(definitionInfoEntity.getRevision());
+    }
+    
+    if (infoNode == null) {
+      infoNode = objectMapper.createObjectNode();
+    }
+    definitionCacheObject.setInfoNode(infoNode);
+    
+    deploymentManager.getProcessDefinitionInfoCache().add(processDefinition.getId(), definitionCacheObject);
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/EventSubscriptionManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/EventSubscriptionManager.java
@@ -1,0 +1,150 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.Message;
+import org.activiti.bpmn.model.MessageEventDefinition;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.Signal;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.event.MessageEventHandler;
+import org.activiti.engine.impl.event.SignalEventHandler;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
+import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManager;
+import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.SignalEventSubscriptionEntity;
+import org.apache.commons.collections.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * Manages event subscriptions for newly-deployed process definitions and their previous versions.
+ */
+public class EventSubscriptionManager {
+  protected void removeObsoleteEventSubscriptionsImpl(ProcessDefinitionEntity processDefinition, String eventHandlerType) {
+    // remove all subscriptions for the previous version
+      CommandContext commandContext = Context.getCommandContext();
+
+      EventSubscriptionEntityManager eventSubscriptionEntityManager = commandContext.getEventSubscriptionEntityManager();
+      List<EventSubscriptionEntity> subscriptionsToDelete = eventSubscriptionEntityManager.findEventSubscriptionsByConfiguration(eventHandlerType,
+          processDefinition.getId(), processDefinition.getTenantId());
+
+      for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsToDelete) {
+        eventSubscriptionEntityManager.delete(eventSubscriptionEntity);
+      }
+    }
+
+  protected void removeObsoleteMessageEventSubscriptions(ProcessDefinitionEntity previousProcessDefinition) {
+    // remove all subscriptions for the previous version
+    if (previousProcessDefinition != null) {
+      removeObsoleteEventSubscriptionsImpl(previousProcessDefinition, MessageEventHandler.EVENT_HANDLER_TYPE);
+    }
+  }
+
+  protected void removeObsoleteSignalEventSubScription(ProcessDefinitionEntity previousProcessDefinition) {
+    // remove all subscriptions for the previous version
+    if (previousProcessDefinition != null) {
+      removeObsoleteEventSubscriptionsImpl(previousProcessDefinition, SignalEventHandler.EVENT_HANDLER_TYPE);
+    }
+  }
+
+  protected void addMessageEventSubscriptions(ProcessDefinitionEntity processDefinition, Process process, BpmnModel bpmnModel) {
+    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
+      for (FlowElement element : process.getFlowElements()) {
+        if (element instanceof StartEvent) {
+          StartEvent startEvent = (StartEvent) element;
+          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
+            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
+            if (eventDefinition instanceof MessageEventDefinition) {
+              MessageEventDefinition messageEventDefinition = (MessageEventDefinition) eventDefinition;
+              insertMessageEvent(messageEventDefinition, startEvent, processDefinition, bpmnModel);
+            }
+          }
+        } 
+      }
+    }
+  }
+
+  protected void insertMessageEvent(MessageEventDefinition messageEventDefinition, StartEvent startEvent, ProcessDefinitionEntity processDefinition, BpmnModel bpmnModel) {
+    CommandContext commandContext = Context.getCommandContext();
+    if (bpmnModel.containsMessageId(messageEventDefinition.getMessageRef())) {
+      Message message = bpmnModel.getMessage(messageEventDefinition.getMessageRef());
+      messageEventDefinition.setMessageRef(message.getName());
+    }
+
+    // look for subscriptions for the same name in db:
+    List<EventSubscriptionEntity> subscriptionsForSameMessageName = commandContext.getEventSubscriptionEntityManager()
+        .findEventSubscriptionsByName(MessageEventHandler.EVENT_HANDLER_TYPE, messageEventDefinition.getMessageRef(), processDefinition.getTenantId());
+
+
+    for (EventSubscriptionEntity eventSubscriptionEntity : subscriptionsForSameMessageName) {
+      // throw exception only if there's already a subscription as start event
+      if (eventSubscriptionEntity.getProcessInstanceId() == null || eventSubscriptionEntity.getProcessInstanceId().isEmpty()) { // processInstanceId != null or not empty -> it's a message related to an execution
+        // the event subscription has no instance-id, so it's a message start event
+        throw new ActivitiException("Cannot deploy process definition '" + processDefinition.getResourceName()
+        + "': there already is a message event subscription for the message with name '" + messageEventDefinition.getMessageRef() + "'.");
+      }
+    }
+
+    MessageEventSubscriptionEntity newSubscription = commandContext.getEventSubscriptionEntityManager().createMessageEventSubscription();
+    newSubscription.setEventName(messageEventDefinition.getMessageRef());
+    newSubscription.setActivityId(startEvent.getId());
+    newSubscription.setConfiguration(processDefinition.getId());
+    newSubscription.setProcessDefinitionId(processDefinition.getId());
+
+    if (processDefinition.getTenantId() != null) {
+      newSubscription.setTenantId(processDefinition.getTenantId());
+    }
+
+    commandContext.getEventSubscriptionEntityManager().insert(newSubscription);
+  }
+
+  protected void addSignalEventSubscriptions(CommandContext commandContext, ProcessDefinitionEntity processDefinition, org.activiti.bpmn.model.Process process, BpmnModel bpmnModel) {
+    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
+      for (FlowElement element : process.getFlowElements()) {
+        if (element instanceof StartEvent) {
+          StartEvent startEvent = (StartEvent) element;
+          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
+            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
+            if (eventDefinition instanceof SignalEventDefinition) {
+              SignalEventDefinition signalEventDefinition = (SignalEventDefinition) eventDefinition;
+              SignalEventSubscriptionEntity subscriptionEntity = commandContext.getEventSubscriptionEntityManager().createSignalEventSubscription();
+              Signal signal = bpmnModel.getSignal(signalEventDefinition.getSignalRef());
+              if (signal != null) {
+                subscriptionEntity.setEventName(signal.getName());
+              } else {
+                subscriptionEntity.setEventName(signalEventDefinition.getSignalRef());
+              }
+              subscriptionEntity.setActivityId(startEvent.getId());
+              subscriptionEntity.setProcessDefinitionId(processDefinition.getId());
+              if (processDefinition.getTenantId() != null) {
+                subscriptionEntity.setTenantId(processDefinition.getTenantId());
+              }
+
+              Context.getCommandContext().getEventSubscriptionEntityManager().insert(subscriptionEntity);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ExpandedDeployment.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ExpandedDeployment.java
@@ -1,0 +1,181 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Process;
+import org.activiti.engine.impl.bpmn.parser.BpmnParse;
+import org.activiti.engine.impl.bpmn.parser.BpmnParser;
+import org.activiti.engine.impl.cmd.DeploymentSettings;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ResourceEntity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An intermediate representation of a DeploymentEntity which keeps track of all of the entity's
+ * ProcessDefinitionEntities and resources, and BPMN parses, models, and processes associated
+ * with each ProcessDefinitionEntity.  The ProcessDefinitionEntities are expected to be
+ * "not fully set-up" - they may be inconsistent with the DeploymentEntity and/or the persisted
+ * versions, and if the deployment is new, they will not yet be persisted.
+ */
+public class ExpandedDeployment {
+  private static final Logger log = LoggerFactory.getLogger(BpmnDeployer.class);
+
+  private DeploymentEntity deploymentEntity;
+
+  private List<ProcessDefinitionEntity> processDefinitions;
+  private Map<ProcessDefinitionEntity, BpmnParse> mapProcessDefinitionsToParses;
+  private Map<ProcessDefinitionEntity, ResourceEntity> mapProcessDefinitionsToResources;
+  
+  private ExpandedDeployment(
+      DeploymentEntity entity, List<ProcessDefinitionEntity> processDefinitions,
+      Map<ProcessDefinitionEntity, BpmnParse> mapProcessDefinitionsToParses,
+      Map<ProcessDefinitionEntity, ResourceEntity> mapProcessDefinitionsToResources) {
+    this.deploymentEntity = entity;
+    this.processDefinitions = processDefinitions;
+    this.mapProcessDefinitionsToParses = mapProcessDefinitionsToParses;
+    this.mapProcessDefinitionsToResources = mapProcessDefinitionsToResources;
+  }
+
+  
+  public DeploymentEntity getDeployment() {
+    return deploymentEntity;
+  }
+
+  public List<ProcessDefinitionEntity> getAllProcessDefinitions() {
+    return processDefinitions;
+  }
+
+  public ResourceEntity getResourceForProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    return mapProcessDefinitionsToResources.get(processDefinition);
+  }
+
+  public BpmnParse getBpmnParseForProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    return mapProcessDefinitionsToParses.get(processDefinition);
+  }
+
+  public BpmnModel getBpmnModelForProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    BpmnParse parse = getBpmnParseForProcessDefinition(processDefinition);
+    
+    return (parse == null ? null : parse.getBpmnModel());
+  }
+  
+  public Process getProcessModelForProcessDefinition(ProcessDefinitionEntity processDefinition) {
+    BpmnModel model = getBpmnModelForProcessDefinition(processDefinition);
+
+    return (model == null ? null : model.getProcessById(processDefinition.getKey()));
+  }
+  
+  public static class Builder {
+    private final DeploymentEntity deployment;
+    private final BpmnParser bpmnParser;
+    private final Map<String, Object> deploymentSettings;
+
+    public Builder(DeploymentEntity deployment, BpmnParser bpmnParser, Map<String, Object> deploymentSettings) {
+      this.deployment = deployment;
+      this.bpmnParser = bpmnParser;
+      this.deploymentSettings = deploymentSettings;
+    }
+
+    public ExpandedDeployment build() {
+      List<ProcessDefinitionEntity> processDefinitions = new ArrayList<ProcessDefinitionEntity>();
+      Map<ProcessDefinitionEntity, BpmnParse> mapProcessDefinitionsToParses = new LinkedHashMap<ProcessDefinitionEntity, BpmnParse>();
+      Map<ProcessDefinitionEntity, ResourceEntity> mapProcessDefinitionsToResources = new LinkedHashMap<ProcessDefinitionEntity, ResourceEntity>();
+
+      for (ResourceEntity resource : deployment.getResources().values()) {
+        if (isBpmnResource(resource.getName())) {
+          log.debug("Processing BPMN resource {}", resource.getName());
+          BpmnParse parse = createExecutedBpmnParseFromResource(resource);
+          for (ProcessDefinitionEntity oneDefinition : parse.getProcessDefinitions()) {
+            processDefinitions.add(oneDefinition);
+            mapProcessDefinitionsToParses.put(oneDefinition, parse);
+            mapProcessDefinitionsToResources.put(oneDefinition, resource);
+          }
+        }
+      }
+
+      return new ExpandedDeployment(deployment,processDefinitions, mapProcessDefinitionsToParses, mapProcessDefinitionsToResources);
+    }
+    
+    private BpmnParse createExecutedBpmnParseFromResource(ResourceEntity resource) {
+      String resourceName = resource.getName();
+      ByteArrayInputStream inputStream = new ByteArrayInputStream(resource.getBytes());
+
+      BpmnParse bpmnParse = bpmnParser.createParse()
+          .sourceInputStream(inputStream)
+          .setSourceSystemId(resourceName)
+          .deployment(deployment)
+          .name(resourceName);
+
+      if (deploymentSettings != null) {
+
+        // Schema validation if needed
+        if (deploymentSettings.containsKey(DeploymentSettings.IS_BPMN20_XSD_VALIDATION_ENABLED)) {
+          bpmnParse.setValidateSchema((Boolean) deploymentSettings.get(DeploymentSettings.IS_BPMN20_XSD_VALIDATION_ENABLED));
+        }
+
+        // Process validation if needed
+        if (deploymentSettings.containsKey(DeploymentSettings.IS_PROCESS_VALIDATION_ENABLED)) {
+          bpmnParse.setValidateProcess((Boolean) deploymentSettings.get(DeploymentSettings.IS_PROCESS_VALIDATION_ENABLED));
+        }
+
+      } else {
+        // On redeploy, we assume it is validated at the first
+        // deploy
+        bpmnParse.setValidateSchema(false);
+        bpmnParse.setValidateProcess(false);
+      }
+      bpmnParse.execute();
+      return bpmnParse;
+    }
+  }
+  
+  public static class BuilderFactory {
+    protected BpmnParser bpmnParser;
+    
+    public BpmnParser getBpmnParser() {
+      return bpmnParser;
+    }
+    
+    public void setBpmnParser(BpmnParser bpmnParser) {
+      this.bpmnParser = bpmnParser;
+    }
+    
+    public Builder getBuilderForDeployment(DeploymentEntity deployment) {
+      return getBuilderForDeploymentAndSettings(deployment, null);
+    }
+    
+    public Builder getBuilderForDeploymentAndSettings(DeploymentEntity deployment, Map<String, Object> deploymentSettings) {
+      return new Builder(deployment, bpmnParser, deploymentSettings);
+    }
+  }
+    
+  private static boolean isBpmnResource(String resourceName) {
+    for (String suffix : ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES) {
+      if (resourceName.endsWith(suffix)) {
+        return true;
+      }
+    }
+     
+    return false;
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ProcessDefinitionDiagrammer.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ProcessDefinitionDiagrammer.java
@@ -1,0 +1,82 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.impl.bpmn.parser.BpmnParse;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ResourceEntity;
+import org.activiti.engine.impl.util.IoUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Creates diagrams from process definitions.
+ */
+public class ProcessDefinitionDiagrammer {
+  private static final Logger log = LoggerFactory.getLogger(ProcessDefinitionDiagrammer.class);
+  /**
+   * Generates a diagram resource for a ProcessDefinitionEntity and associated BpmnParse.  The
+   * returned resource has not yet been persisted, nor attached to the ProcessDefinitionEntity.
+   * This requires that the ProcessDefinitionEntity have its key and resource name already set.
+   * The caller must determine whether creating a diagram for this process definition is appropriate
+   * or not.
+   */
+  public ResourceEntity createDiagramForProcessDefinition(ProcessDefinitionEntity processDefinition, BpmnParse bpmnParse) {
+    if (StringUtils.isEmpty(processDefinition.getKey()) || StringUtils.isEmpty(processDefinition.getResourceName())) {
+      throw new IllegalStateException("Provided process definition must have both key and resource name set.");
+    }
+    
+    ResourceEntity resource = createResourceEntity();
+    ProcessEngineConfiguration processEngineConfiguration = Context.getCommandContext().getProcessEngineConfiguration();
+    try {
+      byte[] diagramBytes = IoUtil.readInputStream(
+          processEngineConfiguration.getProcessDiagramGenerator().generateDiagram(bpmnParse.getBpmnModel(), "png",
+              processEngineConfiguration.getActivityFontName(),
+              processEngineConfiguration.getLabelFontName(),
+              processEngineConfiguration.getClassLoader()), null);
+        String diagramResourceName = ResourceNameUtilities.getProcessImageResourceName(
+            processDefinition.getResourceName(), processDefinition.getKey(), "png");
+        
+        resource.setName(diagramResourceName);
+        resource.setBytes(diagramBytes);
+        resource.setDeploymentId(processDefinition.getDeploymentId());
+
+        // Mark the resource as 'generated'
+        resource.setGenerated(true);
+    } catch (Throwable t) { // if anything goes wrong, we don't store the image (the process will still be executable).
+      log.warn("Error while generating process diagram, image will not be stored in repository", t);
+      resource = null;
+    }
+    
+    return resource;
+  }
+  
+  protected ResourceEntity createResourceEntity() {
+    return Context.getCommandContext().getProcessEngineConfiguration().getResourceEntityManager().create();
+  }
+  
+  public boolean shouldCreateDiagram(ProcessDefinitionEntity processDefinition,
+      DeploymentEntity deployment) {
+    if (deployment.isNew() && processDefinition.isGraphicalNotationDefined()
+        && Context.getCommandContext().getProcessEngineConfiguration().isCreateDiagramOnDeploy()) {
+      return null == ResourceNameUtilities.getDiagramResourceName(processDefinition, deployment.getResources());
+    }
+    
+    return false;
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ResourceNameUtilities.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/ResourceNameUtilities.java
@@ -1,0 +1,85 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ResourceEntity;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Static methods for working with BPMN and image resource names.
+ */
+public class ResourceNameUtilities {
+  public static final String[] BPMN_RESOURCE_SUFFIXES = new String[] { "bpmn20.xml", "bpmn" };
+  public static final String[] DIAGRAM_SUFFIXES = new String[] { "png", "jpg", "gif", "svg" };
+
+  public static String stripBpmnFileSuffix(String bpmnFileResource) {
+    for (String suffix : BPMN_RESOURCE_SUFFIXES) {
+      if (bpmnFileResource.endsWith(suffix)) {
+        return bpmnFileResource.substring(0, bpmnFileResource.length() - suffix.length());
+      }
+    }
+    return bpmnFileResource;
+  }
+
+  public static String getProcessImageResourceName(String bpmnFileResource, String processKey, String diagramSuffix) {
+    String bpmnFileResourceBase = ResourceNameUtilities.stripBpmnFileSuffix(bpmnFileResource);
+    return bpmnFileResourceBase + processKey + "." + diagramSuffix;
+  }
+  
+  /**
+   * Finds the name of a resource for the diagram for a process definition.  Assumes that the
+   * process definition's key and (BPMN) resource name are already set.
+   *
+   * <p>It will first look for an image resource which matches the process specifically, before
+   * resorting to an image resource which matches the BPMN 2.0 xml file resource.
+   *
+   * <p>Example: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml'
+   * containing only one process with key 'myProcess', then this method will look for an image resources
+   * called'abc.myProcess.png' (or .jpg, or .gif, etc.) or 'abc.png' if the previous one wasn't
+   * found.
+   *
+   * <p>Example 2: if the deployment contains a BPMN 2.0 xml resource called 'abc.bpmn20.xml'
+   * containing three processes (with keys a, b and c), then this method will first look for an image resource
+   * called 'abc.a.png' before looking for 'abc.png' (likewise for b and c). Note that if abc.a.png,
+   * abc.b.png and abc.c.png don't exist, all processes will have the same image: abc.png.
+   *
+   * @return name of an existing resource, or null if no matching image resource is found.
+   */
+  public static String getDiagramResourceName(
+      ProcessDefinitionEntity processDefinition, Map<String, ResourceEntity> resources) {
+    if (StringUtils.isEmpty(processDefinition.getResourceName())) {
+      throw new IllegalStateException("Provided process definition must have its resource name set.");
+    }
+    
+    String bpmnResourceBase = stripBpmnFileSuffix(processDefinition.getResourceName());
+    String key = processDefinition.getKey();
+    
+    for (String diagramSuffix : DIAGRAM_SUFFIXES) {
+      String possibleName = bpmnResourceBase + key + "." + diagramSuffix;
+      if (resources.containsKey(possibleName)) {
+        return possibleName;
+      }
+      
+      possibleName = bpmnResourceBase + diagramSuffix;
+      if (resources.containsKey(possibleName)) {
+        return possibleName;
+      }
+    }
+    
+    return null;
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/TimerManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/TimerManager.java
@@ -1,0 +1,94 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.bpmn.deployer;
+
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.TimerEventDefinition;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.impl.cmd.CancelJobsCmd;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.jobexecutor.TimerEventHandler;
+import org.activiti.engine.impl.jobexecutor.TimerStartEventJobHandler;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.TimerEntity;
+import org.activiti.engine.impl.util.TimerUtil;
+import org.activiti.engine.runtime.Job;
+import org.apache.commons.collections.CollectionUtils;
+import org.activiti.bpmn.model.Process;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages timers for newly-deployed process definitions and their previous versions.
+ */
+public class TimerManager {
+  protected void removeObsoleteTimers(ProcessDefinitionEntity processDefinition) {
+    List<Job> jobsToDelete = null;
+
+    if (processDefinition.getTenantId() != null && !ProcessEngineConfiguration.NO_TENANT_ID.equals(processDefinition.getTenantId())) {
+      jobsToDelete = Context.getCommandContext().getJobEntityManager().findJobsByTypeAndProcessDefinitionKeyAndTenantId(
+          TimerStartEventJobHandler.TYPE, processDefinition.getKey(), processDefinition.getTenantId());
+    } else {
+      jobsToDelete = Context.getCommandContext().getJobEntityManager()
+          .findJobsByTypeAndProcessDefinitionKeyNoTenantId(TimerStartEventJobHandler.TYPE, processDefinition.getKey());
+    }
+
+    if (jobsToDelete != null) {
+      for (Job job :jobsToDelete) {
+        new CancelJobsCmd(job.getId()).execute(Context.getCommandContext());
+      }
+    }
+  }
+  
+  protected void scheduleTimers(ProcessDefinitionEntity processDefinition, Process process) {
+    List<TimerEntity> timers = getTimerDeclarations(processDefinition, process);
+    for (TimerEntity timer : timers) {
+      Context.getCommandContext().getJobEntityManager().schedule(timer);
+    }
+  }
+  
+  protected List<TimerEntity> getTimerDeclarations(ProcessDefinitionEntity processDefinition, Process process) {
+    List<TimerEntity> timers = new ArrayList<TimerEntity>();
+    if (CollectionUtils.isNotEmpty(process.getFlowElements())) {
+      for (FlowElement element : process.getFlowElements()) {
+        if (element instanceof StartEvent) {
+          StartEvent startEvent = (StartEvent) element;
+          if (CollectionUtils.isNotEmpty(startEvent.getEventDefinitions())) {
+            EventDefinition eventDefinition = startEvent.getEventDefinitions().get(0);
+            if (eventDefinition instanceof TimerEventDefinition) {
+              TimerEventDefinition timerEventDefinition = (TimerEventDefinition) eventDefinition;
+              TimerEntity timer = TimerUtil.createTimerEntityForTimerEventDefinition(timerEventDefinition, false, null, TimerStartEventJobHandler.TYPE,
+                  TimerEventHandler.createConfiguration(startEvent.getId(), timerEventDefinition.getEndDate()));
+
+              if (timer != null) {
+                timer.setProcessDefinitionId(processDefinition.getId());
+
+                if (processDefinition.getTenantId() != null) {
+                  timer.setTenantId(processDefinition.getTenantId());
+                }
+                timers.add(timer);
+              }
+
+            }
+          }
+        }
+      }
+    }
+
+    return timers;
+  }
+}
+

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/test/TestHelper.java
@@ -26,7 +26,7 @@ import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.impl.ProcessEngineImpl;
-import org.activiti.engine.impl.bpmn.deployer.BpmnDeployer;
+import org.activiti.engine.impl.bpmn.deployer.ResourceNameUtilities;
 import org.activiti.engine.impl.bpmn.parser.factory.ActivityBehaviorFactory;
 import org.activiti.engine.impl.db.DbSqlSession;
 import org.activiti.engine.impl.interceptor.Command;
@@ -191,7 +191,7 @@ public abstract class TestHelper {
    * parameter: <code>BpmnDeployer.BPMN_RESOURCE_SUFFIXES</code>. The first resource matching a suffix will be returned.
    */
   public static String getBpmnProcessDefinitionResource(Class<?> type, String name) {
-    for (String suffix : BpmnDeployer.BPMN_RESOURCE_SUFFIXES) {
+    for (String suffix : ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES) {
       String resource = type.getName().replace('.', '/') + "." + name + "." + suffix;
       InputStream inputStream = ReflectUtil.getResourceAsStream(resource);
       if (inputStream == null) {
@@ -200,7 +200,7 @@ public abstract class TestHelper {
         return resource;
       }
     }
-    return type.getName().replace('.', '/') + "." + name + "." + BpmnDeployer.BPMN_RESOURCE_SUFFIXES[0];
+    return type.getName().replace('.', '/') + "." + name + "." + ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES[0];
   }
 
   // Engine startup and shutdown helpers

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/deployment/ExpandedDeploymentTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/deployment/ExpandedDeploymentTest.java
@@ -1,0 +1,129 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.bpmn.deployment;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.sameInstance;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.activiti.engine.impl.bpmn.deployer.ResourceNameUtilities;
+import org.activiti.engine.impl.bpmn.deployer.ExpandedDeployment;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntity;
+import org.activiti.engine.impl.persistence.entity.DeploymentEntityImpl;
+import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
+import org.activiti.engine.impl.persistence.entity.ResourceEntity;
+import org.activiti.engine.impl.persistence.entity.ResourceEntityImpl;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+
+import java.util.List;
+
+public class ExpandedDeploymentTest extends PluggableActivitiTestCase {
+  private static final String NAMESPACE = "xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL'";
+  private static final String TARGET_NAMESPACE = "targetNamespace='http://activiti.org/BPMN20'";
+  
+  private static final String ID1_ID = "id1";
+  private static final String ID2_ID = "id2";
+  private static final String IDR_PROCESS_XML = aseembleXmlResourceString(
+      "<process id='" + ID1_ID + "' name='Insurance Damage Report 1' />",
+      "<process id='" + ID2_ID + "' name='Insurance Damager Report 2' />");
+  private static final String IDR_XML_NAME = "idr." + ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES[0];
+  
+  private static final String EN1_ID = "en1";
+  private static final String EN2_ID = "en2";
+  private static final String EN_PROCESS_XML = aseembleXmlResourceString(
+      "<process id='" + EN1_ID + "' name='Expense Note 1' />",
+      "<process id='" + EN2_ID + "' name='Expense Note 2' />");
+  private static final String EN_XML_NAME = "en." + ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES[1];
+      
+  @Override
+  public void setUp() {
+    Context.setCommandContext(processEngineConfiguration.getCommandContextFactory().createCommandContext(null));
+  }
+  
+  @Override
+  public void tearDown() {
+    Context.removeCommandContext();
+  }
+  
+  public void testCreateAndQuery() {
+    DeploymentEntity entity = assembleUnpersistedDeploymentEntity();
+
+    ExpandedDeployment.BuilderFactory builderFactory = processEngineConfiguration.getExpandedDeploymentBuilderFactory();
+    ExpandedDeployment.Builder builder = builderFactory.getBuilderForDeployment(entity);
+    ExpandedDeployment expanded = builder.build();
+    
+    List<ProcessDefinitionEntity> processDefinitions = expanded.getAllProcessDefinitions();
+    
+    assertThat(expanded.getDeployment(), sameInstance(entity));
+    assertThat(processDefinitions.size(), equalTo(4));
+
+    ProcessDefinitionEntity id1 = getProcessDefinitionEntityFromList(processDefinitions, ID1_ID);
+    ProcessDefinitionEntity id2 = getProcessDefinitionEntityFromList(processDefinitions, ID2_ID);
+    assertThat(expanded.getBpmnParseForProcessDefinition(id1), 
+        sameInstance(expanded.getBpmnParseForProcessDefinition(id2)));
+    assertThat(expanded.getBpmnModelForProcessDefinition(id1), sameInstance(expanded.getBpmnParseForProcessDefinition(id1).getBpmnModel()));
+    assertThat(expanded.getProcessModelForProcessDefinition(id1), sameInstance(expanded.getBpmnParseForProcessDefinition(id1).getBpmnModel().getProcessById(id1.getKey())));
+    assertThat(expanded.getResourceForProcessDefinition(id1).getName(), equalTo(IDR_XML_NAME));
+    assertThat(expanded.getResourceForProcessDefinition(id2).getName(), equalTo(IDR_XML_NAME));
+    
+    ProcessDefinitionEntity en1 = getProcessDefinitionEntityFromList(processDefinitions, EN1_ID);
+    ProcessDefinitionEntity en2 = getProcessDefinitionEntityFromList(processDefinitions, EN2_ID);
+    assertThat(expanded.getBpmnParseForProcessDefinition(en1), 
+        sameInstance(expanded.getBpmnParseForProcessDefinition(en2)));
+    assertThat(expanded.getBpmnParseForProcessDefinition(en1), not(equalTo(expanded.getBpmnParseForProcessDefinition(id2))));
+    assertThat(expanded.getResourceForProcessDefinition(en1).getName(), equalTo(EN_XML_NAME));
+    assertThat(expanded.getResourceForProcessDefinition(en2).getName(), equalTo(EN_XML_NAME));
+  }
+  
+  private ProcessDefinitionEntity getProcessDefinitionEntityFromList(List<ProcessDefinitionEntity> list, String idString) {
+    for (ProcessDefinitionEntity possible : list) {
+      if (possible.getKey().equals(idString)) {
+        return possible;
+      }
+    }
+    return null;
+  }
+  
+  private DeploymentEntity assembleUnpersistedDeploymentEntity() {
+    DeploymentEntity entity = new DeploymentEntityImpl();
+    entity.addResource(buildResource(IDR_XML_NAME, IDR_PROCESS_XML));
+    entity.addResource(buildResource(EN_XML_NAME, EN_PROCESS_XML));
+    return entity;
+  }
+  
+  private ResourceEntity buildResource(String name, String text) {
+    ResourceEntityImpl result = new ResourceEntityImpl();
+    result.setName(name);
+    result.setBytes(text.getBytes(UTF_8));
+    
+    return result;
+  }
+  
+  private static String aseembleXmlResourceString(String... definitions) {
+    StringBuilder builder = new StringBuilder("<definitions ");
+    builder = builder.append(NAMESPACE).append(" ").append(TARGET_NAMESPACE).append(">\n");
+    
+    for (String definition : definitions) {
+      builder = builder.append(definition).append("\n");
+    }
+    
+    builder = builder.append("</definitions>\n");
+    
+    return builder.toString();
+  }
+}
+

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/processdefinitions/ProcessDefinitionsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/processdefinitions/ProcessDefinitionsTest.java
@@ -19,7 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.activiti.engine.impl.bpmn.deployer.BpmnDeployer;
+import org.activiti.engine.impl.bpmn.deployer.ResourceNameUtilities;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.repository.ProcessDefinition;
 
@@ -148,7 +148,7 @@ public class ProcessDefinitionsTest extends PluggableActivitiTestCase {
   }
 
   private String deployProcessString(String processString) {
-    String resourceName = "xmlString." + BpmnDeployer.BPMN_RESOURCE_SUFFIXES[0];
+    String resourceName = "xmlString." + ResourceNameUtilities.BPMN_RESOURCE_SUFFIXES[0];
     return repositoryService.createDeployment().addString(resourceName, processString).deploy().getId();
   }
 


### PR DESCRIPTION
Refactors BpmnDeployer into a shorter version of itself plus utility classes that handle the implementation of much of what BpmnDeployer does.  This will make it easier to write deployers for other persistence systems which still do much of what BpmnDeployer does.  The new classes are:

* BpmnDeploymentUtilities - which handles making deployments and process
  definitions consistent with one another
* CachingAndArtifactsManager - which ensures that all process
  definitions and process definition infos are cached and stored in the
  appropriate places
* EventSubscriptionManager - which handles removing obsolete event
  subscriptions from previous process definitions, and creating new
  subscriptions for new process definitions.
* ExpandedDeployment - which is an intermediate representation of a
  deployment that makes it relatively convenient to get at all of its
  resources and process definitions, and the BPMN models and parses
  related to the process definitions, and to track the relationships
  between them.
* ProcessDefinitionDiagrammer - which encapsulates the creation of a new
  diagram resource
* ResourceNameUtilities - which encapsulates static methods related to
  resource names, including BPMN and diagram resource names.