### PR TITLE
Fix - getVariableInstancesLocal() returning non-local variables

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -182,11 +182,11 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   }
   
   public Map<String, VariableInstance> getVariableInstancesLocal(String executionId, Collection<String> variableNames) {
-    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, false));
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, true));
   }
 
   public Map<String, VariableInstance> getVariableInstancesLocal(String executionId, Collection<String> variableNames, String locale, boolean withLocalizationFallback) {
-    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, false, locale, withLocalizationFallback));
+    return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, variableNames, true, locale, withLocalizationFallback));
   }
 
   public Object getVariable(String executionId, String variableName) {


### PR DESCRIPTION
The RuntimeService.getVariablesInstancesLocal(...) methods are returning non-local variables due to a value of 'false' being passed into the GetExecutionVariableInstancesCmd constructor. The value should be true.