### PR TITLE
Refactor test to run under JDK7 and JDK8

### DIFF
--- a/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/scripttask/ScriptTaskTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/bpmn/scripttask/ScriptTaskTest.java
@@ -86,20 +86,20 @@ public class ScriptTaskTest extends PluggableActivitiTestCase {
       assertTextPresent("No script provided", e.getMessage());
     }
   }
-  
+
   @Deployment
   public void testDynamicScript() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("testDynamicScript", CollectionUtil.map("a", 20, "b", 22));
-    assertEquals(42.0, runtimeService.getVariable(processInstance.getId(), "test"));
+    assertEquals(42, ((Number) runtimeService.getVariable(processInstance.getId(), "test")).intValue());
     taskService.complete(taskService.createTaskQuery().singleResult().getId());
     assertProcessEnded(processInstance.getId());
-    
+
     String processDefinitionId = processInstance.getProcessDefinitionId();
     ObjectNode infoNode = dynamicBpmnService.changeScriptTaskScript("script1", "var sum = c + d;\nexecution.setVariable('test2', sum);");
     dynamicBpmnService.saveProcessDefinitionInfo(processDefinitionId, infoNode);
-    
+
     processInstance = runtimeService.startProcessInstanceByKey("testDynamicScript", CollectionUtil.map("c", 10, "d", 12));
-    assertEquals(22.0, runtimeService.getVariable(processInstance.getId(), "test2"));
+    assertEquals(22, ((Number) runtimeService.getVariable(processInstance.getId(), "test2")).intValue());
     taskService.complete(taskService.createTaskQuery().singleResult().getId());
     assertProcessEnded(processInstance.getId());
   }


### PR DESCRIPTION
Changed the script test so it works across JDK7 and JDK8 on OSX, Windows, and Linux.  This small change is "copied" from the method used in the previous test method (testAutoStoreVariables) at line 79.  This change "standardizes" the result so the assertEquals() is successful.