### PR TITLE
Fix - Include Process Instance execution in PROCESS_STARTED event.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -52,6 +52,14 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
     this.variables = variables;
   }
 
+  public StartProcessInstanceCmd(String processDefinitionKey, String processDefinitionId, String businessKey, String processInstanceName, Map<String, Object> variables) {
+	    this.processDefinitionKey = processDefinitionKey;
+	    this.processDefinitionId = processDefinitionId;
+	    this.businessKey = businessKey;
+	    this.processInstanceName = processInstanceName;
+	    this.variables = variables;
+  }
+
   public StartProcessInstanceCmd(String processDefinitionKey, String processDefinitionId, String businessKey, Map<String, Object> variables, String tenantId) {
     this(processDefinitionKey, processDefinitionId, businessKey, variables);
     this.tenantId = tenantId;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceUtil.java
@@ -212,7 +212,7 @@ public class ProcessInstanceUtil {
     
     if (Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
       Context.getProcessEngineConfiguration().getEventDispatcher()
-        .dispatchEvent(ActivitiEventBuilder.createProcessStartedEvent(execution, variables, false));
+        .dispatchEvent(ActivitiEventBuilder.createProcessStartedEvent(processInstance, variables, false));
     }
   }
   


### PR DESCRIPTION
The entity included on the ActivityEvent with a type of PROCESS_STARTED is the execution for the start event and not the execution of the process instance. This change updates the entity on the event to the process instance execution.

In addition, I've added a new constructor to the StartProcessInstanceCmd to allow the process instance name to be passed in.