### PR TITLE
Fix NPE occured on referring Historic Variable(JPAEntityVariableType) 

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
@@ -11,6 +11,10 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
+import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.activiti.engine.impl.variable.CacheableVariable;
+import org.activiti.engine.impl.variable.JPAEntityListVariableType;
+import org.activiti.engine.impl.variable.JPAEntityVariableType;
 
 /**
  * @author Joram Barrez
@@ -114,6 +118,12 @@ public class ProcessInstanceHistoryLogQueryImpl implements ProcessInstanceHistor
 			// Make sure all variables values are fetched (similar to the HistoricVariableInstance query)
 			for (HistoricVariableInstance historicVariableInstance : variables) {
 				historicVariableInstance.getValue();
+				
+				// make sure JPA entities are cached for later retrieval
+				HistoricVariableInstanceEntity variableEntity = (HistoricVariableInstanceEntity) historicVariableInstance;
+				if (JPAEntityVariableType.TYPE_NAME.equals(variableEntity.getVariableType().getTypeName()) || JPAEntityListVariableType.TYPE_NAME.equals(variableEntity.getVariableType().getTypeName())) {
+					((CacheableVariable) variableEntity.getVariableType()).setForceCacheable(true);
+				}
 			}
 			
 			processInstanceHistoryLog.addHistoricData(variables);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
@@ -11,10 +11,6 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.HistoricProcessInstanceEntity;
-import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
-import org.activiti.engine.impl.variable.CacheableVariable;
-import org.activiti.engine.impl.variable.JPAEntityListVariableType;
-import org.activiti.engine.impl.variable.JPAEntityVariableType;
 
 /**
  * @author Joram Barrez
@@ -118,12 +114,6 @@ public class ProcessInstanceHistoryLogQueryImpl implements ProcessInstanceHistor
 			// Make sure all variables values are fetched (similar to the HistoricVariableInstance query)
 			for (HistoricVariableInstance historicVariableInstance : variables) {
 				historicVariableInstance.getValue();
-				
-				// make sure JPA entities are cached for later retrieval
-				HistoricVariableInstanceEntity variableEntity = (HistoricVariableInstanceEntity) historicVariableInstance;
-				if (JPAEntityVariableType.TYPE_NAME.equals(variableEntity.getVariableType().getTypeName()) || JPAEntityListVariableType.TYPE_NAME.equals(variableEntity.getVariableType().getTypeName())) {
-					((CacheableVariable) variableEntity.getVariableType()).setForceCacheable(true);
-				}
 			}
 			
 			processInstanceHistoryLog.addHistoricData(variables);

--- a/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/HistoricJPAVariableTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/standalone/jpa/HistoricJPAVariableTest.java
@@ -1,0 +1,126 @@
+package org.activiti.standalone.jpa;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import org.activiti.engine.ProcessEngine;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.history.HistoricData;
+import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.history.ProcessInstanceHistoryLog;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.activiti.engine.impl.test.AbstractActivitiTestCase;
+import org.activiti.engine.impl.variable.EntityManagerSession;
+import org.activiti.engine.impl.variable.EntityManagerSessionFactory;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+
+/**
+ * @author Daisuke Yoshimoto
+ */
+public class HistoricJPAVariableTest extends AbstractActivitiTestCase {
+	
+	protected static ProcessEngine cachedProcessEngine;
+
+	private static EntityManagerFactory entityManagerFactory;
+	
+	private static FieldAccessJPAEntity simpleEntityFieldAccess;
+	private static boolean entitiesInitialized = false;
+	
+	protected String processInstanceId;
+
+	@Override
+	protected void initializeProcessEngine() {
+		if (cachedProcessEngine==null) {
+			ProcessEngineConfigurationImpl processEngineConfiguration = (ProcessEngineConfigurationImpl) ProcessEngineConfiguration
+				.createProcessEngineConfigurationFromResource("org/activiti/standalone/jpa/activiti.cfg.xml");
+
+			cachedProcessEngine = processEngineConfiguration.buildProcessEngine();
+
+			EntityManagerSessionFactory entityManagerSessionFactory = (EntityManagerSessionFactory) processEngineConfiguration
+				.getSessionFactories()
+				.get(EntityManagerSession.class);
+
+			entityManagerFactory = entityManagerSessionFactory.getEntityManagerFactory();
+		}
+		processEngine = cachedProcessEngine;
+	}
+	
+	public void setupJPAEntities() {
+		if(!entitiesInitialized) {
+			EntityManager manager = entityManagerFactory.createEntityManager();
+			manager.getTransaction().begin();
+
+			// Simple test data
+			simpleEntityFieldAccess = new FieldAccessJPAEntity();
+			simpleEntityFieldAccess.setId(1L);
+			simpleEntityFieldAccess.setValue("value1");
+			manager.persist(simpleEntityFieldAccess);
+
+			manager.flush();
+			manager.getTransaction().commit();
+			manager.close();
+			entitiesInitialized = true;
+		}
+	}
+
+	@Deployment
+	public void testGetJPAEntityAsHistoricVariable() {
+		setupJPAEntities();
+		// -----------------------------------------------------------------------------
+		// Simple test, Start process with JPA entities as variables
+		// -----------------------------------------------------------------------------
+		Map<String, Object> variables = new HashMap<String, Object>();
+		variables.put("simpleEntityFieldAccess", simpleEntityFieldAccess);
+
+		// Start the process with the JPA-entities as variables. They will be stored in the DB.
+		this.processInstanceId = runtimeService.startProcessInstanceByKey("JPAVariableProcess", variables).getId();
+
+		for (Task task : taskService.createTaskQuery().includeTaskLocalVariables().list()) {
+			taskService.complete(task.getId());
+		}
+		
+		// Get JPAEntity Variable by HistoricVariableInstanceQuery
+		HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
+				.processInstanceId(processInstanceId).variableName("simpleEntityFieldAccess").singleResult();
+		
+		Object value = historicVariableInstance.getValue();
+		assertTrue(value instanceof FieldAccessJPAEntity);
+		assertEquals(((FieldAccessJPAEntity)value).getValue(), simpleEntityFieldAccess.getValue());
+	}
+	
+	@Deployment
+	public void testGetJPAEntityAsHistoricLog() {
+		setupJPAEntities();
+		// -----------------------------------------------------------------------------
+		// Simple test, Start process with JPA entities as variables
+		// -----------------------------------------------------------------------------
+		Map<String, Object> variables = new HashMap<String, Object>();
+		variables.put("simpleEntityFieldAccess", simpleEntityFieldAccess);
+
+		// Start the process with the JPA-entities as variables. They will be stored in the DB.
+		this.processInstanceId = runtimeService.startProcessInstanceByKey("JPAVariableProcess", variables).getId();
+		
+		// Finish tasks
+		for (Task task : taskService.createTaskQuery().includeTaskLocalVariables().list()) {
+			taskService.complete(task.getId());
+		}
+
+		// Get JPAEntity Variable by ProcessInstanceHistoryLogQuery
+		ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
+				.includeVariables()
+				.singleResult();
+		List<HistoricData> events = log.getHistoricData();
+
+		for (HistoricData event : events) {
+			Object value = ((HistoricVariableInstanceEntity) event).getValue();
+			assertTrue(value instanceof FieldAccessJPAEntity);
+			assertEquals(((FieldAccessJPAEntity)value).getValue(), simpleEntityFieldAccess.getValue());
+		}
+	}
+}

