### PR TITLE
Removal the restriction that latestVersion() can only be used in combination with key() or keyLike()

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -309,11 +309,6 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
   
   public void checkQueryOk() {
     super.checkQueryOk();
-    
-    // latest() makes only sense when used with key() or keyLike()
-    if (latest && ( (id != null) || (name != null) || (nameLike != null) || (version != null) || (deploymentId != null) ) ){
-      throw new ActivitiIllegalArgumentException("Calling latest() can only be used in combination with key(String) and keyLike(String)");
-    }
   }
   
   //getters ////////////////////////////////////////////

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryByLatestTest.java
@@ -1,0 +1,134 @@
+package org.activiti.engine.test.api.repository;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.repository.ProcessDefinitionQuery;
+
+public class ProcessDefinitionQueryByLatestTest extends PluggableActivitiTestCase {
+
+	private static String XML_FILE_PATH = "org/activiti/engine/test/repository/latest/";
+	
+	  @Override
+	  protected void setUp() throws Exception {
+	    super.setUp();
+	  }
+	  
+	  @Override
+	  protected void tearDown() throws Exception {
+	    super.tearDown();
+	}
+	
+	protected List<String> deploy(List<String> xmlFileNameList) throws Exception {
+		List<String> deploymentIdList = new ArrayList<String>();
+		for(String xmlFileName : xmlFileNameList){
+		    String deploymentId = repositoryService
+		  	      .createDeployment()
+		  	      .name(XML_FILE_PATH + xmlFileName)
+		  	      .addClasspathResource(XML_FILE_PATH + xmlFileName)
+		  	      .deploy()
+		  	      .getId();
+		    deploymentIdList.add(deploymentId);
+		}
+		return deploymentIdList;
+	}
+
+	private void unDeploy(List<String> deploymentIdList) throws Exception {
+		for(String deploymentId : deploymentIdList){
+			repositoryService.deleteDeployment(deploymentId, true);
+		}
+	}
+
+	public void testQueryByLatestAndId() throws Exception {
+		// Deploy
+		List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",
+				"name_testProcess1_two.bpmn20.xml", "name_testProcess2_one.bpmn20.xml");
+		List<String> deploymentIdList = deploy(xmlFileNameList);
+		
+		List<String> processDefinitionIdList = new ArrayList<String>();
+		for(String deploymentId : deploymentIdList){
+			String processDefinitionId = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentId).list().get(0).getId();
+			processDefinitionIdList.add(processDefinitionId);
+		}
+
+		ProcessDefinitionQuery idQuery1 = repositoryService.createProcessDefinitionQuery().processDefinitionId(processDefinitionIdList.get(0)).latestVersion();
+		List<ProcessDefinition>  processDefinitions = idQuery1.list();
+		assertEquals(0, processDefinitions.size());
+
+		ProcessDefinitionQuery idQuery2 = repositoryService.createProcessDefinitionQuery().processDefinitionId(processDefinitionIdList.get(1)).latestVersion();
+		processDefinitions = idQuery2.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals("testProcess1", processDefinitions.get(0).getKey());
+
+		ProcessDefinitionQuery idQuery3 = repositoryService.createProcessDefinitionQuery().processDefinitionId(processDefinitionIdList.get(2)).latestVersion();
+		processDefinitions = idQuery3.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals("testProcess2", processDefinitions.get(0).getKey());
+
+		// Undeploy
+		unDeploy(deploymentIdList);
+	}
+
+	public void testQueryByLatestAndName() throws Exception {
+		// Deploy
+		List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",
+				"name_testProcess1_two.bpmn20.xml", "name_testProcess2_one.bpmn20.xml");
+		List<String> deploymentIdList = deploy(xmlFileNameList);
+
+		// name
+		ProcessDefinitionQuery nameQuery = repositoryService.createProcessDefinitionQuery().processDefinitionName("one").latestVersion();
+		List<ProcessDefinition> processDefinitions = nameQuery.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals(1, processDefinitions.get(0).getVersion());
+		assertEquals("testProcess2", processDefinitions.get(0).getKey());
+
+		// nameLike
+		ProcessDefinitionQuery nameLikeQuery = repositoryService.createProcessDefinitionQuery().processDefinitionName("one").latestVersion();
+		processDefinitions = nameLikeQuery.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals(1, processDefinitions.get(0).getVersion());
+		assertEquals("testProcess2", processDefinitions.get(0).getKey());
+		
+		// Undeploy
+		unDeploy(deploymentIdList);
+	}
+
+	public void testQueryByLatestAndVersion() throws Exception {
+		// Deploy
+		List<String> xmlFileNameList = Arrays.asList("version_testProcess1_one.bpmn20.xml",
+				"version_testProcess1_two.bpmn20.xml", "version_testProcess2_one.bpmn20.xml");
+		List<String> deploymentIdList = deploy(xmlFileNameList);
+
+		// version
+		ProcessDefinitionQuery nameQuery = repositoryService.createProcessDefinitionQuery().processDefinitionVersion(1).latestVersion();
+		List<ProcessDefinition> processDefinitions = nameQuery.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals("testProcess2", processDefinitions.get(0).getKey());
+
+		// Undeploy
+		unDeploy(deploymentIdList);
+	}
+
+	public void testQueryByLatestAndDeploymentId() throws Exception {
+		// Deploy
+		List<String> xmlFileNameList = Arrays.asList("name_testProcess1_one.bpmn20.xml",
+				"name_testProcess1_two.bpmn20.xml", "name_testProcess2_one.bpmn20.xml");
+		List<String> deploymentIdList = deploy(xmlFileNameList);
+
+		// deploymentId
+		ProcessDefinitionQuery deploymentQuery1 = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdList.get(0)).latestVersion();
+		List<ProcessDefinition> processDefinitions = deploymentQuery1.list();
+		assertEquals(0, processDefinitions.size());
+
+		ProcessDefinitionQuery deploymentQuery2 = repositoryService.createProcessDefinitionQuery().deploymentId(deploymentIdList.get(1)).latestVersion();
+		processDefinitions = deploymentQuery2.list();
+		assertEquals(1, processDefinitions.size());
+		assertEquals("testProcess1", processDefinitions.get(0).getKey());
+
+		// Undeploy
+		unDeploy(deploymentIdList);
+	}
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -224,33 +224,6 @@ public class ProcessDefinitionQueryTest extends PluggableActivitiTestCase {
     verifyQueryResults(query, 1);
   }
   
