### PR TITLE
Make schema creation consistent with other schema operations

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -58,7 +58,6 @@ import org.activiti.engine.impl.UserQueryImpl;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.db.upgrade.DbUpgradeStep;
-import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.interceptor.Session;
 import org.activiti.engine.impl.persistence.entity.PropertyEntity;
 import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
@@ -1015,8 +1014,6 @@ public class DbSqlSession implements Session {
   }
 
   public void dbSchemaCreate() {
-    ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-    
     if (isEngineTablePresent()) {
       String dbVersion = getDbVersion();
       if (!ProcessEngine.VERSION.equals(dbVersion)) {
@@ -1026,11 +1023,11 @@ public class DbSqlSession implements Session {
       dbSchemaCreateEngine();
     }
 
-    if (processEngineConfiguration.getHistoryLevel() != HistoryLevel.NONE) {
+    if (dbSqlSessionFactory.isDbHistoryUsed()) {
       dbSchemaCreateHistory();
     }
 
-    if (processEngineConfiguration.isDbIdentityUsed()) {
+    if (dbSqlSessionFactory.isDbIdentityUsed()) {
       dbSchemaCreateIdentity();
     }
   }


### PR DESCRIPTION
Checks for creating history and identity schemas are not consistent with other schema operations, which use ```isDbHistoryUsed``` and ```isDbIdentityUsed``` properties on ```DbSqlSessionFactory```.