### PR TITLE
Make explicit update() calls via dataManagers to activate/suspend a p…

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessInstanceStateCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AbstractSetProcessInstanceStateCmd.java
@@ -64,12 +64,14 @@ public abstract class AbstractSetProcessInstanceStateCmd implements Command<Void
     }
 
     SuspensionStateUtil.setSuspensionState(executionEntity, getNewState());
+    commandContext.getExecutionEntityManager().update(executionEntity);
 
     // All child executions are suspended
     Collection<ExecutionEntity> childExecutions = commandContext.getExecutionEntityManager().findChildExecutionsByProcessInstanceId(executionId);
     for (ExecutionEntity childExecution : childExecutions) {
       if (!childExecution.getId().equals(executionId)) {
         SuspensionStateUtil.setSuspensionState(childExecution, getNewState());
+        commandContext.getExecutionEntityManager().update(childExecution);
       }
     }
 
@@ -77,6 +79,7 @@ public abstract class AbstractSetProcessInstanceStateCmd implements Command<Void
     List<TaskEntity> tasks = commandContext.getTaskEntityManager().findTasksByProcessInstanceId(executionId);
     for (TaskEntity taskEntity : tasks) {
       SuspensionStateUtil.setSuspensionState(taskEntity, getNewState());
+      commandContext.getTaskEntityManager().update(taskEntity);
     }
 
     return null;


### PR DESCRIPTION
…rocess instance

instead of relying on Entity cache's implicit update behavior. This will help for better readability, and allow special handling for entities in the overriding data managers.