### PR TITLE
MNT-15609 : Fix for serializable object compare when upgrading JDK version

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -428,11 +428,10 @@ public class DbSqlSession implements Session {
   }
 
   // deserialized objects /////////////////////////////////////////////////////
-  
-  public void addDeserializedObject(Object deserializedObject, byte[] serializedBytes, VariableInstanceEntity variableInstanceEntity) {
-    deserializedObjects.add(new DeserializedObject(deserializedObject, serializedBytes, variableInstanceEntity));
-  }
 
+    public void addDeserializedObject(DeserializedObject deserializedObject) {
+      deserializedObjects.add(deserializedObject);
+    }
   // flush ////////////////////////////////////////////////////////////////////
 
   public void flush() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/DeserializedObject.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/DeserializedObject.java
@@ -21,12 +21,13 @@ import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
  * @author Tom Baeyens
  */
 public class DeserializedObject {
-
+  SerializableType type;
   Object deserializedObject;
   byte[] originalBytes;
   VariableInstanceEntity variableInstanceEntity;
   
-  public DeserializedObject(Object deserializedObject, byte[] serializedBytes, VariableInstanceEntity variableInstanceEntity) {
+  public DeserializedObject(SerializableType type, Object deserializedObject, byte[] serializedBytes, VariableInstanceEntity variableInstanceEntity) {
+    this.type = type;
     this.deserializedObject = deserializedObject;
     this.originalBytes = serializedBytes;
     this.variableInstanceEntity = variableInstanceEntity;
@@ -35,11 +36,16 @@ public class DeserializedObject {
   public void flush() {
     // this first check verifies if the variable value was not overwritten with another object
     if (deserializedObject==variableInstanceEntity.getCachedValue()) {
-      byte[] bytes = SerializableType.serialize(deserializedObject, variableInstanceEntity);
+      byte[] bytes = type.serialize(deserializedObject, variableInstanceEntity);
       if (!Arrays.equals(originalBytes, bytes)) {
-        variableInstanceEntity
-          .getByteArrayValue()
-          .setBytes(bytes);
+          
+          // Add an additional check to prevent byte differences due to JDK changes etc
+          Object originalObject = type.deserialize(originalBytes, variableInstanceEntity);
+          byte[] refreshedOriginalBytes = type.serialize(originalObject, variableInstanceEntity);
+          
+          if (!Arrays.equals(refreshedOriginalBytes, bytes)) {
+            variableInstanceEntity.setByteArrayValue(bytes);
+          }
       }
     }
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/SerializableType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/variable/SerializableType.java
@@ -46,28 +46,25 @@ public class SerializableType extends ByteArrayType {
     if (cachedObject!=null) {
       return cachedObject;
     }
+
     byte[] bytes = (byte[]) super.getValue(valueFields);
-    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
-    Object deserializedObject;
-    try {
-      ObjectInputStream ois = createObjectInputStream(bais);
-      deserializedObject = ois.readObject();
+    if (bytes != null) {
+      Object deserializedObject = deserialize(bytes, valueFields);
+
       valueFields.setCachedValue(deserializedObject);
-      
+
       if (valueFields instanceof VariableInstanceEntity) {
-        Context
-          .getCommandContext()
-          .getDbSqlSession()
-          .addDeserializedObject(deserializedObject, bytes, (VariableInstanceEntity) valueFields);
+        // we need to register the deserialized object for dirty checking, 
+        // so that it can be serialized again if it was changed. 
+        Context.getCommandContext()
+            .getDbSqlSession()
+            .addDeserializedObject(new DeserializedObject(this, deserializedObject, bytes, (VariableInstanceEntity) valueFields));
       }
-      
-    } catch (Exception e) {
-      throw new ActivitiException("Couldn't deserialize object in variable '"+valueFields.getName()+"'", e);
-    } finally {
-      IoUtil.closeSilently(bais);
+
+      return deserializedObject;
+      }
+      return null; // byte array is null
     }
-    return deserializedObject;
-  }
 
   public void setValue(Object value, ValueFields valueFields) {
     byte[] byteArray = serialize(value, valueFields);
@@ -78,7 +75,7 @@ public class SerializableType extends ByteArrayType {
         Context
           .getCommandContext()
           .getDbSqlSession()
-          .addDeserializedObject(valueFields.getCachedValue(), byteArray, (VariableInstanceEntity)valueFields);
+          .addDeserializedObject(new DeserializedObject(this, valueFields.getCachedValue(), byteArray, (VariableInstanceEntity)valueFields));
       }
     }
         
@@ -100,6 +97,20 @@ public class SerializableType extends ByteArrayType {
       IoUtil.closeSilently(ois);
     }
     return baos.toByteArray();
+  }
+
+  public Object deserialize(byte[] bytes, ValueFields valueFields) {
+    ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
+    try {
+      ObjectInputStream ois = createObjectInputStream(bais);
+      Object deserializedObject = ois.readObject();
+
+      return deserializedObject;
+    } catch (Exception e) {
+      throw new ActivitiException("Couldn't deserialize object in variable '"+valueFields.getName()+"'", e);
+    } finally {
+      IoUtil.closeSilently(bais);
+    }
   }
 
   public boolean isAbleToStore(Object value) {


### PR DESCRIPTION
Fix for serializable object compare when upgrading JDK version. 
Backport and reorganize of a fix done in activiti 5.16.4 (SHA-1: efcfb9a899127dc1a0132b074f107ae16d6b1aef)