### PR TITLE
Update CallActivityBehavior to send PROCESS_STARTED event.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -125,6 +125,9 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
     subProcessInitialExecution.setCurrentFlowElement(initialFlowElement);
 
     Context.getAgenda().planContinueProcessOperation(subProcessInitialExecution);
+
+    Context.getProcessEngineConfiguration().getEventDispatcher()
+    .dispatchEvent(ActivitiEventBuilder.createProcessStartedEvent(subProcessInitialExecution.getParent(), variables, false));
   }
 
   public void completing(DelegateExecution execution, DelegateExecution subProcessInstance) throws Exception {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -13,13 +13,17 @@
 
 package org.activiti.engine.impl.bpmn.behavior;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.activiti.bpmn.model.CallActivity;
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.IOParameter;
 import org.activiti.bpmn.model.MapExceptionEntry;
 import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.ValuedDataObject;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -95,6 +99,9 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
 
     ExecutionEntity subProcessInstance = createSubProcessInstance(processDefinition, executionEntity, initialFlowElement);
 
+    // process template-defined data objects
+    Map<String, Object> variables = processDataObjects(subProcess.getDataObjects());
+
     // copy process variables
     ExpressionManager expressionManager = Context.getProcessEngineConfiguration().getExpressionManager();
     for (IOParameter ioParameter : callActivity.getInParameters()) {
@@ -106,7 +113,11 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
       } else {
         value = execution.getVariable(ioParameter.getSource());
       }
-      subProcessInstance.setVariable(ioParameter.getTarget(), value);
+      variables.put(ioParameter.getTarget(), value);
+    }
+
+    if(! variables.isEmpty()) {
+      initializeVariables(subProcessInstance, variables);
     }
 
     // Create the first execution that will visit all the process definition elements
@@ -177,5 +188,22 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
 
   public String getProcessDefinitonKey() {
     return processDefinitonKey;
+  }
+
+  protected Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
+	Map<String, Object> variablesMap = new HashMap<String,Object>();
+	// convert data objects to process variables
+	if (dataObjects != null) {
+      variablesMap = new HashMap<String, Object>(dataObjects.size());
+	  for (ValuedDataObject dataObject : dataObjects) {
+	    variablesMap.put(dataObject.getName(), dataObject.getValue());
+	  }
+	}
+	return variablesMap;
+  }
+
+  // Allow a subclass to override how variables are initialized.
+  protected void initializeVariables(ExecutionEntity subProcessInstance, Map<String,Object> variables) {
+	subProcessInstance.setVariables(variables);
   }
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ProcessInstanceEventsTest.java
@@ -188,7 +188,7 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     String processDefinitionId = processInstance.getProcessDefinitionId();
 
     // Check create-event one main process the second one Scope execution, and the third one subprocess
-    assertEquals(8, listener.getEventsReceived().size());
+    assertEquals(9, listener.getEventsReceived().size());
     assertTrue(listener.getEventsReceived().get(0) instanceof ActivitiEntityEvent);
 
     // process instance created event
@@ -243,8 +243,8 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     assertNotEquals(subProcessInstanceId, event.getExecutionId());
     String subProcessDefinitionId = ((ExecutionEntity) event.getEntity()).getProcessDefinitionId();
     assertNotNull(subProcessDefinitionId);
-    ProcessDefinition processDefinition = repositoryService.getProcessDefinition(subProcessDefinitionId);
-    assertEquals("simpleSubProcess", processDefinition.getKey());
+    ProcessDefinition subProcessDefinition = repositoryService.getProcessDefinition(subProcessDefinitionId);
+    assertEquals("simpleSubProcess", subProcessDefinition.getKey());
 
     // sub process instance start initialized event
     event = (ActivitiEntityEvent) listener.getEventsReceived().get(7);
@@ -253,8 +253,14 @@ public class ProcessInstanceEventsTest extends PluggableActivitiTestCase {
     assertNotEquals(subProcessInstanceId, event.getExecutionId());
     subProcessDefinitionId = ((ExecutionEntity) event.getEntity()).getProcessDefinitionId();
     assertNotNull(subProcessDefinitionId);
-    processDefinition = repositoryService.getProcessDefinition(subProcessDefinitionId);
-    assertEquals("simpleSubProcess", processDefinition.getKey());
+
+    event = (ActivitiEntityEvent) listener.getEventsReceived().get(8);
+    assertEquals(ActivitiEventType.PROCESS_STARTED, event.getType());
+    assertEquals(subProcessInstanceId, event.getProcessInstanceId());
+    assertEquals(subProcessDefinitionId, event.getProcessDefinitionId());
+    assertTrue(event instanceof ActivitiProcessStartedEvent);
+    assertEquals(processDefinitionId, ((ActivitiProcessStartedEvent)event).getNestedProcessDefinitionId());
+    assertEquals(processInstance.getId(), ((ActivitiProcessStartedEvent)event).getNestedProcessInstanceId());
 
     listener.clearEventsReceived();
   }

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/callactivity/CallActivityTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/callactivity/CallActivityTest.java
@@ -45,4 +45,21 @@ public class CallActivityTest extends PluggableActivitiTestCase {
     Task prepareAndShipTask = taskQuery.singleResult();
     assertEquals("Prepare and Ship", prepareAndShipTask.getName());
   }
+
+  @Deployment(resources = { "org/activiti/examples/bpmn/callactivity/mainProcess.bpmn20.xml", "org/activiti/examples/bpmn/callactivity/childProcess.bpmn20.xml" })
+  public void testCallActivityWithModeledDataObjectsInSubProcess() {
+    // After the process has started, the 'verify credit history' task
+    // should be active
+    ProcessInstance pi = runtimeService.startProcessInstanceByKey("mainProcess");
+    TaskQuery taskQuery = taskService.createTaskQuery();
+    Task verifyCreditTask = taskQuery.singleResult();
+    assertEquals("User Task 1", verifyCreditTask.getName());
+
+    // Verify with Query API
+    ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+    assertNotNull(subProcessInstance);
+    assertEquals(pi.getId(), runtimeService.createProcessInstanceQuery().subProcessInstanceId(subProcessInstance.getId()).singleResult().getId());
+
+    assertEquals("Batman", runtimeService.getVariable(subProcessInstance.getId(), "Name"));
+  }
 }

--- a/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/callactivity/childProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/callactivity/childProcess.bpmn20.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:activiti="http://activiti.org/bpmn"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="Examples">
+
+	<process id="childProcess">
+      <dataObject id="dObj1" itemSubjectRef="xsd:string" name="Name">
+        <extensionElements>
+          <activiti:value>Batman</activiti:value>
+         </extensionElements>
+      </dataObject>
+
+	<startEvent id="theStart" />
+	<sequenceFlow id="flow1" sourceRef="theStart" targetRef="userTask1" />
+
+	<userTask id="userTask1" name="User Task 1" />
+    <sequenceFlow id="flow2" sourceRef="userTask1" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+	</process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/callactivity/mainProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/examples/bpmn/callactivity/mainProcess.bpmn20.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+	xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+	xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+	targetNamespace="Examples">
+
+	<process id="mainProcess" name="Main process with call activity">
+	  <startEvent id="theStart" />
+	  <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theChildProcess" />
+
+	  <callActivity id="theChildProcess" name="Child Process" calledElement="childProcess" />
+	  <sequenceFlow id="flow3" sourceRef="theChildProcess" targetRef="theEnd" />
+
+      <endEvent id="theEnd" />
+	</process>
+
+</definitions>


### PR DESCRIPTION
This change is dependent on a prior pull request that refactored CallActivityBehavior to support initializing DataObjects in a subclass. 