### PR TITLE
ACT-4191 BPMNDI data not generated without sequence flows

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/SubprocessXMLConverter.java
@@ -89,7 +89,7 @@ public class SubprocessXMLConverter extends BpmnXMLConverter {
       // refactor each subprocess into a separate Diagram
       List<BpmnModel> subModels = parseSubModels(model);
       for (BpmnModel tempModel : subModels) {
-        if (!tempModel.getFlowLocationMap().isEmpty()) {
+        if (!tempModel.getFlowLocationMap().isEmpty() || !tempModel.getLocationMap().isEmpty()) {
           BPMNDIExport.writeBPMNDI(tempModel, xtw);
         }
       }


### PR DESCRIPTION
If no sequence flows are defined, the BPMNDI export step is skipped.
This is only an issue with partial (draft) diagrams that are saved prior
to completion using the our workflow definition editor. It is unlikely
that a valid diagram will have no sequence flows.