### PR TITLE
Upgrade to Java 1.7 and use Locale.forLanguageTag() for localization

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/context/Context.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/context/Context.java
@@ -122,11 +122,10 @@ public class Context {
         
       } else {
         HashSet<Locale> candidateLocales = new LinkedHashSet<Locale>();
-        candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, new Locale(language)));
-        candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, Locale.getDefault()));
+        candidateLocales.addAll(resourceBundleControl.getCandidateLocales(id, Locale.forLanguageTag(language)));
         for (Locale locale : candidateLocales) {
           localizationProperties = getProcessEngineConfiguration().getDynamicBpmnService().getLocalizationElementProperties(
-              locale.getLanguage(), id, definitionInfoNode);
+              locale.toLanguageTag(), id, definitionInfoNode);
           
           if (localizationProperties != null) {
             break;

--- a/pom.xml
+++ b/pom.xml
@@ -640,8 +640,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
           <optimize>true</optimize>


### PR DESCRIPTION
Hi Tijs,

Here is a pull request to update the Java version used by Activiti to 1.7 as we discussed via email along with a change to the localization fallback support to make use of the Local.forLanguageTag(..) method introduced in 1.7.

thanks,
Rob