### PR TITLE
ACT-4122 cannot start a process instance without history service

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricTaskInstanceEntityManagerImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricTaskInstanceEntityManagerImpl.java
@@ -86,6 +86,14 @@ public class HistoricTaskInstanceEntityManagerImpl extends AbstractEntityManager
   }
 
   @Override
+  public HistoricTaskInstanceEntity findById(String taskId) {
+    if (getHistoryManager().isHistoryEnabled()) {
+      return historicTaskInstanceDataManager.findById(taskId);
+    }
+    return null;
+  }
+
+  @Override
   public void delete(String id) {
     if (getHistoryManager().isHistoryEnabled()) {
       HistoricTaskInstanceEntity historicTaskInstance = findById(id);


### PR DESCRIPTION
A SQL error occurs if a process instance is started without enabling the
history service.

Cause: org.h2.jdbc.JdbcSQLException: Table "ACT_HI_TASKINST" not found;
SQL statement:
select * from ACT_HI_TASKINST where ID_ = ?