### PR TITLE
Minor spelling changes to User Guide

### DIFF
--- a/userguide/src/en/ch07b-BPMN-Constructs.adoc
+++ b/userguide/src/en/ch07b-BPMN-Constructs.adoc
@@ -2890,7 +2890,7 @@ This mechanism should be used *only for business faults* that shall be handled b
 
 ====== Exception mapping
 
-It is also possible to directly map a java exception to business exception by using +mapException+ extention. Single mapping is the simplest form:
+It is also possible to directly map a java exception to business exception by using +mapException+ extension. Single mapping is the simplest form:
 [source,xml,linenums]
 ----
 <serviceTask id="servicetask1" name="Service Task" activiti:class="...">
@@ -2931,7 +2931,7 @@ The most generic mapping is a default map. Default map is a map with no class. I
 </serviceTask>
 ----
 
-The mappings are checked in order, from top to buttom and the first found match will be followed, except for the default map. Default map is selected only after all maps are unsuccessfully checked.
+The mappings are checked in order, from top to bottom and the first found match will be followed, except for the default map. Default map is selected only after all maps are unsuccessfully checked.
 Only the first map with no class will be considered as default map. +includeChildExceptions+ is ignored for default Map.
 
 
@@ -3641,7 +3641,7 @@ The above table explains how Activiti variables are going to be transferred to C
 What is mentioned above about passing variables, only holds for start side of the variable transfer, in both directions from Camel to Activiti and vice versa. +
 It is important to notice that because of special non blocking behavior of Activiti, variables are not automatically returned back from Activiti to Camel.
 For that to happen, a special syntax is available. There can be one or more parameters in Camel route URL in format of +var.return.someVariableName+.
-All variabls having a name equal to one of these parameters without +var.return+ part, will be considered as output variables and will be copied back as camel properties with the same names. +
+All variables having a name equal to one of these parameters without +var.return+ part, will be considered as output variables and will be copied back as camel properties with the same names. +
 For example in a route like:
 ----
 from("direct:start").to("activiti:process?var.return.exampleVar").to("mock:result");
@@ -4264,7 +4264,7 @@ However, when the activity is multi instance, the behavior is different:
 The same reasoning applies for the end event:
 
 * When the actual activity is left, an end even is thrown. The _loopCounter_ variable is set.
-* When the multi instance activity has finised as a whole, an end event is thrown. The _loopCounter_ variable is not set.
+* When the multi instance activity has finished as a whole, an end event is thrown. The _loopCounter_ variable is not set.
 
 For example:
 
@@ -4628,7 +4628,7 @@ You can pass process variables to the sub process and vice versa. The data is co
 <callActivity id="callSubProcess" calledElement="checkCreditProcess" >
   <extensionElements>
 	  <activiti:in source="someVariableInMainProcess" target="nameOfVariableInSubProcess" />
-	  <activiti:out source="someVariableInSubProcss" target="nameOfVariableInMainProcess" />
+	  <activiti:out source="someVariableInSubProcess" target="nameOfVariableInMainProcess" />
   </extensionElements>
 </callActivity>
 ----