-  public void testInvalidUsageOfLatest() {
-    try {
-      repositoryService.createProcessDefinitionQuery().processDefinitionId("test").latestVersion().list();
-      fail();
-    } catch (ActivitiIllegalArgumentException e) {}
-    
-    try {
-      repositoryService.createProcessDefinitionQuery().processDefinitionName("test").latestVersion().list();
-      fail();
-    } catch (ActivitiIllegalArgumentException e) {}
-    
-    try {
-      repositoryService.createProcessDefinitionQuery().processDefinitionNameLike("test").latestVersion().list();
-      fail();
-    } catch (ActivitiIllegalArgumentException e) {}
-    
-    try {
-      repositoryService.createProcessDefinitionQuery().processDefinitionVersion(1).latestVersion().list();
-      fail();
-    } catch (ActivitiIllegalArgumentException e) {}
-    
-    try {
-      repositoryService.createProcessDefinitionQuery().deploymentId("test").latestVersion().list();
-      fail();
-    } catch (ActivitiIllegalArgumentException e) {}
-  }
-  
   public void testQuerySorting() {
     
     // asc 

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess1_one.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess1_one.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="test">
+
+  <process id="testProcess1" name="one">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess1_two.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess1_two.bpmn20.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="test">
+
+  <process id="testProcess1" name="two">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess2_one.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/name_testProcess2_one.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="test">
+
+  <process id="testProcess2" name="one">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess1_one.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess1_one.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="test">
+
+  <process id="testProcess1" name="test">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess1_two.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess1_two.bpmn20.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="test">
+
+  <process id="testProcess1" name="test">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess2_one.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/repository/latest/version_testProcess2_one.bpmn20.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="test">
+
+  <process id="testProcess2" name="test">
+  
+    <startEvent id="start" />
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="end" />
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
# Overview

ProcessDefinitionQuery throws ActivitiIllegalArgumentException when I used latestVersion() with name() and nameLike, and so on.
Because I thought all other criteria (name) don't defeats the purpose of the "latest" concept, I removed the restriction and added test cases.

https://github.com/Activiti/Activiti/blob/master/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java

// latest() makes only sense when used with key() or keyLike()
if (latest && ( (id != null) || (name != null) || (nameLike != null) || (version != null) || (deploymentId != null) ) ){
	throw new ActivitiIllegalArgumentException("Calling latest() can only be used in combination with key(String) and keyLike(String)");
}

# Detail

According to the following exchanges,I thought that ProcessDefinitionQuery 
restricts because using latestVersion() method with name() defeats the purpose of the "latest" concept.
https://forums.activiti.org/content/why-latest-can-only-be-used-combination-key

However , using latestVersion() method with name() do't defeat the purpose of the "latest" concept.

When I customized to remove the restriction , the following SQL was executed.
Since nameLike and latest has become a product set, the purpose of the "latest" concept cannot be defeated.

"select RES.* from ACT_RE_PROCDEF RES 
WHERE
RES.NAME_ like '%NAME%'
and
RES.VERSION_ = (select 
max(VERSION_) from ACT_RE_PROCDEF where KEY_ = RES.KEY_ and ( (TENANT_ID_ IS NOT NULL and TENANT_ID_ 
= RES.TENANT_ID_) or (TENANT_ID_ IS NULL and RES.TENANT_ID_ IS NULL) ) ) order by RES.NAME_ 
asc LIMIT 10 OFFSET 0"