### PR TITLE
Refactor ProcessInstanceUtils

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -285,6 +285,7 @@ import org.activiti.engine.impl.scripting.ScriptingEngines;
 import org.activiti.engine.impl.scripting.VariableScopeResolverFactory;
 import org.activiti.engine.impl.util.DefaultClockImpl;
 import org.activiti.engine.impl.util.IoUtil;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.impl.util.ReflectUtil;
 import org.activiti.engine.impl.variable.BooleanType;
 import org.activiti.engine.impl.variable.ByteArrayType;
@@ -480,6 +481,9 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   protected List<JobHandler> customJobHandlers;
   protected Map<String, JobHandler> jobHandlers;
+
+  // HELPERS //////////////////////////////////////////////////////////////////
+  protected ProcessInstanceHelper processInstanceHelper;
   
   // ASYNC EXECUTOR ///////////////////////////////////////////////////////////
   
@@ -843,7 +847,8 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     if (usingRelationalDatabase) {
       initDataSource();
     }
-    
+
+    initHelpers();
     initVariableTypes();
     initBeans();
     initFormEngines();
@@ -1927,6 +1932,12 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
     }
   }
 
+  public void initHelpers() {
+	if(processInstanceHelper == null) {
+		processInstanceHelper = new ProcessInstanceHelper();
+	}
+  }
+
   public void initVariableTypes() {
     if (variableTypes == null) {
       variableTypes = new DefaultVariableTypes();
@@ -2528,6 +2539,15 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
 
   public ProcessEngineConfigurationImpl setJobHandlers(Map<String, JobHandler> jobHandlers) {
     this.jobHandlers = jobHandlers;
+    return this;
+  }
+
+  public ProcessInstanceHelper getProcessInstanceHelper() {
+	return processInstanceHelper;
+  }
+
+  public ProcessEngineConfigurationImpl setProcessInstanceHelper(ProcessInstanceHelper processInstanceHelper) {
+    this.processInstanceHelper = processInstanceHelper;
     return this;
   }
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceByMessageCmd.java
@@ -23,8 +23,8 @@ import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
 import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
-import org.activiti.engine.impl.util.ProcessInstanceUtil;
 import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.runtime.ProcessInstance;
 
 /**
@@ -69,7 +69,8 @@ public class StartProcessInstanceByMessageCmd implements Command<ProcessInstance
       throw new ActivitiObjectNotFoundException("No process definition found for id '" + processDefinitionId + "'", ProcessDefinition.class);
     }
 
-    ProcessInstance processInstance = ProcessInstanceUtil.createAndStartProcessInstanceByMessage(processDefinition, messageName, processVariables);
+    ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();
+    ProcessInstance processInstance = processInstanceHelper.createAndStartProcessInstanceByMessage(processDefinition, messageName, processVariables);
 
     return processInstance;
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartProcessInstanceCmd.java
@@ -27,7 +27,7 @@ import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.activiti.engine.impl.runtime.ProcessInstanceBuilderImpl;
-import org.activiti.engine.impl.util.ProcessInstanceUtil;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.ProcessInstance;
 
@@ -44,6 +44,7 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
   protected String businessKey;
   protected String tenantId;
   protected String processInstanceName;
+  protected ProcessInstanceHelper processInstanceHelper;
 
   public StartProcessInstanceCmd(String processDefinitionKey, String processDefinitionId, String businessKey, Map<String, Object> variables) {
     this.processDefinitionKey = processDefinitionKey;
@@ -93,13 +94,14 @@ public class StartProcessInstanceCmd<T> implements Command<ProcessInstance>, Ser
       throw new ActivitiIllegalArgumentException("processDefinitionKey and processDefinitionId are null");
     }
 
+    processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();
     ProcessInstance processInstance = createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
 
     return processInstance;
   }
 
   protected ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, String businessKey, String processInstanceName, Map<String,Object> variables) {
-    return ProcessInstanceUtil.createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
+    return processInstanceHelper.createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables);
   }
   
   protected Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SubmitStartFormCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SubmitStartFormCmd.java
@@ -23,7 +23,7 @@ import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
 import org.activiti.engine.impl.util.Activiti5Util;
 import org.activiti.engine.impl.util.FormHandlerUtil;
-import org.activiti.engine.impl.util.ProcessInstanceUtil;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.runtime.ProcessInstance;
 
 /**
@@ -50,12 +50,13 @@ public class SubmitStartFormCmd extends NeedsActiveProcessDefinitionCmd<ProcessI
     }
     
     ExecutionEntity processInstance = null;
+    ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();
     
     // TODO: backwards compatibility? Only create the process instance and not start it? How?
     if (businessKey != null) {
-      processInstance = (ExecutionEntity) ProcessInstanceUtil.createProcessInstance(processDefinition, businessKey, null, null);
+      processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, businessKey, null, null);
     } else {
-      processInstance = (ExecutionEntity) ProcessInstanceUtil.createProcessInstance(processDefinition, null, null, null);
+      processInstance = (ExecutionEntity) processInstanceHelper.createProcessInstance(processDefinition, null, null, null);
     }
 
     commandContext.getHistoryManager().recordFormPropertiesSubmitted(processInstance.getExecutions().get(0), properties, null);
@@ -63,7 +64,7 @@ public class SubmitStartFormCmd extends NeedsActiveProcessDefinitionCmd<ProcessI
     StartFormHandler startFormHandler = FormHandlerUtil.getStartFormHandler(commandContext, processDefinition); 
     startFormHandler.submitFormProperties(properties, processInstance);
     
-    ProcessInstanceUtil.startProcessInstance(processInstance, commandContext, convertPropertiesToVariablesMap());
+    processInstanceHelper.startProcessInstance(processInstance, commandContext, convertPropertiesToVariablesMap());
 
     return processInstance;
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
@@ -22,7 +22,7 @@ import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntity;
-import org.activiti.engine.impl.util.ProcessInstanceUtil;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.repository.ProcessDefinition;
 
 /**
@@ -58,7 +58,8 @@ public class SignalEventHandler extends AbstractEventHandler {
         variables = (Map<String, Object>) payload;
       }
 
-      ProcessInstanceUtil.createAndStartProcessInstance(processDefinition, null, null, variables);
+      ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();
+      processInstanceHelper.createAndStartProcessInstance(processDefinition, null, null, variables);
     } else {
       throw new ActivitiException("Invalid signal handling: no execution nor process definition set");
     }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProcessInstanceHelper.java
@@ -38,21 +38,21 @@ import org.activiti.engine.runtime.ProcessInstance;
  * @author Tijs Rademakers
  * @author Joram Barrez
  */
-public class ProcessInstanceUtil {
+public class ProcessInstanceHelper {
   
-  public static ProcessInstance createProcessInstance(ProcessDefinitionEntity processDefinition, 
+  public ProcessInstance createProcessInstance(ProcessDefinitionEntity processDefinition, 
       String businessKey, String processInstanceName, Map<String, Object> variables) {
     
     return createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables, false);
   }
   
-  public static ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, 
+  public ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, 
       String businessKey, String processInstanceName, Map<String, Object> variables) {
     
     return createAndStartProcessInstance(processDefinition, businessKey, processInstanceName, variables, true);
   }
   
-  protected static ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, 
+  protected ProcessInstance createAndStartProcessInstance(ProcessDefinitionEntity processDefinition, 
       String businessKey, String processInstanceName, Map<String, Object> variables, boolean startProcessInstance) {
     
     CommandContext commandContext = Context.getCommandContext(); // Todo: ideally, context should be passed here
@@ -82,7 +82,7 @@ public class ProcessInstanceUtil {
         processInstanceName, initialFlowElement, process, variables, startProcessInstance);
   }
 
-  public static ProcessInstance createAndStartProcessInstanceByMessage(ProcessDefinitionEntity processDefinition, String messageName, Map<String, Object> variables) {
+  public ProcessInstance createAndStartProcessInstanceByMessage(ProcessDefinitionEntity processDefinition, String messageName, Map<String, Object> variables) {
     CommandContext commandContext = Context.getCommandContext();
     if (processDefinition.getEngineVersion() != null) {
       if (Activiti5CompatibilityHandler.ACTIVITI_5_ENGINE_TAG.equals(processDefinition.getEngineVersion())) {
@@ -131,7 +131,7 @@ public class ProcessInstanceUtil {
     return createAndStartProcessInstanceWithInitialFlowElement(processDefinition, null, null, initialFlowElement, process, variables, true);
   }
 
-  protected static ProcessInstance createAndStartProcessInstanceWithInitialFlowElement(ProcessDefinitionEntity processDefinition, 
+  protected ProcessInstance createAndStartProcessInstanceWithInitialFlowElement(ProcessDefinitionEntity processDefinition, 
       String businessKey, String processInstanceName, FlowElement initialFlowElement, 
       Process process, Map<String, Object> variables, boolean startProcessInstance) {
 
@@ -206,7 +206,7 @@ public class ProcessInstanceUtil {
     return processInstance;
   }
   
-  public static void startProcessInstance(ExecutionEntity processInstance, CommandContext commandContext, Map<String, Object> variables) {
+  public void startProcessInstance(ExecutionEntity processInstance, CommandContext commandContext, Map<String, Object> variables) {
     ExecutionEntity execution = processInstance.getExecutions().get(0); // There will always be one child execution created
     commandContext.getAgenda().planContinueProcessOperation(execution);
     
@@ -216,7 +216,7 @@ public class ProcessInstanceUtil {
     }
   }
   
-  protected static Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
+  protected Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
     Map<String, Object> variablesMap = new HashMap<String, Object>();
     // convert data objects to process variables
     if (dataObjects != null) {


### PR DESCRIPTION
Refactor ProcessInstanceUtils to be a helper class that can be configured in the ProcessEngineConfiguration to allow a subclass to override the behavior.  We require this change in order to override the processDataObjects method without copying the StartProcessInstanceCmd and the ProcessInstanceUtils classes into our codebase.