--- a/userguide/src/en/ch14-REST.adoc
+++ b/userguide/src/en/ch14-REST.adoc
@@ -10,7 +10,7 @@ Activiti includes a REST API to the Activiti Engine that can be installed by dep
 By default the Activiti Engine will connect to an in-memory H2 database. You can change the database settings in the db.properties file in the WEB-INF/classes folder. The REST API uses JSON format (http://www.json.org) and is built upon the Spring MVC (http://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html).
 
 All REST-resources require a valid Activiti-user to be authenticated by default. Basic HTTP access authentication is used, so you should always include a +Authorization: Basic ...==+ HTTP-header when performing requests or include the username and password in the request-url (e.g. ++http://username:password@localhost...++).
-      
+
 *It's recommended to use Basic Authentication in combination with HTTPS.*
 
 ==== Configuration
@@ -26,11 +26,11 @@ An example configuration is already in comments in this file. This is also the p
 ==== Usage in Tomcat
 
 Due to link:$$http://tomcat.apache.org/tomcat-7.0-doc/security-howto.html$$[ default security properties on Tomcat], *escaped forward slashes (++%2F++ and ++%5C++) are not allowed by default (400-result is returned).* This may have an impact on the deployment resources and their data-URL, as the URL can potentially contain escaped forward slashes.
-      
+
 *When issues are experienced with unexpected 400-results, set the following system-property: +$$-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true.$$+*
 
 It's a best practice to always set the *Accept* and *Content-Type* (in case of posting/putting JSON) headers to *application/json* on the HTTP requests described below.
-      
+
 
 ==== Methods and return-codes
 
@@ -64,8 +64,8 @@ It's a best practice to always set the *Accept* and *Content-Type* (in case of p
 |===============
 
 
-The media-type of the HTTP-responses is always +application/json+ unless binary content is requested (e.g. deployment resource data), the media-type of the content is used. 
-        
+The media-type of the HTTP-responses is always +application/json+ unless binary content is requested (e.g. deployment resource data), the media-type of the content is used.
+
 ==== Error response body
 
 When an error occurs (both client and server, 4XX and 5XX status-codes) the response body contains an object describing the error that occurred. An example for a 404-status when a task is not found:
@@ -90,7 +90,7 @@ Parameters that are part of the url (e.g. the deploymentId parameter in ++http:/
 ===== Rest URL query parameters
 
 Parameters added as query-string in the URL (e.g. the name parameter used in ++http://host/activiti-rest/service/deployments?name=Deployment++) can have the following types and are mentioned in the corresponding REST-API documentation:
-            
+
 .URL query parameter types
 [options="header"]
 |===============
@@ -145,10 +145,10 @@ Paging and order parameters can be added as query-string in the URL (e.g. the na
 
 ===== JSON query variable format
 
-[source,json,linenums]      
+[source,json,linenums]
 ----
 
-{ 
+{
   "name" : "variableName",
   "value" : "variableValue",
   "operation" : "equals",
@@ -165,7 +165,7 @@ Paging and order parameters can be added as query-string in the URL (e.g. the na
 |value|Yes|Value of the variable included in the query, should include a correct format for the given type.
 |operator|Yes|Operator to use in query, can have the following values: +equals, notEquals, equalsIgnoreCase, notEqualsIgnoreCase, lessThan, greaterThan, lessThanOrEquals, greaterThanOrEquals+ and +like+.
 |type|No|Type of variable to use. When omitted, the type will be deducted from the +value+ parameter. Any JSON text-values will be considered of type +string+, JSON booleans of type +boolean+, JSON numbers of type +long+ or +integer+ depending on the size of the number. It's recommended to include an explicit type when in doubt. Types supported out of the box are listed below.
-                    
+
 
 |===============
 
@@ -183,7 +183,7 @@ Paging and order parameters can be added as query-string in the URL (e.g. the na
 |date|Value is treated as and converted to a +java.util.Date+. The JSON string will be converted using ISO-8601 date format.
 
 |===============
-    
+
 
 [[restVariables]]
 
@@ -191,9 +191,9 @@ Paging and order parameters can be added as query-string in the URL (e.g. the na
 
 When working with variables (execution/process and task), the REST-api uses some common principles and JSON-format for both reading and writing. The JSON representation of a variable looks like this:
 
-[source,json,linenums]                 
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "variableName",
   "value" : "variableValue",
   "valueUrl" : "http://...",
@@ -201,7 +201,7 @@ When working with variables (execution/process and task), the REST-api uses some
   "type" : "string"
 }
 ----
-   
+
 .Variable JSON attributes
 [options="header"]
 |===============
@@ -225,7 +225,7 @@ When working with variables (execution/process and task), the REST-api uses some
 |double|Value is threaded as a +java.lang.Double+. When writing, JSON number value is used as base for conversion, falls back to JSON text.
 |boolean|Value is threaded as a +java.lang.Boolean+. When writing, JSON boolean value is used for conversion.
 |date|Value is treated as a +java.util.Date+. When writing, the JSON text will be converted using ISO-8601 date format.
-|binary|Binary variable, threated as an array of bytes. The +value+ attribute is null, the +valueUrl+ contains an URL pointing to the raw binary stream.
+|binary|Binary variable, treated as an array of bytes. The +value+ attribute is null, the +valueUrl+ contains an URL pointing to the raw binary stream.
 |serializable|Serialized representation of a Serializable Java-object. As with the +binary+ type, the +value+ attribute is null, the +valueUrl+ contains an URL pointing to the raw binary stream. All serializable variables (which are not of any of the above types) will be exposed as a variable of this type.
 
 |===============
@@ -238,7 +238,7 @@ It's possible to support additional variable-types with a custom JSON representa
 *When using tomcat, please read <<restUsageInTomcat,Usage in Tomcat>>.*
 
 ==== List of Deployments
-     
+
 ----
 GET repository/deployments
 ----
@@ -270,7 +270,7 @@ GET repository/deployments
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "data": [
@@ -292,7 +292,7 @@ GET repository/deployments
 ----
 
 ==== Get a deployment
-     
+
 ----
 GET repository/deployments/{deploymentId}
 ----
@@ -317,7 +317,7 @@ GET repository/deployments/{deploymentId}
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "id": "10",
@@ -330,13 +330,13 @@ GET repository/deployments/{deploymentId}
 ----
 
 ==== Create a new deployment
-          
+
 ----
 POST repository/deployments
 ----
 
 *Request body:*
-        
+
 The request body should contain data of type _multipart/form-data_. There should be exactly one file in the request, any additional files will be ignored. The deployment name is the name of the file-field passed in. If multiple resources need to be deployed in a single deployment, compress the resources in a zip and make sure the file-name ends with +.bar+ or +.zip+.
 
 An additional parameter (form-field) can be passed in the request body with name +tenantId+. The value of this field will be used as the id of the tenant this deployment is done in.
@@ -353,7 +353,7 @@ An additional parameter (form-field) can be passed in the request body with name
 *Success response body:*
 
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "id": "10",
@@ -366,7 +366,7 @@ An additional parameter (form-field) can be passed in the request body with name
 ----
 
 ==== Delete a deployment
-     
+
 ----
 DELETE repository/deployments/{deploymentId}
 ----
@@ -391,7 +391,7 @@ DELETE repository/deployments/{deploymentId}
 
 
 ==== List resources in a deployment
-     
+
 ----
 GET repository/deployments/{deploymentId}/resources
 ----
@@ -415,7 +415,7 @@ GET repository/deployments/{deploymentId}/resources
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 [
   {
@@ -443,10 +443,10 @@ GET repository/deployments/{deploymentId}/resources
 * ++processImage++: Resource that represents a deployed process definition's graphical layout.
 
 _The dataUrl property in the resulting JSON for a single resource contains the actual URL to use for retrieving the binary resource._
-    
+
 
 ==== Get a deployment resource
-     
+
 ----
 GET repository/deployments/{deploymentId}/resources/{resourceId}
 ----
@@ -473,7 +473,7 @@ GET repository/deployments/{deploymentId}/resources/{resourceId}
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "id": "diagrams/my-process.bpmn20.xml",
@@ -484,7 +484,7 @@ GET repository/deployments/{deploymentId}/resources/{resourceId}
 }
 ----
 
-  
+
 * ++mediaType++: Contains the media-type the resource has. This is resolved using a (pluggable) +MediaTypeResolver+ and contains, by default, a limited number of mime-type mappings.
 * ++type++: Type of resource, possible values:
 * ++resource++: Plain old resource.
@@ -493,7 +493,7 @@ GET repository/deployments/{deploymentId}/resources/{resourceId}
 
 
 ==== Get a deployment resource content
-        
+
 ----
 GET repository/deployments/{deploymentId}/resourcedata/{resourceId}
 ----
@@ -509,7 +509,7 @@ GET repository/deployments/{deploymentId}/resourcedata/{resourceId}
 
 
 
-        
+
 
 
           .Get a deployment resource content - Response codes
@@ -522,17 +522,17 @@ GET repository/deployments/{deploymentId}/resourcedata/{resourceId}
 |===============
 
 *Success response body:*
-    
+
 
 The response body will contain the binary resource-content for the requested resource. The response content-type will be the same as the type returned in the resources 'mimeType' property. Also, a content-disposition header is set, allowing browsers to download the file instead of displaying it.
-    
+
 
 === Process Definitions
 
 
 ==== List of process definitions
 
-     
+
 ----
 GET repository/process-definitions
 ----
@@ -573,11 +573,11 @@ GET repository/process-definitions
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "oneTaskProcess:1:4",
       "url" : "http://localhost:8182/repository/process-definitions/oneTaskProcess%3A1%3A4",
       "version" : 1,
@@ -609,7 +609,7 @@ GET repository/process-definitions
 
 
 ==== Get a process definition
-     
+
 ----
 GET repository/process-definitions/{processDefinitionId}
 ----
@@ -635,9 +635,9 @@ GET repository/process-definitions/{processDefinitionId}
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
-{ 
+{
   "id" : "oneTaskProcess:1:4",
   "url" : "http://localhost:8182/repository/process-definitions/oneTaskProcess%3A1%3A4",
   "version" : 1,
@@ -654,14 +654,14 @@ GET repository/process-definitions/{processDefinitionId}
   "startFormDefined" : false
 }
 ----
- 
+
 * ++graphicalNotationDefined++: Indicates the process definition contains graphical information (BPMN DI).
 * ++resource++: Contains the actual deployed BPMN 2.0 xml.
 * ++diagramResource++: Contains a graphical representation of the process, null when no diagram is available.
 
 
 ==== Update category for a process definition
-       
+
 ----
 PUT repository/process-definitions/{processDefinitionId}
 ----
@@ -669,9 +669,9 @@ PUT repository/process-definitions/{processDefinitionId}
 
 *Body JSON:*
 
-[source,json,linenums]                 
+[source,json,linenums]
 ----
-{ 
+{
   "category" : "updatedcategory"
 }
 ----
@@ -689,10 +689,10 @@ PUT repository/process-definitions/{processDefinitionId}
 
 
 *Success response body:* see response for +repository/process-definitions/{processDefinitionId}+.
-      
+
 
 ==== Get a process definition resource content
-     
+
 ----
 GET repository/process-definitions/{processDefinitionId}/resourcedata
 ----
@@ -706,12 +706,12 @@ GET repository/process-definitions/{processDefinitionId}/resourcedata
 |===============
 
 *Response:*
-    
+
 Exactly the same response codes/boy as +GET repository/deployment/{deploymentId}/resourcedata/{resourceId}+.
 
 
 ==== Get a process definition BPMN model
-     
+
 ----
 GET repository/process-definitions/{processDefinitionId}/model
 ----
@@ -738,7 +738,7 @@ GET repository/process-definitions/{processDefinitionId}/model
 *Response body:*
 The response body is a JSON representation of the +org.activiti.bpmn.model.BpmnModel+ and contains the full process definition model.
 
-[source,json,linenums]      
+[source,json,linenums]
 ----
 {
    "processes":[
@@ -752,24 +752,24 @@ The response body is a JSON representation of the +org.activiti.bpmn.model.BpmnM
          "name":"The One Task Process",
          "executable":true,
          "documentation":"One task process description",
-         
-    ] 
+
+    ]
 }
 ----
 
 
 ==== Suspend a process definition
 
-     
+
 ----
 PUT repository/process-definitions/{processDefinitionId}
 ----
 
 *Body JSON:*
 
-[source,json,linenums]                 
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "suspend",
   "includeProcessInstances" : "false",
   "date" : "2013-04-15T00:42:12Z"
@@ -784,7 +784,7 @@ PUT repository/process-definitions/{processDefinitionId}
 |Parameter|Description|Required
 |action|Action to perform. Either +activate+ or +suspend+.|Yes
 |includeProcessInstances|Whether or not to suspend/activate running process-instances for this process-definition. If omitted, the process-instances are left in the state they are.|No
-|date|Date (ISO-8601) when the suspension/activation should be executed. If omitted, the suspend/activation is effective immediatly.|No
+|date|Date (ISO-8601) when the suspension/activation should be executed. If omitted, the suspend/activation is effective immediately.|No
 
 |===============
 
@@ -800,18 +800,18 @@ PUT repository/process-definitions/{processDefinitionId}
 |===============
 
 *Success response body:* see response for +repository/process-definitions/{processDefinitionId}+.
-      
+
 ==== Activate a process definition
-     
+
 ----
 PUT repository/process-definitions/{processDefinitionId}
 ----
-    
+
 *Body JSON:*
 
-[source,json,linenums]                 
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "activate",
   "includeProcessInstances" : "true",
   "date" : "2013-04-15T00:42:12Z"
@@ -819,7 +819,7 @@ PUT repository/process-definitions/{processDefinitionId}
 ----
 
 See suspend process definition <<processDefinitionActionBodyParameters,JSON Body parameters>>.
-        
+
 .Activate a process definition - Response codes
 [options="header"]
 |===============
@@ -832,10 +832,10 @@ See suspend process definition <<processDefinitionActionBodyParameters,JSON Body
 
 
 *Success response body:* see response for +repository/process-definitions/{processDefinitionId}+.
-     
-      
+
+
 ==== Get all candidate starters for a process-definition
-      
+
 ----
 GET repository/process-definitions/{processDefinitionId}/identitylinks
 ----
@@ -862,7 +862,7 @@ GET repository/process-definitions/{processDefinitionId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 [
    {
@@ -883,7 +883,7 @@ GET repository/process-definitions/{processDefinitionId}/identitylinks
 
 ==== Add a candidate starter to a process definition
 
-   
+
 ----
 POST repository/process-definitions/{processDefinitionId}/identitylinks
 ----
@@ -899,7 +899,7 @@ POST repository/process-definitions/{processDefinitionId}/identitylinks
 
 *Request body (user):*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "user" : "kermit"
@@ -908,7 +908,7 @@ POST repository/process-definitions/{processDefinitionId}/identitylinks
 
 *Request body (group):*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "groupId" : "sales"
@@ -927,7 +927,7 @@ POST repository/process-definitions/{processDefinitionId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 
 {
@@ -941,7 +941,7 @@ POST repository/process-definitions/{processDefinitionId}/identitylinks
 
 ==== Delete a candidate starter from a process definition
 
-        
+
 ----
 DELETE repository/process-definitions/{processDefinitionId}/identitylinks/{family}/{identityId}
 ----
@@ -969,7 +969,7 @@ DELETE repository/process-definitions/{processDefinitionId}/identitylinks/{famil
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 
 {
@@ -982,7 +982,7 @@ DELETE repository/process-definitions/{processDefinitionId}/identitylinks/{famil
 
 
 ==== Get a candidate starter from a process definition
-   
+
 ----
 GET repository/process-definitions/{processDefinitionId}/identitylinks/{family}/{identityId}
 ----
@@ -1010,7 +1010,7 @@ GET repository/process-definitions/{processDefinitionId}/identitylinks/{family}/
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
   "url":"http://localhost:8182/repository/process-definitions/oneTaskProcess%3A1%3A4/identitylinks/users/kermit",
@@ -1025,7 +1025,7 @@ GET repository/process-definitions/{processDefinitionId}/identitylinks/{family}/
 
 ==== Get a list of models
 
-          
+
 ----
 GET repository/models
 ----
@@ -1066,7 +1066,7 @@ GET repository/models
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "data":[
@@ -1084,9 +1084,9 @@ GET repository/models
          "deploymentUrl":"http://localhost:8182/repository/deployments/7",
          "tenantId":null
       },
-      
+
       ...
-      
+
    ],
    "total":2,
    "start":0,
@@ -1099,7 +1099,7 @@ GET repository/models
 
 ==== Get a model
 
-     
+
 ----
 GET repository/models/{modelId}
 ----
@@ -1125,7 +1125,7 @@ GET repository/models/{modelId}
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "id":"5",
@@ -1146,14 +1146,14 @@ GET repository/models/{modelId}
 
 
 ==== Update a model
-     
+
 ----
 PUT repository/models/{modelId}
 ----
 
 *Request body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "name":"Model name",
@@ -1167,7 +1167,7 @@ PUT repository/models/{modelId}
 ----
 
 All request values are optional. For example, you can only include the 'name' attribute in the request body JSON-object, only updating the name of the model, leaving all other fields unaffected. When an attribute is explicitly included and is set to null, the model-value will be updated to null. Example: +{"metaInfo" : null}+ will clear the metaInfo of the model).
-    
+
 .Update a model - Response codes
 [options="header"]
 |===============
@@ -1179,7 +1179,7 @@ All request values are optional. For example, you can only include the 'name' at
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "id":"5",
@@ -1199,14 +1199,14 @@ All request values are optional. For example, you can only include the 'name' at
 
 
 ==== Create a model
-     
+
 ----
 POST repository/models
 ----
 
 *Request body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "name":"Model name",
@@ -1221,7 +1221,7 @@ POST repository/models
 
 
 All request values are optional. For example, you can only include the 'name' attribute in the request body JSON-object, only setting the name of the model, leaving all other fields null.
-    
+
 .Create a model - Response codes
 [options="header"]
 |===============
@@ -1232,7 +1232,7 @@ All request values are optional. For example, you can only include the 'name' at
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "id":"5",
@@ -1252,7 +1252,7 @@ All request values are optional. For example, you can only include the 'name' at
 
 
 ==== Delete a model
-     
+
 ----
 DELETE repository/models/{modelId}
 ----
@@ -1279,7 +1279,7 @@ DELETE repository/models/{modelId}
 
 ==== Get the editor source for a model
 
-          
+
 ----
 GET repository/models/{modelId}/source
 ----
@@ -1308,10 +1308,10 @@ GET repository/models/{modelId}/source
 *Success response body:*
 
 Response body contains the model's raw editor source. The response's content-type is set to +application/octet-stream+, regardless of the content of the source.
-    
+
 
 ==== Set the editor source for a model
-   
+
 ----
 PUT repository/models/{modelId}/source
 ----
@@ -1341,10 +1341,10 @@ The request should be of type +multipart/form-data+. There should be a single fi
 *Success response body:*
 
 Response body contains the model's raw editor source. The response's content-type is set to +application/octet-stream+, regardless of the content of the source.
-    
+
 
 ==== Get the extra editor source for a model
-     
+
 ----
 GET repository/models/{modelId}/source-extra
 ----
@@ -1371,7 +1371,7 @@ GET repository/models/{modelId}/source-extra
 *Success response body:*
 
 Response body contains the model's raw extra editor source. The response's content-type is set to +application/octet-stream+, regardless of the content of the extra source.
-    
+
 
 ==== Set the extra editor source for a model
 
@@ -1391,7 +1391,7 @@ PUT repository/models/{modelId}/source-extra
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the extra source.
-        
+
 .Set the extra editor source for a model - Response codes
 [options="header"]
 |===============
@@ -1410,7 +1410,7 @@ Response body contains the model's raw editor source. The response's content-typ
 === Process Instances
 
 ==== Get a process instance
-          
+
 ----
 GET runtime/process-instances/{processInstanceId}
 ----
@@ -1436,7 +1436,7 @@ GET runtime/process-instances/{processInstanceId}
 
 *Success response body:*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "id":"7",
@@ -1451,7 +1451,7 @@ GET runtime/process-instances/{processInstanceId}
 
 
 ==== Delete a process instance
-     
+
 ----
 DELETE runtime/process-instances/{processInstanceId}
 ----
@@ -1477,7 +1477,7 @@ DELETE runtime/process-instances/{processInstanceId}
 
 ==== Activate or suspend a process instance
 
-       
+
 ----
 PUT runtime/process-instances/{processInstanceId}
 ----
@@ -1494,7 +1494,7 @@ PUT runtime/process-instances/{processInstanceId}
 
 *Request response body (suspend):*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "action":"suspend"
@@ -1503,7 +1503,7 @@ PUT runtime/process-instances/{processInstanceId}
 
 *Request response body (activate):*
 
-[source,json,linenums]                  
+[source,json,linenums]
 ----
 {
    "action":"activate"
@@ -1525,7 +1525,7 @@ PUT runtime/process-instances/{processInstanceId}
 
 ==== Start a process instance
 
-     
+
 ----
 POST runtime/process-instances
 ----
@@ -1548,7 +1548,7 @@ POST runtime/process-instances
 
 *Request body (start by process definition key):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "processDefinitionKey":"oneTaskProcess",
@@ -1565,7 +1565,7 @@ POST runtime/process-instances
 
 *Request body (start by message):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "message":"newOrderMessage",
@@ -1582,7 +1582,7 @@ POST runtime/process-instances
 
 
 Only one of +processDefinitionId+, +processDefinitionKey+ or +message+ can be used in the request body. Parameters +businessKey+, +variables+ and +tenantId+ are optional. If +tenantId+ is omitted, the default tenant will be used. More information about the variable format can be found in <<restVariables,the REST variables section>>. Note that the variable-scope that is supplied is ignored, process-variables are always +local+.
-    
+
 
 .Start a process instance - Response codes
 [options="header"]
@@ -1596,7 +1596,7 @@ Only one of +processDefinitionId+, +processDefinitionKey+ or +message+ can be us
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"7",
@@ -1614,7 +1614,7 @@ Only one of +processDefinitionId+, +processDefinitionKey+ or +message+ can be us
 
 
 ==== List of process instances
-     
+
 ----
 GET runtime/process-instances
 ----
@@ -1654,7 +1654,7 @@ GET runtime/process-instances
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -1667,8 +1667,8 @@ GET runtime/process-instances
          "activityId":"processTask",
          "tenantId" : null
       }
-      
-      
+
+
    ],
    "total":2,
    "start":0,
@@ -1680,18 +1680,18 @@ GET runtime/process-instances
 
 
 ==== Query process instances
-     
+
 ----
 POST query/process-instances
 ----
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "processDefinitionKey":"oneTaskProcess",
-  "variables": 
+  "variables":
   [
     {
         "name" : "myVariable",
@@ -1705,7 +1705,7 @@ POST query/process-instances
 
 The request body can contain all possible filters that can be used in the <<restProcessInstancesGet,List process instances>> URL query. On top of these, it's possible to provide an array of variables
 to include in the query, with their format <<restQueryVariable, described here>>.
-    
+
 
 The general <<restPagingAndSort,paging and sorting query-parameters>> can be used for this URL.
 
@@ -1721,7 +1721,7 @@ The general <<restPagingAndSort,paging and sorting query-parameters>> can be use
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -1734,8 +1734,8 @@ The general <<restPagingAndSort,paging and sorting query-parameters>> can be use
          "activityId":"processTask",
          "tenantId" : null
       }
-      
-      
+
+
    ],
    "total":2,
    "start":0,
@@ -1747,7 +1747,7 @@ The general <<restPagingAndSort,paging and sorting query-parameters>> can be use
 
 
 ==== Get diagram for a process instance
-     
+
 ----
 GET runtime/process-instances/{processInstanceId}/diagram
 ----
@@ -1774,7 +1774,7 @@ GET runtime/process-instances/{processInstanceId}/diagram
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"7",
@@ -1788,7 +1788,7 @@ GET runtime/process-instances/{processInstanceId}/diagram
 
 
 ==== Get involved people for process instance
-     
+
 ----
 GET runtime/process-instances/{processInstanceId}/identitylinks
 ----
@@ -1815,7 +1815,7 @@ GET runtime/process-instances/{processInstanceId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -1835,11 +1835,11 @@ GET runtime/process-instances/{processInstanceId}/identitylinks
 
 
 Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
-    
+
 
 ==== Add an involved user to a process instance
 
-          
+
 ----
 POST runtime/process-instances/{processInstanceId}/identitylinks
 ----
@@ -1855,7 +1855,7 @@ POST runtime/process-instances/{processInstanceId}/identitylinks
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "userId":"kermit",
@@ -1865,7 +1865,7 @@ POST runtime/process-instances/{processInstanceId}/identitylinks
 
 
 Both +userId+ and +type+ are required.
-    
+
 
 .Add an involved user to a process instance - Response codes
 [options="header"]
@@ -1880,7 +1880,7 @@ Both +userId+ and +type+ are required.
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "url":"http://localhost:8182/runtime/process-instances/5/identitylinks/users/john/customType",
@@ -1892,10 +1892,10 @@ Both +userId+ and +type+ are required.
 
 
 Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
-    
+
 
 ==== Remove an involved user to from process instance
-     
+
 ----
 DELETE runtime/process-instances/{processInstanceId}/identitylinks/users/{userId}/{type}
 ----
@@ -1923,7 +1923,7 @@ DELETE runtime/process-instances/{processInstanceId}/identitylinks/users/{userId
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "url":"http://localhost:8182/runtime/process-instances/5/identitylinks/users/john/customType",
@@ -1935,10 +1935,10 @@ DELETE runtime/process-instances/{processInstanceId}/identitylinks/users/{userId
 
 
 Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
-    
+
 
 ==== List of variables for a process instance
-          
+
 ----
 GET runtime/process-instances/{processInstanceId}/variables
 ----
@@ -1965,7 +1965,7 @@ GET runtime/process-instances/{processInstanceId}/variables
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -1985,14 +1985,14 @@ GET runtime/process-instances/{processInstanceId}/variables
 ----
 
 
-In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response. 
+In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response.
 Note that only +local+ scoped variables are returned, as there is no +global+ scope for process-instance variables.
 
 
 
 ==== Get a variable for a process instance
 
-    
+
 ----
 GET runtime/process-instances/{processInstanceId}/variables/{variableName}
 ----
@@ -2021,7 +2021,7 @@ GET runtime/process-instances/{processInstanceId}/variables/{variableName}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
    {
       "name":"intProcVar",
@@ -2036,11 +2036,11 @@ In case the variable is a binary variable or serializable, the +valueUrl+ points
 
 
 ==== Create (or update) variables on a process instance
-     
+
 ----
 POST runtime/process-instances/{processInstanceId}/variables
 ----
-          
+
 ----
 PUT runtime/process-instances/{processInstanceId}/variables
 ----
@@ -2058,7 +2058,7 @@ When using +POST+, all variables that are passed are created. In case one of the
 
 
 *Request body:*
-            
+
 ----
 [
    {
@@ -2066,14 +2066,14 @@ When using +POST+, all variables that are passed are created. In case one of the
       "type":"integer"
       "value":123
    },
-   
+
    ...
 ]
 ----
 
 
 Any number of variables can be passed into the request body array. More information about the variable format can be found in <<restVariables,the REST variables section>>. Note that scope is ignored, only +local+ variables can be set in a process instance.
-        
+
 .Create (or update) variables on a process instance - Response codes
 [options="header"]
 |===============
@@ -2087,7 +2087,7 @@ Any number of variables can be passed into the request body array. More informat
 
 
 *Success response body:*
-            
+
 ----
 [
    {
@@ -2096,15 +2096,15 @@ Any number of variables can be passed into the request body array. More informat
       "value":123,
       "scope":"local"
    },
-   
+
    ...
-   
+
 ]
 ----
 
 
 ==== Update a single variable on a process instance
-     
+
 ----
 PUT runtime/process-instances/{processInstanceId}/variables/{variableName}
 ----
@@ -2120,7 +2120,7 @@ PUT runtime/process-instances/{processInstanceId}/variables/{variableName}
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
  {
     "name":"intProcVar"
@@ -2131,7 +2131,7 @@ PUT runtime/process-instances/{processInstanceId}/variables/{variableName}
 
 
 More information about the variable format can be found in <<restVariables,the REST variables section>>. Note that scope is ignored, only +local+ variables can be set in a process instance.
-        
+
 .Update a single variable on a process instance - Response codes
 [options="header"]
 |===============
@@ -2144,7 +2144,7 @@ More information about the variable format can be found in <<restVariables,the R
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "name":"intProcVar",
@@ -2156,9 +2156,9 @@ More information about the variable format can be found in <<restVariables,the R
 
 
 In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response. Note that only +local+ scoped variables are returned, as there is no +global+ scope for process-instance variables.
-  
+
 ==== Create a new binary variable on a process-instance
-     
+
 ----
 POST runtime/process-instances/{processInstanceId}/variables
 ----
@@ -2177,16 +2177,16 @@ POST runtime/process-instances/{processInstanceId}/variables
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++type++: Type of variable that is created. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
 
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -2211,7 +2211,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Update an existing binary variable on a process-instance
-          
+
 ----
 PUT runtime/process-instances/{processInstanceId}/variables
 ----
@@ -2227,15 +2227,15 @@ PUT runtime/process-instances/{processInstanceId}/variables
 
 *Request body:*
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++type++: Type of variable that is created. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
 
 *Success response body:*
-            
+
 [source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -2262,7 +2262,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Get an execution
-     
+
 ----
 GET runtime/executions/{executionId}
 ----
@@ -2289,7 +2289,7 @@ GET runtime/executions/{executionId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"5",
@@ -2324,7 +2324,7 @@ PUT runtime/executions/{executionId}
 
 *Request body (signal an execution):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "action":"signal"
@@ -2334,7 +2334,7 @@ PUT runtime/executions/{executionId}
 
 *Request body (signal event received for execution):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "action":"signalEventReceived",
@@ -2344,10 +2344,10 @@ PUT runtime/executions/{executionId}
 ----
 
 Notifies the execution that a signal event has been received, requires a +signalName+ parameter. Optional +variables+ can be passed that are set on the execution before the action is executed.
-    
+
 *Request body (signal event received for execution):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "action":"messageEventReceived",
@@ -2358,7 +2358,7 @@ Notifies the execution that a signal event has been received, requires a +signal
 
 
 Notifies the execution that a message event has been received, requires a +messageName+ parameter. Optional +variables+ can be passed that are set on the execution before the action is executed.
-    
+
 .Execute an action on an execution - Response codes
 [options="header"]
 |===============
@@ -2372,7 +2372,7 @@ Notifies the execution that a message event has been received, requires a +messa
 
 *Success response body (in case execution is not ended due to action):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"5",
@@ -2389,13 +2389,13 @@ Notifies the execution that a message event has been received, requires a +messa
 
 
 ==== Get active activities in an execution
-       
+
 ----
 GET runtime/executions/{executionId}/activities
 ----
 
 Returns all activities which are active in the execution and in all child-executions (and their children, recursively), if any.
-        
+
 .Get active activities in an execution - URL parameters
 [options="header"]
 |===============
@@ -2417,7 +2417,7 @@ Returns all activities which are active in the execution and in all child-execut
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
   "userTaskForManager",
@@ -2431,7 +2431,7 @@ Returns all activities which are active in the execution and in all child-execut
 
 ==== List of executions
 
-     
+
 ----
 GET runtime/executions
 ----
@@ -2469,7 +2469,7 @@ GET runtime/executions
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -2508,18 +2508,18 @@ GET runtime/executions
 
 ==== Query executions
 
-     
+
 ----
 POST query/executions
 ----
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "processDefinitionKey":"oneTaskProcess",
-  "variables": 
+  "variables":
   [
     {
         "name" : "myVariable",
@@ -2528,7 +2528,7 @@ POST query/executions
         "type" : "long"
     }
   ],
-  "processInstanceVariables": 
+  "processInstanceVariables":
   [
     {
         "name" : "processVariable",
@@ -2543,7 +2543,7 @@ POST query/executions
 
 The request body can contain all possible filters that can be used in the <<restExecutionsGet,List executions>> URL query. On top of these, it's possible to provide an array of +variables+ and +processInstanceVariables+
 to include in the query, with their format <<restQueryVariable, described here>>.
-    
+
 The general <<restPagingAndSort,paging and sorting query-parameters>> can be used for this URL.
 
 .Query executions - Response codes
@@ -2557,7 +2557,7 @@ The general <<restPagingAndSort,paging and sorting query-parameters>> can be use
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -2595,7 +2595,7 @@ The general <<restPagingAndSort,paging and sorting query-parameters>> can be use
 
 
 ==== List of variables for an execution
-          
+
 ----
 GET runtime/executions/{executionId}/variables?scope={scope}
 ----
@@ -2623,7 +2623,7 @@ GET runtime/executions/{executionId}/variables?scope={scope}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -2639,8 +2639,8 @@ GET runtime/executions/{executionId}/variables?scope={scope}
       "valueUrl":"http://localhost:8182/runtime/process-instances/5/variables/byteArrayProcVar/data",
       "scope":"local"
    }
-   
-   
+
+
 ]
 ----
 
@@ -2649,7 +2649,7 @@ In case the variable is a binary variable or serializable, the +valueUrl+ points
 
 
 ==== Get a variable for an execution
-          
+
 ----
 GET runtime/executions/{executionId}/variables/{variableName}?scope={scope}
 ----
@@ -2680,7 +2680,7 @@ GET runtime/executions/{executionId}/variables/{variableName}?scope={scope}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
    {
       "name":"intProcVar",
@@ -2692,14 +2692,14 @@ GET runtime/executions/{executionId}/variables/{variableName}?scope={scope}
 
 
 In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response.
-    
+
 
 ==== Create (or update) variables on an execution
-     
+
 ----
 POST runtime/executions/{executionId}/variables
 ----
-          
+
 ----
 PUT runtime/executions/{executionId}/variables
 ----
@@ -2718,7 +2718,7 @@ When using +POST+, all variables that are passed are created. In case one of the
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -2727,14 +2727,14 @@ When using +POST+, all variables that are passed are created. In case one of the
       "value":123,
       "scope":"local"
    }
-   
-   
-   
+
+
+
 ]
 ----
 
 *Note that you can only provide variables that have the same scope. If the request-body array contains variables from mixed scopes, the request results in an error (400 - BAD REQUEST).*Any number of variables can be passed into the request body array. More information about the variable format can be found in <<restVariables,the REST variables section>>. Note that scope is ignored, only +local+ variables can be set in a process instance.
-        
+
 .Create (or update) variables on an execution - Response codes
 [options="header"]
 |===============
@@ -2749,7 +2749,7 @@ When using +POST+, all variables that are passed are created. In case one of the
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -2758,9 +2758,9 @@ When using +POST+, all variables that are passed are created. In case one of the
       "value":123,
       "scope":"local"
    }
-   
-   
-   
+
+
+
 ]
 ----
 
@@ -2768,7 +2768,7 @@ When using +POST+, all variables that are passed are created. In case one of the
 
 ==== Update a variable on an execution
 
-     
+
 ----
 PUT runtime/executions/{executionId}/variables/{variableName}
 ----
@@ -2786,7 +2786,7 @@ PUT runtime/executions/{executionId}/variables/{variableName}
 
 *Request body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
  {
     "name":"intProcVar"
@@ -2797,7 +2797,7 @@ PUT runtime/executions/{executionId}/variables/{variableName}
 ----
 
 More information about the variable format can be found in <<restVariables,the REST variables section>>.
-        
+
 .Update a variable on an execution - Response codes
 [options="header"]
 |===============
@@ -2810,7 +2810,7 @@ More information about the variable format can be found in <<restVariables,the R
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
    {
       "name":"intProcVar",
@@ -2821,11 +2821,11 @@ More information about the variable format can be found in <<restVariables,the R
 ----
 
 
-In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response. 
-  
+In case the variable is a binary variable or serializable, the +valueUrl+ points to an URL to fetch the raw value. If it's a plain variable, the value is present in the response.
+
 
 ==== Create a new binary variable on an execution
-          
+
 ----
 POST runtime/executions/{executionId}/variables
 ----
@@ -2843,16 +2843,16 @@ POST runtime/executions/{executionId}/variables
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++type++: Type of variable that is created. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
 * ++scope++: Scope of variable that is created. If omitted, +local+ is assumed.
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -2877,7 +2877,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Update an existing binary variable on a process-instance
-     
+
 ----
 PUT runtime/executions/{executionId}/variables/{variableName}
 ----
@@ -2894,7 +2894,7 @@ PUT runtime/executions/{executionId}/variables/{variableName}
 
 *Request body:*
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++type++: Type of variable that is created. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
 * ++scope++: Scope of variable that is created. If omitted, +local+ is assumed.
@@ -2902,9 +2902,9 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -2931,7 +2931,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Get a task
-       
+
 ----
 GET runtime/tasks/{taskId}
 ----
@@ -2958,9 +2958,9 @@ GET runtime/tasks/{taskId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "assignee" : "kermit",
   "createTime" : "2013-04-17T10:17:43.902+0000",
   "delegationState" : "pending",
@@ -2981,15 +2981,15 @@ GET runtime/tasks/{taskId}
 }
 ----
 
-    
+
 * ++delegationState++: Delegation-state of the task, can be +null+, +"pending"+ or +"resolved".+
-    
+
 
 [[restTasksGet]]
 
 
 ==== List of tasks
-          
+
 ----
 GET runtime/tasks
 ----
@@ -3059,11 +3059,11 @@ GET runtime/tasks
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "assignee" : "kermit",
       "createTime" : "2013-04-17T10:17:43.902+0000",
       "delegationState" : "pending",
@@ -3094,7 +3094,7 @@ GET runtime/tasks
 
 
 ==== Query for tasks
-     
+
 ----
 POST query/tasks
 ----
@@ -3102,14 +3102,14 @@ POST query/tasks
 
 *Request body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "name" : "My task",
   "description" : "The task description",
-  
+
   ...
-  
+
   "taskVariables" : [
     {
       "name" : "myVariable",
@@ -3118,10 +3118,10 @@ POST query/tasks
       "type" : "long"
     }
   ],
-    
+
     "processInstanceVariables" : [
       {
-         ... 
+         ...
       }
     ]
   ]
@@ -3131,7 +3131,7 @@ POST query/tasks
 
 
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restTasksGet,getting a collection of tasks>> (except for candidateGroupIn which is only available in this POST task query REST service), but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows for filtering based on task and process variables. The +taskVariables+ and +processInstanceVariables+ are both JSON-arrays containing objects with the format <<restQueryVariable, as described here.>>
-        
+
 
 .Query for tasks - Response codes
 [options="header"]
@@ -3146,11 +3146,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "assignee" : "kermit",
       "createTime" : "2013-04-17T10:17:43.902+0000",
       "delegationState" : "pending",
@@ -3181,7 +3181,7 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 ==== Update a task
 
-     
+
 ----
 PUT runtime/tasks/{taskId}
 ----
@@ -3189,9 +3189,9 @@ PUT runtime/tasks/{taskId}
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "assignee" : "assignee",
   "delegationState" : "resolved",
   "description" : "New task description",
@@ -3204,7 +3204,7 @@ PUT runtime/tasks/{taskId}
 ----
 
 All request values are optional. For example, you can only include the 'assignee' attribute in the request body JSON-object, only updating the assignee of the task, leaving all other fields unaffected. When an attribute is explicitly included and is set to null, the task-value will be updated to null. Example: +{"dueDate" : null}+ will clear the duedate of the task).
-       
+
 
 .Update a task - Response codes
 [options="header"]
@@ -3218,19 +3218,19 @@ All request values are optional. For example, you can only include the 'assignee
 
 
 *Success response body:* see response for +runtime/tasks/{taskId}+.
-    
-    
+
+
 ==== Task actions
-      
+
 ----
 POST runtime/tasks/{taskId}
 ----
 
 *Complete a task - Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "complete",
   "variables" : []
 }
@@ -3241,21 +3241,21 @@ Completes the task. Optional variable array can be passed in using the +variable
 
 *Claim a task - Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "claim",
   "assignee" : "userWhoClaims"
 }
 ----
 
 Claims the task by the given assignee. If the assignee is +null+, the task is assigned to no-one, claimable again.
-       
+
 *Delegate a task - Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "delegate",
   "assignee" : "userToDelegateTo"
 }
@@ -3263,20 +3263,20 @@ Claims the task by the given assignee. If the assignee is +null+, the task is as
 
 
 Delegates the task to the given assignee. The assignee is required.
-       
+
 *Resolve a task - Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 
-{ 
+{
   "action" : "resolve"
 }
 ----
 
 
 Resolves the task delegation. The task is assigned back to the task owner (if any).
-       
+
 
 .Task actions - Response codes
 [options="header"]
@@ -3291,11 +3291,11 @@ Resolves the task delegation. The task is assigned back to the task owner (if an
 
 
 *Success response body:* see response for +runtime/tasks/{taskId}+.
-      
+
 
 ==== Delete a task
 
-    
+
 ----
 DELETE runtime/tasks/{taskId}?cascadeHistory={cascadeHistory}&deleteReason={deleteReason}
 ----
@@ -3325,7 +3325,7 @@ DELETE runtime/tasks/{taskId}?cascadeHistory={cascadeHistory}&deleteReason={dele
 
 
 ==== Get all variables for a task
-     
+
 ----
 GET runtime/tasks/{taskId}/variables?scope={scope}
 ----
@@ -3353,10 +3353,10 @@ GET runtime/tasks/{taskId}/variables?scope={scope}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "name" : "doubleTaskVar",
     "scope" : "local",
     "type" : "double",
@@ -3368,17 +3368,17 @@ GET runtime/tasks/{taskId}/variables?scope={scope}
     "type" : "string",
     "value" : "This is a ProcVariable"
   }
-  
-  
-  
+
+
+
 ]
 ----
 
-The variables are returned as a JSON array. Full response description can be found in the general <<restVariables,REST-variables section>>. 
+The variables are returned as a JSON array. Full response description can be found in the general <<restVariables,REST-variables section>>.
 
 
 ==== Get a variable from a task
-     
+
 ----
 GET runtime/tasks/{taskId}/variables/{variableName}?scope={scope}
 ----
@@ -3407,9 +3407,9 @@ GET runtime/tasks/{taskId}/variables/{variableName}?scope={scope}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "myTaskVariable",
   "scope" : "local",
   "type" : "string",
@@ -3418,11 +3418,11 @@ GET runtime/tasks/{taskId}/variables/{variableName}?scope={scope}
 ----
 
 
-Full response body description can be found in the general <<restVariables,REST-variables section>>. 
+Full response body description can be found in the general <<restVariables,REST-variables section>>.
 
 
 ==== Get the binary data for a variable
-          
+
 ----
 GET runtime/tasks/{taskId}/variables/{variableName}/data?scope={scope}
 ----
@@ -3453,13 +3453,13 @@ GET runtime/tasks/{taskId}/variables/{variableName}/data?scope={scope}
 
 *Success response body:*
 
-The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type. 
-    
+The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type.
+
 
 
 ==== Create new variables on a task
 
-     
+
 ----
 POST runtime/tasks/{taskId}/variables
 ----
@@ -3476,39 +3476,39 @@ POST runtime/tasks/{taskId}/variables
 
 *Request body for creating simple (non-binary) variables:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "name" : "myTaskVariable",
     "scope" : "local",
     "type" : "string",
     "value" : "Hello my friend"
   },
   {
-  
+
   }
 ]
 ----
 
 
 The request body should be an array containing one or more JSON-objects representing the variables that should be created.
-      
+
 * ++name++: Required name of the variable
 * ++scope++: Scope of variable that is created. If omitted, +local+ is assumed.
 * ++type++: Type of variable that is created. If omitted, reverts to raw JSON-value type (string, boolean, integer or double).
 * ++value++: Variable value.
 
 More information about the variable format can be found in <<restVariables,the REST variables section>>.
-        
+
 
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "name" : "myTaskVariable",
     "scope" : "local",
     "type" : "string",
@@ -3534,7 +3534,7 @@ More information about the variable format can be found in <<restVariables,the R
 
 
 ==== Create a new binary variable on a task
-          
+
 ----
 POST runtime/tasks/{taskId}/variables
 ----
@@ -3552,7 +3552,7 @@ POST runtime/tasks/{taskId}/variables
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++scope++: Scope of variable that is created. If omitted, +local+ is assumed.
 * ++type++: Type of variable that is created. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
@@ -3560,9 +3560,9 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -3587,7 +3587,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 ==== Update an existing variable on a task
 
-     
+
 ----
 PUT runtime/tasks/{taskId}/variables/{variableName}
 ----
@@ -3605,9 +3605,9 @@ PUT runtime/tasks/{taskId}/variables/{variableName}
 
 *Request body for updating simple (non-binary) variables:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "myTaskVariable",
   "scope" : "local",
   "type" : "string",
@@ -3615,7 +3615,7 @@ PUT runtime/tasks/{taskId}/variables/{variableName}
 }
 ----
 
-      
+
 * ++name++: Required name of the variable
 * ++scope++: Scope of variable that is updated. If omitted, +local+ is assumed.
 * ++type++: Type of variable that is updated. If omitted, reverts to raw JSON-value type (string, boolean, integer or double).
@@ -3623,13 +3623,13 @@ PUT runtime/tasks/{taskId}/variables/{variableName}
 
 
 More information about the variable format can be found in <<restVariables,the REST variables section>>.
-        
+
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "myTaskVariable",
   "scope" : "local",
   "type" : "string",
@@ -3646,12 +3646,12 @@ More information about the variable format can be found in <<restVariables,the R
 |400|Indicates the name of a variable to update was missing or that an attempt is done to update a variable on a standalone task (without a process associated) with scope +global+. Status message provides additional information.
 |404|Indicates the requested task was not found or the task doesn't have a variable with the given name in the given scope. Status message contains additional information about the error.
 
-|===============    
+|===============
 
 
 
 ==== Updating a binary variable on a task
-     
+
 ----
 PUT runtime/tasks/{taskId}/variables/{variableName}
 ----
@@ -3664,13 +3664,13 @@ PUT runtime/tasks/{taskId}/variables/{variableName}
 |variableName|Yes|String|The name of the variable to update.
 
 |===============
-  
+
 
 
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++scope++: Scope of variable that is updated. If omitted, +local+ is assumed.
 * ++type++: Type of variable that is updated. If omitted, +binary+ is assumed and the binary data in the request will be stored as an array of bytes.
@@ -3678,9 +3678,9 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "name" : "binaryVariable",
   "scope" : "local",
   "type" : "binary",
@@ -3704,7 +3704,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Delete a variable on a task
-          
+
 ----
 DELETE runtime/tasks/{taskId}/variables/{variableName}?scope={scope}
 ----
@@ -3733,7 +3733,7 @@ DELETE runtime/tasks/{taskId}/variables/{variableName}?scope={scope}
 
 
 ==== Delete all local variables on a task
-          
+
 ----
 DELETE runtime/tasks/{taskId}/variables
 ----
@@ -3760,7 +3760,7 @@ DELETE runtime/tasks/{taskId}/variables
 
 ==== Get all identity links for a task
 
-       
+
 ----
 GET runtime/tasks/{taskId}/identitylinks
 ----
@@ -3787,10 +3787,10 @@ GET runtime/tasks/{taskId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "userId" : "kermit",
     "groupId" : null,
     "type" : "candidate",
@@ -3802,7 +3802,7 @@ GET runtime/tasks/{taskId}/identitylinks
     "type" : "candidate",
     "url" : "http://localhost:8081/activiti-rest/service/runtime/tasks/100/identitylinks/groups/sales/candidate"
   },
-  
+
   ...
 ]
 ----
@@ -3810,7 +3810,7 @@ GET runtime/tasks/{taskId}/identitylinks
 
 
 ==== Get all identitylinks for a task for either groups or users
-     
+
 ----
 GET runtime/tasks/{taskId}/identitylinks/users
 GET runtime/tasks/{taskId}/identitylinks/groups
@@ -3818,15 +3818,15 @@ GET runtime/tasks/{taskId}/identitylinks/groups
 
 
 Returns only identity links targetting either users or groups. Response body and status-codes are exactly the same as when getting the full list of identity links for a task.
-        
+
 
 ==== Get a single identity link on a task
 
 
-        
+
 ----
 GET runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
-----   
+----
 
 
 .Get all identitylinks for a task for either groups or users - URL parameters
@@ -3853,7 +3853,7 @@ GET runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "userId" : null,
@@ -3866,7 +3866,7 @@ GET runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
 
 ==== Create an identity link on a task
 
-   
+
 ----
 POST runtime/tasks/{taskId}/identitylinks
 ----
@@ -3884,7 +3884,7 @@ POST runtime/tasks/{taskId}/identitylinks
 
 *Request body (user):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "userId" : "kermit",
@@ -3895,7 +3895,7 @@ POST runtime/tasks/{taskId}/identitylinks
 
 *Request body (group):*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "groupId" : "sales",
@@ -3916,7 +3916,7 @@ POST runtime/tasks/{taskId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "userId" : null,
@@ -3928,7 +3928,7 @@ POST runtime/tasks/{taskId}/identitylinks
 
 
 ==== Delete an identity link on a task
-   
+
 ----
 DELETE runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
 ----
@@ -3959,7 +3959,7 @@ DELETE runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
 
 ==== Create a new comment on a task
 
-     
+
 ----
 POST runtime/tasks/{taskId}/comments
 ----
@@ -3975,9 +3975,9 @@ POST runtime/tasks/{taskId}/comments
 
 *Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
-{ 
+{
   "message" : "This is a comment on the task.",
   "saveProcessInstanceId" : true
 }
@@ -3985,12 +3985,12 @@ POST runtime/tasks/{taskId}/comments
 
 
 Parameter +saveProcessInstanceId+ is optional, if +true+ save process instance id of task with comment.
-        
+
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "id" : "123",
   "taskUrl" : "http://localhost:8081/activiti-rest/service/runtime/tasks/101/comments/123",
   "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/123",
@@ -4016,7 +4016,7 @@ Parameter +saveProcessInstanceId+ is optional, if +true+ save process instance i
 
 
 ==== Get all comments on a task
-          
+
 ----
 GET runtime/tasks/{taskId}/comments
 ----
@@ -4031,10 +4031,10 @@ GET runtime/tasks/{taskId}/comments
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "id" : "123",
     "taskUrl" : "http://localhost:8081/activiti-rest/service/runtime/tasks/101/comments/123",
     "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/123",
@@ -4044,7 +4044,7 @@ GET runtime/tasks/{taskId}/comments
     "taskId" : "101",
     "processInstanceId" : "100"
   },
-  { 
+  {
     "id" : "456",
     "taskUrl" : "http://localhost:8081/activiti-rest/service/runtime/tasks/101/comments/456",
     "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/456",
@@ -4070,7 +4070,7 @@ GET runtime/tasks/{taskId}/comments
 
 
 ==== Get a comment on a task
-     
+
 ----
 GET runtime/tasks/{taskId}/comments/{commentId}
 ----
@@ -4088,9 +4088,9 @@ GET runtime/tasks/{taskId}/comments/{commentId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "id" : "123",
   "taskUrl" : "http://localhost:8081/activiti-rest/service/runtime/tasks/101/comments/123",
   "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/123",
@@ -4113,7 +4113,7 @@ GET runtime/tasks/{taskId}/comments/{commentId}
 
 
 ==== Delete a comment on a task
-     
+
 ----
 DELETE runtime/tasks/{taskId}/comments/{commentId}
 ----
@@ -4126,7 +4126,7 @@ DELETE runtime/tasks/{taskId}/comments/{commentId}
 |commentId|Yes|String|The id of the comment.
 
 |===============
-      
+
 
 .Delete a comment on a task - Response codes
 [options="header"]
@@ -4139,7 +4139,7 @@ DELETE runtime/tasks/{taskId}/comments/{commentId}
 
 
 ==== Get all events for a task
-      
+
 ----
 GET runtime/tasks/{taskId}/events
 ----
@@ -4155,10 +4155,10 @@ GET runtime/tasks/{taskId}/events
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "action" : "AddUserLink",
     "id" : "4",
     "message" : [ "gonzo", "contributor" ],
@@ -4184,7 +4184,7 @@ GET runtime/tasks/{taskId}/events
 
 
 ==== Get an event on a task
-         
+
 ----
 GET runtime/tasks/{taskId}/events/{eventId}
 ----
@@ -4202,9 +4202,9 @@ GET runtime/tasks/{taskId}/events/{eventId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "AddUserLink",
   "id" : "4",
   "message" : [ "gonzo", "contributor" ],
@@ -4228,7 +4228,7 @@ GET runtime/tasks/{taskId}/events/{eventId}
 
 
 ==== Create a new attachment on a task, containing a link to an external resource
-     
+
 ----
 POST runtime/tasks/{taskId}/attachments
 ----
@@ -4244,9 +4244,9 @@ POST runtime/tasks/{taskId}/attachments
 
 *Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
-{ 
+{
   "name":"Simple attachment",
   "description":"Simple attachment description",
   "type":"simpleType",
@@ -4256,12 +4256,12 @@ POST runtime/tasks/{taskId}/attachments
 
 
 Only the attachment name is required to create a new attachment.
-        
+
 
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "id":"3",
@@ -4290,7 +4290,7 @@ Only the attachment name is required to create a new attachment.
 
 
 ==== Create a new attachment on a task, with an attached file
-        
+
 ----
 POST runtime/tasks/{taskId}/attachments
 ----
@@ -4307,14 +4307,14 @@ POST runtime/tasks/{taskId}/attachments
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the variable. On top of that, the following additional form-fields can be present:
-      
+
 * ++name++: Required name of the variable.
 * ++description++: Description of the attachment, optional.
 * ++type++: Type of attachment, optional. Supports any arbitrary string or a valid HTTP content-type.
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
 	"id":"5",
@@ -4342,7 +4342,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== Get all attachments on a task
-     
+
 ----
 GET runtime/tasks/{taskId}/attachments
 ----
@@ -4359,7 +4359,7 @@ GET runtime/tasks/{taskId}/attachments
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
   {
@@ -4401,7 +4401,7 @@ GET runtime/tasks/{taskId}/attachments
 
 
 ==== Get an attachment on a task
-     
+
 ----
 GET runtime/tasks/{taskId}/attachments/{attachmentId}
 ----
@@ -4418,7 +4418,7 @@ GET runtime/tasks/{taskId}/attachments/{attachmentId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
   "id":"5",
@@ -4433,10 +4433,10 @@ GET runtime/tasks/{taskId}/attachments/{attachmentId}
 }
 ----
 
-  
+
 *  ++externalUrl - contentUrl:++In case the attachment is a link to an external resource, the +externalUrl+ contains the URL to the external content. If the attachment content is present in the Activiti engine, the +contentUrl+ will contain an URL where the binary content can be streamed from.
 *  ++type:++Can be any arbitrary value. When a valid formatted media-type (e.g. application/xml, text/plain) is included, the binary content HTTP response content-type will be set the the given value.
-      
+
 .Get an attachment on a task - Response codes
 [options="header"]
 |===============
@@ -4450,7 +4450,7 @@ GET runtime/tasks/{taskId}/attachments/{attachmentId}
 
 ==== Get the content for an attachment
 
-     
+
 ----
 GET runtime/tasks/{taskId}/attachment/{attachmentId}/content
 ----
@@ -4477,12 +4477,12 @@ GET runtime/tasks/{taskId}/attachment/{attachmentId}/content
 
 *Success response body:*
 
-The response body contains the binary content. By default, the content-type of the response is set to +application/octet-stream+ unless the attachment type contains a valid Content-type. 
-    
+The response body contains the binary content. By default, the content-type of the response is set to +application/octet-stream+ unless the attachment type contains a valid Content-type.
+
 
 ==== Delete an attachment on a task
 
-     
+
 ----
 DELETE runtime/tasks/{taskId}/attachments/{attachmentId}
 ----
@@ -4528,11 +4528,11 @@ GET history/historic-process-instances/{processInstanceId}
 
 *Success response body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "businessKey" : "myKey",
       "processDefinitionId" : "oneTaskProcess%3A1%3A4",
@@ -4558,12 +4558,12 @@ GET history/historic-process-instances/{processInstanceId}
 }
 ----
 
- 
+
 [[restHistoricProcessInstancesGet]]
 
 
 ==== List of historic process instances
-   
+
 ----
 GET history/historic-process-instances
 ----
@@ -4606,11 +4606,11 @@ GET history/historic-process-instances
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "businessKey" : "myKey",
       "processDefinitionId" : "oneTaskProcess%3A1%3A4",
@@ -4644,19 +4644,19 @@ GET history/historic-process-instances
 
 
 ==== Query for historic process instances
-   
+
 ----
 POST query/historic-process-instances
 ----
 
 *Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "processDefinitionId" : "oneTaskProcess%3A1%3A4",
 
-  
+
   "variables" : [
     {
       "name" : "myVariable",
@@ -4669,7 +4669,7 @@ POST query/historic-process-instances
 ----
 
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restHistoricProcessInstancesGet,getting a collection of historic process instances>>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows for filtering based on process variables. The +variables+ property is a JSON-array containing objects with the format <<restQueryVariable, as described here.>>
-      
+
 
 .Query for historic process instances - Response codes
 [options="header"]
@@ -4683,11 +4683,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "businessKey" : "myKey",
       "processDefinitionId" : "oneTaskProcess%3A1%3A4",
@@ -4721,7 +4721,7 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 
 ==== Delete a historic process instance
-   
+
 ----
 DELETE history/historic-process-instances/{processInstanceId}
 ----
@@ -4739,7 +4739,7 @@ DELETE history/historic-process-instances/{processInstanceId}
 
 ==== Get the identity links of a historic process instance
 
-   
+
 ----
 GET history/historic-process-instance/{processInstanceId}/identitylinks
 ----
@@ -4752,12 +4752,12 @@ GET history/historic-process-instance/{processInstanceId}/identitylinks
 |200|Indicates request was successful and the identity links are returned
 |404|Indicates the process instance could not be found.
 
-|===============  
+|===============
 
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 [
  {
@@ -4775,7 +4775,7 @@ GET history/historic-process-instance/{processInstanceId}/identitylinks
 
 
 ==== Get the binary data for a historic process instance variable
-   
+
 ----
 GET history/historic-process-instances/{processInstanceId}/variables/{variableName}/data
 ----
@@ -4793,11 +4793,11 @@ GET history/historic-process-instances/{processInstanceId}/variables/{variableNa
 
 *Success response body:*
 
-The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type. 
+The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type.
 
 
 ==== Create a new comment on a historic process instance
-          
+
 ----
 POST history/historic-process-instances/{processInstanceId}/comments
 ----
@@ -4814,21 +4814,21 @@ POST history/historic-process-instances/{processInstanceId}/comments
 
 *Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
-{ 
+{
   "message" : "This is a comment.",
   "saveProcessInstanceId" : true
 }
 ----
 
 Parameter +saveProcessInstanceId+ is optional, if +true+ save process instance id of task with comment.
-       
+
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "id" : "123",
   "taskUrl" : "http://localhost:8081/activiti-rest/service/runtime/tasks/101/comments/123",
   "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/123",
@@ -4855,7 +4855,7 @@ Parameter +saveProcessInstanceId+ is optional, if +true+ save process instance i
 
 ==== Get all comments on a historic process instance
 
-     
+
 ----
 GET history/historic-process-instances/{processInstanceId}/comments
 ----
@@ -4871,10 +4871,10 @@ GET history/historic-process-instances/{processInstanceId}/comments
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
-  { 
+  {
     "id" : "123",
     "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/123",
     "message" : "This is a comment on the task.",
@@ -4882,7 +4882,7 @@ GET history/historic-process-instances/{processInstanceId}/comments
     "time" : "2014-07-13T13:13:52.232+08:00",
     "processInstanceId" : "100"
   },
-  { 
+  {
     "id" : "456",
     "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/456",
     "message" : "This is another comment.",
@@ -4905,7 +4905,7 @@ GET history/historic-process-instances/{processInstanceId}/comments
 
 
 ==== Get a comment on a historic process instance
-     
+
 ----
 GET history/historic-process-instances/{processInstanceId}/comments/{commentId}
 ----
@@ -4923,9 +4923,9 @@ GET history/historic-process-instances/{processInstanceId}/comments/{commentId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
-{ 
+{
   "id" : "123",
   "processInstanceUrl" : "http://localhost:8081/activiti-rest/service/history/historic-process-instances/100/comments/456",
   "message" : "This is another comment.",
@@ -4948,7 +4948,7 @@ GET history/historic-process-instances/{processInstanceId}/comments/{commentId}
 
 
 ==== Delete a comment on a historic process instance
-          
+
 ----
 DELETE history/historic-process-instances/{processInstanceId}/comments/{commentId}
 ----
@@ -4974,7 +4974,7 @@ DELETE history/historic-process-instances/{processInstanceId}/comments/{commentI
 
 
 ==== Get a single historic task instance
-      
+
 ----
 GET history/historic-task-instances/{taskId}
 ----
@@ -4990,8 +4990,8 @@ GET history/historic-task-instances/{taskId}
 
 
 *Success response body:*
-  
-[source,json,linenums]        
+
+[source,json,linenums]
 ----
 {
   "id" : "5",
@@ -5026,7 +5026,7 @@ GET history/historic-task-instances/{taskId}
 
 
 ==== Get historic task instances
-        
+
 ----
 GET history/historic-task-instances
 ----
@@ -5095,11 +5095,11 @@ GET history/historic-task-instances
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "processDefinitionId" : "oneTaskProcess%3A1%3A4",
       "processDefinitionUrl" : "http://localhost:8182/repository/process-definitions/oneTaskProcess%3A1%3A4",
@@ -5149,7 +5149,7 @@ GET history/historic-task-instances
 
 
 ==== Query for historic task instances
-   
+
 ----
 POST query/historic-task-instances
 ----
@@ -5157,12 +5157,12 @@ POST query/historic-task-instances
 
 *Query for historic task instances - Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "processDefinitionId" : "oneTaskProcess%3A1%3A4",
   ...
-  
+
   "variables" : [
     {
       "name" : "myVariable",
@@ -5174,9 +5174,9 @@ POST query/historic-task-instances
 }
 ----
 
- 
+
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restHistoricTaskInstancesGet,getting a collection of historic task instances>>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows for filtering based on process variables. The +taskVariables+ and +processVariables+ properties are JSON-arrays containing objects with the format <<restQueryVariable, as described here.>>
-      
+
 .Query for historic task instances - Response codes
 [options="header"]
 |===============
@@ -5189,11 +5189,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "processDefinitionId" : "oneTaskProcess%3A1%3A4",
       "processDefinitionUrl" : "http://localhost:8182/repository/process-definitions/oneTaskProcess%3A1%3A4",
@@ -5243,7 +5243,7 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 
 ==== Delete a historic task instance
-    
+
 ----
 DELETE history/historic-task-instances/{taskId}
 ----
@@ -5260,7 +5260,7 @@ DELETE history/historic-task-instances/{taskId}
 
 
 ==== Get the identity links of a historic task instance
-   
+
 ----
 GET history/historic-task-instance/{taskId}/identitylinks
 ----
@@ -5277,7 +5277,7 @@ GET history/historic-task-instance/{taskId}/identitylinks
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 [
  {
@@ -5294,7 +5294,7 @@ GET history/historic-task-instance/{taskId}/identitylinks
 
 
 ==== Get the binary data for a historic task instance variable
-   
+
 ----
 GET history/historic-task-instances/{taskId}/variables/{variableName}/data
 ----
@@ -5311,14 +5311,14 @@ GET history/historic-task-instances/{taskId}/variables/{variableName}/data
 
 *Success response body:*
 
-The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type. 
-      
+The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type.
+
 
 [[restHistoricActivityInstancesGet]]
 
 
 ==== Get historic activity instances
-   
+
 ----
 GET history/historic-activity-instances
 ----
@@ -5358,11 +5358,11 @@ GET history/historic-activity-instances
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "activityId" : "4",
       "activityName" : "My user task",
@@ -5391,15 +5391,15 @@ GET history/historic-activity-instances
 
 
 ==== Query for historic activity instances
-   
+
 ----
 POST query/historic-activity-instances
 ----
 
 
 *Request body:*
-    
-[source,json,linenums]    
+
+[source,json,linenums]
 ----
 {
   "processDefinitionId" : "oneTaskProcess%3A1%3A4"
@@ -5408,7 +5408,7 @@ POST query/historic-activity-instances
 
 
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restHistoricTaskInstancesGet,getting a collection of historic task instances>>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long.
-      
+
 
 .Query for historic activity instances - Response codes
 [options="header"]
@@ -5422,11 +5422,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "5",
       "activityId" : "4",
       "activityName" : "My user task",
@@ -5458,7 +5458,7 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 
 ==== List of historic variable instances
-      
+
 ----
 GET history/historic-variable-instances
 ----
@@ -5489,11 +5489,11 @@ GET history/historic-variable-instances
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "14",
       "processInstanceId" : "5",
       "processInstanceUrl" : "http://localhost:8182/history/historic-process-instances/5",
@@ -5516,7 +5516,7 @@ GET history/historic-variable-instances
 
 
 ==== Query for historic variable instances
-   
+
 ----
 POST query/historic-variable-instances
 ----
@@ -5524,12 +5524,12 @@ POST query/historic-variable-instances
 
 *Request body:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "processDefinitionId" : "oneTaskProcess%3A1%3A4",
   ...
-  
+
   "variables" : [
     {
       "name" : "myVariable",
@@ -5543,7 +5543,7 @@ POST query/historic-variable-instances
 
 
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restHistoricVariableInstancesGet,getting a collection of historic process instances>>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long. On top of that, the query allows for filtering based on process variables. The +variables+ property is a JSON-array containing objects with the format <<restQueryVariable, as described here.>>
-      
+
 .Query for historic variable instances - Response codes
 [options="header"]
 |===============
@@ -5556,11 +5556,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "14",
       "processInstanceId" : "5",
       "processInstanceUrl" : "http://localhost:8182/history/historic-process-instances/5",
@@ -5600,14 +5600,14 @@ GET history/historic-variable-instances/{varInstanceId}/data
 
 *Success response body:*
 
-The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type. 
-    
+The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type.
+
 
 [[restHistoricDetailGet]]
 
 
 ==== Get historic detail
-        
+
 ----
 GET history/historic-detail
 ----
@@ -5640,11 +5640,11 @@ GET history/historic-detail
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "26",
       "processInstanceId" : "5",
       "processInstanceUrl" : "http://localhost:8182/history/historic-process-instances/5",
@@ -5674,13 +5674,13 @@ GET history/historic-detail
 
 
 ==== Query for historic details
-   
+
 ----
 POST query/historic-detail
 ----
 
 *Request body:*
-        
+
 ----
 {
   "processInstanceId" : "5",
@@ -5689,7 +5689,7 @@ POST query/historic-detail
 
 
 All supported JSON parameter fields allowed are exactly the same as the parameters found for <<restHistoricDetailGet,getting a collection of historic process instances>>, but passed in as JSON-body arguments rather than URL-parameters to allow for more advanced querying and preventing errors with request-uri's that are too long.
-    
+
 .Query for historic details - Response codes
 [options="header"]
 |===============
@@ -5702,11 +5702,11 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "id" : "26",
       "processInstanceId" : "5",
       "processInstanceUrl" : "http://localhost:8182/history/historic-process-instances/5",
@@ -5736,7 +5736,7 @@ All supported JSON parameter fields allowed are exactly the same as the paramete
 
 
 ==== Get the binary data for a historic detail variable
-   
+
 ----
 GET history/historic-detail/{detailId}/data
 ----
@@ -5754,12 +5754,12 @@ GET history/historic-detail/{detailId}/data
 
 *Success response body:*
 
-The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type. 
-    
+The response body contains the binary value of the variable. When the variable is of type +binary+, the content-type of the response is set to +application/octet-stream+, regardless of the content of the variable or the request accept-type header. In case of +serializable+, +application/x-java-serialized-object+ is used as content-type.
+
 === Forms
 
 ==== Get form data
-        
+
 ----
 GET form/form-data
 ----
@@ -5786,11 +5786,11 @@ GET form/form-data
 
 *Success response body:*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "data": [
-    { 
+    {
       "formKey" : null,
       "deploymentId" : "2",
       "processDefinitionId" : "3",
@@ -5831,14 +5831,14 @@ GET form/form-data
 
 
 ==== Submit task form data
-   
+
 ----
 POST form/form-data
 ----
 
 *Request body for task form:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "taskId" : "5",
@@ -5854,7 +5854,7 @@ POST form/form-data
 
 *Request body for start event form:*
 
-[source,json,linenums]        
+[source,json,linenums]
 ----
 {
   "processDefinitionId" : "5",
@@ -5881,7 +5881,7 @@ POST form/form-data
 
 *Success response body for start event form data (no response for task form data):*
 
-[source,json,linenums]          
+[source,json,linenums]
 ----
 {
   "id" : "5",
@@ -5898,7 +5898,7 @@ POST form/form-data
 === Database tables
 
 ==== List of tables
-   
+
 ----
 GET management/tables
 ----
@@ -5914,7 +5914,7 @@ GET management/tables
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 [
    {
@@ -5927,13 +5927,13 @@ GET management/tables
       "url":"http://localhost:8182/management/tables/ACT_RU_EVENT_SUBSCR",
       "count":3
    }
-   
+
 ]
 ----
 
 
 ==== Get a single table
-     
+
 ----
 GET management/tables/{tableName}
 ----
@@ -5950,7 +5950,7 @@ GET management/tables/{tableName}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
       "name":"ACT_RE_PROCDEF",
@@ -5973,7 +5973,7 @@ GET management/tables/{tableName}
 
 
 ==== Get column info for a single table
-          
+
 ----
 GET management/tables/{tableName}/columns
 ----
@@ -5989,7 +5989,7 @@ GET management/tables/{tableName}/columns
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 
 {
@@ -5999,16 +5999,16 @@ GET management/tables/{tableName}/columns
       "REV_",
       "TYPE_",
       "NAME_"
-      
-      
+
+
    ],
    "columnTypes":[
       "VARCHAR",
       "INTEGER",
       "VARCHAR",
       "VARCHAR"
-      
-      
+
+
    ]
 }
 ----
@@ -6026,7 +6026,7 @@ GET management/tables/{tableName}/columns
 
 
 ==== Get row data for a single table
-     
+
 ----
 GET management/tables/{tableName}/data
 ----
@@ -6053,8 +6053,8 @@ GET management/tables/{tableName}/data
 
 
 *Success response body:*
- 
-[source,json,linenums]           
+
+[source,json,linenums]
 ----
 {
   "total":3,
@@ -6062,7 +6062,7 @@ GET management/tables/{tableName}/data
    "sort":null,
    "order":null,
    "size":3,
-   
+
    "data":[
       {
          "TASK_ID_":"2",
@@ -6073,11 +6073,11 @@ GET management/tables/{tableName}/data
          "ID_":"3",
          "TYPE_":"integer"
       }
-      
-      
-      
+
+
+
    ]
- 
+
 }
 ----
 
@@ -6094,7 +6094,7 @@ GET management/tables/{tableName}/data
 === Engine
 
 ==== Get engine properties
-          
+
 ----
 GET management/properties
 ----
@@ -6104,7 +6104,7 @@ Returns a read-only view of the properties used internally in the engine.
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "next.dbid":"101",
@@ -6125,18 +6125,18 @@ Returns a read-only view of the properties used internally in the engine.
 
 
 ==== Get engine info
-   
+
 ----
 GET management/engine
 ----
 
 
 Returns a read-only view of the engine that is used in this REST-service.
-        
+
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "name":"default",
@@ -6160,25 +6160,25 @@ Returns a read-only view of the engine that is used in this REST-service.
 === Runtime
 
 ==== Signal event received
-          
+
 ----
 POST runtime/signals
 ----
 
 
 Notifies the engine that a signal event has been received, not explicitly related to a specific execution.
-        
+
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "signalName": "My Signal",
   "tenantId" : "execute",
   "async": true,
   "variables": [
       {"name": "testVar", "value": "This is a string"}
-      
+
   ]
 }
 ----
@@ -6190,7 +6190,7 @@ Notifies the engine that a signal event has been received, not explicitly relate
 |Parameter|Description|Required
 |signalName|Name of the signal|Yes
 |tenantId|ID of the tenant that the signal event should be processed in|No
-|async|If +true+, handling of the signal will happen asynchronously. Return code will be +202 - Accepted+ to indicate the request is accepted but not yet executed. If +false+, 
+|async|If +true+, handling of the signal will happen asynchronously. Return code will be +202 - Accepted+ to indicate the request is accepted but not yet executed. If +false+,
                     handling the signal will be done immediately and result (++200 - OK++) will only return after this completed successfully. Defaults to ++false++ if omitted.|No
 |variables|Array of variables (in the general variables format) to use as payload to pass along with the signal. Cannot be used in case +async+ is set to +true+, this will result in an error.|No
 
@@ -6205,7 +6205,7 @@ Notifies the engine that a signal event has been received, not explicitly relate
 |Response code|Description
 |200|Indicated signal has been processed and no errors occurred.
 |202|Indicated signal processing is queued as a job, ready to be executed.
-|400|Signal not processed. The signal name is missing or variables are used toghether with async, which is not allowed. Response body contains additional information about the error.
+|400|Signal not processed. The signal name is missing or variables are used together with async, which is not allowed. Response body contains additional information about the error.
 
 |===============
 
@@ -6214,7 +6214,7 @@ Notifies the engine that a signal event has been received, not explicitly relate
 === Jobs
 
 ==== Get a single job
-     
+
 ----
 GET management/jobs/{jobId}
 ----
@@ -6230,7 +6230,7 @@ GET management/jobs/{jobId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"8",
@@ -6260,7 +6260,7 @@ GET management/jobs/{jobId}
 
 
 ==== Delete a job
-     
+
 ----
 DELETE management/jobs/{jobId}
 ----
@@ -6287,7 +6287,7 @@ DELETE management/jobs/{jobId}
 
 
 ==== Execute a single job
-     
+
 ----
 POST management/jobs/{jobId}
 ----
@@ -6295,9 +6295,9 @@ POST management/jobs/{jobId}
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
-{ 
+{
   "action" : "execute"
 }
 ----
@@ -6325,7 +6325,7 @@ POST management/jobs/{jobId}
 
 
 ==== Get the exception stacktrace for a job
-          
+
 ----
 GET management/jobs/{jobId}/exception-stacktrace
 ----
@@ -6352,7 +6352,7 @@ GET management/jobs/{jobId}/exception-stacktrace
 
 ==== Get a list of jobs
 
-          
+
 ----
 GET management/jobs
 ----
@@ -6385,7 +6385,7 @@ GET management/jobs
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -6403,9 +6403,9 @@ GET management/jobs
          "dueDate":"2013-06-07T10:00:24.653+0000",
          "tenantId":null
       }
-      
-      
-      
+
+
+
    ],
    "total":2,
    "start":0,
@@ -6430,7 +6430,7 @@ GET management/jobs
 === Users
 
 ==== Get a single user
-     
+
 ----
 GET identity/users/{userId}
 ----
@@ -6447,7 +6447,7 @@ GET identity/users/{userId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"testuser",
@@ -6472,7 +6472,7 @@ GET identity/users/{userId}
 
 ==== Get a list of users
 
-     
+
 ----
 GET identity/users
 ----
@@ -6498,7 +6498,7 @@ GET identity/users
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -6544,14 +6544,14 @@ GET identity/users
 
 
 ==== Update a user
-          
+
 ----
 PUT identity/users/{userId}
 ----
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
   "firstName":"Tijs",
@@ -6562,7 +6562,7 @@ PUT identity/users/{userId}
 ----
 
 All request values are optional. For example, you can only include the 'firstName' attribute in the request body JSON-object, only updating the firstName of the user, leaving all other fields unaffected. When an attribute is explicitly included and is set to null, the user-value will be updated to null. Example: +{"firstName" : null}+ will clear the firstName of the user).
-       
+
 
 .Update a user - Response codes
 [options="header"]
@@ -6576,16 +6576,16 @@ All request values are optional. For example, you can only include the 'firstNam
 
 
 *Success response body:* see response for +identity/users/{userId}+.
-      
+
 
 ==== Create a user
-     
+
 ----
 POST identity/users
-----     
+----
 
 *Body JSON:*
-           
+
 ----
 {
   "id":"tijs",
@@ -6607,9 +6607,9 @@ POST identity/users
 
 
 *Success response body:* see response for +identity/users/{userId}+.
-    
+
 ==== Delete a user
-   
+
 ----
 DELETE identity/users/{userId}
 ----
@@ -6632,10 +6632,10 @@ DELETE identity/users/{userId}
 |404|Indicates the requested user was not found.
 
 |===============
-        
+
 
 ==== Get a user's picture
-   
+
 ----
 GET identity/users/{userId}/picture
 ----
@@ -6666,10 +6666,10 @@ The response body contains the raw picture data, representing the user's picture
 
 
 ==== Updating a user's picture
-        
+
 ----
 GET identity/users/{userId}/picture
----- 
+----
 
 .Updating a user's picture - URL parameters
 [options="header"]
@@ -6683,7 +6683,7 @@ GET identity/users/{userId}/picture
 *Request body:*
 
 The request should be of type +multipart/form-data+. There should be a single file-part included with the binary value of the picture. On top of that, the following additional form-fields can be present:
-        
+
 * ++mimeType++: Optional mime-type for the uploaded picture. If omitted, the default of +image/jpeg+ is used as a mime-type for the picture.
 
 
@@ -6699,7 +6699,7 @@ The request should be of type +multipart/form-data+. There should be a single fi
 
 
 ==== List a user's info
-   
+
 ----
 PUT identity/users/{userId}/info
 ----
@@ -6758,7 +6758,7 @@ GET identity/users/{userId}/info/{key}
 |userId|Yes|String|The id of the user to get the info for.
 |key|Yes|String|The key of the user info to get.
 
-|===============  
+|===============
 
 
 *Response Body:*
@@ -6785,7 +6785,7 @@ GET identity/users/{userId}/info/{key}
 
 
 ==== Update a user's info
-   
+
 ----
 PUT identity/users/{userId}/info/{key}
 ----
@@ -6833,7 +6833,7 @@ PUT identity/users/{userId}/info/{key}
 
 
 ==== Create a new user's info entry
-   
+
 ----
 POST identity/users/{userId}/info
 ----
@@ -6885,7 +6885,7 @@ POST identity/users/{userId}/info
 
 
 ==== Delete a user's info
-   
+
 ----
 DELETE identity/users/{userId}/info/{key}
 ----
@@ -6920,7 +6920,7 @@ DELETE identity/users/{userId}/info/{key}
 ==== Get a single group
 
 
-          
+
 ----
 GET identity/groups/{groupId}
 ----
@@ -6937,7 +6937,7 @@ GET identity/groups/{groupId}
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "id":"testgroup",
@@ -6961,7 +6961,7 @@ GET identity/groups/{groupId}
 
 ==== Get a list of groups
 
-     
+
 ----
 GET identity/groups
 ----
@@ -6985,7 +6985,7 @@ GET identity/groups
 
 *Success response body:*
 
-[source,json,linenums]            
+[source,json,linenums]
 ----
 {
    "data":[
@@ -7017,14 +7017,14 @@ GET identity/groups
 
 
 ==== Update a group
-     
+
 ----
 PUT identity/groups/{groupId}
 ----
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
    "name":"Test group",
@@ -7034,7 +7034,7 @@ PUT identity/groups/{groupId}
 
 
 All request values are optional. For example, you can only include the 'name' attribute in the request body JSON-object, only updating the name of the group, leaving all other fields unaffected. When an attribute is explicitly included and is set to null, the group-value will be updated to null.
-       
+
 
 .Update a group - Response codes
 [options="header"]
@@ -7048,16 +7048,16 @@ All request values are optional. For example, you can only include the 'name' at
 
 
 *Success response body:* see response for +identity/groups/{groupId}+.
-      
+
 ==== Create a group
-     
+
 ----
 POST identity/groups
 ----
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
    "id":"testgroup",
@@ -7077,10 +7077,10 @@ POST identity/groups
 |===============
 
 *Success response body:* see response for +identity/groups/{groupId}+.
-      
+
 
 ==== Delete a group
-   
+
 ----
 DELETE identity/groups/{groupId}
 ----
@@ -7115,7 +7115,7 @@ There is no GET allowed on +identity/groups/members+. Use the +identity/users?me
 ==== Add a member to a group
 
 
-        
+
 ----
 POST identity/groups/{groupId}/members
 ----
@@ -7133,7 +7133,7 @@ POST identity/groups/{groupId}/members
 
 *Body JSON:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
    "userId":"kermit"
@@ -7155,7 +7155,7 @@ POST identity/groups/{groupId}/members
 
 *Response Body:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
    "userId":"kermit",
@@ -7167,7 +7167,7 @@ POST identity/groups/{groupId}/members
 
 ==== Delete a member from a group
 
-   
+
 ----
 DELETE identity/groups/{groupId}/members/{userId}
 ----
@@ -7195,7 +7195,7 @@ DELETE identity/groups/{groupId}/members/{userId}
 
 *Response Body:*
 
-[source,json,linenums]           
+[source,json,linenums]
 ----
 {
    "userId":"kermit",
@@ -7205,5 +7205,5 @@ DELETE identity/groups/{groupId}/members/{userId}
 ----
 
 
-       
+
 

--- a/userguide/src/en/ch17-Advanced.adoc
+++ b/userguide/src/en/ch17-Advanced.adoc
@@ -757,7 +757,7 @@ runtimeService.addEventListener(databaseEventLogger);
 
 The EventLogger class can be subclassed. In particular, the _createEventFlusher()_ method needs to return an instance of the _org.activiti.engine.impl.event.logger.EventFlusher_ interface if the default database logging is not wanted. The _managementService.getEventLogEntries(startLogNr, size);_  can be used to retrieve the _EventLogEntryEntity_ instances through Activiti.
 
-It is easy to see how this table data can now be used to feed the JSON into a big data NoSQL store such as MongDb, Elastic Search, etc. It is also easy to see that the classes used here (org.activiti.engine.impl.event.logger.EventLogger/EventFlusher and many EventHandler classes) are pluggable and can be tweaked to your own use case (eg not storing the JSON in the database, but firing it straight onto a queue or big data store).
+It is easy to see how this table data can now be used to feed the JSON into a big data NoSQL store such as MongoDB, Elastic Search, etc. It is also easy to see that the classes used here (org.activiti.engine.impl.event.logger.EventLogger/EventFlusher and many EventHandler classes) are pluggable and can be tweaked to your own use case (eg not storing the JSON in the database, but firing it straight onto a queue or big data store).
 
 Note that this event logging mechanism is additional to the 'traditional' history manager of Activiti. Although all the data is in the database tables,
 it is not optimized for querying nor for easy retrieval. The real use case is audit trailing and feeding it into a big data store.

--- a/userguide/src/en/ch19-tooling.adoc
+++ b/userguide/src/en/ch19-tooling.adoc
@@ -50,7 +50,7 @@ Here is a list available attributes and operations at this moment. This list may
 [options="header"]
 |===============
 |MBean|Type|Name|Description
-|ProcessDefinitionsMBean|Attribute|processDefinitons|+Id+, +Name+, +Version+, +IsSuspended+ properties of deployed process definitions as a list of list of Strings
+|ProcessDefinitionsMBean|Attribute|processDefinitions|+Id+, +Name+, +Version+, +IsSuspended+ properties of deployed process definitions as a list of list of Strings
 ||Attribute|deployments|+Id+, +Name+, +TenantId+ properties of current deployments
 ||method|getProcessDefinitionById(String id)|+Id+, +Name+, +Version+ and +IsSuspended+ properties of the process definition with given id
 ||method|deleteDeployment(String id)|Deletes deployment with the given +Id+
@@ -137,7 +137,7 @@ bug reports and feature requests.
 Having a test case attached to a bug report or feature request jira issue, considerably reduces its fixing time.
 
 To facilitate creation of a test case, a maven archetype is available. By use of this archetype, one can rapidly create a standard test case.
-The archetype should be already avilable in the standard repository. if not, you can easily install it in your local maven repository folder by just typing
+The archetype should be already available in the standard repository. If not, you can easily install it in your local maven repository folder by just typing
   *mvn install* in *tooling/archtypes* folder.
 
 The following command creates the unit test project:


### PR DESCRIPTION
I was reviewing some of the recent pull requests and noticed some spelling errors.

The majority of the 517 "changes" are just white space.