### PR TITLE
Fix NPE occured on referring HistoricVariableUpdate(Serializable Type)

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceHistoryLogQueryImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.activiti.engine.history.HistoricActivityInstance;
 import org.activiti.engine.history.HistoricData;
 import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.history.HistoricVariableUpdate;
 import org.activiti.engine.history.ProcessInstanceHistoryLog;
 import org.activiti.engine.history.ProcessInstanceHistoryLogQuery;
 import org.activiti.engine.impl.interceptor.Command;
@@ -139,6 +140,13 @@ public class ProcessInstanceHistoryLogQueryImpl implements ProcessInstanceHistor
 		if (includeVariableUpdates) {
 			List<? extends HistoricData> variableUpdates = commandContext.getHistoricDetailEntityManager()
 					.findHistoricDetailsByQueryCriteria(new HistoricDetailQueryImpl(commandExecutor).variableUpdates(), null);
+			
+			// Make sure all variables values are fetched (similar to the HistoricVariableInstance query)
+			for(HistoricData historicData : variableUpdates){
+				HistoricVariableUpdate variableUpdate = (HistoricVariableUpdate) historicData;
+				variableUpdate.getValue();
+			}
+			
 			processInstanceHistoryLog.addHistoricData(variableUpdates);
 		}
 		

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/ProcessInstanceLogQueryAndByteArrayTypeVariableTest.java
@@ -6,9 +6,11 @@ import java.util.Map;
 
 import org.activiti.engine.history.HistoricData;
 import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.history.HistoricVariableUpdate;
 import org.activiti.engine.history.ProcessInstanceHistoryLog;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.persistence.entity.HistoricVariableInstanceEntity;
+import org.activiti.engine.impl.persistence.entity.HistoricDetailVariableInstanceUpdateEntity;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.task.Task;
 
@@ -69,6 +71,26 @@ public class ProcessInstanceLogQueryAndByteArrayTypeVariableTest extends Pluggab
 			for (HistoricData event : events) {
 				assertTrue(event instanceof HistoricVariableInstance);
 				assertEquals(((HistoricVariableInstanceEntity) event).getValue(), LARGE_STRING_VALUE);
+			}
+		}
+	}
+	
+	public void testIncludeVariableUpdates() {
+		if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.FULL)) {
+			
+			HistoricVariableInstance historicVariableInstance = historyService.createHistoricVariableInstanceQuery()
+					.processInstanceId(processInstanceId).variableName("var").singleResult();
+			assertEquals(historicVariableInstance.getValue(), LARGE_STRING_VALUE);
+			
+			ProcessInstanceHistoryLog log = historyService.createProcessInstanceHistoryLogQuery(processInstanceId)
+				.includeVariableUpdates()
+				.singleResult();
+			List<HistoricData> events = log.getHistoricData();
+			assertEquals(1, events.size());
+			
+			for (HistoricData event : events) {
+				assertTrue(event instanceof HistoricVariableUpdate);
+				assertEquals(((HistoricDetailVariableInstanceUpdateEntity) event).getValue(), LARGE_STRING_VALUE);
 			}
 		}
 	}


### PR DESCRIPTION
We fixed that NullpointerException occured on referring HistoricVariableUpdate(Serializable Type).

## Similar issues

* https://activiti.atlassian.net/browse/ACT-863

* https://github.com/Activiti/Activiti/pull/755