### PR TITLE
Move security-related parts of RestApiAutoConfiguration to SecurityAutoConfiguration

### DIFF
--- a/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/test/java/org/activiti/test/spring/boot/RestApiAutoConfigurationTest.java
+++ b/modules/activiti-spring-boot/spring-boot-samples/spring-boot-sample-rest-api/src/test/java/org/activiti/test/spring/boot/RestApiAutoConfigurationTest.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.activiti.spring.boot.DataSourceProcessEngineAutoConfiguration;
 import org.activiti.spring.boot.RestApiAutoConfiguration;
+import org.activiti.spring.boot.SecurityAutoConfiguration;
 import org.junit.After;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
@@ -35,6 +36,7 @@ public class RestApiAutoConfigurationTest {
           ServerPropertiesAutoConfiguration.class,
           DataSourceAutoConfiguration.class,
           DataSourceProcessEngineAutoConfiguration.DataSourceProcessEngineConfiguration.class,
+          SecurityAutoConfiguration.class,
           RestApiAutoConfiguration.class,
           JacksonAutoConfiguration.class
   })

--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/RestApiAutoConfiguration.java
@@ -17,18 +17,12 @@ package org.activiti.spring.boot;
 
 import org.activiti.rest.common.application.ContentTypeResolver;
 import org.activiti.rest.common.application.DefaultContentTypeResolver;
-import org.activiti.rest.security.BasicAuthenticationProvider;
 import org.activiti.rest.service.api.RestResponseFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.config.annotation.web.servlet.configuration.EnableWebMvcSecurity;
 
 /**
  * Auto-configuration and starter for the Activiti REST APIs.
@@ -64,28 +58,4 @@ public class RestApiAutoConfiguration {
   	
   }
 
-  @Configuration
-  @ConditionalOnClass(name = {"org.activiti.rest.service.api.RestUrls", "org.springframework.web.servlet.DispatcherServlet"})
-  @EnableWebSecurity
-  @EnableWebMvcSecurity
-  public static class SecurityConfiguration extends WebSecurityConfigurerAdapter {
-    
-    @Bean
-    public AuthenticationProvider authenticationProvider() {
-      return new BasicAuthenticationProvider();
-    }
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-      http
-        .authenticationProvider(authenticationProvider())
-        .csrf().disable()
-        .authorizeRequests()
-          .anyRequest().authenticated()
-          .and()
-        .httpBasic();
-    }
-  }
-
-  
 }

--- a/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/SecurityAutoConfiguration.java
+++ b/modules/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter-basic/src/main/java/org/activiti/spring/boot/SecurityAutoConfiguration.java
@@ -13,14 +13,19 @@
 package org.activiti.spring.boot;
 
 import org.activiti.engine.IdentityService;
+import org.activiti.rest.security.BasicAuthenticationProvider;
 import org.activiti.spring.security.IdentityServiceUserDetailsService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configurers.GlobalAuthenticationConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
 
 /**
@@ -28,6 +33,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
  * {@link org.activiti.engine.IdentityService}.
  *
  * @author Josh Long
+ * @author Vedran Pavic
  */
 @Configuration
 @AutoConfigureBefore(org.springframework.boot.autoconfigure.security.SecurityAutoConfiguration.class)
@@ -51,4 +57,27 @@ public class SecurityAutoConfiguration {
     @Autowired
     private IdentityService identityService;
   }
+
+  @Configuration
+  @ConditionalOnClass(name = {"org.activiti.rest.service.api.RestUrls", "org.springframework.web.servlet.DispatcherServlet"})
+  @EnableWebSecurity
+  public static class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+      return new BasicAuthenticationProvider();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      http
+        .authenticationProvider(authenticationProvider())
+        .csrf().disable()
+        .authorizeRequests()
+          .anyRequest().authenticated()
+          .and()
+        .httpBasic();
+    }
+  }
+
 }


### PR DESCRIPTION
As described in #683/[ACT-4074](https://activiti.atlassian.net/browse/ACT-4074), customizing security configuration is difficult because one cannot exclude ```SecurityConfiguration``` without excluding entire ```RestApiAutoConfiguration```. This in turn requires the user to rewrite non security related parts of ```RestApiAutoConfiguration```.

This PR makes it easier for users to provide their own security confiugration.