### PR TITLE
Add the process definition search criteria.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstance.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstance.java
@@ -35,6 +35,20 @@ public interface HistoricProcessInstance {
   /** The process definition reference. */
   String getProcessDefinitionId();
 
+  /** The name of the process definition of the process instance. */
+  String getProcessDefinitionName();
+  
+  /** The key of the process definition of the process instance. */
+  String getProcessDefinitionKey();
+  
+  /** The version of the process definition of the process instance. */
+  Integer getProcessDefinitionVersion();
+  
+  /**
+   * The deployment id of the process definition of the process instance.
+   */
+  String getDeploymentId();
+  
   /** The time the process was started. */
   Date getStartTime();
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstanceQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstanceQuery.java
@@ -53,6 +53,18 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
   /** Only select historic process instances that don't have a process-definition of which the key is present in the given list */
   HistoricProcessInstanceQuery processDefinitionKeyNotIn(List<String> processDefinitionKeys);
 
+  /** Only select historic process instances whose process definition category is processDefinitionCategory. */
+  HistoricProcessInstanceQuery processDefinitionCategory(String processDefinitionCategory);
+
+  /** Select process historic instances whose process definition name is processDefinitionName*/
+  HistoricProcessInstanceQuery processDefinitionName(String processDefinitionName);
+
+  /**
+   * Only select historic process instances with a certain process definition version.
+   * Particulary useful when used in combination with {@link #processDefinitionKey(String)}
+   */
+  HistoricProcessInstanceQuery processDefinitionVersion(Integer processDefinitionVersion);
+
   /** Only select historic process instances with the given business key */
   HistoricProcessInstanceQuery processInstanceBusinessKey(String processInstanceBusinessKey);
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
@@ -42,7 +42,9 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
   private static final long serialVersionUID = 1L;
   protected String processDefinitionId;
   protected String processDefinitionKey;
+  protected String processDefinitionCategory;
   protected String processDefinitionName;
+  protected Integer processDefinitionVersion;
   protected String activityId;
   protected String executionId;
   protected String parentId;
@@ -108,11 +110,29 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
   }
 
   @Override
+  public ExecutionQuery processDefinitionCategory(String processDefinitionCategory) {
+    if (processDefinitionCategory == null) {
+      throw new ActivitiIllegalArgumentException("Process definition category is null");
+    }
+    this.processDefinitionCategory = processDefinitionCategory;
+    return this;
+  }
+
+  @Override
   public ExecutionQuery processDefinitionName(String processDefinitionName) {
     if (processDefinitionName == null) {
       throw new ActivitiIllegalArgumentException("Process definition name is null");
     }
     this.processDefinitionName = processDefinitionName;
+    return this;
+  }
+
+  @Override
+  public ExecutionQuery processDefinitionVersion(Integer processDefinitionVersion) {
+    if (processDefinitionVersion == null) {
+      throw new ActivitiIllegalArgumentException("Process definition version is null");
+    }
+    this.processDefinitionVersion = processDefinitionVersion;
     return this;
   }
 
@@ -357,8 +377,14 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
   public String getProcessDefinitionId() {
     return processDefinitionId;
   }
+  public String getProcessDefinitionCategory() {
+    return processDefinitionCategory;
+  }
   public String getProcessDefinitionName() {
     return processDefinitionName;
+  }
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
   }
   public String getActivityId() {
     return activityId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -61,6 +61,9 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected Date finishedBefore;
   protected Date finishedAfter;
   protected String processDefinitionKey;
+  protected String processDefinitionCategory;
+  protected String processDefinitionName;
+  protected Integer processDefinitionVersion;
   protected Set<String> processInstanceIds;
   protected String involvedUser;
   protected boolean includeProcessVariables;
@@ -137,6 +140,33 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
       currentOrQueryObject.processDefinitionKeyIn = processDefinitionKeys;
     } else {
       this.processDefinitionKeyIn = processDefinitionKeys;
+    }
+    return this;
+  }
+
+  public HistoricProcessInstanceQuery processDefinitionCategory(String processDefinitionCategory) {
+    if (inOrStatement) {
+      this.currentOrQueryObject.processDefinitionCategory = processDefinitionCategory;
+    } else {
+      this.processDefinitionCategory = processDefinitionCategory;
+    }
+    return this;
+  }
+
+  public HistoricProcessInstanceQuery processDefinitionName(String processDefinitionName) {
+    if (inOrStatement) {
+      this.currentOrQueryObject.processDefinitionName = processDefinitionName;
+    } else {
+      this.processDefinitionName = processDefinitionName;
+    }
+    return this;
+  }
+
+  public HistoricProcessInstanceQuery processDefinitionVersion(Integer processDefinitionVersion) {
+    if (inOrStatement) {
+      this.currentOrQueryObject.processDefinitionVersion = processDefinitionVersion;
+    } else {
+      this.processDefinitionVersion = processDefinitionVersion;
     }
     return this;
   }
