### PR TITLE
Activiti6

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -684,10 +684,13 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
 
     VariableType type = variableTypes.findVariableType(value);
 
-    VariableInstanceEntity variableInstance = Context.getCommandContext().getVariableInstanceEntityManager()
-        .createAndInsert(variableName, type, value);
+    VariableInstanceEntity variableInstance =
+        Context.getCommandContext()
+            .getVariableInstanceEntityManager()
+            .create(variableName, type, value);
     initializeVariableInstanceBackPointer(variableInstance);
-
+    Context.getCommandContext().getVariableInstanceEntityManager().insert(variableInstance);
+    
     if (variableInstances != null) {
       variableInstances.put(variableName, variableInstance);
     }


### PR DESCRIPTION
Changes to initializeVariableInstanceBackPointer before inserting the variable scope entity. This change makes it easier for the datamanager to insert the entity and not rely on any caching.