### PR TITLE
Fixed problem with process instances query

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -516,6 +516,16 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
       return variableValueLike(name, value, false);
     }
   }
+
+  @Override
+  public ProcessInstanceQuery variableValueLikeIgnoreCase(String name, String value) {
+    if (inOrStatement) {
+        currentOrQueryObject.variableValueLikeIgnoreCase(name, value, false);
+        return this;
+    } else {
+        return variableValueLikeIgnoreCase(name, value, false);
+    }
+  }
   
   public ProcessInstanceQuery locale(String locale) {
     this.locale = locale;

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceAndVariablesQueryTest.java
@@ -150,4 +150,14 @@ public class ProcessInstanceAndVariablesQueryTest extends PluggableActivitiTestC
         .listPage(4, 5);
     assertEquals(0, instanceList.size());
   }
+
+  public void testOrProcessVariablesLikeIgnoreCase() {
+      List<ProcessInstance> instanceList = runtimeService
+          .createProcessInstanceQuery().or()
+          .variableValueLikeIgnoreCase("test", "TES%")
+          .variableValueLikeIgnoreCase("test", "%XYZ").endOr()
+          .list();
+      assertEquals(4, instanceList.size());
+  }
+
 }


### PR DESCRIPTION
Fixed a bug that arises when querying process instances with process variables like 'ignore case' conditions in an 'or' clause.
Fixes #856.