### PR TITLE
Separate out TaskEntity creation and insertion.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -64,9 +64,12 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
   }
 
   public void execute(DelegateExecution execution) {
-    TaskEntity task = Context.getCommandContext().getTaskEntityManager().createAndInsert(execution); 
+    Date currentTime =
+        Context.getCommandContext().getProcessEngineConfiguration().getClock().getCurrentTime();
+    TaskEntity task = Context.getCommandContext().getTaskEntityManager().create(currentTime);
     task.setExecution((ExecutionEntity) execution);
     task.setTaskDefinitionKey(userTask.getId());
+    Context.getCommandContext().getTaskEntityManager().insert(task, (ExecutionEntity) execution);
     
     String activeTaskName = null;
     String activeTaskDescription = null;


### PR DESCRIPTION
Instead of creating and inserting the task entity in one go, this changes creates the task entity with necessary values and then inserts it.