--- a/modules/activiti-engine/src/test/resources/org/activiti/standalone/jpa/HistoricJPAVariableTest.testGetJPAEntityAsHistoricLog.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/standalone/jpa/HistoricJPAVariableTest.testGetJPAEntityAsHistoricLog.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+	
+  <process id="JPAVariableProcess" name="Process containing JPA varaibles">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/standalone/jpa/HistoricJPAVariableTest.testGetJPAEntityAsHistoricVariable.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/standalone/jpa/HistoricJPAVariableTest.testGetJPAEntityAsHistoricVariable.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+	
+  <process id="JPAVariableProcess" name="Process containing JPA varaibles">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
I solved the fix leaks of https://github.com/Activiti/Activiti/pull/755 .

NPE on referring Historic Variable(JPAEntityVariableType):

((HistoricVariableInstance) historicData).getValue();

java.lang.NullPointerException
	at org.activiti.engine.impl.variable.JPAEntityMappings.findEntity(JPAEntityMappings.java:127)
	at org.activiti.engine.impl.variable.JPAEntityMappings.getJPAEntity(JPAEntityMappings.java:121)
	at org.activiti.engine.impl.variable.JPAEntityVariableType.getValue(JPAEntityVariableType.java:79)
	at org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity.getValue(HistoricVariableInstanceEntity.java:129)

# Occurrence condition
We are experiencing a NPE on referring HistoricVariableInstance(JPAEntityVariableType).
We are not experiencing a NPE on referring HistoricVariableInstance(String Type, etc.).

# Cause
In the case of JPAEntityVariableType, HistoricVariableInstance.class#getValue gets data from not Cache but RDB.
Therefore, HistoricVariableInstance.class#getValue try to get Context, but Context is null.