### PR TITLE
Act-4116 Custom subprocess parser

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -312,10 +312,10 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
           throw new XMLException("Error reading XML", e);
         }
 
-        if (xtr.isEndElement() && (ELEMENT_SUBPROCESS.equals(xtr.getLocalName()) || 
+        if (xtr.isEndElement() && (ELEMENT_SUBPROCESS.equals(xtr.getLocalName()) ||
             ELEMENT_TRANSACTION.equals(xtr.getLocalName()) ||
             ELEMENT_ADHOC_SUBPROCESS.equals(xtr.getLocalName()))) {
-          
+
           activeSubProcessList.remove(activeSubProcessList.size() - 1);
         }
 
@@ -325,13 +325,13 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
 
 				if (ELEMENT_DEFINITIONS.equals(xtr.getLocalName())) {
 				  definitionsParser.parse(xtr, model);
-				  
+
         } else if (ELEMENT_RESOURCE.equals(xtr.getLocalName())) {
           resourceParser.parse(xtr, model);
-          
+
 				} else if (ELEMENT_SIGNAL.equals(xtr.getLocalName())) {
 					signalParser.parse(xtr, model);
-					
+
 				} else if (ELEMENT_MESSAGE.equals(xtr.getLocalName())) {
           messageParser.parse(xtr, model);
 
@@ -402,7 +402,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
 
         } else if (ELEMENT_SUBPROCESS.equals(xtr.getLocalName()) || ELEMENT_TRANSACTION.equals(xtr.getLocalName()) || ELEMENT_ADHOC_SUBPROCESS.equals(xtr.getLocalName())) {
           subProcessParser.parse(xtr, activeSubProcessList, activeProcess);
-          
+
         } else if (ELEMENT_COMPLETION_CONDITION.equals(xtr.getLocalName())) {
           if (!activeSubProcessList.isEmpty()) {
             SubProcess subProcess = activeSubProcessList.get(activeSubProcessList.size() - 1);
@@ -461,13 +461,13 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
           sourceNode.getOutgoingFlows().add(sequenceFlow);
           sequenceFlow.setSourceFlowElement(sourceNode);
         }
-        
+
         FlowNode targetNode = getFlowNodeFromScope(sequenceFlow.getTargetRef(), parentScope);
         if (targetNode != null) {
           targetNode.getIncomingFlows().add(sequenceFlow);
           sequenceFlow.setTargetFlowElement(targetNode);
         }
-        
+
       } else if (flowElement instanceof BoundaryEvent) {
         BoundaryEvent boundaryEvent = (BoundaryEvent) flowElement;
         FlowElement attachedToElement = getFlowNodeFromScope(boundaryEvent.getAttachedToRefId(), parentScope);
@@ -476,7 +476,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
           boundaryEvent.setAttachedToRef(attachedActivity);
           attachedActivity.getBoundaryEvents().add(boundaryEvent);
         }
-        
+
       } else if (flowElement instanceof SubProcess) {
         SubProcess subProcess = (SubProcess) flowElement;
         processFlowElements(subProcess.getFlowElements(), subProcess);
@@ -557,7 +557,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
     }
   }
 
