### PR TITLE
ACT-4116 Custom subprocess parser

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
@@ -1,0 +1,213 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.bpmn.converter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.activiti.bpmn.converter.export.BPMNDIExport;
+import org.activiti.bpmn.converter.export.CollaborationExport;
+import org.activiti.bpmn.converter.export.DataStoreExport;
+import org.activiti.bpmn.converter.export.DefinitionsRootExport;
+import org.activiti.bpmn.converter.export.ProcessExport;
+import org.activiti.bpmn.converter.export.SignalAndMessageDefinitionExport;
+import org.activiti.bpmn.exceptions.XMLException;
+import org.activiti.bpmn.model.Artifact;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.DataObject;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.GraphicInfo;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.SequenceFlow;
+import org.activiti.bpmn.model.SubProcess;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Lori Small
+ */
+public class SubprocessXMLConverter extends BpmnXMLConverter {
+
+  protected static final Logger LOGGER = LoggerFactory.getLogger(SubprocessXMLConverter.class);
+
+  @Override
+  public byte[] convertToXML(BpmnModel model, String encoding) {
+    try {
+
+      ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+      XMLOutputFactory xof = XMLOutputFactory.newInstance();
+      OutputStreamWriter out = new OutputStreamWriter(outputStream, encoding);
+
+      XMLStreamWriter writer = xof.createXMLStreamWriter(out);
+      XMLStreamWriter xtw = new IndentingXMLStreamWriter(writer);
+
+      DefinitionsRootExport.writeRootElement(model, xtw, encoding);
+      CollaborationExport.writePools(model, xtw);
+      DataStoreExport.writeDataStores(model, xtw);
+      SignalAndMessageDefinitionExport.writeSignalsAndMessages(model, xtw);
+
+      for (Process process : model.getProcesses()) {
+
+        if (process.getFlowElements().isEmpty() && process.getLanes().isEmpty()) {
+          // empty process, ignore it
+          continue;
+        }
+
+        ProcessExport.writeProcess(process, xtw);
+
+        for (FlowElement flowElement : process.getFlowElements()) {
+          createXML(flowElement, model, xtw);
+        }
+
+        for (Artifact artifact : process.getArtifacts()) {
+          createXML(artifact, model, xtw);
+        }
+
+        // end process element
+        xtw.writeEndElement();
+      }
+
+      // refactor each subprocess into a separate Diagram
+      List<BpmnModel> subModels = parseSubModels(model);
+      for (BpmnModel tempModel : subModels)
+      {
+        if (!tempModel.getFlowLocationMap().isEmpty()) {
+          BPMNDIExport.writeBPMNDI(tempModel, xtw);
+        }
+      }
+
+      // end definitions root element
+      xtw.writeEndElement();
+      xtw.writeEndDocument();
+
+      xtw.flush();
+      byte[] bytes = outputStream.toByteArray().clone();
+
+      // cleanup
+      outputStream.close();
+      xtw.close();
+
+      return bytes;
+    } catch (Exception e) {
+      LOGGER.error("Error writing BPMN XML", e);
+      throw new XMLException("Error writing BPMN XML", e);
+    }
+  }
+
+  private List<BpmnModel> parseSubModels(BpmnModel model) {
+    List<BpmnModel> subModels = new ArrayList<BpmnModel>();
+
+    // find all subprocesses
+    Collection<FlowElement> flowElements = model.getMainProcess().getFlowElements();
+    Map<String, GraphicInfo> locations = new HashMap<String, GraphicInfo>();
+    Map<String, List<GraphicInfo>> flowLocations = new HashMap<String, List<GraphicInfo>>();
+    Map<String, GraphicInfo> labelLocations = new HashMap<String, GraphicInfo>();
+
+    locations.putAll(model.getLocationMap());
+    flowLocations.putAll(model.getFlowLocationMap());
+    labelLocations.putAll(model.getLabelLocationMap());
+
+    // include main process as separate model
+    BpmnModel mainModel = new BpmnModel();
+    // set main process in submodel to subprocess
+    mainModel.addProcess(model.getMainProcess());
+
+    String elementId = null;
+    for (FlowElement element : flowElements)
+    {
+      elementId = element.getId();
+      if (element instanceof SubProcess)
+      {
+        subModels.addAll(parseSubModels(element, locations, flowLocations, labelLocations));
+      }
+      
+      if (element instanceof SequenceFlow && null != flowLocations.get(elementId))
+      {
+        // must be an edge
+        mainModel.getFlowLocationMap().put(elementId, flowLocations.get(elementId));
+      }
+      else
+      {
+        // do not include data objects because they do not have a corresponding shape in the BPMNDI data
+        if (!(element instanceof DataObject) && null != locations.get(elementId))
+        {
+          // must be a shape
+          mainModel.getLocationMap().put(elementId, locations.get(elementId));
+        }
+      }
+      // also check for any labels
+      if (null != labelLocations.get(elementId)) {
+        mainModel.getLabelLocationMap().put(elementId, labelLocations.get(elementId));
+      }
+    }
+    // add main process model to list
+    subModels.add(mainModel);
+
+    return subModels;
+  }
+
+  private List<BpmnModel> parseSubModels(FlowElement subElement, Map<String, GraphicInfo> locations, 
+                                         Map<String, List<GraphicInfo>> flowLocations, Map<String, GraphicInfo> labelLocations) {
+    List<BpmnModel> subModels = new ArrayList<BpmnModel>();
+    BpmnModel subModel = new BpmnModel();
+    String elementId = null;
+
+    // find nested subprocess models
+    Collection<FlowElement> subFlowElements = ((SubProcess)subElement).getFlowElements();
+    // set main process in submodel to subprocess
+    Process newMainProcess = new Process();
+    newMainProcess.setId(subElement.getId());
+    newMainProcess.getFlowElements().addAll(subFlowElements);
+    newMainProcess.getArtifacts().addAll(((SubProcess)subElement).getArtifacts());
+    subModel.addProcess(newMainProcess);
+
+    for (FlowElement element : subFlowElements)
+    {
+      elementId = element.getId();
+      if (element instanceof SubProcess)
+      {
+        subModels.addAll(parseSubModels(element, locations, flowLocations, labelLocations));
+      }
+      if (element instanceof SequenceFlow && null != flowLocations.get(elementId))
+      {
+        // must be an edge
+        subModel.getFlowLocationMap().put(elementId, flowLocations.get(elementId));
+      }
+      else
+      {
+        // do not include data objects because they do not have a corresponding shape in the BPMNDI data
+        if (!(element instanceof DataObject) && null != locations.get(elementId))
+        {
+          // must be a shape
+          subModel.getLocationMap().put(elementId, locations.get(elementId));
+        }
+      }
+      // also check for any labels
+      if (null != labelLocations.get(elementId)) {
+        subModel.getLabelLocationMap().put(elementId, labelLocations.get(elementId));
+      }
+    }
+    subModels.add(subModel);
+
+    return subModels;
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessConverterNoDITest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessConverterNoDITest.java
@@ -1,0 +1,85 @@
+package org.activiti.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.activiti.bpmn.model.ActivitiListener;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.ImplementationType;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.TimerEventDefinition;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+public class SubProcessConverterNoDITest extends AbstractConverterTest {
+
+  @Test
+  public void connvertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+
+  protected String getResource() {
+    return "subprocessmodel-noDI.bpmn";
+  }
+
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+
+    flowElement = model.getMainProcess().getFlowElement("userTask1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof UserTask);
+    assertEquals("userTask1", flowElement.getId());
+    UserTask userTask = (UserTask) flowElement;
+    assertTrue(userTask.getCandidateUsers().size() == 1);
+    assertTrue(userTask.getCandidateGroups().size() == 1);
+    assertTrue(userTask.getFormProperties().size() == 2);
+
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertTrue(subProcess.getLoopCharacteristics().isSequential());
+    assertEquals("10", subProcess.getLoopCharacteristics().getLoopCardinality());
+    assertEquals("${assignee == \"\"}", subProcess.getLoopCharacteristics().getCompletionCondition());
+    assertTrue(subProcess.getFlowElements().size() == 5);
+
+    assertEquals(1, subProcess.getExecutionListeners().size());
+    ActivitiListener listenerSubProcess = subProcess.getExecutionListeners().get(0);
+    assertEquals("SubProcessTestClass", listenerSubProcess.getImplementation());
+    assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listenerSubProcess.getImplementationType());
+    assertEquals("start", listenerSubProcess.getEvent());
+
+    flowElement = model.getMainProcess().getFlowElement("boundaryEvent1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof BoundaryEvent);
+    assertEquals("boundaryEvent1", flowElement.getId());
+    BoundaryEvent boundaryEvent = (BoundaryEvent) flowElement;
+    assertNotNull(boundaryEvent.getAttachedToRef());
+    assertEquals("subprocess1", boundaryEvent.getAttachedToRef().getId());
+    assertEquals(1, boundaryEvent.getEventDefinitions().size());
+    assertTrue(boundaryEvent.getEventDefinitions().get(0) instanceof TimerEventDefinition);
+
+    assertEquals(1, model.getMainProcess().getExecutionListeners().size());
+    ActivitiListener listenerMainProcess = model.getMainProcess().getExecutionListeners().get(0);
+    assertEquals("TestClass", listenerMainProcess.getImplementation());
+    assertEquals(ImplementationType.IMPLEMENTATION_TYPE_CLASS, listenerMainProcess.getImplementationType());
+    assertEquals("start", listenerMainProcess.getEvent());
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterNoDITest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterNoDITest.java
@@ -1,0 +1,82 @@
+package org.activiti.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+
+import org.activiti.bpmn.converter.SubprocessXMLConverter;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+public class SubProcessMultiDiagramConverterNoDITest extends AbstractConverterTest {
+
+  @Override
+  protected BpmnModel readXMLFile() throws Exception {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream(getResource());
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Override
+  protected BpmnModel exportAndReadXMLFile(BpmnModel bpmnModel) throws Exception {
+    byte[] xml = new SubprocessXMLConverter().convertToXML(bpmnModel);
+    System.out.println("xml " + new String(xml, "UTF-8"));
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(xml), "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Test
+  public void convertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+
+  protected String getResource() {
+    return "subprocessmultidiagrammodel-noDI.bpmn";
+  }
+
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+
+    flowElement = model.getMainProcess().getFlowElement("userTask1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof UserTask);
+    assertEquals("userTask1", flowElement.getId());
+    UserTask userTask = (UserTask) flowElement;
+    assertTrue(userTask.getCandidateUsers().size() == 1);
+    assertTrue(userTask.getCandidateGroups().size() == 1);
+
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertTrue(subProcess.getFlowElements().size() == 11);
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/SubProcessMultiDiagramConverterTest.java
@@ -1,0 +1,82 @@
+package org.activiti.editor.language.xml;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+
+import org.activiti.bpmn.converter.SubprocessXMLConverter;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+public class SubProcessMultiDiagramConverterTest extends AbstractConverterTest {
+
+  @Override
+  protected BpmnModel readXMLFile() throws Exception {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream(getResource());
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Override
+  protected BpmnModel exportAndReadXMLFile(BpmnModel bpmnModel) throws Exception {
+    byte[] xml = new SubprocessXMLConverter().convertToXML(bpmnModel);
+    System.out.println("xml " + new String(xml, "UTF-8"));
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(xml), "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    return new SubprocessXMLConverter().convertToBpmnModel(xtr);
+  }
+
+  @Test
+  public void convertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    validateModel(bpmnModel);
+  }
+
+  @Test
+  public void convertModelToXML() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+    validateModel(parsedModel);
+    deployProcess(parsedModel);
+  }
+
+  protected String getResource() {
+    return "subprocessmultidiagrammodel.bpmn";
+  }
+
+  private void validateModel(BpmnModel model) {
+    FlowElement flowElement = model.getMainProcess().getFlowElement("start1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof StartEvent);
+    assertEquals("start1", flowElement.getId());
+
+    flowElement = model.getMainProcess().getFlowElement("userTask1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof UserTask);
+    assertEquals("userTask1", flowElement.getId());
+    UserTask userTask = (UserTask) flowElement;
+    assertTrue(userTask.getCandidateUsers().size() == 1);
+    assertTrue(userTask.getCandidateGroups().size() == 1);
+
+    flowElement = model.getMainProcess().getFlowElement("subprocess1");
+    assertNotNull(flowElement);
+    assertTrue(flowElement instanceof SubProcess);
+    assertEquals("subprocess1", flowElement.getId());
+    SubProcess subProcess = (SubProcess) flowElement;
+    assertTrue(subProcess.getFlowElements().size() == 11);
+  }
+}

--- a/modules/activiti-bpmn-converter/src/test/resources/subprocessmodel-noDI.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/subprocessmodel-noDI.bpmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <extensionElements>
+      <activiti:executionListener event="start" class="TestClass"></activiti:executionListener>
+    </extensionElements>
+    <sequenceFlow id="sid-4BE8FBF0-B946-48DB-9B18-488BF8DFE4D1" sourceRef="boundaryEvent1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <subProcess id="subprocess1" name="subProcess">
+      <extensionElements>
+        <activiti:executionListener event="start" class="SubProcessTestClass"></activiti:executionListener>
+      </extensionElements>
+      <multiInstanceLoopCharacteristics isSequential="true">
+        <loopCardinality>10</loopCardinality>
+        <completionCondition>${assignee == ""}</completionCondition>
+      </multiInstanceLoopCharacteristics>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <userTask id="subUserTask1" name="User task 2"></userTask>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+    </subProcess>
+    <startEvent id="start1"></startEvent>
+    <boundaryEvent id="boundaryEvent1" attachedToRef="subprocess1" cancelActivity="false">
+      <timerEventDefinition>
+        <timeDuration>PT5M</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="sid-D6D5AFA6-7673-4DFB-B118-675622C58DF2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+    <sequenceFlow id="sid-287D861F-4498-4A5C-8EC8-E07F79265E90" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" activiti:async="true" activiti:exclusive="false" activiti:candidateUsers="kermit" activiti:candidateGroups="management">
+      <extensionElements>
+        <activiti:formProperty id="test" name="Test" type="string"></activiti:formProperty>
+        <activiti:formProperty id="test2" name="Test 2" type="string"></activiti:formProperty>
+        <activiti:taskListener event="create" class="test"></activiti:taskListener>
+      </extensionElements>
+    </userTask>
+  </process>
+</definitions>

--- a/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel-noDI.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel-noDI.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <dataObject id="dObj1" name="StringTest" itemSubjectRef="xsd:string"/>
+    <dataObject id="dObj2" name="BooleanTest" itemSubjectRef="xsd:boolean"/>
+    <dataObject id="dObj3" name="DateTest" itemSubjectRef="xsd:datetime"/>
+    <dataObject id="dObj4" name="DoubleTest" itemSubjectRef="xsd:double"/>
+    <dataObject id="dObj5" name="IntegerTest" itemSubjectRef="xsd:int"/>
+    <dataObject id="dObj6" name="LongTest" itemSubjectRef="xsd:long"/>
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <startEvent id="start1"></startEvent>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" activiti:async="true" activiti:exclusive="false" activiti:candidateUsers="kermit" activiti:candidateGroups="management"></userTask>
+    <subProcess id="subprocess1" name="Sub Process" isExpanded="false">
+      <dataObject id="dObj7" name="StringSubTest" itemSubjectRef="xsd:string"/>
+      <dataObject id="dObj8" name="BooleanSubTest" itemSubjectRef="xsd:boolean"/>
+      <dataObject id="dObj9" name="DateSubTest" itemSubjectRef="xsd:datetime"/>
+      <dataObject id="dObj10" name="DoubleSubTest" itemSubjectRef="xsd:double"/>
+      <dataObject id="dObj11" name="IntegerSubTest" itemSubjectRef="xsd:int"/>
+      <dataObject id="dObj12" name="LongSubTest" itemSubjectRef="xsd:long"/>
+      <userTask id="subUserTask1" name="User task 2"></userTask>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+    </subProcess>
+    <sequenceFlow id="flow1" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+  </process>
+</definitions>

--- a/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/subprocessmultidiagrammodel.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="process" name="process1" isExecutable="true">
+    <dataObject id="dObj1" name="StringTest" itemSubjectRef="xsd:string"/>
+    <dataObject id="dObj2" name="BooleanTest" itemSubjectRef="xsd:boolean"/>
+    <dataObject id="dObj3" name="DateTest" itemSubjectRef="xsd:datetime"/>
+    <dataObject id="dObj4" name="DoubleTest" itemSubjectRef="xsd:double"/>
+    <dataObject id="dObj5" name="IntegerTest" itemSubjectRef="xsd:int"/>
+    <dataObject id="dObj6" name="LongTest" itemSubjectRef="xsd:long"/>
+    <sequenceFlow id="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" sourceRef="start1" targetRef="userTask1"></sequenceFlow>
+    <startEvent id="start1"></startEvent>
+    <endEvent id="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></endEvent>
+    <userTask id="userTask1" name="User task 1" activiti:async="true" activiti:exclusive="false" activiti:candidateUsers="kermit" activiti:candidateGroups="management"></userTask>
+    <subProcess id="subprocess1" name="Sub Process" isExpanded="false">
+      <dataObject id="dObj7" name="StringSubTest" itemSubjectRef="xsd:string"/>
+      <dataObject id="dObj8" name="BooleanSubTest" itemSubjectRef="xsd:boolean"/>
+      <dataObject id="dObj9" name="DateSubTest" itemSubjectRef="xsd:datetime"/>
+      <dataObject id="dObj10" name="DoubleSubTest" itemSubjectRef="xsd:double"/>
+      <dataObject id="dObj11" name="IntegerSubTest" itemSubjectRef="xsd:int"/>
+      <dataObject id="dObj12" name="LongSubTest" itemSubjectRef="xsd:long"/>
+      <userTask id="subUserTask1" name="User task 2"></userTask>
+      <sequenceFlow id="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" sourceRef="subUserTask1" targetRef="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></sequenceFlow>
+      <startEvent id="subStartEvent"></startEvent>
+      <sequenceFlow id="subFlowId1" sourceRef="subStartEvent" targetRef="subUserTask1"></sequenceFlow>
+      <endEvent id="sid-565296D1-FCF9-4B31-9048-528B10A27C46"></endEvent>
+    </subProcess>
+    <sequenceFlow id="flow1" sourceRef="userTask1" targetRef="subprocess1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="subprocess1" targetRef="sid-194696BA-1A7D-47D7-95A9-A77390D25048"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process">
+    <bpmndi:BPMNPlane bpmnElement="process" id="BPMNPlane_process">
+      <bpmndi:BPMNShape bpmnElement="start1" id="BPMNShape_start1">
+        <omgdc:Bounds height="35.0" width="35.0" x="106.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-194696BA-1A7D-47D7-95A9-A77390D25048" id="BPMNShape_sid-194696BA-1A7D-47D7-95A9-A77390D25048">
+        <omgdc:Bounds height="35.0" width="35.0" x="780.0" y="191.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="211.0" y="169.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess1" id="BPMNShape_subprocess1">
+        <omgdc:Bounds height="205.0" width="335.0" x="380.0" y="105.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9" id="BPMNEdge_sid-04DAFAA0-34C1-48DF-BAD5-1038344BBFA9">
+        <omgdi:waypoint x="141.0" y="208.0"></omgdi:waypoint>
+        <omgdi:waypoint x="211.0" y="209.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="311.0" y="209.0"></omgdi:waypoint>
+        <omgdi:waypoint x="380.0" y="207.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="715.0" y="207.0"></omgdi:waypoint>
+        <omgdi:waypoint x="780.0" y="208.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_subprocess1">
+    <bpmndi:BPMNPlane bpmnElement="subprocess1" id="BPMNPlane_subprocess1">
+      <bpmndi:BPMNShape bpmnElement="subUserTask1" id="BPMNShape_subUserTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="490.0" y="170.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subStartEvent" id="BPMNShape_subStartEvent">
+        <omgdc:Bounds height="35.0" width="35.0" x="400.0" y="195.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-565296D1-FCF9-4B31-9048-528B10A27C46" id="BPMNShape_sid-565296D1-FCF9-4B31-9048-528B10A27C46">
+        <omgdc:Bounds height="35.0" width="35.0" x="650.0" y="192.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-C7145ECA-31A2-4A91-B20A-023CF0764155" id="BPMNEdge_sid-C7145ECA-31A2-4A91-B20A-023CF0764155">
+        <omgdi:waypoint x="590.0" y="210.0"></omgdi:waypoint>
+        <omgdi:waypoint x="650.0" y="209.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subFlowId1" id="BPMNEdge_subFlowId1">
+        <omgdi:waypoint x="435.0" y="212.0"></omgdi:waypoint>
+        <omgdi:waypoint x="490.0" y="210.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Note that this is dependent upon ACT-4135 as I separated out the base BpmnXMLConverter update top avoid future merge conflicts.

I tried to get it working with the existing Designer code, but got to where the next id was determined for each BPMN element within the UI and it was looping through and finding the next one. Wouldn't it be better to use a UUID or keep a key list somewhere with the next key value? Don't you use ids or sids for the web-based design tool already?