### PR TITLE
test case for act-4066

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.java
@@ -1,0 +1,75 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.bpmn.event.timer;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventListener;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.test.Deployment;
+
+/**
+ * @author Saeid Mirzaei
+ * Test case for ACT-4066
+ */
+
+public class StartTimerEventRepeatWithoutN extends PluggableActivitiTestCase {
+
+	long counter = 0;
+	
+	class startEventListener implements ActivitiEventListener {
+
+		@Override
+		public void onEvent(ActivitiEvent event) {
+			if (event.getType().equals(ActivitiEventType.TIMER_FIRED)) {
+				counter++;
+			}
+		}
+
+		@Override
+		public boolean isFailOnException() {
+			return false;
+		}
+		
+	}
+
+	@Override
+	protected void setUp() throws Exception {
+		super.setUp();
+		
+		startEventListener listener = new startEventListener();
+		processEngineConfiguration.getEventDispatcher().addEventListener(
+				listener);				
+	}
+
+	@Deployment
+	public void testStartTimerEventRepeatWithoutN() {
+		counter = 0;
+		
+		Boolean exceptionOccured = false;
+		try {
+			waitForJobExecutorToProcessAllJobs(12000, 100);
+		} catch (ActivitiException e) {
+			assertTrue(e.getMessage().startsWith("time limit"));
+			assertEquals(2, counter);
+			exceptionOccured = true;
+		}
+		if (!exceptionOccured)
+			fail("job is finished sooner than expected");
+
+	}
+
+}

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.testStartTimerEventRepeatWithoutN.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/StartTimerEventRepeatWithoutN.testStartTimerEventRepeatWithoutN.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="testProcess" isExecutable="true">
+    <startEvent id="timerstartevent1" name="Timer start">
+      <timerEventDefinition>
+        <timeCycle>R/PT5S</timeCycle>
+      </timerEventDefinition>
+    </startEvent>
+    
+    <sequenceFlow id="flow1" sourceRef="timerstartevent1" targetRef="end"></sequenceFlow>
+  
+    <endEvent id="end"></endEvent>
+  </process>
+  
+</definitions>


### PR DESCRIPTION
The issue mentioned in https://activiti.atlassian.net/browse/ACT-4066 is valid for version 5.18.0
It is already resolved in snapshot version of 5.18.1.
Here is a test case to prove the correctness and make sure the problem does not return back.