### PR TITLE
Add support for localizing Variable names and descriptions.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/DynamicBpmnConstants.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/DynamicBpmnConstants.java
@@ -41,4 +41,5 @@ public interface DynamicBpmnConstants {
   String LOCALIZATION_LANGUAGE = "language";
   String LOCALIZATION_NAME = "name";
   String LOCALIZATION_DESCRIPTION = "description";
+  String LOCALIZATION_DEFAULT_LANGUAGE = "default-language";
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -28,6 +28,7 @@ import org.activiti.engine.runtime.NativeProcessInstanceQuery;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.runtime.ProcessInstanceBuilder;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
+import org.activiti.engine.runtime.VariableInstance;
 import org.activiti.engine.task.Event;
 import org.activiti.engine.task.IdentityLink;
 import org.activiti.engine.task.IdentityLinkType;
@@ -459,6 +460,21 @@ public interface RuntimeService {
   Map<String, Object> getVariables(String executionId);
 
   /**
+   * All variables visible from the given execution scope (including parent scopes).
+   *
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found.
+   * @return the variable instances or an empty map if no such variables are found.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  Map<String, VariableInstance> getVariableInstances(String executionId, String locale, boolean withLocalizationFallback);
+
+  /**
    * All variable values that are defined in the execution scope, without taking outer scopes into account. If you have many task local variables and you only need a few, consider using
    * {@link #getVariablesLocal(String, Collection)} for better performance.
    * 
@@ -469,6 +485,22 @@ public interface RuntimeService {
    *           when no execution is found for the given executionId.
    */
   Map<String, Object> getVariablesLocal(String executionId);
+
+  /**
+   * All variable values that are defined in the execution scope, without taking outer scopes into account. If you have many task local variables and you only need a few, consider using
+   * {@link #getVariableInstancesLocal(String, Collection)} for better performance.
+   *
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found. 
+   * @return the variables or an empty map if no such variables are found.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  Map<String, VariableInstance> getVariableInstancesLocal(String executionId, String locale, boolean withLocalizationFallback);
 
   /**
    * The variable values for all given variableNames, takes all variables into account which are visible from the given execution scope (including parent scopes).
@@ -484,6 +516,23 @@ public interface RuntimeService {
   Map<String, Object> getVariables(String executionId, Collection<String> variableNames);
 
   /**
+   * The variable values for all given variableNames, takes all variables into account which are visible from the given execution scope (including parent scopes).
+   * 
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param variableNames
+   *          the collection of variable names that should be retrieved.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found. 
+   * @return the variables or an empty map if no such variables are found.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  Map<String, VariableInstance> getVariableInstances(String executionId, Collection<String> variableNames, String locale, boolean withLocalizationFallback);  
+
+  /**
    * The variable values for the given variableNames only taking the given execution scope into account, not looking in outer scopes.
    * 
    * @param executionId
@@ -495,6 +544,23 @@ public interface RuntimeService {
    *           when no execution is found for the given executionId.
    */
   Map<String, Object> getVariablesLocal(String executionId, Collection<String> variableNames);
+
+  /**
+   * The variable values for the given variableNames only taking the given execution scope into account, not looking in outer scopes.
+   *
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param variableNames
+   *          the collection of variable names that should be retrieved.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found. 
+   * @return the variables or an empty map if no such variables are found.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  Map<String, VariableInstance> getVariableInstancesLocal(String executionId, Collection<String> variableNames, String locale, boolean withLocalizationFallback);  
 
   /**
    * The variable value. Searching for the variable is done in all scopes that are visible to the given execution (including parent scopes). Returns null when no variable value is found with the given
@@ -509,6 +575,24 @@ public interface RuntimeService {
    *           when no execution is found for the given executionId.
    */
   Object getVariable(String executionId, String variableName);
+
+  /**
+   * The variable. Searching for the variable is done in all scopes that are visible to the given execution (including parent scopes). Returns null when no variable value is found with the given
+   * name or when the value is set to null.
+   *
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param variableName
+   *          name of variable, cannot be null.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found. 
+   * @return the variable or null if the variable is undefined.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  VariableInstance getVariableInstance(String executionId, String variableName, String locale, boolean withLocalizationFallback);
 
   /**
    * The variable value. Searching for the variable is done in all scopes that are visible to the given execution (including parent scopes). Returns null when no variable value is found with the given
@@ -536,6 +620,24 @@ public interface RuntimeService {
    * name or when the value is set to null.
    */
   Object getVariableLocal(String executionId, String variableName);
+
+  /**
+   * The variable for an execution. Returns the variable when it is set for the execution (and not searching parent scopes). Returns null when no variable is found with the given
+   * name or when the value is set to null.
+   *
+   * @param executionId
+   *          id of execution, cannot be null.
+   * @param variableName
+   *          name of variable, cannot be null.
+   * @param locale
+   *          locale the variable name and description should be returned in (if available).
+   * @param withLocalizationFallback
+   *          When true localization will fallback to more general locales including the default locale of the JVM if the specified locale is not found.
+   * @return the variable or null if the variable is undefined.
+   * @throws ActivitiObjectNotFoundException
+   *           when no execution is found for the given executionId.
+   */
+  VariableInstance getVariableInstanceLocal(String executionId, String variableName, String locale, boolean withLocalizationFallback);
 
   /**
    * The variable value for an execution. Returns the value casted to given class when the variable is set for the execution (and not searching parent scopes). Returns null when no variable value is

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -32,6 +32,8 @@ import org.activiti.engine.impl.cmd.DeleteProcessInstanceCmd;
 import org.activiti.engine.impl.cmd.DispatchEventCommand;
 import org.activiti.engine.impl.cmd.FindActiveActivityIdsCmd;
 import org.activiti.engine.impl.cmd.GetExecutionVariableCmd;
+import org.activiti.engine.impl.cmd.GetExecutionVariableInstanceCmd;
+import org.activiti.engine.impl.cmd.GetExecutionVariableInstancesCmd;
 import org.activiti.engine.impl.cmd.GetExecutionVariablesCmd;
 import org.activiti.engine.impl.cmd.GetIdentityLinksForProcessInstanceCmd;
 import org.activiti.engine.impl.cmd.GetProcessInstanceEventsCmd;
@@ -54,6 +56,7 @@ import org.activiti.engine.runtime.NativeExecutionQuery;
 import org.activiti.engine.runtime.NativeProcessInstanceQuery;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
+import org.activiti.engine.runtime.VariableInstance;
 import org.activiti.engine.runtime.ProcessInstanceBuilder;
 import org.activiti.engine.task.Event;
 import org.activiti.engine.task.IdentityLink;
@@ -137,20 +140,47 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
     return commandExecutor.execute(new GetExecutionVariablesCmd(executionId, null, false));
   }
 
+  @Override
+  public Map<String, VariableInstance> getVariableInstances(String executionId, String locale, boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, null, false, locale, withLocalizationFallback));
+  }
+
   public Map<String, Object> getVariablesLocal(String executionId) {
     return commandExecutor.execute(new GetExecutionVariablesCmd(executionId, null, true));
+  }
+
+  @Override
+  public Map<String, VariableInstance> getVariableInstancesLocal(String executionId, String locale, boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, null, true, locale, withLocalizationFallback));
   }
 
   public Map<String, Object> getVariables(String executionId, Collection<String> variableNames) {
     return commandExecutor.execute(new GetExecutionVariablesCmd(executionId, variableNames, false));
   }
 
+  @Override
+  public Map<String, VariableInstance> getVariableInstances(String executionId, Collection<String> variableNames, String locale,
+          boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, false, locale, withLocalizationFallback));
+  }
+
   public Map<String, Object> getVariablesLocal(String executionId, Collection<String> variableNames) {
     return commandExecutor.execute(new GetExecutionVariablesCmd(executionId, variableNames, true));
   }
 
+  @Override
+  public Map<String, VariableInstance> getVariableInstancesLocal(String executionId, Collection<String> variableNames, String locale,
+          boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, false, locale, withLocalizationFallback));
+  }
+
   public Object getVariable(String executionId, String variableName) {
     return commandExecutor.execute(new GetExecutionVariableCmd(executionId, variableName, false));
+  }
+
+  @Override
+  public VariableInstance getVariableInstance(String executionId, String variableName, String locale, boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstanceCmd(executionId, variableName, false, locale, withLocalizationFallback));
   }
 
   @Override
@@ -165,6 +195,11 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
 
   public Object getVariableLocal(String executionId, String variableName) {
     return commandExecutor.execute(new GetExecutionVariableCmd(executionId, variableName, true));
+  }
+
+  @Override
+  public VariableInstance getVariableInstanceLocal(String executionId, String variableName, String locale, boolean withLocalizationFallback) {
+    return commandExecutor.execute(new GetExecutionVariableInstanceCmd(executionId, variableName, true, locale, withLocalizationFallback));
   }
 
   @Override

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionVariableInstanceCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionVariableInstanceCmd.java
@@ -1,0 +1,109 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.cmd;
+
+import java.io.Serializable;
+
+import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.DynamicBpmnConstants;
+import org.activiti.engine.compatibility.Activiti5CompatibilityHandler;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.util.Activiti5Util;
+import org.activiti.engine.runtime.Execution;
+import org.activiti.engine.runtime.VariableInstance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class GetExecutionVariableInstanceCmd implements Command<VariableInstance>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String executionId;
+  protected String variableName;
+  protected boolean isLocal;
+  protected String locale;
+  protected boolean withLocalizationFallback;
+  
+  public GetExecutionVariableInstanceCmd(String executionId, String variableName, boolean isLocal, String locale, boolean withLocalizationFallback) {
+    this.executionId = executionId;
+    this.variableName = variableName;
+    this.isLocal = isLocal;
+    this.locale = locale;
+    this.withLocalizationFallback = withLocalizationFallback;
+  }
+
+  public VariableInstance execute(CommandContext commandContext) {
+    if (executionId == null) {
+      throw new ActivitiIllegalArgumentException("executionId is null");
+    }
+    if (variableName == null) {
+      throw new ActivitiIllegalArgumentException("variableName is null");
+    }
+    if (locale == null) {
+      throw new ActivitiIllegalArgumentException("locale is null");
+    }
+    
+    ExecutionEntity execution = commandContext.getExecutionEntityManager().findById(executionId);
+
+    if (execution == null) {
+      throw new ActivitiObjectNotFoundException("execution " + executionId + " doesn't exist", Execution.class);
+    }
+    
+    Object value;
+    if (execution != null && Activiti5Util.isActiviti5ProcessDefinitionId(commandContext, execution.getProcessDefinitionId())) {
+      Activiti5CompatibilityHandler activiti5CompatibilityHandler = Activiti5Util.getActiviti5CompatibilityHandler(); 
+      value = activiti5CompatibilityHandler.getExecutionVariable(executionId, variableName, isLocal);
+    }
+    else {  
+      if (isLocal) {
+        value = execution.getVariableLocal(variableName, false);
+      } else {
+        value = execution.getVariable(variableName, false);
+      }
+    }
+
+    String description = null;
+    String localizedName = null;
+    String localizedDescription = null;
+    
+    ObjectNode languageNode = Context.getLocalizationElementProperties(DynamicBpmnConstants.LOCALIZATION_DEFAULT_LANGUAGE, variableName, execution.getProcessDefinitionId(), false);
+    if (languageNode != null) {
+      JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
+      if(descriptionNode != null) {
+        description = descriptionNode.asText();
+      }
+    }
+        
+    languageNode = Context.getLocalizationElementProperties(locale, variableName, execution.getProcessDefinitionId(), withLocalizationFallback);
+    if (languageNode != null) {
+      JsonNode nameNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_NAME);
+      if(nameNode != null) {
+        localizedName = nameNode.asText();
+      }
+      JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
+      if(descriptionNode != null) {
+        localizedDescription = descriptionNode.asText();
+      }
+    }
+    
+    boolean exists = (value != null) || (isLocal && execution.hasVariableLocal(variableName)) || (!isLocal && execution.hasVariable(variableName));
+    if(exists) {
+      return new VariableInstance(variableName, description, localizedName, localizedDescription, value);
+    }
+    return null;
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionVariableInstancesCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionVariableInstancesCmd.java
@@ -1,0 +1,127 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.DynamicBpmnConstants;
+import org.activiti.engine.compatibility.Activiti5CompatibilityHandler;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.util.Activiti5Util;
+import org.activiti.engine.runtime.Execution;
+import org.activiti.engine.runtime.VariableInstance;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public class GetExecutionVariableInstancesCmd implements Command<Map<String, VariableInstance>>, Serializable {
+
+  private static final long serialVersionUID = 1L;
+  protected String executionId;
+  protected Collection<String> variableNames;
+  protected boolean isLocal;
+  protected String locale;
+  protected boolean withLocalizationFallback;
+
+  public GetExecutionVariableInstancesCmd(String executionId, Collection<String> variableNames, boolean isLocal, String locale, boolean withLocalizationFallback) {
+    this.executionId = executionId;
+    this.variableNames = variableNames;
+    this.isLocal = isLocal;
+    this.locale = locale;
+    this.withLocalizationFallback = withLocalizationFallback;
+  }
+
+  public Map<String, VariableInstance> execute(CommandContext commandContext) {
+
+    // Verify existance of execution
+    if (executionId == null) {
+      throw new ActivitiIllegalArgumentException("executionId is null");
+    }
+
+    ExecutionEntity execution = commandContext.getExecutionEntityManager().findById(executionId);
+
+    if (execution == null) {
+      throw new ActivitiObjectNotFoundException("execution " + executionId + " doesn't exist", Execution.class);
+    }
+    
+    Map<String,Object> variables = null;
+    
+    if (execution != null && Activiti5Util.isActiviti5ProcessDefinitionId(commandContext, execution.getProcessDefinitionId())) {
+      Activiti5CompatibilityHandler activiti5CompatibilityHandler = Activiti5Util.getActiviti5CompatibilityHandler(); 
+      variables = activiti5CompatibilityHandler.getExecutionVariables(executionId, variableNames, isLocal);
+    }
+
+    if (variableNames == null || variableNames.isEmpty()) {
+      // Fetch all
+      if (isLocal) {
+        variables = execution.getVariablesLocal();
+      } else {
+        variables = execution.getVariables();
+      }
+
+    } else {
+      // Fetch specific collection of variables
+      if (isLocal) {
+        variables = execution.getVariablesLocal(variableNames, false);
+      } else {
+        variables = execution.getVariables(variableNames, false);
+      }
+    }
+
+    Map<String,VariableInstance> variableInstances = new HashMap<String,VariableInstance>(variables.size());
+    for(Entry<String,Object> entry : variables.entrySet()) {
+      String variableName = entry.getKey();
+      Object value = entry.getValue();
+      
+      String description = null;
+      String localizedName = null;
+      String localizedDescription = null;
+      
+      ObjectNode languageNode = Context.getLocalizationElementProperties(DynamicBpmnConstants.LOCALIZATION_DEFAULT_LANGUAGE, variableName, execution.getProcessDefinitionId(), false);
+      if (languageNode != null) {
+        JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
+        if(descriptionNode != null) {
+          description = descriptionNode.asText();
+        }
+      }
+          
+      languageNode = Context.getLocalizationElementProperties(locale, variableName, execution.getProcessDefinitionId(), withLocalizationFallback);
+      if (languageNode != null) {
+        JsonNode nameNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_NAME);
+        if(nameNode != null) {
+          localizedName = nameNode.asText();
+        }
+        JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
+        if(descriptionNode != null) {
+          localizedDescription = descriptionNode.asText();
+        }
+      }
+      
+      boolean exists = (value != null) || (isLocal && execution.hasVariableLocal(variableName)) || (!isLocal && execution.hasVariable(variableName));
+      if(exists) {
+        variableInstances.put(variableName, new VariableInstance(variableName, description, localizedName, localizedDescription, value));
+      }
+    }
+    
+    return variableInstances;
+  }
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/VariableInstance.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/VariableInstance.java
@@ -1,0 +1,52 @@
+package org.activiti.engine.runtime;
+
+public class VariableInstance {
+  protected String name;
+  protected String description;
+  protected String localizedName;
+  protected String localizedDescription;
+  protected Object value;
+  
+  public VariableInstance(String name, String description, String localizedName, String localizedDescription, Object value) {
+    this.name = name;
+    this.description = description;
+    this.localizedName = localizedName;
+    this.localizedDescription = localizedDescription;
+    this.value = value;
+  }
+  
+  /**
+   * Name of the variable.
+   */
+  public String getName() {
+    return name;
+  }
+  
+  /**
+   * Localized variable name.
+   */
+  public String getLocalizedName() {
+    return localizedName;
+  }
+  
+  /** 
+   * Localized variable description.
+   */
+  public String getLocalizedDescription() {
+    return localizedDescription;
+  }
+  
+  /**
+   * Description of the variable.
+   */
+  public String getDescription() {
+    return description;
+  }
+  
+  /**
+   * Value of the variable
+   */
+  public Object getValue() {
+    return value;
+  }
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
@@ -18,17 +18,22 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import org.activiti.engine.DynamicBpmnConstants;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.impl.variable.ValueFields;
 import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.runtime.VariableInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * @author Tom Baeyens
@@ -176,6 +181,241 @@ public class VariablesTest extends PluggableActivitiTestCase {
     Task task = taskService.createTaskQuery().singleResult();
     taskService.complete(task.getId());
 
+  }
+
+  @Deployment
+  public void testLocalizeVariables() {
+    // Start process instance with different types of variables
+    Map<String, Object> variables = new HashMap<String, Object>();
+    variables.put("stringVar", "coca-cola");
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("localizeVariables", variables);
+
+    ObjectNode infoNode = dynamicBpmnService.getProcessDefinitionInfo(processInstance.getProcessDefinitionId());
+    dynamicBpmnService.changeLocalizationDescription(DynamicBpmnConstants.LOCALIZATION_DEFAULT_LANGUAGE, "stringVar", "stringVar 'default' Description", infoNode);
+    dynamicBpmnService.changeLocalizationName("en-US", "stringVar", "stringVar 'en-US' Name", infoNode);
+    dynamicBpmnService.changeLocalizationDescription("en-US", "stringVar", "stringVar 'en-US' Description", infoNode);
+    dynamicBpmnService.changeLocalizationName("en-AU", "stringVar", "stringVar 'en-AU' Name", infoNode);
+    dynamicBpmnService.changeLocalizationDescription("en-AU", "stringVar", "stringVar 'en-AU' Description", infoNode);
+    dynamicBpmnService.changeLocalizationName("en", "stringVar", "stringVar 'en' Name", infoNode);
+    dynamicBpmnService.changeLocalizationDescription("en", "stringVar", "stringVar 'en' Description", infoNode);
+    dynamicBpmnService.saveProcessDefinitionInfo(processInstance.getProcessDefinitionId(), infoNode);
+
+    Map<String, VariableInstance> variableInstances = runtimeService.getVariableInstances(processInstance.getId(), "es", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'es' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'es' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    // getVariableInstances
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), "en-US", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), "en-AU", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), "en-GB", true);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), "en-GB", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedName());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedDescription());
+
+    List<String> variableNames = new ArrayList<String>();
+    variableNames.add("stringVar");
+
+    // getVariablesInstances via names
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames, "en-US", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames, "en-AU", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames, "en-GB", true);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstances(processInstance.getId(), variableNames, "en-GB", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedName());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedDescription());
+
+    // getVariableInstancesLocal
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), "en-US", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), "en-AU", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), "en-GB", true);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), "en-GB", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedName());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedDescription());
+
+    // getVariableInstancesLocal via names
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames, "en-US", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames, "en-AU", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames, "en-GB", true);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals("stringVar 'en' Name", variableInstances.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstances.get("stringVar").getLocalizedDescription());
+
+    variableInstances = runtimeService.getVariableInstancesLocal(processInstance.getId(), variableNames, "en-GB", false);
+    assertEquals(1, variableInstances.size());
+    assertEquals("stringVar", variableInstances.get("stringVar").getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstances.get("stringVar").getValue());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedName());
+    assertEquals(null, variableInstances.get("stringVar").getLocalizedDescription());
+
+    // getVariableInstance
+    VariableInstance variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar", "en-GB", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals(null, variableInstance.getLocalizedName());
+    assertEquals(null, variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar","en-US", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstances.get("stringVar").getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar", "en-AU", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar", "en-GB", true);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstance(processInstance.getId(), "stringVar", "en-GB", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals(null, variableInstance.getLocalizedName());
+    assertEquals(null, variableInstance.getLocalizedDescription());
+
+    // getVariableInstanceLocal
+    variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar", "en-US", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en-US' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en-US' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar", "en-AU", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en-AU' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en-AU' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar", "en-GB", true);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals("stringVar 'en' Name", variableInstance.getLocalizedName());
+    assertEquals("stringVar 'en' Description", variableInstance.getLocalizedDescription());
+
+    variableInstance = runtimeService.getVariableInstanceLocal(processInstance.getId(), "stringVar", "en-GB", false);
+    assertNotNull(variableInstance);
+    assertEquals("stringVar", variableInstance.getName());
+    assertEquals("stringVar 'default' Description", variableInstance.getDescription());
+    assertEquals("coca-cola", variableInstance.getValue());
+    assertEquals(null, variableInstance.getLocalizedName());
+    assertEquals(null, variableInstance.getLocalizedDescription());
   }
 
   // Test case for ACT-1839

