### PR TITLE
Fix the test case failures by the execution speed problem.

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
@@ -693,7 +693,11 @@ public class HistoryServiceTest extends PluggableActivitiTestCase {
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess", vars);
     taskService.complete(taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult().getId());    
 
-    Date date2 = Calendar.getInstance().getTime();
+    // Fix for Faster Computer
+    Calendar date2Calendar = Calendar.getInstance();
+    date2Calendar.add(Calendar.MILLISECOND, 1);
+    
+    Date date2 = date2Calendar.getTime();
     vars = new HashMap<String, Object>();
     vars.put("dateVar", date1);
     vars.put("dateVar2", date2);

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -280,7 +280,7 @@ public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
   }
   
   @Deployment(resources = {"org/activiti/engine/test/history/oneTaskProcess.bpmn20.xml"})
-  public void testHistoricProcessInstanceSorting() {
+  public void testHistoricProcessInstanceSorting() throws InterruptedException {
     ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
     assertEquals(1, historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceId().asc().list().size());
@@ -317,6 +317,9 @@ public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
     for (Task task : taskService.createTaskQuery().processInstanceId(processInstance2.getId()).list()) {
     	taskService.complete(task.getId());
     }
+    
+    // Fix for Faster Computer
+    Thread.sleep(1);
     
     // Then process instance 1
     for (Task task : taskService.createTaskQuery().processInstanceId(processInstance1.getId()).list()) {

--- a/modules/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -1393,7 +1393,7 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
    // Test for https://activiti.atlassian.net/browse/ACT-2186
    @Deployment(resources={
    	"org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml"})
-   public void testHistoricVariableRemovedWhenRuntimeVariableIsRemoved() {
+   public void testHistoricVariableRemovedWhenRuntimeVariableIsRemoved() throws InterruptedException {
    	 Map<String, Object> vars = new HashMap<String, Object>();
       vars.put("var1", "Hello");
       vars.put("var2", "World");
@@ -1415,6 +1415,9 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
       for (HistoricDetail historicDetail : details) {
       	assertNotNull( ((HistoricVariableUpdate) historicDetail).getValue());
       }
+      
+      // Fix for Faster Computer
+      Thread.sleep(1);
       
       // Remove one variable
       runtimeService.removeVariable(processInstance.getId(), "var2");


### PR DESCRIPTION
We have to ensure the success of HistoricProcessInstanceTest and FullHistoryTest and HistoryServiceTest.java.

These test case fail when these are executed in a faster computer.
These test case sort list by time,but time becomes the same when these are executed in a faster computer.
Therefore, the order becomes random and unexpected results may occur.

# Fix

## HistoricProcessInstanceTest.java

We fixed this problem by adding sleep.

```java
// Fix for Faster Computer
Thread.sleep(1);
```

## HistoryServiceTest.java

We plused 1 millisecond to the second variable not to be same time.

```java
// Fix for Faster Computer
Calendar date2Calendar = Calendar.getInstance();
date2Calendar.add(Calendar.MILLISECOND, 1);
```

As soon as possible, please merge this fix.
If not, these test case fail in our eclipse.

# StackTrace

## HistoricProcessInstanceTest.java and FullHistoryTest.java

```java
junit.framework.ComparisonFailure: expected:<4681[5]> but was:<4681[9]>
	at junit.framework.Assert.assertEquals(Assert.java:100)
	at junit.framework.Assert.assertEquals(Assert.java:107)
	at junit.framework.TestCase.assertEquals(TestCase.java:269)
	at org.activiti.engine.test.history.HistoricProcessInstanceTest.testHistoricProcessInstanceSorting(HistoricProcessInstanceTest.java:356)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at org.activiti.engine.impl.test.PvmTestCase.runTest(PvmTestCase.java:65)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at org.activiti.engine.impl.test.AbstractActivitiTestCase.runBare(AbstractActivitiTestCase.java:100)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:255)
	at junit.framework.TestSuite.run(TestSuite.java:250)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:35)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:146)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.booter.ProviderFactory$ClassLoaderProxy.invoke(ProviderFactory.java:103)
	at com.sun.proxy.$Proxy0.invoke(Unknown Source)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:145)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:87)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:69)
```

## FullHistoryTest.java

```java
junit.framework.AssertionFailedError
	at junit.framework.Assert.fail(Assert.java:55)
	at junit.framework.Assert.assertTrue(Assert.java:22)
	at junit.framework.Assert.assertNotNull(Assert.java:256)
	at junit.framework.Assert.assertNotNull(Assert.java:248)
	at junit.framework.TestCase.assertNotNull(TestCase.java:417)
	at org.activiti.standalone.history.FullHistoryTest.testHistoricVariableRemovedWhenRuntimeVariableIsRemoved(FullHistoryTest.java:1438)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at org.activiti.engine.impl.test.PvmTestCase.runTest(PvmTestCase.java:65)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at org.activiti.engine.impl.test.AbstractActivitiTestCase.runBare(AbstractActivitiTestCase.java:100)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:255)
	at junit.framework.TestSuite.run(TestSuite.java:250)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:35)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:146)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.booter.ProviderFactory$ClassLoaderProxy.invoke(ProviderFactory.java:103)
	at com.sun.proxy.$Proxy0.invoke(Unknown Source)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:145)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:87)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:69)
```

## HistoryServiceTest.java

Not only junit problem,but this error suggest bug of HistoricProcessInstanceQuery#variableValueEquals.
Because 'distinct' is not, HistoricProcessInstanceQuery#variableValueEquals may get duplicate process instances.
We will fix this bug by another pull request.

```java
junit.framework.AssertionFailedError: expected:<2> but was:<3>
	at junit.framework.Assert.fail(Assert.java:57)
	at junit.framework.Assert.failNotEquals(Assert.java:329)
	at junit.framework.Assert.assertEquals(Assert.java:78)
	at junit.framework.Assert.assertEquals(Assert.java:234)
	at junit.framework.Assert.assertEquals(Assert.java:241)
	at junit.framework.TestCase.assertEquals(TestCase.java:409)
	at org.activiti.engine.test.api.history.HistoryServiceTest.testQueryDateVariable(HistoryServiceTest.java:784)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at org.activiti.engine.impl.test.PvmTestCase.runTest(PvmTestCase.java:65)
	at junit.framework.TestCase.runBare(TestCase.java:141)
	at org.activiti.engine.impl.test.AbstractActivitiTestCase.runBare(AbstractActivitiTestCase.java:100)
	at junit.framework.TestResult$1.protect(TestResult.java:122)
	at junit.framework.TestResult.runProtected(TestResult.java:142)
	at junit.framework.TestResult.run(TestResult.java:125)
	at junit.framework.TestCase.run(TestCase.java:129)
	at junit.framework.TestSuite.runTest(TestSuite.java:255)
	at junit.framework.TestSuite.run(TestSuite.java:250)
	at org.junit.internal.runners.JUnit38ClassRunner.run(JUnit38ClassRunner.java:84)
	at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:35)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:146)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:97)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:606)
	at org.apache.maven.surefire.booter.ProviderFactory$ClassLoaderProxy.invoke(ProviderFactory.java:103)
	at com.sun.proxy.$Proxy0.invoke(Unknown Source)
	at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:145)
	at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcess(SurefireStarter.java:87)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:69)
```