### PR TITLE
Fix for ACT-2081, use userIdForCandidateAndAssignee for retrieving groups if set

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -1104,6 +1104,9 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     
     } else if (candidateUser != null) {
       return getGroupsForCandidateUser(candidateUser);
+
+    } else if (userIdForCandidateAndAssignee != null) {
+      return getGroupsForCandidateUser(userIdForCandidateAndAssignee);
     } 
     return null;
   }


### PR DESCRIPTION
This appears to fix the issue described in ACT-2081.  The code was retrieving the groups for the user only if candidateUser was set, but in the case of taskCandidateOrAssigned candidateUser is not set, instead userIdForCandidateAndAssignee is.  So added code to use that user if candidateUser is not set but userIdForCandidateAndAssignee is.

It would be great if this can be part of 5.20 or 5.19.0.3 if there is one.