### PR TITLE
The runAs token for Alfresco should be "runAs" not "runAS" as defined in

### DIFF
--- a/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/conversion/AlfrescoConversionConstants.java
+++ b/modules/activiti-simple-workflow-alfresco/src/main/java/org/activiti/workflow/simple/alfresco/conversion/AlfrescoConversionConstants.java
@@ -174,7 +174,7 @@ public interface AlfrescoConversionConstants {
 	String CLASSNAME_SCRIPT_DELEGATE = "org.alfresco.repo.workflow.activiti.script.AlfrescoScriptDelegate";
 	String SCRIPT_TASK_LISTENER_SCRIPT_FIELD_NAME = "script";
 	String SCRIPT_DELEGATE_SCRIPT_FIELD_NAME = "script";
-	String SCRIPT_DELEGATE_RUN_AS_FIELD_NAME = "runAS";
+	String SCRIPT_DELEGATE_RUN_AS_FIELD_NAME = "runAs"; /* webrecs bugfix */
 	String TASK_LISTENER_EVENT_CREATE = "create";
 	String TASK_LISTENER_EVENT_COMPLETE = "complete";
 


### PR DESCRIPTION
SCRIPT_DELEGATE_RUN_AS_FIELD_NAME. This causes Eclipse plugin to output
wrong XML which causes Activiti run time error for at scripts defined
with Run As users