### PR TITLE
ACT-4135 increase accessibility of base createXML method

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -557,7 +557,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
     }
   }
 
-  private void createXML(FlowElement flowElement, BpmnModel model, XMLStreamWriter xtw) throws Exception {
+  protected void createXML(FlowElement flowElement, BpmnModel model, XMLStreamWriter xtw) throws Exception {
 
     if (flowElement instanceof SubProcess) {
 


### PR DESCRIPTION
BpmnXMLConverter has 2 createXML method calls. It looks like the second one has been updated already (since my last attempt at a pull request). It would be helpful to have the second method updated as well so we can generate alternative BPMNDI required for ACT-4116.