### PR TITLE
Fixes activiti-explorer login form

### DIFF
--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/login/ExplorerLoginForm.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/login/ExplorerLoginForm.java
@@ -48,8 +48,7 @@ public class ExplorerLoginForm extends LoginForm {
   // Hack-alert !! See explanation at http://vaadin.com/book/-/page/components.loginform.html
   protected byte[] getLoginHTML() {
     // Application URI needed for submitting form
-    String appUri = getApplication().getURL().toString()
-            + getWindow().getName() + "/";
+    String appUri = getWindow().getName() + "/";
 
     String x, h, b; // XML header, HTML head and body
     


### PR DESCRIPTION
When application is behind proxy (like nginx) over https - login form.action has http scheme.

The issue is that when I'm running activiti-explorer behind proxy and proxy exposes application over https, I cannot log in because of 'mixed-content'. This is because on my browser I have https:// url but inside the application thinks I'm running unsecured and provides login form action param like http://<host>/activiti-explorer/ui/1/loginHandler. After the fix the url here would simply be "1/loginHandler" so it will not try to guess the scheme. It seems to work. Please check the patch, I don't know activiti internals too good so there may be a reason why login form's action param was composed the way it was.