### PR TITLE
Activiti 5.17.0.dorsale

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -4,7 +4,32 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>Activiti - Engine</name>
+  <groupId>eu.europa.ec.digit.dorsale.third.org.activiti</groupId>
   <artifactId>activiti-engine</artifactId>
+  
+  <repositories>
+		<repository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<repository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+		</repository>
+		<snapshotRepository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+		</snapshotRepository>
+	</distributionManagement>
 
   <parent>
     <groupId>org.activiti</groupId>

--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -4,6 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>Activiti - Engine</name>
+  <groupId>eu.europa.ec.digit.dorsale.third.org.activiti</groupId>
   <artifactId>activiti-engine</artifactId>
 
   <parent>
@@ -12,6 +13,30 @@
     <relativePath>../..</relativePath>
     <version>5.17.0</version>
   </parent>
+  
+  <repositories>
+		<repository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
+
+	<distributionManagement>
+		<repository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+		</repository>
+		<snapshotRepository>
+			<id>3rd_party</id>
+			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
+		</snapshotRepository>
+	</distributionManagement>
 
   <dependencies>
     <dependency>

--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -4,7 +4,6 @@
   <modelVersion>4.0.0</modelVersion>
 
   <name>Activiti - Engine</name>
-  <groupId>eu.europa.ec.digit.dorsale.third.org.activiti</groupId>
   <artifactId>activiti-engine</artifactId>
 
   <parent>
@@ -13,30 +12,6 @@
     <relativePath>../..</relativePath>
     <version>5.17.0</version>
   </parent>
-  
-  <repositories>
-		<repository>
-			<id>3rd_party</id>
-			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</repository>
-	</repositories>
-
-	<distributionManagement>
-		<repository>
-			<id>3rd_party</id>
-			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
-		</repository>
-		<snapshotRepository>
-			<id>3rd_party</id>
-			<url>https://webgate.ec.europa.eu/CITnet/nexus/content/repositories/digit/</url>
-		</snapshotRepository>
-	</distributionManagement>
 
   <dependencies>
     <dependency>

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
@@ -241,7 +241,7 @@
     from ${prefix}ACT_HI_TASKINST RES
     <choose>
       <when test="includeTaskLocalVariables &amp;&amp; includeProcessVariables">
-        left outer join ${prefix}ACT_HI_VARINST VAR ON RES.ID_ = VAR.TASK_ID_ or RES.PROC_INST_ID_ = VAR.EXECUTION_ID_
+        left outer join ${prefix}ACT_HI_VARINST VAR ON RES.ID_ = VAR.TASK_ID_ or (RES.PROC_INST_ID_ = VAR.EXECUTION_ID_ and VAR.TASK_ID_ is null)
       </when>
       <otherwise>
         <if test="includeTaskLocalVariables">

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
@@ -241,7 +241,7 @@
     from ${prefix}ACT_HI_TASKINST RES
     <choose>
       <when test="includeTaskLocalVariables &amp;&amp; includeProcessVariables">
-        left outer join ${prefix}ACT_HI_VARINST VAR ON RES.ID_ = VAR.TASK_ID_ or (RES.PROC_INST_ID_ = VAR.EXECUTION_ID_ and VAR.TASK_ID_ is null)
+        left outer join ${prefix}ACT_HI_VARINST VAR ON RES.ID_ = VAR.TASK_ID_ or RES.PROC_INST_ID_ = VAR.EXECUTION_ID_
       </when>
       <otherwise>
         <if test="includeTaskLocalVariables">


### PR DESCRIPTION
There is a bug when we want to retrieve the task's local variables plus the process variables. The local variables of the current task are returned as well.

This problem presents itself when retrieving a historicTask. Along with the historicTask's local variables, the current task local variables are returned.

To fix this, the SQL in the HistoricTaskInstance.xml has been modified when includeTaskLocalVariables and includeProcessVariables are true, by adding the condition already present when only includeProcessVariables is true: `and VAR.TASK_ID_ is null`