### PR TITLE
fix: only draw the first process in bpmn model

### DIFF
--- a/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
+++ b/modules/activiti-image-generator/src/main/java/org/activiti/image/impl/DefaultProcessDiagramGenerator.java
@@ -489,8 +489,10 @@ public class DefaultProcessDiagramGenerator implements ProcessDiagramGenerator {
     }
     
     // Draw activities and their sequence-flows
-    for (FlowNode flowNode : bpmnModel.getProcesses().get(0).findFlowElementsOfType(FlowNode.class)) {
-      drawActivity(processDiagramCanvas, bpmnModel, flowNode, highLightedActivities, highLightedFlows, scaleFactor);
+    for (Process process: bpmnModel.getProcesses()) {
+      for (FlowNode flowNode : process.findFlowElementsOfType(FlowNode.class)) {
+        drawActivity(processDiagramCanvas, bpmnModel, flowNode, highLightedActivities, highLightedFlows, scaleFactor);
+      }
     }
     
     // Draw artifacts


### PR DESCRIPTION
Now  DefaultProcessDiagramGenerator has a bug:
  It only draw the first process in bpmn model, if there are more than one processes in the model.

Example:
model in the eclipse desinger:
![snap2](https://cloud.githubusercontent.com/assets/8803140/15932330/d079155c-2e8d-11e6-8ff7-2765b29b0fec.png)
image generated by DefaultProcessDiagramGenerator:
![snap3](https://cloud.githubusercontent.com/assets/8803140/15932345/dcd37e8c-2e8d-11e6-8e69-f549762d8df2.jpg)

This patch fixes it.
Image generated by the patched code:
![snap5](https://cloud.githubusercontent.com/assets/8803140/15932409/2a4cec8e-2e8e-11e6-848c-49c6fc9aab88.jpg)

