### PR TITLE
Short-circuit logic should be used in boolean contexts

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/ActivitiFailedjobRetryParser.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/ActivitiFailedjobRetryParser.java
@@ -19,7 +19,7 @@ public class ActivitiFailedjobRetryParser extends BaseChildElementParser {
 		 if (!(parentElement instanceof Activity)) 
             return;
 		 String cycle = xtr.getElementText();
-		 if (cycle == null | cycle.isEmpty())
+		 if (cycle == null || cycle.isEmpty())
 			 return;
 		 ((Activity) parentElement).setFailedJobRetryTimeCycleValue(cycle);
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2178 - Short-circuit logic should be used in boolean contexts

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2178

Please let me know if you have any questions.

Kirill Vlasov