--- a/modules/activiti-engine/src/test/resources/org/activiti/examples/variables/VariablesTest.testLocalizeVariables.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/examples/variables/VariablesTest.testLocalizeVariables.bpmn20.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  targetNamespace="Examples">
+	
+	<process id="localizeVariables" name="Localize Variables">
+		<dataObject id="dObj1" name="stringVar" itemSubjectRef="xsd:string">
+    		<documentation>stringVar 'default' description</documentation>
+    
+    		<extensionElements>
+    	  		<activiti:localization locale="es" name="stringVar 'es' Name">
+    				<activiti:documentation>stringVar 'es' Description</activiti:documentation>
+    	  		</activiti:localization>
+    		</extensionElements>		
+		</dataObject>
+	
+		<startEvent id="theStart" />
+		
+		<sequenceFlow id="flow1" sourceRef="theStart" targetRef="subprocess1" />
+
+		<subProcess id="subprocess1" name="subprocess">
+			<dataObject id="dObj2" name="intVar" itemSubjectRef="xsd:int">
+	    		<documentation>intVar 'default' description</documentation>
+	    
+	    		<extensionElements>
+	    	  		<activiti:localization locale="es" name="intVar 'es' Name">
+	    				<activiti:documentation>intVar 'es' Description</activiti:documentation>
+	    	  		</activiti:localization>
+	    		</extensionElements>		
+			</dataObject>
+					
+			<startEvent id="subStart" />
+			<sequenceFlow id="flow3" sourceRef="subStart" targetRef="theTask" />
+			
+			<userTask id="theTask" name="Schedule meeting" >
+			  <documentation>
+			    Schedule an engineering meeting for next week with the new hire.
+			  </documentation>
+			  <humanPerformer>
+			    <resourceAssignmentExpression>
+			      <formalExpression>kermit</formalExpression>
+			    </resourceAssignmentExpression>
+			  </humanPerformer>
+			</userTask>
+				
+			<sequenceFlow id="flow4" sourceRef="theTask" targetRef="subEnd" />
+			<endEvent id="subEnd" />
+		</subProcess>
+		
+		<sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="theEnd" />
+		
+		<endEvent id="theEnd" />
+		
+	</process>
+
+</definitions>


### PR DESCRIPTION
Summary:
* Add support for localizing variable name and descriptions via the DynamicBpmnService.
* Add support for populating localized values for DataObject names and descriptions into the DynamicBpmnService cache when a process definition is deployed.
* Update RuntimeService interface to support the retrieval of localized values for variables by introducing a new class VariableInstance.