@@ -622,6 +652,15 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   }
   public String getProcessDefinitionIdLike() {
     return processDefinitionKey + ":%:%";
+  }
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+  public String getProcessDefinitionCategory() {
+    return processDefinitionCategory;
+  }
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
   }
   public String getProcessInstanceId() {
     return processInstanceId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryProperty.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryProperty.java
@@ -32,6 +32,7 @@ public class HistoricProcessInstanceQueryProperty implements QueryProperty {
 
   public static final HistoricProcessInstanceQueryProperty PROCESS_INSTANCE_ID_ = new HistoricProcessInstanceQueryProperty("RES.PROC_INST_ID_");
   public static final HistoricProcessInstanceQueryProperty PROCESS_DEFINITION_ID = new HistoricProcessInstanceQueryProperty("RES.PROC_DEF_ID_");
+  public static final HistoricProcessInstanceQueryProperty PROCESS_DEFINITION_KEY = new HistoricProcessInstanceQueryProperty("DEF.KEY_");
   public static final HistoricProcessInstanceQueryProperty BUSINESS_KEY = new HistoricProcessInstanceQueryProperty("RES.BUSINESS_KEY_");
   public static final HistoricProcessInstanceQueryProperty START_TIME = new HistoricProcessInstanceQueryProperty("RES.START_TIME_");
   public static final HistoricProcessInstanceQueryProperty END_TIME = new HistoricProcessInstanceQueryProperty("RES.END_TIME_");

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -49,7 +49,9 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean includeChildExecutionsWithBusinessKeyQuery;
   protected String processDefinitionId;
   protected Set<String> processDefinitionIds;
+  protected String processDefinitionCategory;
   protected String processDefinitionName;
+  protected Integer processDefinitionVersion;
   protected Set<String> processInstanceIds;
   protected String processDefinitionKey;
   protected Set<String> processDefinitionKeys;
@@ -178,6 +180,20 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   }
 
   @Override
+  public ProcessInstanceQuery processDefinitionCategory(String processDefinitionCategory) {
+    if (processDefinitionCategory == null) {
+      throw new ActivitiIllegalArgumentException("Process definition category is null");
+    }
+    
+    if (inOrStatement) {
+      this.currentOrQueryObject.processDefinitionCategory = processDefinitionCategory;
+    } else {
+      this.processDefinitionCategory = processDefinitionCategory;
+    }
+    return this;
+  }
+
+  @Override
   public ProcessInstanceQuery processDefinitionName(String processDefinitionName) {
     if (processDefinitionName == null) {
       throw new ActivitiIllegalArgumentException("Process definition name is null");
@@ -187,6 +203,20 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
       this.currentOrQueryObject.processDefinitionName = processDefinitionName;
     } else {
       this.processDefinitionName = processDefinitionName;
+    }
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceQuery processDefinitionVersion(Integer processDefinitionVersion) {
+    if (processDefinitionVersion == null) {
+      throw new ActivitiIllegalArgumentException("Process definition version is null");
+    }
+    
+    if (inOrStatement) {
+      this.currentOrQueryObject.processDefinitionVersion = processDefinitionVersion;
+    } else {
+      this.processDefinitionVersion = processDefinitionVersion;
     }
     return this;
   }
@@ -610,8 +640,14 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   public Set<String> getProcessDefinitionIds() {
     return processDefinitionIds;
   }
+  public String getProcessDefinitionCategory() {
+    return processDefinitionCategory;
+  }
   public String getProcessDefinitionName() {
     return processDefinitionName;
+  }
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
   }
   public String getProcessDefinitionKey() {
     return processDefinitionKey;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntity.java
@@ -53,6 +53,10 @@ public class HistoricProcessInstanceEntity extends HistoricScopeInstanceEntity i
     processInstanceId = processInstance.getId();
     businessKey = processInstance.getBusinessKey();
     processDefinitionId = processInstance.getProcessDefinitionId();
+    processDefinitionKey = processInstance.getProcessDefinitionKey();
+    processDefinitionName = processInstance.getProcessDefinitionName();
+    processDefinitionVersion = processInstance.getProcessDefinitionVersion();
+    deploymentId = processInstance.getDeploymentId();
     startTime = Context.getProcessEngineConfiguration().getClock().getCurrentTime();
     startUserId = Authentication.getAuthenticatedUserId();
     startActivityId = processInstance.getActivityId();
@@ -75,6 +79,10 @@ public class HistoricProcessInstanceEntity extends HistoricScopeInstanceEntity i
     persistentState.put("endStateName", endActivityId);
     persistentState.put("superProcessInstanceId", superProcessInstanceId);
     persistentState.put("processDefinitionId", processDefinitionId);
+    persistentState.put("processDefinitionKey", processDefinitionKey);
+    persistentState.put("processDefinitionName", processDefinitionName);
+    persistentState.put("processDefinitionVersion", processDefinitionVersion);
+    persistentState.put("deploymentId", deploymentId);
     return persistentState;
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricScopeInstanceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricScopeInstanceEntity.java
@@ -30,6 +30,10 @@ public abstract class HistoricScopeInstanceEntity implements PersistentObject, S
   protected String id;
   protected String processInstanceId;
   protected String processDefinitionId;
+  protected String processDefinitionKey;
+  protected String processDefinitionName;
+  protected Integer processDefinitionVersion;
+  protected String deploymentId;
   protected Date startTime;
   protected Date endTime;
   protected Long durationInMillis;
@@ -48,6 +52,18 @@ public abstract class HistoricScopeInstanceEntity implements PersistentObject, S
   }
   public String getProcessDefinitionId() {
     return processDefinitionId;
+  }
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
+  public String getDeploymentId() {
+    return deploymentId;
   }
   public Date getStartTime() {
     return startTime;
@@ -69,6 +85,18 @@ public abstract class HistoricScopeInstanceEntity implements PersistentObject, S
   }
   public void setProcessDefinitionId(String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
+  }
+  public void setProcessDefinitionKey(String processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+  public void setProcessDefinitionName(String processDefinitionName) {
+    this.processDefinitionName = processDefinitionName;
+  }
+  public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+  public void setDeploymentId(String deploymentId) {
+    this.deploymentId = deploymentId;
   }
   public void setStartTime(Date startTime) {
     this.startTime = startTime;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ExecutionQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ExecutionQuery.java
@@ -36,8 +36,17 @@ public interface ExecutionQuery extends Query<ExecutionQuery, Execution>{
   /** Only select executions which have the given process definition id. **/
   ExecutionQuery processDefinitionId(String processDefinitionId);
 
+  /** Only select executions which have the given process definition category. */
+  ExecutionQuery processDefinitionCategory(String processDefinitionCategory);
+
   /** Only select executions which have the given process definition name. */
   ExecutionQuery processDefinitionName(String processDefinitionName);
+
+  /**
+   * Only select executions which have the given process definition version.
+   * Particulary useful when used in combination with {@link #processDefinitionKey(String)}
+  */
+  ExecutionQuery processDefinitionVersion(Integer processDefinitionVersion);
 
   /** Only select executions which have the given process instance id. **/
   ExecutionQuery processInstanceId(String processInstanceId);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstanceQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstanceQuery.java
@@ -56,8 +56,17 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
 	 */
   ProcessInstanceQuery processInstanceWithoutTenantId();
 
+  /** Only select process instances whose process definition category is processDefinitionCategory. */
+  ProcessInstanceQuery processDefinitionCategory(String processDefinitionCategory);
+
   /** Select process instances whose process definition name is processDefinitionName*/
   ProcessInstanceQuery processDefinitionName(String processDefinitionName);
+
+  /**
+   * Only select process instances with a certain process definition version.
+   * Particulary useful when used in combination with {@link #processDefinitionKey(String)}
+   */
+  ProcessInstanceQuery processDefinitionVersion(Integer processDefinitionVersion);
 
   /**
    * Select the process instances which are defined by a process definition with

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -391,7 +391,7 @@
       </choose> 
     </foreach>
     <foreach collection="orQueryObjects" index="orIndex" item="orQueryObject">
-      <if test="orQueryObject.processDefinitionId != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionName != null || (orQueryObject.processDefinitionIds != null &amp;&amp; !orQueryObject.processDefinitionIds.isEmpty()) || (orQueryObject.processDefinitionKeys != null &amp;&amp; !orQueryObject.processDefinitionKeys.isEmpty())">
+      <if test="orQueryObject.processDefinitionId != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionVersion != null || orQueryObject.processDefinitionCategory != null || orQueryObject.processDefinitionName != null || (orQueryObject.processDefinitionIds != null &amp;&amp; !orQueryObject.processDefinitionIds.isEmpty()) || (orQueryObject.processDefinitionKeys != null &amp;&amp; !orQueryObject.processDefinitionKeys.isEmpty())">
         inner join ${prefix}ACT_RE_PROCDEF P_OR${orIndex} on RES.PROC_DEF_ID_ = P_OR${orIndex}.ID_
       </if>
       <foreach collection="orQueryObject.queryVariableValues" index="index" item="queryVariableValue">
@@ -437,8 +437,14 @@
           #{item}
         </foreach>
       </if>
+      <if test="processDefinitionCategory != null">
+        and P.CATEGORY_ = #{processDefinitionCategory}
+      </if>
       <if test="processDefinitionName != null">
         and P.NAME_ = #{processDefinitionName}
+      </if>
+      <if test="processDefinitionVersion != null">
+        and P.VERSION_ = #{processDefinitionVersion}
       </if>
       <if test="executionId != null">
         and RES.ID_ = #{executionId}
@@ -600,8 +606,14 @@
               #{item}
             </foreach>
           </if>
+          <if test="orQueryObject.processDefinitionCategory != null">
+            or P_OR${orIndex}.CATEGORY_ = #{orQueryObject.processDefinitionCategory}
+          </if>
           <if test="orQueryObject.processDefinitionName != null">
             or P_OR${orIndex}.NAME_ = #{orQueryObject.processDefinitionName}
+          </if>
+          <if test="orQueryObject.processDefinitionVersion != null">
+            or P_OR${orIndex}.VERSION_ = #{orQueryObject.processDefinitionVersion}
           </if>
           <if test="orQueryObject.executionId != null">
             or RES.ID_ = #{orQueryObject.executionId}

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -161,6 +161,10 @@
     <result property="processInstanceId" column="PROC_INST_ID_" jdbcType="VARCHAR" />
     <result property="businessKey" column="BUSINESS_KEY_" jdbcType="VARCHAR"/>
     <result property="processDefinitionId" column="PROC_DEF_ID_" jdbcType="VARCHAR" />
+    <result property="processDefinitionName" column="PROC_DEF_NAME_" jdbcType="VARCHAR" /> 
+    <result property="processDefinitionKey" column="PROC_DEF_KEY_" jdbcType="VARCHAR" />
+    <result property="processDefinitionVersion" column="PROC_DEF_VERSION_" jdbcType="INTEGER" />
+    <result property="deploymentId" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
     <result property="startTime" column="START_TIME_" jdbcType="TIMESTAMP" />
     <result property="endTime" column="END_TIME_" jdbcType="TIMESTAMP" />
     <result property="durationInMillis" column="DURATION_" jdbcType="BIGINT" />
@@ -178,6 +182,10 @@
     <result property="processInstanceId" column="PROC_INST_ID_" jdbcType="VARCHAR" />
     <result property="businessKey" column="BUSINESS_KEY_" jdbcType="VARCHAR"/>
     <result property="processDefinitionId" column="PROC_DEF_ID_" jdbcType="VARCHAR" />
+    <result property="processDefinitionName" column="PROC_DEF_NAME_" jdbcType="VARCHAR" /> 
+    <result property="processDefinitionKey" column="PROC_DEF_KEY_" jdbcType="VARCHAR" />
+    <result property="processDefinitionVersion" column="PROC_DEF_VERSION_" jdbcType="INTEGER" />
+    <result property="deploymentId" column="DEPLOYMENT_ID_" jdbcType="VARCHAR" />
     <result property="startTime" column="START_TIME_" jdbcType="TIMESTAMP" />
     <result property="endTime" column="END_TIME_" jdbcType="TIMESTAMP" />
     <result property="durationInMillis" column="DURATION_" jdbcType="BIGINT" />
@@ -218,8 +226,9 @@
   
 
   <select id="selectHistoricProcessInstancesByQueryCriteria" parameterType="org.activiti.engine.impl.HistoricProcessInstanceQueryImpl" resultMap="historicProcessInstanceResultMap">
-  	${limitBefore}
-    select distinct RES.* ${limitBetween}
+    ${limitBefore}
+    select distinct RES.* , DEF.KEY_ as PROC_DEF_KEY_, DEF.NAME_ as PROC_DEF_NAME_, DEF.VERSION_ as PROC_DEF_VERSION_, DEF.DEPLOYMENT_ID_ as DEPLOYMENT_ID_
+    ${limitBetween}
     <include refid="selectHistoricProcessInstancesByQueryCriteriaSql"/>
     ${orderBy}
     ${limitAfter}
@@ -232,12 +241,13 @@
   
   <sql id="selectHistoricProcessInstancesByQueryCriteriaSql">  
     from ${prefix}ACT_HI_PROCINST RES
+    left outer join ${prefix}ACT_RE_PROCDEF DEF on RES.PROC_DEF_ID_ = DEF.ID_
     <include refid="commonSelectHistoricProcessInstancesByQueryCriteriaSql"/>
   </sql>
   
   <select id="selectHistoricProcessInstancesWithVariablesByQueryCriteria" parameterType="org.activiti.engine.impl.HistoricProcessInstanceQueryImpl" resultMap="historicProcessInstanceAndVariablesResultMap">
     ${limitBefore}
-    select distinct RES.*,
+    select distinct RES.*, DEF.KEY_ as PROC_DEF_KEY_, DEF.NAME_ as PROC_DEF_NAME_, DEF.VERSION_ as PROC_DEF_VERSION_, DEF.DEPLOYMENT_ID_ as DEPLOYMENT_ID_,
     VAR.ID_ as VAR_ID_, 
     VAR.NAME_ as VAR_NAME_, 
     VAR.VAR_TYPE_ as VAR_TYPE_, 
@@ -320,6 +330,7 @@
   
   <sql id="selectHistoricProcessInstancesWithVariablesByQueryCriteriaSql">  
     from ${prefix}ACT_HI_PROCINST RES
+    left outer join ${prefix}ACT_RE_PROCDEF DEF on RES.PROC_DEF_ID_ = DEF.ID_
     <if test="includeProcessVariables">
       left outer join ${prefix}ACT_HI_VARINST VAR ON RES.PROC_INST_ID_ = VAR.EXECUTION_ID_ and VAR.TASK_ID_ is null
     </if>
@@ -327,14 +338,11 @@
   </sql>
   
   <sql id="commonSelectHistoricProcessInstancesByQueryCriteriaSql">
-    <if test="processKeyNotIn != null || processDefinitionKey != null || (processDefinitionKeyIn != null &amp;&amp; processDefinitionKeyIn.size() &gt; 0)">
-      inner join ${prefix}ACT_RE_PROCDEF DEF on RES.PROC_DEF_ID_ = DEF.ID_
-    </if>
     <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
       inner join ${prefix}ACT_HI_VARINST  A${index} on RES.PROC_INST_ID_ = A${index}.PROC_INST_ID_
     </foreach>
     <foreach collection="orQueryObjects" index="orIndex" item="orQueryObject">
-      <if test="orQueryObject.processKeyNotIn != null || orQueryObject.processDefinitionKey != null || (orQueryObject.processDefinitionKeyIn != null &amp;&amp; orQueryObject.processDefinitionKeyIn.size() &gt; 0)">
+      <if test="orQueryObject.processKeyNotIn != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionCategory != null || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionVersion != null || (orQueryObject.processDefinitionKeyIn != null &amp;&amp; orQueryObject.processDefinitionKeyIn.size() &gt; 0)">
         inner join ${prefix}ACT_RE_PROCDEF DEF_OR${orIndex} on RES.PROC_DEF_ID_ = DEF_OR${orIndex}.ID_
       </if>
       <if test="orQueryObject.deploymentId != null || (orQueryObject.deploymentIds != null &amp;&amp; orQueryObject.deploymentIds.size() &gt; 0)">
@@ -372,6 +380,15 @@
                  open="(" separator="," close=")">
           #{definition}
         </foreach>
+      </if>
+      <if test="processDefinitionVersion != null">
+        and DEF.VERSION_ = #{processDefinitionVersion}
+      </if>
+      <if test="processDefinitionCategory != null">
+        and DEF.CATEGORY_ = #{processDefinitionCategory}
+      </if>
+      <if test="processDefinitionName != null">
+        and DEF.NAME_ = #{processDefinitionName}
       </if>
       <if test="businessKey != null">
         and RES.BUSINESS_KEY_ = #{businessKey}
@@ -525,6 +542,15 @@
                      open="(" separator="," close=")">
               #{definition}
             </foreach>
+          </if>
+          <if test="orQueryObject.processDefinitionVersion != null">
+            or DEF_OR${orIndex}.VERSION_ = #{orQueryObject.processDefinitionVersion}
+          </if>
+          <if test="orQueryObject.processDefinitionCategory != null">
+            or DEF_OR${orIndex}.CATEGORY_ = #{orQueryObject.processDefinitionCategory}
+          </if>
+          <if test="orQueryObject.processDefinitionName != null">
+            or DEF_OR${orIndex}.NAME_ = #{orQueryObject.processDefinitionName}
           </if>
           <if test="orQueryObject.businessKey != null">
             or RES.BUSINESS_KEY_ = #{orQueryObject.businessKey}

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -227,8 +227,7 @@
 
   <select id="selectHistoricProcessInstancesByQueryCriteria" parameterType="org.activiti.engine.impl.HistoricProcessInstanceQueryImpl" resultMap="historicProcessInstanceResultMap">
     ${limitBefore}
-    select distinct RES.* , DEF.KEY_ as PROC_DEF_KEY_, DEF.NAME_ as PROC_DEF_NAME_, DEF.VERSION_ as PROC_DEF_VERSION_, DEF.DEPLOYMENT_ID_ as DEPLOYMENT_ID_
-    ${limitBetween}
+    select distinct RES.* ${limitBetween}, DEF.KEY_ as PROC_DEF_KEY_, DEF.NAME_ as PROC_DEF_NAME_, DEF.VERSION_ as PROC_DEF_VERSION_, DEF.DEPLOYMENT_ID_ as DEPLOYMENT_ID_
     <include refid="selectHistoricProcessInstancesByQueryCriteriaSql"/>
     ${orderBy}
     ${limitAfter}
@@ -282,6 +281,10 @@
     TEMPRES_DELETE_REASON_ as DELETE_REASON_,
     TEMPRES_NAME_ as NAME_,
     TEMPRES_TENANT_ID_ as TENANT_ID_,
+    TEMPRES_PROC_DEF_KEY_ as PROC_DEF_KEY_,
+    TEMPRES_PROC_DEF_NAME_ as PROC_DEF_NAME_,
+    TEMPRES_PROC_DEF_VERSION_ as PROC_DEF_VERSION_,
+    TEMPRES_DEPLOYMENT_ID_ as DEPLOYMENT_ID_,
     TEMPVAR_ID_ as VAR_ID_, 
     TEMPVAR_NAME_ as VAR_NAME_, 
     TEMPVAR_TYPE_ as VAR_TYPE_, 
@@ -310,6 +313,10 @@
     RES.DELETE_REASON_ as TEMPRES_DELETE_REASON_,
     RES.NAME_ as TEMPRES_NAME_, 
     RES.TENANT_ID_ as TEMPRES_TENANT_ID_,
+    DEF.KEY_ as TEMPRES_PROC_DEF_KEY_,
+    DEF.NAME_ as TEMPRES_PROC_DEF_NAME_,
+    DEF.VERSION_ as TEMPRES_PROC_DEF_VERSION_,
+    DEF.DEPLOYMENT_ID_ as TEMPRES_DEPLOYMENT_ID_,
     VAR.ID_ as TEMPVAR_ID_, 
     VAR.NAME_ as TEMPVAR_NAME_, 
     VAR.VAR_TYPE_ as TEMPVAR_TYPE_, 

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryVersionTest.java
@@ -1,0 +1,115 @@
+package org.activiti.engine.test.api.history;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+
+public class HistoricProcessInstanceQueryVersionTest extends PluggableActivitiTestCase{
+
+  private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+  private static final String DEPLOYMENT_FILE_PATH = "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml";
+
+  private org.activiti.engine.repository.Deployment oldDeployment;
+  private org.activiti.engine.repository.Deployment newDeployment;
+  private List<String> processInstanceIds;
+  
+  protected void setUp() throws Exception {
+    super.setUp();
+    oldDeployment = repositoryService.createDeployment()
+      .addClasspathResource(DEPLOYMENT_FILE_PATH)
+      .deploy();
+    
+    processInstanceIds = new ArrayList<String>();
+    
+    Map<String, Object> startMap = new HashMap<String, Object>();
+    startMap.put("test", 123);
+    processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+    
+    newDeployment = repositoryService.createDeployment()
+          .addClasspathResource(DEPLOYMENT_FILE_PATH)
+          .deploy();
+    
+    startMap.clear();
+    startMap.put("anothertest", 456);
+    processInstanceIds.add(runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY, startMap).getId());
+  }
+  
+  protected void tearDown() throws Exception {
+    repositoryService.deleteDeployment(oldDeployment.getId(), true);
+    repositoryService.deleteDeployment(newDeployment.getId(), true);
+  }
+  
+  public void testHistoricProcessInstanceQueryByProcessDefinitionVersion() {
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).list().get(0).getProcessDefinitionVersion().intValue());
+    assertEquals(2, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().get(0).getProcessDefinitionVersion().intValue());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(1).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(2).list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionVersion(3).list().size());
+    
+    // Variables Case
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+        HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .variableValueEquals("test", 123).processDefinitionVersion(1).singleResult();
+        assertEquals(1, processInstance.getProcessDefinitionVersion().intValue());
+        Map<String, Object> variableMap = processInstance.getProcessVariables();
+        assertEquals(123, variableMap.get("test"));
+
+        processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .variableValueEquals("anothertest", 456).processDefinitionVersion(1).singleResult();
+        assertNull(processInstance);
+        
+        processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .variableValueEquals("anothertest", 456).processDefinitionVersion(2).singleResult();
+        assertEquals(2, processInstance.getProcessDefinitionVersion().intValue());
+        variableMap = processInstance.getProcessVariables();
+        assertEquals(456, variableMap.get("anothertest"));
+    }
+  }
+
+  public void testHistoricProcessInstanceQueryByProcessDefinitionVersionAndKey() {
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+  }
+  
+  public void testHistoricProcessInstanceOrQueryByProcessDefinitionVersion() {
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list().size());
+    
+    // Variables Case
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+        HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .or().variableValueEquals("test", "invalid").processDefinitionVersion(1).endOr().singleResult();
+        assertEquals(1, processInstance.getProcessDefinitionVersion().intValue());
+        Map<String, Object> variableMap = processInstance.getProcessVariables();
+        assertEquals(123, variableMap.get("test"));
+        
+        processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .or().variableValueEquals("anothertest", "invalid").processDefinitionVersion(2).endOr().singleResult();
+        assertEquals(2, processInstance.getProcessDefinitionVersion().intValue());
+        variableMap = processInstance.getProcessVariables();
+        assertEquals(456, variableMap.get("anothertest"));
+        
+        processInstance = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+                .variableValueEquals("anothertest", "invalid").processDefinitionVersion(3).singleResult();
+        assertNull(processInstance);
+    }
+  }
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoryServiceTest.java
@@ -145,7 +145,7 @@ public class HistoryServiceTest extends PluggableActivitiTestCase {
     HistoricProcessInstance historicProcessInstance = historyService.createHistoricProcessInstanceQuery().processDefinitionKey(processDefinitionKey)
             .singleResult();
     assertNotNull(historicProcessInstance);
-    assertTrue(historicProcessInstance.getProcessDefinitionId().startsWith(processDefinitionKey));
+    assertTrue(historicProcessInstance.getProcessDefinitionKey().equals(processDefinitionKey));
     assertEquals("theStart", historicProcessInstance.getStartActivityId());
 
     // now complete the task to end the process instance
@@ -163,6 +163,37 @@ public class HistoryServiceTest extends PluggableActivitiTestCase {
     assertEquals(historicProcessInstanceSuper.getId(), historicProcessInstanceSub.getSuperProcessInstanceId());
   }
 
+  @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  public void testHistoricProcessInstanceQueryByProcessDefinitionName() {
+
+    String processDefinitionKey = "oneTaskProcess";
+    String processDefinitionName = "The One Task Process";
+    runtimeService.startProcessInstanceByKey(processDefinitionKey);
+    
+    assertEquals(processDefinitionName, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().get(0).getProcessDefinitionName());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionName(processDefinitionName).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionName("invalid").count());
+    assertEquals(processDefinitionName, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().list().get(0).getProcessDefinitionName());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionName(processDefinitionName).processDefinitionId("invalid").endOr().count());
+  }
+  
+  @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  public void testHistoricProcessInstanceQueryByProcessDefinitionCategory() {
+    String processDefinitionKey = "oneTaskProcess";
+    String processDefinitionCategory = "ExamplesCategory";
+    runtimeService.startProcessInstanceByKey(processDefinitionKey);
+    
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory(processDefinitionCategory).count());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").list().size());
+    assertEquals(0, historyService.createHistoricProcessInstanceQuery().processDefinitionCategory("invalid").count());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid").endOr().list().size());
+    assertEquals(1, historyService.createHistoricProcessInstanceQuery().or().processDefinitionCategory(processDefinitionCategory).processDefinitionId("invalid").endOr().count());
+  }
+  
   @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml" })
   public void testHistoricProcessInstanceQueryByProcessInstanceIds() {
     HashSet<String> processInstanceIds = new HashSet<String>();
@@ -258,6 +289,7 @@ public class HistoryServiceTest extends PluggableActivitiTestCase {
 
     HistoricProcessInstanceQuery processInstanceQuery = historyService.createHistoricProcessInstanceQuery().deploymentId(deployment.getId());
     assertEquals(5, processInstanceQuery.count());
+    assertEquals(deployment.getId(), processInstanceQuery.list().get(0).getDeploymentId());
 
     List<HistoricProcessInstance> processInstances = processInstanceQuery.list();
     assertNotNull(processInstances);

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/NonCascadeDeleteTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/NonCascadeDeleteTest.java
@@ -1,0 +1,50 @@
+package org.activiti.engine.test.api.history;
+
+import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.task.Task;
+import org.junit.Test;
+
+public class NonCascadeDeleteTest extends PluggableActivitiTestCase {
+
+  private static String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+  
+  private String deploymentId;
+  
+  private String processInstanceId;
+  
+  protected void setUp() throws Exception {
+    super.setUp();
+  }
+  
+  protected void tearDown() throws Exception {
+	  super.tearDown();
+  }
+  @Test
+  public void testHistoricProcessInstanceQuery(){
+    deploymentId = repositoryService.createDeployment()
+      .addClasspathResource("org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml")
+      .deploy().getId();
+
+    processInstanceId = runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId();
+    Task task = taskService.createTaskQuery().processInstanceId(processInstanceId).singleResult();
+    taskService.complete(task.getId());
+    
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+        HistoricProcessInstance processInstance = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
+        assertEquals(PROCESS_DEFINITION_KEY, processInstance.getProcessDefinitionKey());
+
+        // Delete deployment and historic process instance remains.
+        repositoryService.deleteDeployment(deploymentId, false);
+
+        HistoricProcessInstance processInstanceAfterDelete = historyService.createHistoricProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
+        assertEquals(null, processInstanceAfterDelete.getProcessDefinitionKey());
+        assertEquals(null, processInstanceAfterDelete.getProcessDefinitionName());
+        assertEquals(null, processInstanceAfterDelete.getProcessDefinitionVersion());
+        
+        // clean
+        historyService.deleteHistoricProcessInstance(processInstanceId);
+    }
+  }
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionAndProcessInstanceQueryVersionTest.java
@@ -1,0 +1,81 @@
+package org.activiti.engine.test.api.runtime;
+
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+
+public class ExecutionAndProcessInstanceQueryVersionTest extends PluggableActivitiTestCase {
+
+  private static final String PROCESS_DEFINITION_KEY = "oneTaskProcess";
+  private static final String DEPLOYMENT_FILE_PATH = "org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml";
+
+  private org.activiti.engine.repository.Deployment oldDeployment;
+  private org.activiti.engine.repository.Deployment newDeployment;
+
+  protected void setUp() throws Exception {
+    super.setUp();
+    oldDeployment = repositoryService.createDeployment()
+      .addClasspathResource(DEPLOYMENT_FILE_PATH)
+      .deploy();
+    
+    runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId();
+    
+    newDeployment = repositoryService.createDeployment()
+          .addClasspathResource(DEPLOYMENT_FILE_PATH)
+          .deploy();
+        
+    runtimeService.startProcessInstanceByKey(PROCESS_DEFINITION_KEY).getId();
+  }
+
+  protected void tearDown() throws Exception {
+    repositoryService.deleteDeployment(oldDeployment.getId(), true);
+    repositoryService.deleteDeployment(newDeployment.getId(), true);
+  }
+
+  public void testProcessInstanceQueryByProcessDefinitionVersion() {
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).count());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(1).count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionVersion(2).list().size());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionVersion(3).list().size());
+  }
+
+  public void testProcessInstanceQueryByProcessDefinitionVersionAndKey() {
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+  }
+  
+  public void testProcessInstanceOrQueryByProcessDefinitionVersion() {
+    assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().count());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().count());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(1).processDefinitionId("undefined").endOr().list().size());
+    assertEquals(1, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(2).processDefinitionId("undefined").endOr().list().size());
+    assertEquals(0, runtimeService.createProcessInstanceQuery().or().processDefinitionVersion(3).processDefinitionId("undefined").endOr().list().size());
+  }
+
+  public void testExecutionQueryByProcessDefinitionVersion() {
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionVersion(1).count());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionVersion(2).count());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionVersion(3).count());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionVersion(1).list().size());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionVersion(2).list().size());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionVersion(3).list().size());
+  }
+  
+  public void testExecutionQueryByProcessDefinitionVersionAndKey() {
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).count());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).count());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).count());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).count());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(1).list().size());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionKey(PROCESS_DEFINITION_KEY).processDefinitionVersion(2).list().size());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(1).list().size());
+    assertEquals(0, runtimeService.createExecutionQuery().processDefinitionKey("undefined").processDefinitionVersion(2).list().size());
+  }
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -59,6 +59,8 @@ public class ExecutionQueryTest extends PluggableActivitiTestCase {
   private static String SEQUENTIAL_PROCESS_KEY = "oneTaskProcess";
   private static String CONCURRENT_PROCESS_NAME = "concurrentName";
   private static String SEQUENTIAL_PROCESS_NAME = "oneTaskProcessName";
+  private static String CONCURRENT_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.concurrent.Category";
+  private static String SEQUENTIAL_PROCESS_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
   
   private List<String> concurrentProcessInstanceIds;
   private List<String> sequentialProcessInstanceIds;
@@ -105,6 +107,19 @@ public class ExecutionQueryTest extends PluggableActivitiTestCase {
   
   public void testQueryByInvalidProcessDefinitionKey() {
     ExecutionQuery query = runtimeService.createExecutionQuery().processDefinitionKey("invalid");
+    assertNull(query.singleResult());
+    assertEquals(0, query.list().size());
+    assertEquals(0, query.count());
+  }
+
+  public void testQueryByProcessDefinitionCategory() {
+    // Concurrent process with 3 executions for each process instance
+    assertEquals(12, runtimeService.createExecutionQuery().processDefinitionCategory(CONCURRENT_PROCESS_CATEGORY).list().size());
+    assertEquals(1, runtimeService.createExecutionQuery().processDefinitionCategory(SEQUENTIAL_PROCESS_CATEGORY).list().size());
+  }
+
+  public void testQueryByInvalidProcessDefinitionCategory() {
+    ExecutionQuery query = runtimeService.createExecutionQuery().processDefinitionCategory("invalid");
     assertNull(query.singleResult());
     assertEquals(0, query.list().size());
     assertEquals(0, query.count());

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -51,6 +51,8 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
   private static final String PROCESS_DEFINITION_KEY_2 = "oneTaskProcess2";
   private static final String PROCESS_DEFINITION_NAME = "oneTaskProcessName";
   private static final String PROCESS_DEFINITION_NAME_2 = "oneTaskProcess2Name";
+  private static final String PROCESS_DEFINITION_CATEGORY = "org.activiti.enginge.test.api.runtime.Category";
+  private static final String PROCESS_DEFINITION_CATEGORY_2 = "org.activiti.enginge.test.api.runtime.2Category";
   
   private org.activiti.engine.repository.Deployment deployment;
   private List<String> processInstanceIds;
@@ -314,6 +316,16 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
     } catch (ActivitiException e) {
       // Exception is expected
     }
+  }
+
+  public void testQueryByProcessDefinitionCategory() {
+    assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY).count());
+    assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).count());
+  }
+  
+  public void testOrQueryByProcessDefinitionCategory() {
+    assertEquals(PROCESS_DEFINITION_KEY_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY).processDefinitionId("undefined").endOr().count());
+    assertEquals(PROCESS_DEFINITION_KEY_2_DEPLOY_COUNT, runtimeService.createProcessInstanceQuery().or().processDefinitionCategory(PROCESS_DEFINITION_CATEGORY_2).processDefinitionId("undefined").endOr().count());
   }
 
   public void testQueryByProcessDefinitionName() {

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="Examples">
+  targetNamespace="ExamplesCategory">
 
   <process id="oneTaskProcess" name="The One Task Process">
     <documentation>This is a process for testing purposes</documentation>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/concurrentExecution.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/concurrentExecution.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions id="definitions" 
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.enginge.test.api.runtime.concurrent.Category">
   
   <process id="concurrent" name="concurrentName">
   

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
 
   <process id="oneTaskProcess" name="oneTaskProcessName">
     <extensionElements>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/oneTaskProcess2.bpmn20.xml
@@ -2,7 +2,7 @@
 <definitions
   xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
   xmlns:activiti="http://activiti.org/bpmn"
-  targetNamespace="org.activiti.enginge.test.api.runtime">
+  targetNamespace="org.activiti.enginge.test.api.runtime.2Category">
 
   <process id="oneTaskProcess2" name="oneTaskProcess2Name">
   


### PR DESCRIPTION
We added the search criteria related to process definition.

# ExecutionQuery

We added the following search criteria.
ExecutionQuery#processDefinitionCategory(String processDefinitionCategory)
ExecutionQuery#processDefinitionVersion(Integer processDefinitionVersion)

# ProcessInstanceQuery

We added the following search criteria.
ProcessInstanceQuery#processDefinitionCategory(String processDefinitionCategory)
ProcessInstanceQuery#processDefinitionVersion(Integer processDefinitionVersion)

# HistoricProcessInstanceQuery

1. In the same way as ProcessInstanceQuery, we became able to get processDefinitionName/ProcessDefinitionKey/processDefinitionVersion/deploymentId by using HistoricProcessInstanceQuery.

	In each case, we joined table ACT_RE_PROCDEF like ProcessInstanceQuery.

	In consideration of RepositoryService.deleteDeployment(String deploymentId, false), we selected outer join not inner join.After using this method, ProcessDefinition data was removed but Historic Process Instance data remains.
	http://activiti.org/javadocs/org/activiti/engine/RepositoryService.html#deleteDeployment(java.lang.String, boolean)

2. We added the following search criteria.

	HistoricProcessInstanceQuery#processDefinitionCategory(String processDefinitionCategory)
	HistoricProcessInstanceQuery#processDefinitionName(String processDefinitionName)
	HistoricProcessInstanceQuery#processDefinitionVersion(Integer processDefinitionVersion)
