### PR TITLE
Amazon RDS 5.6 is not using anymore the defaults for timestamp

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.engine.sql
@@ -28,7 +28,7 @@ create table ACT_RE_DEPLOYMENT (
     ID_ varchar(64),
     NAME_ varchar(255),
     CATEGORY_ varchar(255),
-    DEPLOY_TIME_ timestamp,
+    DEPLOY_TIME_ timestamp null,
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
@@ -117,7 +117,7 @@ create table ACT_RU_TASK (
     ASSIGNEE_ varchar(255),
     DELEGATION_ varchar(64),
     PRIORITY_ integer,
-    CREATE_TIME_ timestamp,
+    CREATE_TIME_ timestamp null,
     DUE_DATE_ datetime,
     SUSPENSION_STATE_ integer,
     primary key (ID_)


### PR DESCRIPTION
Fix - modified columns timestamp default to null for ACT_RU_TASK and ACT_RE_DEPLOYMENT for mysql dialect, since Amazon RDS 5.6 is not using anymore defaults for timestamp. Same fix as in https://github.com/Activiti/Activiti/pull/720/