### PR TITLE
ACT-4051 - Spring Boot support does not discover processes in externa…

### DIFF
--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
@@ -64,12 +64,12 @@ public abstract class AbstractProcessEngineConfiguration {
   public List<Resource> discoverProcessDefinitionResources(ResourcePatternResolver applicationContext, String prefix, String suffix, boolean checkPDs) throws IOException {
     String path = prefix + suffix;
     if (checkPDs) {
-    	if (!applicationContext.getResource(prefix).exists()) {
-    		logger.warn(String.format("No process definitions were found using the specified path (%s).", path));
-    		return new ArrayList<Resource>();
-    	}
-
-      return Arrays.asList(applicationContext.getResources(path));
+      final Resource[] resources = applicationContext.getResources(path);
+      if (resources == null || resources.length == 0) {
+        logger.warn(String.format("No process definitions were found using the specified path (%s).", path));
+        return new ArrayList<Resource>();
+      }
+      return Arrays.asList(resources);
     }
     return new ArrayList<Resource>();
   }


### PR DESCRIPTION
Fix for ACT-4051

Simply needs to getResources (instead of getResource) since `classpath*:/processes/` can result in an array of processes folders