### PR TITLE
IllegalAccessException using the activiti-context.xml file inside a cdi context

### DIFF
--- a/modules/activiti-cdi/pom.xml
+++ b/modules/activiti-cdi/pom.xml
@@ -118,6 +118,10 @@
       <artifactId>activiti-engine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.activiti</groupId>
+      <artifactId>activiti-spring</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>

--- a/modules/activiti-cdi/src/test/resources/activiti-context.xml
+++ b/modules/activiti-cdi/src/test/resources/activiti-context.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="processEngineConfiguration"
+		class="org.activiti.cdi.CdiStandaloneProcessEngineConfiguration">
+
+		<property name="jdbcUrl" value="jdbc:h2:mem:activiti" />
+		<property name="databaseSchemaUpdate" value="true" />				
+		<property name="jobExecutorActivate" value="false" />
+		<property name="mailServerPort" value="5025" />
+		
+		<property name="postBpmnParseHandlers">
+			<list>
+				<bean class="org.activiti.cdi.impl.event.CdiEventSupportBpmnParseHandler" />
+			</list>
+		</property>
+
+	</bean>
+
+</beans>

--- a/modules/activiti-cdi/src/test/resources/activiti-context.xml
+++ b/modules/activiti-cdi/src/test/resources/activiti-context.xml
@@ -20,4 +20,9 @@
 
 	</bean>
 
+	<bean id="processEngine" class="org.activiti.spring.ProcessEngineFactoryBean"
+		destroy-method="destroy">
+		<property name="processEngineConfiguration" ref="processEngineConfiguration" />
+	</bean>
+
 </beans>

--- a/modules/activiti-spring/src/main/java/org/activiti/spring/SpringConfigurationHelper.java
+++ b/modules/activiti-spring/src/main/java/org/activiti/spring/SpringConfigurationHelper.java
@@ -28,7 +28,7 @@ import java.util.Map;
 /**
  * @author Tom Baeyens
  */
-class SpringConfigurationHelper {
+public class SpringConfigurationHelper {
 
     private static Logger log = LoggerFactory.getLogger(SpringConfigurationHelper.class);
 


### PR DESCRIPTION
I emule a bug using the activiti-context.xml file inside a cdi environmnent. Adding this file in the resources of the application I
have this exception:

Caused by: java.lang.IllegalAccessException: Class
org.activiti.engine.ProcessEngines can not access a member of class
org.activiti.spring.SpringConfigurationHelper with modifiers "public
static"

Infact we cannot use the reflection to call the
SpringConfigurationHelper because the class is protected through the
default access modifier. I see two solutions to resolve this problem:

1 - set to public the org.activiti.spring.SpringConfigurationHelper
class:
    public class SpringConfigurationHelper
    instead of:
    class SpringConfigurationHelper
2 - remove the managing of activiti-context.xml file in the
org.activiti.cdi.impl.ActivitiExtension of the activiti-cdi project so
it doesn't catch the IllegalAccessException