### PR TITLE
exclude testcase from history level none mode

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -763,6 +763,9 @@
                 <exclude>**/RepeatingServiceTaskTest.java</exclude>
                 <exclude>**/ProcessInstanceLogQueryTest.java</exclude>
                 <exclude>org/activiti/standalone/**</exclude>
+                <exclude>**/HistoricProcessInstanceQueryVersionTest.java</exclude>
+                <exclude>**/NonCascadeDeleteTest.java</exclude>
+                <exclude>**/HistoricProcessInstanceQueryAndWithExceptionTest.java</exclude>
               </excludes>
               <runOrder>alphabetical</runOrder>
             </configuration>


### PR DESCRIPTION
We excluded testcase from history level none mode.
Because testcases that we added in this following pull request don't work in history level none mode, we excluded them.
https://github.com/Activiti/Activiti/pull/833
https://github.com/Activiti/Activiti/pull/807