### PR TITLE
Fix - GetTaskDataObjectCmd should return a dataobject when locale is …

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskDataObjectCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/GetTaskDataObjectCmd.java
@@ -72,54 +72,53 @@ public class GetTaskDataObjectCmd implements Command<DataObject>, Serializable {
     DataObject dataObject = null;
     VariableInstance variableEntity = task.getVariableInstance(variableName, false);
 
-    if (locale != null) {
-      String localizedName = null;
-      String localizedDescription = null;
-      
-      if (variableEntity != null) {
-        ExecutionEntity executionEntity = commandContext.getExecutionEntityManager().findById(variableEntity.getExecutionId());
-        while (!executionEntity.isScope()) {
-          executionEntity = executionEntity.getParent();
-        }
-        
-        BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(executionEntity.getProcessDefinitionId());
-        ValuedDataObject foundDataObject = null;
-        if (executionEntity.getParentId() == null) {
-          for (ValuedDataObject dataObjectDefinition : bpmnModel.getMainProcess().getDataObjects()) {
-            if (dataObjectDefinition.getName().equals(variableEntity.getName())) {
-              foundDataObject = dataObjectDefinition;
-              break;
-            }
+    String localizedName = null;
+    String localizedDescription = null;
+
+    if (variableEntity != null) {
+      ExecutionEntity executionEntity = commandContext.getExecutionEntityManager().findById(variableEntity.getExecutionId());
+      while (!executionEntity.isScope()) {
+        executionEntity = executionEntity.getParent();
+      }
+
+      BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(executionEntity.getProcessDefinitionId());
+      ValuedDataObject foundDataObject = null;
+      if (executionEntity.getParentId() == null) {
+        for (ValuedDataObject dataObjectDefinition : bpmnModel.getMainProcess().getDataObjects()) {
+          if (dataObjectDefinition.getName().equals(variableEntity.getName())) {
+            foundDataObject = dataObjectDefinition;
+            break;
           }
-       
-        } else {
-          SubProcess subProcess = (SubProcess) bpmnModel.getFlowElement(executionEntity.getActivityId());
-          for (ValuedDataObject dataObjectDefinition : subProcess.getDataObjects()) {
-            if (dataObjectDefinition.getName().equals(variableEntity.getName())) {
-              foundDataObject = dataObjectDefinition;
-              break;
-            }
+        } 
+      } else {
+        SubProcess subProcess = (SubProcess) bpmnModel.getFlowElement(executionEntity.getActivityId());
+        for (ValuedDataObject dataObjectDefinition : subProcess.getDataObjects()) {
+          if (dataObjectDefinition.getName().equals(variableEntity.getName())) {
+            foundDataObject = dataObjectDefinition;
+            break;
           }
-        }
-        
-        if (locale != null && foundDataObject != null) {
-          ObjectNode languageNode = Context.getLocalizationElementProperties(locale, foundDataObject.getId(), task.getProcessDefinitionId(), withLocalizationFallback);
-          if (languageNode != null) {
-            JsonNode nameNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_NAME);
-            if (nameNode != null) {
-              localizedName = nameNode.asText();
-            }
-            JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
-            if (descriptionNode != null) {
-              localizedDescription = descriptionNode.asText();
-            }
-          }
-        }
-        if (foundDataObject != null) {
-          dataObject = new DataObjectImpl(variableEntity, foundDataObject.getDocumentation(), localizedName, localizedDescription, foundDataObject.getId());
         }
       }
+
+      if (locale != null && foundDataObject != null) {
+        ObjectNode languageNode = Context.getLocalizationElementProperties(locale, foundDataObject.getId(), task.getProcessDefinitionId(), withLocalizationFallback);
+        if (languageNode != null) {
+          JsonNode nameNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_NAME);
+          if (nameNode != null) {
+            localizedName = nameNode.asText();
+          }
+          JsonNode descriptionNode = languageNode.get(DynamicBpmnConstants.LOCALIZATION_DESCRIPTION);
+          if (descriptionNode != null) {
+            localizedDescription = descriptionNode.asText();
+          }
+        }
+      }
+
+      if (foundDataObject != null) {
+        dataObject = new DataObjectImpl(variableEntity, foundDataObject.getDocumentation(), localizedName, localizedDescription, foundDataObject.getId());
+      }
     }
+
     return dataObject;
   }
 }

--- a/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/examples/variables/VariablesTest.java
@@ -791,8 +791,21 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertEquals("intVar 'default' description", dataObject.getDescription());
     assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
     assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
-    
+
     // getDataObjects
+    dataObjects = taskService.getDataObjects(task.getId());
+    assertEquals(2, dataObjects.size());
+    assertEquals("stringVar", dataObjects.get("stringVar").getName());
+    assertEquals("coca-cola", dataObjects.get("stringVar").getValue());
+    assertEquals("stringVar", dataObjects.get("stringVar").getLocalizedName());
+    assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
+    assertEquals("intVar", dataObject.getName());
+    assertEquals(null, dataObject.getValue());
+    assertEquals("intVar", dataObject.getLocalizedName());
+    assertEquals("intVar 'default' description", dataObject.getDescription());
+    assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
+    assertEquals("intVarId", dataObjects.get("intVar").getDataObjectDefinitionKey());
+
     dataObjects = taskService.getDataObjects(task.getId(), "en-US", false);
     assertEquals(2, dataObjects.size());
     assertEquals("stringVar", dataObjects.get("stringVar").getName());
@@ -872,7 +885,7 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertEquals("stringVar 'en' Name", dataObjects.get("stringVar").getLocalizedName());
     assertEquals("stringVar 'en' Description", dataObjects.get("stringVar").getDescription());
     assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-    
+
     dataObjects = taskService.getDataObjects(task.getId(), variableNames, "en-GB", false);
     assertEquals(1, dataObjects.size());
     assertEquals("stringVar", dataObjects.get("stringVar").getName());
@@ -881,8 +894,16 @@ public class VariablesTest extends PluggableActivitiTestCase {
     assertEquals("stringVar 'default' description", dataObjects.get("stringVar").getDescription());
     assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
     assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
-    
+
     // getDataObject
+    dataObject = taskService.getDataObject(task.getId(), "stringVar");
+    assertNotNull(dataObject);
+    assertEquals("stringVar", dataObject.getName());
+    assertEquals("coca-cola", dataObject.getValue());
+    assertEquals("stringVar", dataObject.getLocalizedName());
+    assertEquals("stringVar 'default' description", dataObject.getDescription());
+    assertEquals("stringVarId", dataObjects.get("stringVar").getDataObjectDefinitionKey());
+
     dataObject = taskService.getDataObject(task.getId(), "stringVar", "en-GB", false);
     assertNotNull(dataObject);
     assertEquals("stringVar", dataObject.getName());


### PR DESCRIPTION
…null.

Missed removing the if(locale != null) check when refactoring the GetTaskDataObjectCmd. Including the check results in a null value being returned when the locale is null. 

Added two additional tests to verify behavior retrieving a data object from a task without a locale works correctly.
