### PR TITLE
Add the alternative query method to includeProcessVariables criteria.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -15,6 +15,7 @@ package org.activiti.engine;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.delegate.event.ActivitiEvent;
@@ -490,6 +491,16 @@ public interface RuntimeService {
    */
   Map<String, VariableInstance> getVariableInstances(String executionId);
 
+  /**
+   * All variables visible from the given execution scope (including parent
+   * scopes).
+   * 
+   * @param executionIds
+   *          ids of execution, cannot be null.
+   * @return the variables.
+   */
+  List<VariableInstance> getVariableInstancesByExecutionIds(Set<String> executionIds);
+  
   /**
    * All variables visible from the given execution scope (including parent scopes).
    *

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
@@ -17,7 +17,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
 import org.activiti.engine.query.NativeQuery;
 import org.activiti.engine.task.Attachment;
 import org.activiti.engine.task.Comment;
@@ -376,6 +378,9 @@ public interface TaskService {
 
   /** get a variable on a task */
   Map<String, Object> getVariablesLocal(String taskId, Collection<String> variableNames);
+  
+  /** get all variables and search only in the task scope. */
+  List<VariableInstance> getVariableInstancesLocalByTaskIds(Set<String> taskIds);
   
   /**
    * Removes the variable from the task.

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricVariableInstanceQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/history/HistoricVariableInstanceQuery.java
@@ -13,6 +13,8 @@
 
 package org.activiti.engine.history;
 
+import java.util.Set;
+
 import org.activiti.engine.query.Query;
 
 /** 
@@ -28,11 +30,17 @@ public interface HistoricVariableInstanceQuery extends Query<HistoricVariableIns
   /** Only select historic process variables with the given process instance. */
   HistoricVariableInstanceQuery processInstanceId(String processInstanceId);
   
+  /** Only select historic process variables whose id is in the given set of ids. */
+  HistoricVariableInstanceQuery processInstanceIds(Set<String> processInstanceIds);
+  
   /** Only select historic process variables with the given id. **/
   HistoricVariableInstanceQuery executionId(String executionId);
 
   /** Only select historic process variables with the given task. */
   HistoricVariableInstanceQuery taskId(String taskId);
+
+  /** Only select historic process variables whose id is in the given set of ids. */
+  HistoricVariableInstanceQuery taskIds(Set<String> taskIds);
 
   /** Only select historic process variables with the given variable name. */
   HistoricVariableInstanceQuery variableName(String variableName);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricVariableInstanceQueryImpl.java
@@ -14,6 +14,7 @@
 package org.activiti.engine.impl;
 
 import java.util.List;
+import java.util.Set;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.history.HistoricVariableInstance;
@@ -36,8 +37,10 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
   private static final long serialVersionUID = 1L;
   protected String id;
   protected String taskId;
+  protected Set<String> taskIds;
   protected String executionId;
   protected String processInstanceId;
+  protected Set<String> processInstanceIds;
   protected String activityInstanceId;
   protected String variableName;
   protected String variableNameLike;
@@ -69,6 +72,17 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
     return this;
   }
 
