### PR TITLE
omitting the protocol (scheme) / behind SSL proxy

### DIFF
--- a/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/login/ExplorerLoginForm.java
+++ b/modules/activiti-explorer/src/main/java/org/activiti/explorer/ui/login/ExplorerLoginForm.java
@@ -51,6 +51,11 @@ public class ExplorerLoginForm extends LoginForm {
     String appUri = getApplication().getURL().toString()
             + getWindow().getName() + "/";
 
+    // omitting the protocol (scheme) in order to preserve the one of the current page
+    // getURL() returns "http" scheme when SSL is provided by e.g. load-balancer
+    // http://stackoverflow.com/questions/4978235/absolute-urls-omitting-the-protocol-scheme-in-order-to-preserve-the-one-of-the
+    appUri = appUri.replaceFirst("^(http://|https://)","//");
+
     String x, h, b; // XML header, HTML head and body
     
     x = "<!DOCTYPE html PUBLIC \"-//W3C//DTD "


### PR DESCRIPTION
.getURL() returns "http" scheme when SSL is provided by e.g. load-balancer.

Browser warning:
"Mixed Content: The page at 'https://domain/activiti-explorer/ui/APP/2/login' was loaded over a secure connection, but contains a form which targets an insecure endpoint 'http://domain/activiti-explorer/ui/1/loginHandler'. This endpoint should be made available over a secure connection."

If you hit "login", request is blocked by browser:
"Mixed Content: The page at 'https://domain/activiti-explorer/ui/APP/2/login' was loaded over HTTPS, but requested an insecure form action 'http://domain/activiti-explorer/ui/1/loginHandler'. This request has been blocked; the content must be served over HTTPS."

Solution is omitting the protocol (scheme) in order to preserve the one of the current page:
http://stackoverflow.com/questions/4978235/absolute-urls-omitting-the-protocol-scheme-in-order-to-preserve-the-one-of-the