### PR TITLE
Remove duplicate creation of indexes for DB2 engine table.

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
@@ -379,10 +379,7 @@ alter table ACT_RU_VARIABLE
     foreign key (BYTEARRAY_ID_) 
     references ACT_GE_BYTEARRAY (ID_);
     
-create index ACT_IDX_JOB_PROCESS_INSTANCE_ID on ACT_RU_JOB(PROCESS_INSTANCE_ID_);
-create index ACT_IDX_JOB_PROC_DEF_ID on ACT_RU_JOB(PROC_DEF_ID_);
-
-alter table ACT_RU_JOB 
+alter table ACT_RU_JOB
     add constraint ACT_FK_JOB_EXECUTION 
     foreign key (EXECUTION_ID_) 
     references ACT_RU_EXECUTION (ID_);


### PR DESCRIPTION
These two indexes are created on lines 291 and 292 and again on lines 382 and 283.
This request removes the second set.

```sql
create index ACT_IDX_JOB_PROCESS_INSTANCE_ID on ACT_RU_JOB(PROCESS_INSTANCE_ID_);
create index ACT_IDX_JOB_PROC_DEF_ID on ACT_RU_JOB(PROC_DEF_ID_);
```