+  public HistoricVariableInstanceQueryImpl processInstanceIds(Set<String> processInstanceIds) {
+    if (processInstanceIds == null) {
+      throw new ActivitiIllegalArgumentException("processInstanceIds is null");
+    }
+    if(processInstanceIds.isEmpty()){
+        throw new ActivitiIllegalArgumentException("Set of processInstanceIds is empty");
+    }
+    this.processInstanceIds = processInstanceIds;
+    return this;
+  }
+  
   public HistoricVariableInstanceQueryImpl executionId(String executionId) {
     if (executionId == null) {
       throw new ActivitiIllegalArgumentException("Execution id is null");
@@ -90,6 +104,20 @@ public class HistoricVariableInstanceQueryImpl extends AbstractQuery<HistoricVar
       throw new ActivitiIllegalArgumentException("Cannot use taskId together with excludeTaskVariables");
     }
     this.taskId = taskId;
+    return this;
+  }
+  
+  public HistoricVariableInstanceQueryImpl taskIds(Set<String> taskIds) {
+    if (taskIds == null) {
+      throw new ActivitiIllegalArgumentException("taskIds is null");
+    }
+    if(taskIds.isEmpty()){
+        throw new ActivitiIllegalArgumentException("Set of taskIds is empty");
+    }
+    if(excludeTaskRelated) {
+        throw new ActivitiIllegalArgumentException("Cannot use taskIds together with excludeTaskVariables");
+    }
+    this.taskIds = taskIds;
     return this;
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.RuntimeService;
@@ -35,6 +36,7 @@ import org.activiti.engine.impl.cmd.GetExecutionVariableCmd;
 import org.activiti.engine.impl.cmd.GetExecutionVariableInstanceCmd;
 import org.activiti.engine.impl.cmd.GetExecutionVariableInstancesCmd;
 import org.activiti.engine.impl.cmd.GetExecutionVariablesCmd;
+import org.activiti.engine.impl.cmd.GetExecutionsVariablesCmd;
 import org.activiti.engine.impl.cmd.GetIdentityLinksForProcessInstanceCmd;
 import org.activiti.engine.impl.cmd.GetProcessInstanceEventsCmd;
 import org.activiti.engine.impl.cmd.GetStartFormCmd;
@@ -142,6 +144,10 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
   
   public Map<String, VariableInstance> getVariableInstances(String executionId) {
     return commandExecutor.execute(new GetExecutionVariableInstancesCmd(executionId, null, false));
+  }
+  
+  public List<VariableInstance> getVariableInstancesByExecutionIds(Set<String> executionIds) {
+    return commandExecutor.execute(new GetExecutionsVariablesCmd(executionIds));
   }
   
   public Map<String, VariableInstance> getVariableInstances(String executionId, String locale, boolean withLocalizationFallback) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
@@ -19,6 +19,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.TaskService;
@@ -47,6 +48,7 @@ import org.activiti.engine.impl.cmd.GetTaskEventCmd;
 import org.activiti.engine.impl.cmd.GetTaskEventsCmd;
 import org.activiti.engine.impl.cmd.GetTaskVariableCmd;
 import org.activiti.engine.impl.cmd.GetTaskVariablesCmd;
+import org.activiti.engine.impl.cmd.GetTasksLocalVariablesCmd;
 import org.activiti.engine.impl.cmd.GetTypeCommentsCmd;
 import org.activiti.engine.impl.cmd.HasTaskVariableCmd;
 import org.activiti.engine.impl.cmd.NewTaskCmd;
@@ -57,6 +59,7 @@ import org.activiti.engine.impl.cmd.SaveTaskCmd;
 import org.activiti.engine.impl.cmd.SetTaskDueDateCmd;
 import org.activiti.engine.impl.cmd.SetTaskPriorityCmd;
 import org.activiti.engine.impl.cmd.SetTaskVariablesCmd;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
 import org.activiti.engine.task.Attachment;
 import org.activiti.engine.task.Comment;
 import org.activiti.engine.task.Event;
@@ -211,24 +214,24 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
     return new NativeTaskQueryImpl(commandExecutor);
   }
   
