### PR TITLE
String comparison should use equals()

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/json/JSONML.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/json/JSONML.java
@@ -155,7 +155,7 @@ public class JSONML {
             // attribute = value
 
             attribute = (String) token;
-            if (!arrayForm && (attribute == "tagName" || attribute == "childNode")) {
+            if (!arrayForm && (attribute.equals("tagName") || attribute.equals("childNode"))) {
               throw x.syntaxError("Reserved attribute.");
             }
             token = x.nextToken();


### PR DESCRIPTION
This same fix was made to the [reference implementation](https://github.com/stleary/JSON-java) code base from which this was dervived on 01/03/2012. The commits are [a264baea ](https://github.com/stleary/JSON-java/commit/a264baea0e02c2c1494847306a2d31a13002d331) and [48dccd9 ](https://github.com/stleary/JSON-java/commit/48dccd91e78466a1943783fa914aebce50e2cab0).