-  private void createXML(FlowElement flowElement, BpmnModel model, XMLStreamWriter xtw) throws Exception {
+  protected void createXML(FlowElement flowElement, BpmnModel model, XMLStreamWriter xtw) throws Exception {
 
     if (flowElement instanceof SubProcess) {
 
@@ -569,7 +569,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
       } else {
         xtw.writeStartElement(ELEMENT_SUBPROCESS);
       }
-      
+
       xtw.writeAttribute(ATTRIBUTE_ID, subProcess.getId());
       if (StringUtils.isNotEmpty(subProcess.getName())) {
         xtw.writeAttribute(ATTRIBUTE_NAME, subProcess.getName());
@@ -579,7 +579,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
 
       if (subProcess instanceof EventSubProcess) {
         xtw.writeAttribute(ATTRIBUTE_TRIGGERED_BY, ATTRIBUTE_VALUE_TRUE);
-        
+
       } else if (subProcess instanceof Transaction == false) {
         if (subProcess.isAsynchronous()) {
           BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_ACTIVITY_ASYNCHRONOUS, ATTRIBUTE_VALUE_TRUE, xtw);
@@ -587,7 +587,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
             BpmnXMLUtil.writeQualifiedAttribute(ATTRIBUTE_ACTIVITY_EXCLUSIVE, ATTRIBUTE_VALUE_FALSE, xtw);
           }
         }
-        
+
       } else if (subProcess instanceof AdhocSubProcess) {
         AdhocSubProcess adhocSubProcess = (AdhocSubProcess) subProcess;
         BpmnXMLUtil.writeDefaultAttribute(ATTRIBUTE_CANCEL_REMAINING_INSTANCES, String.valueOf(adhocSubProcess.isCancelRemainingInstances()), xtw);
@@ -612,7 +612,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
       }
 
       MultiInstanceExport.writeMultiInstance(subProcess, xtw);
-      
+
       if (subProcess instanceof AdhocSubProcess) {
         AdhocSubProcess adhocSubProcess = (AdhocSubProcess) subProcess;
         if (StringUtils.isNotEmpty(adhocSubProcess.getCompletionCondition())) {

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
@@ -1,0 +1,198 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.bpmn.converter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.activiti.bpmn.converter.export.BPMNDIExport;
+import org.activiti.bpmn.converter.export.CollaborationExport;
+import org.activiti.bpmn.converter.export.DataStoreExport;
+import org.activiti.bpmn.converter.export.DefinitionsRootExport;
+import org.activiti.bpmn.converter.export.ProcessExport;
+import org.activiti.bpmn.converter.export.SignalAndMessageDefinitionExport;
+import org.activiti.bpmn.exceptions.XMLException;
+import org.activiti.bpmn.model.Artifact;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.GraphicInfo;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.SequenceFlow;
+import org.activiti.bpmn.model.SubProcess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Lori Small
+ */
+public class SubprocessXMLConverter extends BpmnXMLConverter {
+
+  protected static final Logger LOGGER = LoggerFactory.getLogger(SubprocessXMLConverter.class);
+
+  @Override
+  public byte[] convertToXML(BpmnModel model, String encoding) {
+    try {
+
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+      XMLOutputFactory xof = XMLOutputFactory.newInstance();
+      OutputStreamWriter out = new OutputStreamWriter(outputStream, encoding);
+
+      XMLStreamWriter writer = xof.createXMLStreamWriter(out);
+      XMLStreamWriter xtw = new IndentingXMLStreamWriter(writer);
+
+      DefinitionsRootExport.writeRootElement(model, xtw, encoding);
+      CollaborationExport.writePools(model, xtw);
+      DataStoreExport.writeDataStores(model, xtw);
+      SignalAndMessageDefinitionExport.writeSignalsAndMessages(model, xtw);
+
+      for (Process process : model.getProcesses()) {
+
+        if (process.getFlowElements().isEmpty() && process.getLanes().isEmpty()) {
+          // empty process, ignore it
+          continue;
+        }
+
+        ProcessExport.writeProcess(process, xtw);
+
+        for (FlowElement flowElement : process.getFlowElements()) {
+          createXML(flowElement, model, xtw);
+        }
+
+        for (Artifact artifact : process.getArtifacts()) {
+          createXML(artifact, model, xtw);
+        }
+
+        // end process element
+        xtw.writeEndElement();
+      }
+
+      // refactor each subprocess into a separate Diagram
+      List<BpmnModel> subModels = parseSubModels(model);
+      for (BpmnModel tempModel : subModels)
+      {
+        BPMNDIExport.writeBPMNDI(tempModel, xtw);
+      }
+
+      // end definitions root element
+      xtw.writeEndElement();
+      xtw.writeEndDocument();
+
+      xtw.flush();
+      byte[] bytes = outputStream.toByteArray().clone();
+
+      // cleanup
+      outputStream.close();
+      xtw.close();
+
+      return bytes;
+    } catch (Exception e) {
+      LOGGER.error("Error writing BPMN XML", e);
+      throw new XMLException("Error writing BPMN XML", e);
+    }
+  }
+
+  private List<BpmnModel> parseSubModels(BpmnModel model) {
+    List<BpmnModel> subModels = new ArrayList<BpmnModel>();
+
+    // find all subprocesses
+    Collection<FlowElement> flowElements = model.getMainProcess().getFlowElements();
+    Map<String, GraphicInfo> locations = new HashMap<String, GraphicInfo>();
+    Map<String, List<GraphicInfo>> flowLocations = new HashMap<String, List<GraphicInfo>>();
+    Map<String, GraphicInfo> labelLocations = new HashMap<String, GraphicInfo>();
+
+    locations.putAll(model.getLocationMap());
+    flowLocations.putAll(model.getFlowLocationMap());
+    labelLocations.putAll(model.getLabelLocationMap());
+
+    // include main process as separate model
+    BpmnModel mainModel = new BpmnModel();
+    // set main process in submodel to subprocess
+    mainModel.addProcess(model.getMainProcess());
+
+    String elementId = null;
+    for (FlowElement element : flowElements)
+    {
+      elementId = element.getId();
+      if (element instanceof SubProcess)
+      {
+        subModels.addAll(parseSubModels(element, locations, flowLocations, labelLocations));
+      }
+      
+      if (element instanceof SequenceFlow)
+      {
+        // must be an edge
+        mainModel.getFlowLocationMap().put(elementId, flowLocations.get(elementId));
+      }
+      else
+      {
+        // must be a shape
+        mainModel.getLocationMap().put(elementId, locations.get(elementId));
+      }
+      // also check for any labels
+      mainModel.getLabelLocationMap().put(elementId, labelLocations.get(elementId));
+    }
+    // add main process model to list
+    subModels.add(mainModel);
+
+    return subModels;
+  }
+
+  private List<BpmnModel> parseSubModels(FlowElement subElement, Map<String, GraphicInfo> locations, 
+                                         Map<String, List<GraphicInfo>> flowLocations, Map<String, GraphicInfo> labelLocations) {
+    List<BpmnModel> subModels = new ArrayList<BpmnModel>();
+    BpmnModel subModel = new BpmnModel();
+    String elementId = null;
+
+    // find nested subprocess models
+    Collection<FlowElement> subFlowElements = ((SubProcess)subElement).getFlowElements();
+    // set main process in submodel to subprocess
+    Process newMainProcess = new Process();
+    newMainProcess.setId(subElement.getId());
+    newMainProcess.getFlowElements().addAll(subFlowElements);
+    newMainProcess.getArtifacts().addAll(((SubProcess)subElement).getArtifacts());
+    subModel.addProcess(newMainProcess);
+
+    for (FlowElement element : subFlowElements)
+    {
+      elementId = element.getId();
+      if (element instanceof SubProcess)
+      {
+        subModels.addAll(parseSubModels(element, locations, flowLocations, labelLocations));
+      }
+      if (element instanceof SequenceFlow)
+      {
+        // must be an edge
+        subModel.getFlowLocationMap().put(elementId, flowLocations.get(elementId));
+      }
+      else
+      {
+        // must be a shape
+        subModel.getLocationMap().put(elementId, locations.get(elementId));
+      }
+      // also check for any labels
+      subModel.getLabelLocationMap().put(elementId, labelLocations.get(elementId));
+    }
+    subModels.add(subModel);
+
+    return subModels;
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterTest.java
@@ -1,0 +1,82 @@
+package org.activiti.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+
+import org.activiti.bpmn.converter.SubprocessXMLConverter;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+public class SubProcessMultiDiagramConverterTest extends AbstractConverterTest {
+
+  @Override
+  protected BpmnModel readXMLFile() throws Exception {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream(getResource());
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Override
+  protected BpmnModel exportAndReadXMLFile(BpmnModel bpmnModel) throws Exception {
+    byte[] xml = new SubprocessXMLConverter().convertToXML(bpmnModel);
+    System.out.println("xml " + new String(xml, "UTF-8"));
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(xml), "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Test
+  public void convertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+
+  protected String getResource() {
+    return "subprocessmultidiagrammodel.bpmn";
+  }
+
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+
+    flowElement = model.getMainProcess().getFlowElement("userTask1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof UserTask);
+    assertEquals("userTask1", flowElement.getId());
+    UserTask userTask = (UserTask) flowElement;
+    assertTrue(userTask.getCandidateUsers().size() == 1);
+    assertTrue(userTask.getCandidateGroups().size() == 1);
+
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertTrue(subProcess.getFlowElements().size() == 5);
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel.bpmn
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <startEvent id="start1"></startEvent>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" activiti:async="true" activiti:exclusive="false" activiti:candidateUsers="kermit" activiti:candidateGroups="management"></userTask>
+    <subProcess id="subprocess1" name="Sub Process" isExpanded="false">
+      <userTask id="subUserTask1" name="User task 2"></userTask>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+    </subProcess>
+    <sequenceFlow id="flow1" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="106.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
+        <omgdc:Bounds height="35.0" width="35.0" x="780.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="211.0" y="169.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+        <omgdc:Bounds height="205.0" width="335.0" x="380.0" y="105.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
+        <omgdi:waypoint x="141.0" y="208.0"></omgdi:waypoint>
+        <omgdi:waypoint x="211.0" y="209.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="311.0" y="209.0"></omgdi:waypoint>
+        <omgdi:waypoint x="380.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="715.0" y="207.0"></omgdi:waypoint>
+        <omgdi:waypoint x="780.0" y="208.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_subprocess1">
+    <bpmndi:BPMNPlane bpmnElement="subprocess1" id="BPMNPlane_subprocess1">
+      <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="490.0" y="170.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="400.0" y="195.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="650.0" y="192.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
+        <omgdi:waypoint x="590.0" y="210.0"></omgdi:waypoint>
+        <omgdi:waypoint x="650.0" y="209.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="435.0" y="212.0"></omgdi:waypoint>
+        <omgdi:waypoint x="490.0" y="210.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
We really need both createXML() method calls in BpmnXMLConverter to be protected. It looks like the second one has been updated already (since my last attempt at a pull request). But if you could also consider adding the new SubprocessXMLConverter that would be great. I tried to get it working with the existing Designer code, but got to where the next id was determined for each BPMN element within the UI and it was looping through and finding the next one. Wouldn't it be better to use a UUID or keep a key list somewhere with the next key value? Don't you use ids or sids for the web-based design tool already?