-  public Map<String, Object> getVariables(String executionId) {
-    return commandExecutor.execute(new GetTaskVariablesCmd(executionId, null, false));
+  public Map<String, Object> getVariables(String taskId) {
+    return commandExecutor.execute(new GetTaskVariablesCmd(taskId, null, false));
+  }
+  
+  public Map<String, Object> getVariablesLocal(String taskId) {
+    return commandExecutor.execute(new GetTaskVariablesCmd(taskId, null, true));
   }
 
-  public Map<String, Object> getVariablesLocal(String executionId) {
-    return commandExecutor.execute(new GetTaskVariablesCmd(executionId, null, true));
+  public Map<String, Object> getVariables(String taskId, Collection<String> variableNames) {
+    return commandExecutor.execute(new GetTaskVariablesCmd(taskId, variableNames, false));
   }
 
-  public Map<String, Object> getVariables(String executionId, Collection<String> variableNames) {
-    return commandExecutor.execute(new GetTaskVariablesCmd(executionId, variableNames, false));
+  public Map<String, Object> getVariablesLocal(String taskId, Collection<String> variableNames) {
+    return commandExecutor.execute(new GetTaskVariablesCmd(taskId, variableNames, true));
   }
 
-  public Map<String, Object> getVariablesLocal(String executionId, Collection<String> variableNames) {
-    return commandExecutor.execute(new GetTaskVariablesCmd(executionId, variableNames, true));
-  }
-
-  public Object getVariable(String executionId, String variableName) {
-    return commandExecutor.execute(new GetTaskVariableCmd(executionId, variableName, false));
+  public Object getVariable(String taskId, String variableName) {
+    return commandExecutor.execute(new GetTaskVariableCmd(taskId, variableName, false));
   }
 
   @Override
@@ -240,43 +243,47 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
     return commandExecutor.execute(new HasTaskVariableCmd(taskId, variableName, false));
   }
   
-  public Object getVariableLocal(String executionId, String variableName) {
-    return commandExecutor.execute(new GetTaskVariableCmd(executionId, variableName, true));
+  public Object getVariableLocal(String taskId, String variableName) {
+    return commandExecutor.execute(new GetTaskVariableCmd(taskId, variableName, true));
   }
 
   @Override
   public <T> T getVariableLocal(String taskId, String variableName, Class<T> variableClass) {
   	return variableClass.cast(getVariableLocal(taskId, variableName));
   }
+  
+  public List<VariableInstance> getVariableInstancesLocalByTaskIds(Set<String> taskIds) {
+    return commandExecutor.execute(new GetTasksLocalVariablesCmd(taskIds));
+  }
 
   public boolean hasVariableLocal(String taskId, String variableName) {
     return commandExecutor.execute(new HasTaskVariableCmd(taskId, variableName, true));
   }
   
-  public void setVariable(String executionId, String variableName, Object value) {
+  public void setVariable(String taskId, String variableName, Object value) {
     if(variableName == null) {
       throw new ActivitiIllegalArgumentException("variableName is null");
     }
     Map<String, Object> variables = new HashMap<String, Object>();
     variables.put(variableName, value);
-    commandExecutor.execute(new SetTaskVariablesCmd(executionId, variables, false));
+    commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, false));
   }
   
-  public void setVariableLocal(String executionId, String variableName, Object value) {
+  public void setVariableLocal(String taskId, String variableName, Object value) {
     if(variableName == null) {
       throw new ActivitiIllegalArgumentException("variableName is null");
     }
     Map<String, Object> variables = new HashMap<String, Object>();
     variables.put(variableName, value);
-    commandExecutor.execute(new SetTaskVariablesCmd(executionId, variables, true));
+    commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, true));
   }
 
-  public void setVariables(String executionId, Map<String, ? extends Object> variables) {
-    commandExecutor.execute(new SetTaskVariablesCmd(executionId, variables, false));
+  public void setVariables(String taskId, Map<String, ? extends Object> variables) {
+    commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, false));
   }
 
-  public void setVariablesLocal(String executionId, Map<String, ? extends Object> variables) {
-    commandExecutor.execute(new SetTaskVariablesCmd(executionId, variables, true));
+  public void setVariablesLocal(String taskId, Map<String, ? extends Object> variables) {
+    commandExecutor.execute(new SetTaskVariablesCmd(taskId, variables, true));
   }
 
   public void removeVariable(String taskId, String variableName) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionsVariablesCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetExecutionsVariablesCmd.java
@@ -1,0 +1,44 @@
+package org.activiti.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
+
+/**
+ * @author Daisuke Yoshimoto
+ */
+public class GetExecutionsVariablesCmd implements Command<List<VariableInstance>>, Serializable{
+
+  private static final long serialVersionUID = 7576838206239649561L;
+  protected Set<String> executionIds;
+  
+  public GetExecutionsVariablesCmd(Set<String> executionIds) {
+    this.executionIds = executionIds;
+  }
+  
+  @Override
+  public List<VariableInstance> execute(CommandContext commandContext) {
+    // Verify existance of executions
+    if(executionIds == null) {
+      throw new ActivitiIllegalArgumentException("executionIds is null");
+    }
+    if(executionIds.isEmpty()){
+        throw new ActivitiIllegalArgumentException("Set of executionIds is empty");
+    }
+    
+    List<VariableInstance> instances = new ArrayList<VariableInstance>();
+    List<VariableInstanceEntity> entities = commandContext.getVariableInstanceEntityManager().findVariableInstancesByExecutionIds(executionIds);
+    for(VariableInstanceEntity entity : entities){
+        instances.add(entity);
+    }
+    return instances;
+  }
+
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTasksLocalVariablesCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTasksLocalVariablesCmd.java
@@ -1,0 +1,58 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.cmd;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.impl.persistence.entity.VariableInstanceEntity;
+
+/**
+ * @author Daisuke Yoshimoto
+ */
+public class GetTasksLocalVariablesCmd implements Command<List<VariableInstance>>, Serializable{
+
+
+  private static final long serialVersionUID = 4326522873059188196L;
+  protected Set<String> taskIds;
+
+  public GetTasksLocalVariablesCmd(Set<String> taskIds) {
+    this.taskIds = taskIds;
+  }
+	
+	@Override
+  public List<VariableInstance> execute(CommandContext commandContext) {
+    if(taskIds == null) {
+      throw new ActivitiIllegalArgumentException("taskIds is null");
+    }
+    if(taskIds.isEmpty()){
+        throw new ActivitiIllegalArgumentException("Set of taskIds is empty");
+    }
+    
+    List<VariableInstance> instances = new ArrayList<VariableInstance>();
+    List<VariableInstanceEntity> entities = commandContext.getVariableInstanceEntityManager().findVariableInstancesByTaskIds(taskIds);
+    for(VariableInstanceEntity entity : entities){
+    	instances.add(entity);
+    }
+    
+    return instances;
+  }
+
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntityManager.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.activiti.engine.impl.persistence.AbstractManager;
 
@@ -34,8 +35,18 @@ public class VariableInstanceEntityManager extends AbstractManager {
   }
   
   @SuppressWarnings("unchecked")
+  public List<VariableInstanceEntity> findVariableInstancesByTaskIds(Set<String> taskIds) {
+    return getDbSqlSession().selectList("selectVariablesByTaskIds", taskIds);
+  }
+  
+  @SuppressWarnings("unchecked")
   public List<VariableInstanceEntity> findVariableInstancesByExecutionId(String executionId) {
     return getDbSqlSession().selectList("selectVariablesByExecutionId", executionId);
+  }
+  
+  @SuppressWarnings("unchecked")
+  public List<VariableInstanceEntity> findVariableInstancesByExecutionIds(Set<String> executionIds) {
+    return getDbSqlSession().selectList("selectVariablesByExecutionIds", executionIds);
   }
   
 	public VariableInstanceEntity findVariableInstanceByExecutionAndName(String executionId, String variableName) {

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricVariableInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricVariableInstance.xml
@@ -155,11 +155,23 @@
       <if test="processInstanceId != null">
         and RES.PROC_INST_ID_ = #{processInstanceId}
       </if>
+      <if test="processInstanceIds != null and !processInstanceIds.isEmpty()">
+          and RES.PROC_INST_ID_ in
+          <foreach item="item" index="index" collection="processInstanceIds" open="(" separator="," close=")">
+            #{item}
+          </foreach>
+      </if>
       <if test="executionId != null">
         and RES.EXECUTION_ID_ = #{executionId}
       </if>
       <if test="taskId != null">
         and RES.TASK_ID_ = #{taskId}
+      </if>
+      <if test="taskIds != null and !taskIds.isEmpty()">
+          and RES.TASK_ID_ in
+          <foreach item="item" index="index" collection="taskIds" open="(" separator="," close=")">
+            #{item}
+          </foreach>
       </if>
       <if test="excludeTaskRelated">
         and RES.TASK_ID_ is NULL

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/VariableInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/VariableInstance.xml
@@ -139,6 +139,17 @@
     and TASK_ID_ is null
   </select>
   
+  <select id="selectVariablesByExecutionIds"
+    parameterType="org.activiti.engine.impl.db.ListQueryParameterObject"
+    resultMap="variableInstanceResultMap">
+    select * from ${prefix}ACT_RU_VARIABLE
+    where TASK_ID_ is null
+    and EXECUTION_ID_ in
+    <foreach item="item" index="index" collection="parameter" open="(" separator="," close=")">
+      #{item}
+    </foreach>
+  </select>
+  
   <select id="selectVariableInstanceByExecutionAndName" parameterType="java.util.Map" resultMap="variableInstanceResultMap">
 	select * from ${prefix}ACT_RU_VARIABLE 
     where EXECUTION_ID_ = #{executionId, jdbcType=VARCHAR} and NAME_= #{name, jdbcType=VARCHAR} and TASK_ID_ is null
@@ -161,6 +172,16 @@
     resultMap="variableInstanceResultMap">
     select * from ${prefix}ACT_RU_VARIABLE where
     TASK_ID_ = #{parameter, jdbcType=VARCHAR}
+  </select>
+  
+  <select id="selectVariablesByTaskIds"
+    parameterType="org.activiti.engine.impl.db.ListQueryParameterObject"
+    resultMap="variableInstanceResultMap">
+    select * from ${prefix}ACT_RU_VARIABLE
+    where TASK_ID_ in
+    <foreach item="item" index="index" collection="parameter" open="(" separator="," close=")">
+      #{item}
+    </foreach>
   </select>
   
   <select id="selectVariableInstanceByTaskAndName" parameterType="java.util.Map" resultMap="variableInstanceResultMap">

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.java
@@ -1,0 +1,62 @@
+package org.activiti.engine.test.api.runtime;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+
+/**
+ * @author Daisuke Yoshimoto
+ */
+public class RuntimeVariablesTest  extends PluggableActivitiTestCase {
+
+  @Deployment
+  public void testGetVariablesByExecutionIds(){
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+    Task task1 = taskService.createTaskQuery().processInstanceId(processInstance1.getId()).singleResult();
+    Task task2 = taskService.createTaskQuery().processInstanceId(processInstance2.getId()).singleResult();
+
+    // Task local variables
+    taskService.setVariableLocal(task1.getId(), "taskVar1", "sayHello1");
+    // Execution variables
+    taskService.setVariable(task1.getId(), "executionVar1", "helloWorld1");
+
+    // Task local variables
+    taskService.setVariableLocal(task2.getId(), "taskVar2", "sayHello2");
+    // Execution variables
+    taskService.setVariable(task2.getId(), "executionVar2", "helloWorld2");
+    
+    // only 1 process
+    Set<String> executionIds = new HashSet<String>();
+    executionIds.add(task1.getExecutionId());
+    List<VariableInstance> variables = runtimeService.getVariableInstancesByExecutionIds(executionIds);
+    assertEquals(1, variables.size());
+    checkVariable(task1.getExecutionId(), "executionVar1", "helloWorld1", variables);
+    
+    // 2 process
+    executionIds = new HashSet<String>();
+    executionIds.add(task1.getExecutionId());
+    executionIds.add(task2.getExecutionId());
+    variables = runtimeService.getVariableInstancesByExecutionIds(executionIds);
+    assertEquals(2, variables.size());
+    checkVariable(task1.getExecutionId(), "executionVar1", "helloWorld1", variables);
+    checkVariable(task2.getExecutionId(), "executionVar2", "helloWorld2", variables);
+  }
+  
+  private void checkVariable(String executionId, String name, String value, List<VariableInstance> variables){
+    for(VariableInstance variable : variables){
+        if(executionId.equals(variable.getExecutionId())){
+            assertEquals(name, variable.getName());
+            assertEquals(value, variable.getValue());
+            return;
+        }
+    }
+    fail();
+  }
+}

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.testGetVariablesByExecutionIds.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/RuntimeVariablesTest.testGetVariablesByExecutionIds.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="taskAssigneeExample" 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="oneTaskProcess">
+  
+    <startEvent id="start"/>
+    
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="task" />
+
+    <userTask id="task" />
+    
+    <sequenceFlow id="flow2" sourceRef="task" targetRef="end" />
+    
+    <endEvent id="end" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskVariablesTest.testGetVariablesLocalByTaskIds.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskVariablesTest.testGetVariablesLocalByTaskIds.bpmn20.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  targetNamespace="Examples"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:activiti="http://activiti.org/bpmn"
+  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+  typeLanguage="http://www.w3.org/2001/XMLSchema"
+  expressionLanguage="http://www.w3.org/1999/XPath">
+  <process id="twoTaskProcess">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <parallelGateway id="parallelgateway1" name="Parallel Gateway"></parallelGateway>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <userTask id="usertask1" name="User Task"></userTask>
+    <userTask id="usertask2" name="User Task"></userTask>
+    <parallelGateway id="parallelgateway2" name="Parallel Gateway"></parallelGateway>
+    <sequenceFlow id="flow1" sourceRef="startevent1" targetRef="parallelgateway1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="parallelgateway1" targetRef="usertask1"></sequenceFlow>
+    <sequenceFlow id="flow3" sourceRef="parallelgateway1" targetRef="usertask2"></sequenceFlow>
+    <sequenceFlow id="flow4" sourceRef="usertask1" targetRef="parallelgateway2"></sequenceFlow>
+    <sequenceFlow id="flow5" sourceRef="usertask2" targetRef="parallelgateway2"></sequenceFlow>
+    <userTask id="usertask3" name="User Task"></userTask>
+    <sequenceFlow id="flow6" sourceRef="parallelgateway2" targetRef="usertask3"></sequenceFlow>
+    <sequenceFlow id="flow7" sourceRef="usertask3" targetRef="endevent1"></sequenceFlow>
+  </process>
+</definitions>


### PR DESCRIPTION
We added the alternative query method to includeProcessVariables criteria.
We intend to resolve includeProcessVariables problem by this fix.

# IncludeProcessVariables problem

If we use includeProcessVariables, we cannot use LIMIT/OFFSET sql pagination and cannot get records after 20,000.
https://github.com/Activiti/Activiti/commit/093aed84401c7f7b33f1bdb3adaea5959b406bbd
https://forums.activiti.org/content/using-includeprocessvariables-historyservicecreatehistoricprocessinstancequery
https://forums.activiti.org/content/limitation-query-tasks-variables
https://forums.activiti.org/content/static-records-limit-taskentitymanager

# Solution

We can resolve includeProcessVariables problem by dividing the query.

1. First query

We get only tasks/processInstances by setting includeProcessVariables flag false.

2. Second query

We get only variables by setting the search criteria of tasks/processInstances.