### PR TITLE
Methods named "equals" should override Object.equals(Object)

### DIFF
--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ValuedDataObject.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ValuedDataObject.java
@@ -22,14 +22,20 @@ public abstract class ValuedDataObject extends DataObject {
       setValue(otherElement.getValue());
     }
   }
-  
-  public boolean equals(ValuedDataObject otherObject) {
-    
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    ValuedDataObject otherObject = (ValuedDataObject) o;
+
     if (!otherObject.getItemSubjectRef().getStructureRef().equals(this.itemSubjectRef.getStructureRef())) return false;
     if (!otherObject.getId().equals(this.id)) return false;
     if (!otherObject.getName().equals(this.name)) return false;
     if (!otherObject.getValue().equals(this.value.toString())) return false;
-    
+
     return true;
   }
+
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1201 - Methods named "equals" should override Object.equals(Object)

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1201

Please let me know if you have any questions.

Kirill Vlasov