### PR TITLE
Add support for DB2/LINUXPPC64LE

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -815,6 +815,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     databaseTypeMappings.setProperty("DB2/LINUXX8664",DATABASE_TYPE_DB2);
     databaseTypeMappings.setProperty("DB2/LINUXZ64",DATABASE_TYPE_DB2);
     databaseTypeMappings.setProperty("DB2/LINUXPPC64",DATABASE_TYPE_DB2);
+    databaseTypeMappings.setProperty("DB2/LINUXPPC64LE",DATABASE_TYPE_DB2);
     databaseTypeMappings.setProperty("DB2/400 SQL",DATABASE_TYPE_DB2);
     databaseTypeMappings.setProperty("DB2/6000",DATABASE_TYPE_DB2);
     databaseTypeMappings.setProperty("DB2 UDB iSeries",DATABASE_TYPE_DB2);


### PR DESCRIPTION
Activiti did not work when db2 was running on a linux ppc64 little endian. This patch simply add that to the lookup table used to identify the database type. 