### PR TITLE
Activiti currently uses commons-email 1.4 which in turn uses javax.ma…

### DIFF
--- a/distro/src/notice.txt
+++ b/distro/src/notice.txt
@@ -117,7 +117,7 @@ commons-collections-3.2.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-dbcp-1.4.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-digester-1.6.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-el-1.0.jar : http://www.apache.org/licenses/LICENSE-2.0.html
-commons-email-1.2.jar : http://www.apache.org/licenses/LICENSE-2.0.html
+commons-email-1.4.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-fileupload-1.2.1.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-httpclient-3.1.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 commons-io-1.4.jar : http://www.apache.org/licenses/LICENSE-2.0.html
@@ -180,7 +180,7 @@ jtds-1.2.4.jar : LGPL http://www.opensource.org/licenses/lgpl-2.1.php (no versio
 junit-4.8.1.jar : http://www.opensource.org/licenses/cpl1.0.php
 livetribe-jsr223-2.0.6.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 log4j-1.2.14.jar : http://www.apache.org/licenses/LICENSE-2.0.html
-mail-1.4.1.jar : CDDL https://glassfish.dev.java.net/javaee5/mail/ 
+mail-1.5.2.jar : CDDL https://java.net/projects/javamail/pages/License
 mime-util-2.1.3.jar : http://www.apache.org/licenses/LICENSE-2.0.html
 mockito-core-1.8.2.jar : MIT http://www.opensource.org/licenses/mit-license.php
 mvel2-2.0.16.jar : http://www.apache.org/licenses/LICENSE-2.0.html


### PR DESCRIPTION
…il 1.5.2, so update notice.txt accordingly