### PR TITLE
Javadoc fix

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/RepositoryService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/RepositoryService.java
@@ -222,7 +222,7 @@ public interface RepositoryService {
    * Activates the process definition with the given id. 
    * 
    * @param activationDate The date on which the process definition will be activated. If null, the
-   *                       process definition is suspended immediately. 
+   *                       process definition is activated immediately. 
    *                       Note: The job executor needs to be active to use this!                                 
    *                                
    * @throws ActivitiObjectNotFoundException if no such processDefinition can be found.
@@ -242,7 +242,7 @@ public interface RepositoryService {
    * Activates the process definition with the given key (=id in the bpmn20.xml file). 
    * 
    * @param activationDate The date on which the process definition will be activated. If null, the
-   *                       process definition is suspended immediately. 
+   *                       process definition is activated immediately. 
    *                       Note: The job executor needs to be active to use this!                                 
    *                                
    * @throws ActivitiObjectNotFoundException if no such processDefinition can be found.

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/repository/ProcessDefinitionQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/repository/ProcessDefinitionQuery.java
@@ -106,7 +106,6 @@ public interface ProcessDefinitionQuery extends Query<ProcessDefinitionQuery, Pr
    * Only select the process definitions which are the latest deployed
    * (ie. which have the highest version number for the given key).
    * 
-   * Can only be used in combination with {@link #processDefinitionKey(String)} of {@link #processDefinitionKeyLike(String)}.
    * Can also be used without any other criteria (ie. query.latest().list()), which
    * will then give all the latest versions of all the deployed process definitions.
    * 


### PR DESCRIPTION
# RepositoryService
Not suspended but activate.

# ProcessDefinitionQuery
I removed the description of the old specification.
Relation to https://github.com/Activiti/Activiti/pull/788 .