### PR TITLE
ACT-2146: Switch around event firing for Task creation

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -203,14 +203,14 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
     
     handleAssignments(activeAssigneeExpression, activeOwnerExpression, activeCandidateUserExpressions, 
         activeCandidateGroupExpressions, task, execution);
-   
+
+    task.fireEvent(TaskListener.EVENTNAME_CREATE);
+
     // All properties set, now firing 'create' events
     if (Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
       Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
         ActivitiEventBuilder.createEntityEvent(ActivitiEventType.TASK_CREATED, task));
     }
-
-    task.fireEvent(TaskListener.EVENTNAME_CREATE);
 
     if (SkipExpressionUtil.isSkipExpressionEnabled(execution, activeSkipExpression) &&
         SkipExpressionUtil.shouldSkipFlowElement(execution, activeSkipExpression)) {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestActivitiEntityEventTaskListener.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/TestActivitiEntityEventTaskListener.java
@@ -1,0 +1,67 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.event;
+
+import org.activiti.engine.delegate.event.ActivitiEntityEvent;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventListener;
+import org.activiti.engine.impl.persistence.entity.TaskEntity;
+import org.activiti.engine.task.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Records a copy of the tasks involved in the events
+ */
+public class TestActivitiEntityEventTaskListener extends TestActivitiEntityEventListener {
+
+	private List<Task> tasks;
+
+	public TestActivitiEntityEventTaskListener(Class<?> entityClass) {
+		super(entityClass);
+		tasks = new ArrayList<Task>();
+  	}
+
+	@Override
+	public void clearEventsReceived() {
+		super.clearEventsReceived();
+		tasks.clear();
+	}
+	
+	@Override
+	public void onEvent(ActivitiEvent event) {
+		super.onEvent(event);
+		if(event instanceof ActivitiEntityEvent && Task.class.isAssignableFrom(((ActivitiEntityEvent) event).getEntity().getClass())) {
+			tasks.add(copy((Task) ((ActivitiEntityEvent) event).getEntity()));
+		}
+	}
+
+	private Task copy(Task aTask)
+	{
+		TaskEntity ent = TaskEntity.create(aTask.getCreateTime());
+		ent.setId(aTask.getId());
+		ent.setName(aTask.getName());
+		ent.setDescription(aTask.getDescription());
+		ent.setOwner(aTask.getOwner());
+		ent.setDueDateWithoutCascade(aTask.getDueDate());
+		ent.setAssignee(aTask.getAssignee());
+		ent.setPriority(aTask.getPriority());
+		return ent;
+	}
+
+	public List<Task> getTasks()
+	{
+		return tasks;
+	}
+}

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/event/TaskEventsTest.testEventFiring.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/event/TaskEventsTest.testEventFiring.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="TwoTaskCategory">
+
+  <process id="testTaskLocalVars" name="The Two Task Process" activiti:candidateStarterUsers="kermit">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task">
+         <extensionElements>
+            <activiti:taskListener event="create" class="org.activiti.engine.impl.bpmn.listener.ScriptTaskListener" >
+              <activiti:field name="script">
+                <activiti:string>
+                  task.setPriority(877);
+                  task.setAssignee("scriptedAssignee");
+                </activiti:string>
+              </activiti:field>
+              <activiti:field name="language" stringValue="JavaScript" />
+            </activiti:taskListener>
+        </extensionElements>
+    </userTask>    
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theSecondTask" />
+    <userTask id="theSecondTask" name="my task" />    
+    <sequenceFlow id="flow3" sourceRef="theSecondTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
I have changed around the event firing for UserTaskActivityBehavior.  See ACT-2146.  This should make the event firing consistent.

I don't know all the implications of doing this but I have added a test which checks the new ordering.  The test is a little more complicated than anticipated because the in-memory Task object was getting updated after the event fired.  An external event listener would not have known about the changes.

I hope it meets your standards!