### PR TITLE
further changes after the removal of ActivityExecution

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BpmnActivityBehavior.java
@@ -55,15 +55,15 @@ public class BpmnActivityBehavior implements Serializable {
    * @param activityExecution
    */
   protected void dispatchJobCanceledEvents(ExecutionEntity activityExecution) {
-    if (activityExecution instanceof ExecutionEntity) {
-      List<JobEntity> jobs = ((ExecutionEntity) activityExecution).getJobs();
+    if (activityExecution != null) {
+      List<JobEntity> jobs = activityExecution.getJobs();
       for (JobEntity job : jobs) {
         if (Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
           Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.JOB_CANCELED, job));
         }
       }
       
-      List<TimerJobEntity> timerJobs = ((ExecutionEntity) activityExecution).getTimerJobs();
+      List<TimerJobEntity> timerJobs = activityExecution.getTimerJobs();
       for (TimerJobEntity job : timerJobs) {
         if (Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
           Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.JOB_CANCELED, job));
@@ -73,7 +73,7 @@ public class BpmnActivityBehavior implements Serializable {
   }
 
   /**
-   * Performs the default outgoing BPMN 2.0 behavior (@see {@link #performDefaultOutgoingBehavior(ActivityExecution)}), but without checking the conditions on the outgoing sequence flow.
+   * Performs the default outgoing BPMN 2.0 behavior (@see {@link #performDefaultOutgoingBehavior(ExecutionEntity)}), but without checking the conditions on the outgoing sequence flow.
    * 
    * This means that every outgoing sequence flow is selected for continuing the process instance, regardless of having a condition or not. In case of multiple outgoing sequence flow, multiple
    * parallel paths of executions will be created.


### PR DESCRIPTION
As part of the [19fad05](https://github.com/Activiti/Activiti/commit/19fad051eb349eee9abd570bd44c86c8473c4983#diff-7f31b80a406e836752411a3dcdfa6766) commit on 8/27/2015, when ActivityExecution was removed it appears that a change to the method parameters was made but there are some subsequent changes to the code that are applicable:

(1) fix the javadoc
(2) remove the ExecutionEntity casts as the parameter is already an ExecutionEintity
(3) remove the instanceOf test for the same reason; I replaced it with a null check just to be safe