### PR TITLE
set retries makes job reexecutable again

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Job.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Job.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" ?> 
+<?xml version="1.0" encoding="UTF-8" ?>
 
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd"> 
-  
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
 <mapper namespace="org.activiti.engine.impl.persistence.entity.JobEntity">
 
   <!-- JOB DELETE STATEMENTS-->
@@ -9,36 +9,36 @@
   <delete id="deleteJob" parameterType="org.activiti.engine.impl.persistence.entity.JobEntity">
     delete from ${prefix}ACT_RU_JOB where ID_ = #{id} and REV_ = #{revision}
   </delete>
-  
+
   <delete id="bulkDeleteJob" parameterType="java.util.Collection">
     delete from ${prefix}ACT_RU_JOB where
      <foreach item="job" collection="list" index="index" separator=" or ">
         ID_ = #{job.id, jdbcType=VARCHAR}
-    </foreach> 
+    </foreach>
   </delete>
-  
+
   <delete id="deleteTimer" parameterType="org.activiti.engine.impl.persistence.entity.JobEntity">
     delete from ${prefix}ACT_RU_JOB where ID_ = #{id} and REV_ = #{revision}
   </delete>
-  
+
   <delete id="bulkDeleteTimer" parameterType="java.util.Collection">
     delete from ${prefix}ACT_RU_JOB where
      <foreach item="job" collection="list" index="index" separator=" or ">
         ID_ = #{job.id, jdbcType=VARCHAR}
-    </foreach> 
+    </foreach>
   </delete>
-  
+
   <delete id="deleteMessage" parameterType="org.activiti.engine.impl.persistence.entity.JobEntity">
     delete from ${prefix}ACT_RU_JOB where ID_ = #{id} and REV_ = #{revision}
   </delete>
-  
+
   <delete id="bulkDeleteMessage" parameterType="java.util.Collection">
     delete from ${prefix}ACT_RU_JOB where
      <foreach item="job" collection="list" index="index" separator=" or ">
         ID_ = #{job.id, jdbcType=VARCHAR}
-    </foreach> 
+    </foreach>
   </delete>
-  
+
   <!-- JOB UPDATE STATEMENTS -->
   <update id="updateJobTenantIdForDeployment" parameterType="java.util.Map">
     update ${prefix}ACT_RU_JOB set
@@ -47,11 +47,11 @@
       ID_ in (
         SELECT J.ID_ from ${prefix}ACT_RU_JOB J
         inner join ${prefix}ACT_RE_PROCDEF P on J.PROC_DEF_ID_  = P.ID_
-        inner join ${prefix}ACT_RE_DEPLOYMENT D on P.DEPLOYMENT_ID_ = D.ID_ 
+        inner join ${prefix}ACT_RE_DEPLOYMENT D on P.DEPLOYMENT_ID_ = D.ID_
         where D.ID_ = #{deploymentId, jdbcType=VARCHAR}
-      ) 
+      )
   </update>
-  
+
   <update id="updateJobLockForAllJobs" parameterType="java.util.Map">
     update ${prefix}ACT_RU_JOB set
       LOCK_OWNER_ = #{lockOwner, jdbcType=VARCHAR},
@@ -60,15 +60,15 @@
       (RETRIES_ &gt; 0)
       and (DUEDATE_ is null or DUEDATE_ &lt;= #{dueDate, jdbcType=TIMESTAMP})
       and (LOCK_OWNER_ is null)
-      
+
 	 <!--  and (
 	  	    (EXECUTION_ID_ is null)
-	  		or 
+	  		or
 	  		(PI.SUSPENSION_STATE_ = 1)
-      ) 
+      )
         -->
   </update>
-    
+
   <!-- See http://stackoverflow.com/questions/4429319/you-cant-specify-target-table-for-update-in-from-clause
        Tested this on MySQL 5.6: does NOT use a temporary table (so good, performance) -->
   <update id="updateJobTenantIdForDeployment_mysql" parameterType="java.util.Map">
@@ -82,14 +82,14 @@
                 SELECT J.ID_ as tempId
                 FROM  ${prefix}ACT_RU_JOB J
                 inner join ${prefix}ACT_RE_PROCDEF P on J.PROC_DEF_ID_  = P.ID_
-                inner join ${prefix}ACT_RE_DEPLOYMENT D on P.DEPLOYMENT_ID_ = D.ID_ 
+                inner join ${prefix}ACT_RE_DEPLOYMENT D on P.DEPLOYMENT_ID_ = D.ID_
                 where D.ID_ = #{deploymentId, jdbcType=VARCHAR}
-                
-        ) AS tempTask 
+
+        ) AS tempTask
 
     )
   </update>
-  
+
   <!-- JOB RESULTMAP (FOR TIMER AND MESSAGE) -->
 
   <resultMap id="jobResultMap" type="org.activiti.engine.impl.persistence.entity.JobEntity">
@@ -108,8 +108,8 @@
     <result property="jobHandlerConfiguration" column="HANDLER_CFG_" jdbcType="VARCHAR" />
     <result property="tenantId" column="TENANT_ID_" jdbcType="VARCHAR" />
     <discriminator javaType="string" column="TYPE_">
-      <case value="message" resultMap="messageResultMap"/> 
-      <case value="timer" resultMap="timerResultMap"/> 
+      <case value="message" resultMap="messageResultMap"/>
+      <case value="timer" resultMap="timerResultMap"/>
     </discriminator>
   </resultMap>
 
@@ -120,7 +120,7 @@
     <result property="repeat" column="REPEAT_" jdbcType="VARCHAR" />
   </resultMap>
 
-  <!-- JOB SELECT (FOR TIMER AND MESSAGE) -->  
+  <!-- JOB SELECT (FOR TIMER AND MESSAGE) -->
 
   <select id="selectJob" parameterType="string" resultMap="jobResultMap">
     select * from ${prefix}ACT_RU_JOB where ID_ = #{id}
@@ -128,26 +128,26 @@
 
   <select id="selectNextJobsToExecute" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
   	${limitBefore}
-    select 
-    	RES.* ${limitBetween}    		
-    from ${prefix}ACT_RU_JOB RES    
+    select
+    	RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
     	LEFT OUTER JOIN ${prefix}ACT_RU_EXECUTION PI ON PI.ID_ = RES.PROCESS_INSTANCE_ID_
     where (RES.RETRIES_ &gt; 0)
       and (RES.DUEDATE_ is null or RES.DUEDATE_ &lt;= #{parameter, jdbcType=TIMESTAMP})
       and (RES.LOCK_OWNER_ is null or RES.LOCK_EXP_TIME_ &lt;= #{parameter, jdbcType=TIMESTAMP})
 	    and (
 	  	    (RES.EXECUTION_ID_ is null)
-	  		  or 
+	  		  or
 	  		  (PI.SUSPENSION_STATE_ = 1)
-      )  
-    ${limitAfter}	    
+      )
+    ${limitAfter}
   </select>
-  
+
   <select id="selectNextTimerJobsToExecute" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     ${limitBefore}
-    select 
-      RES.* ${limitBetween}       
-    from ${prefix}ACT_RU_JOB RES    
+    select
+      RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
       LEFT OUTER JOIN ${prefix}ACT_RU_EXECUTION PI ON PI.ID_ = RES.PROCESS_INSTANCE_ID_
     where (RES.RETRIES_ &gt; 0)
       and (RES.DUEDATE_ is null or RES.DUEDATE_ &lt;= #{parameter, jdbcType=TIMESTAMP})
@@ -155,67 +155,69 @@
       and TYPE_ = 'timer'
       and (
           (RES.EXECUTION_ID_ is null)
-          or 
+          or
           (PI.SUSPENSION_STATE_ = 1)
-      )  
-    ${limitAfter}     
+      )
+    ${limitAfter}
   </select>
-  
+
   <select id="selectAsyncJobsDueToExecute" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     ${limitBefore}
-    select 
-      RES.* ${limitBetween}       
-    from ${prefix}ACT_RU_JOB RES    
+    select
+      RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
       LEFT OUTER JOIN ${prefix}ACT_RU_EXECUTION PI ON PI.ID_ = RES.PROCESS_INSTANCE_ID_
     where RES.RETRIES_ &gt; 0
-       and ( 
+       and (
+        (RES.LOCK_EXP_TIME_ is null and RES.DUEDATE_ is null)
+        or
         (RES.DUEDATE_ is not null and RES.DUEDATE_ &lt;= #{parameter, jdbcType=TIMESTAMP} and RES.LOCK_EXP_TIME_ is null)
-        or 
+        or
         (RES.LOCK_EXP_TIME_ is not null and RES.LOCK_EXP_TIME_ &lt;= #{parameter, jdbcType=TIMESTAMP})
       )
       and TYPE_ = 'message'
       and (
           (RES.EXECUTION_ID_ is null)
-          or 
+          or
           (PI.SUSPENSION_STATE_ = 1)
-      )  
-    ${limitAfter}     
+      )
+    ${limitAfter}
   </select>
-  
+
   <select id="selectJobsByLockOwner" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
   	${limitBefore}
-    select 
-    	RES.* ${limitBetween}    		
-    from ${prefix}ACT_RU_JOB RES    
+    select
+    	RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
     where (RES.LOCK_OWNER_ = #{parameter, jdbcType=VARCHAR})
     order by ID_ <!-- Need to have some definitive ordering to have a correct check in place during job fetching -->
-    ${limitAfter}	    
-  </select>   
-  
+    ${limitAfter}
+  </select>
+
   <select id="selectExclusiveJobsToExecute" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
   	${limitBefore}
-    select RES.* ${limitBetween} 
-    from ${prefix}ACT_RU_JOB RES    
+    select RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
     where (RETRIES_ &gt; 0)
       and (DUEDATE_ is null or DUEDATE_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (LOCK_OWNER_ is null or LOCK_EXP_TIME_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (EXCLUSIVE_ = TRUE)
-      and (PROCESS_INSTANCE_ID_ = #{parameter.pid})  
+      and (PROCESS_INSTANCE_ID_ = #{parameter.pid})
     ${limitAfter}
   </select>
-  
+
   <select id="selectExclusiveJobsToExecute_integerBoolean" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
   	${limitBefore}
-    select RES.* ${limitBetween} 
-    from ${prefix}ACT_RU_JOB RES  
+    select RES.* ${limitBetween}
+    from ${prefix}ACT_RU_JOB RES
     where (RETRIES_ &gt; 0)
       and (DUEDATE_ is null or DUEDATE_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (LOCK_OWNER_ is null or LOCK_EXP_TIME_ &lt;= #{parameter.now, jdbcType=TIMESTAMP})
       and (EXCLUSIVE_ = 1)
-      and (PROCESS_INSTANCE_ID_ = #{parameter.pid})  
-    ${limitAfter}   
+      and (PROCESS_INSTANCE_ID_ = #{parameter.pid})
+    ${limitAfter}
   </select>
-  
+
   <select id="selectJobsByConfiguration" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
       select * from ${prefix}ACT_RU_JOB
       where HANDLER_TYPE_ = #{parameter.handlerType}
@@ -227,32 +229,32 @@
     from ${prefix}ACT_RU_JOB J
     where J.EXECUTION_ID_ = #{parameter}
   </select>
-  
+
    <select id="selectJobByTypeAndProcessDefinitionKeyNoTenantId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     select J.*
     from ${prefix}ACT_RU_JOB J
     inner join ${prefix}ACT_RE_PROCDEF P on J.PROC_DEF_ID_ = P.ID_
-    where J.HANDLER_TYPE_ = #{parameter.handlerType} 
+    where J.HANDLER_TYPE_ = #{parameter.handlerType}
     and P.KEY_ = #{parameter.processDefinitionKey}
-    and (P.TENANT_ID_ = ''  or P.TENANT_ID_ is null)  
+    and (P.TENANT_ID_ = ''  or P.TENANT_ID_ is null)
   </select>
-  
+
   <select id="selectJobByTypeAndProcessDefinitionKeyAndTenantId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     select J.*
     from ${prefix}ACT_RU_JOB J
     inner join ${prefix}ACT_RE_PROCDEF P on J.PROC_DEF_ID_ = P.ID_
-    where J.HANDLER_TYPE_ = #{parameter.handlerType} 
+    where J.HANDLER_TYPE_ = #{parameter.handlerType}
     and P.KEY_ = #{parameter.processDefinitionKey}
-    and P.TENANT_ID_ = #{parameter.tenantId} 
+    and P.TENANT_ID_ = #{parameter.tenantId}
   </select>
-  
+
   <select id="selectJobByTypeAndProcessDefinitionId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     select J.*
     from ${prefix}ACT_RU_JOB J
     where J.HANDLER_TYPE_ = #{parameter.handlerType}
-    and J.PROC_DEF_ID_ = #{parameter.processDefinitionId} 
+    and J.PROC_DEF_ID_ = #{parameter.processDefinitionId}
   </select>
-  
+
   <select id="selectJobByQueryCriteria" parameterType="org.activiti.engine.impl.JobQueryImpl" resultMap="jobResultMap">
   	${limitBefore}
     select RES.* ${limitBetween}
@@ -265,7 +267,7 @@
     select count(distinct RES.ID_)
     <include refid="selectJobByQueryCriteriaSql"/>
   </select>
-  
+
   <sql id="selectJobByQueryCriteriaSql">
     from ${prefix}ACT_RU_JOB RES
     <if test="executable">
@@ -295,8 +297,8 @@
         and (RES.DUEDATE_ is null or RES.DUEDATE_ &lt;= #{now, jdbcType=TIMESTAMP})
         and (
             (RES.EXECUTION_ID_ is null)
-            or 
-            (PI.SUSPENSION_STATE_ = 1)     
+            or
+            (PI.SUSPENSION_STATE_ = 1)
       )
       </if>
       <if test="onlyTimers">
@@ -336,19 +338,19 @@
   </sql>
 
   <!-- TIMER INSERT -->
-  
+
   <insert id="insertTimer" parameterType="org.activiti.engine.impl.persistence.entity.TimerEntity">
     insert into ${prefix}ACT_RU_JOB (
-            ID_, 
+            ID_,
             REV_,
             TYPE_,
-            LOCK_OWNER_, 
+            LOCK_OWNER_,
             LOCK_EXP_TIME_,
             EXCLUSIVE_,
-            EXECUTION_ID_, 
+            EXECUTION_ID_,
             PROCESS_INSTANCE_ID_,
             PROC_DEF_ID_,
-            RETRIES_, 
+            RETRIES_,
             EXCEPTION_STACK_ID_,
             EXCEPTION_MSG_,
             DUEDATE_,
@@ -378,24 +380,24 @@
 
   <insert id="bulkInsertTimer" parameterType="java.util.List">
     INSERT INTO ${prefix}ACT_RU_JOB (
-            ID_, 
+            ID_,
             REV_,
             TYPE_,
-            LOCK_OWNER_, 
+            LOCK_OWNER_,
             LOCK_EXP_TIME_,
             EXCLUSIVE_,
-            EXECUTION_ID_, 
+            EXECUTION_ID_,
             PROCESS_INSTANCE_ID_,
             PROC_DEF_ID_,
-            RETRIES_, 
+            RETRIES_,
             EXCEPTION_STACK_ID_,
             EXCEPTION_MSG_,
             DUEDATE_,
             REPEAT_,
             HANDLER_TYPE_,
             HANDLER_CFG_,
-            TENANT_ID_) VALUES 
-    <foreach collection="list" item="job" index="index" separator=","> 
+            TENANT_ID_) VALUES
+    <foreach collection="list" item="job" index="index" separator=",">
         (#{job.id, jdbcType=VARCHAR},
          1,
          #{job.jobType, jdbcType=VARCHAR},
@@ -417,26 +419,26 @@
   </insert>
 
   <insert id="bulkInsertTimer_oracle" parameterType="java.util.List">
-    INSERT ALL 
-    <foreach collection="list" item="job" index="index"> 
+    INSERT ALL
+    <foreach collection="list" item="job" index="index">
       INTO ${prefix}ACT_RU_JOB (
-              ID_, 
+              ID_,
               REV_,
               TYPE_,
-              LOCK_OWNER_, 
+              LOCK_OWNER_,
               LOCK_EXP_TIME_,
               EXCLUSIVE_,
-              EXECUTION_ID_, 
+              EXECUTION_ID_,
               PROCESS_INSTANCE_ID_,
               PROC_DEF_ID_,
-              RETRIES_, 
+              RETRIES_,
               EXCEPTION_STACK_ID_,
               EXCEPTION_MSG_,
               DUEDATE_,
               REPEAT_,
               HANDLER_TYPE_,
               HANDLER_CFG_,
-              TENANT_ID_) VALUES 
+              TENANT_ID_) VALUES
           (#{job.id, jdbcType=VARCHAR},
            1,
            #{job.jobType, jdbcType=VARCHAR},
@@ -474,9 +476,9 @@
     where ID_= #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
   </update>
-  
+
   <!-- TIMER SELECT -->
-  
+
   <select id="selectUnlockedTimersByDuedate" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
     select RES.*
     from ${prefix}ACT_RU_JOB RES
@@ -487,8 +489,8 @@
       and (RES.RETRIES_  &gt; 0)
       and (
         (RES.EXECUTION_ID_ is null)
-        or 
-        (PI.SUSPENSION_STATE_ = 1)    
+        or
+        (PI.SUSPENSION_STATE_ = 1)
       )
     order by DUEDATE_
   </select>
@@ -510,34 +512,34 @@
   </select>
 
   <select id="selectTimersByExecutionId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="jobResultMap">
-    select * 
-    from ${prefix}ACT_RU_JOB 
+    select *
+    from ${prefix}ACT_RU_JOB
     where (RETRIES_ &gt; 0)
       and (TYPE_ = 'timer')
       and (EXECUTION_ID_ = #{parameter})
   </select>
-  
+
 
   <!-- MESSAGE INSERT -->
 
   <insert id="bulkInsertMessage" parameterType="java.util.List">
     INSERT INTO ${prefix}ACT_RU_JOB (
-        ID_, 
-        REV_, 
+        ID_,
+        REV_,
         TYPE_,
-        LOCK_OWNER_, 
+        LOCK_OWNER_,
         LOCK_EXP_TIME_,
         EXCLUSIVE_,
-        EXECUTION_ID_, 
+        EXECUTION_ID_,
         PROCESS_INSTANCE_ID_,
         PROC_DEF_ID_,
         DUEDATE_,
-        RETRIES_, 
+        RETRIES_,
         EXCEPTION_STACK_ID_,
         EXCEPTION_MSG_,
         HANDLER_TYPE_,
         HANDLER_CFG_,
-        TENANT_ID_) VALUES 
+        TENANT_ID_) VALUES
     <foreach collection="list" item="job" index="index" separator=",">
       (#{job.id, jdbcType=VARCHAR},
        1,
@@ -559,25 +561,25 @@
   </insert>
 
   <insert id="bulkInsertMessage_oracle" parameterType="java.util.List">
-    INSERT ALL 
+    INSERT ALL
     <foreach collection="list" item="job" index="index">
       INTO ${prefix}ACT_RU_JOB (
-          ID_, 
-          REV_, 
+          ID_,
+          REV_,
           TYPE_,
-          LOCK_OWNER_, 
+          LOCK_OWNER_,
           LOCK_EXP_TIME_,
           EXCLUSIVE_,
-          EXECUTION_ID_, 
+          EXECUTION_ID_,
           PROCESS_INSTANCE_ID_,
           PROC_DEF_ID_,
           DUEDATE_,
-          RETRIES_, 
+          RETRIES_,
           EXCEPTION_STACK_ID_,
           EXCEPTION_MSG_,
           HANDLER_TYPE_,
           HANDLER_CFG_,
-          TENANT_ID_) VALUES 
+          TENANT_ID_) VALUES
       (#{job.id, jdbcType=VARCHAR},
        1,
        #{job.jobType, jdbcType=VARCHAR},
@@ -600,17 +602,17 @@
 
   <insert id="insertMessage" parameterType="org.activiti.engine.impl.persistence.entity.MessageEntity">
     insert into ${prefix}ACT_RU_JOB (
-            ID_, 
-            REV_, 
+            ID_,
+            REV_,
             TYPE_,
-            LOCK_OWNER_, 
+            LOCK_OWNER_,
             LOCK_EXP_TIME_,
             EXCLUSIVE_,
-            EXECUTION_ID_, 
+            EXECUTION_ID_,
             PROCESS_INSTANCE_ID_,
             PROC_DEF_ID_,
             DUEDATE_,
-            RETRIES_, 
+            RETRIES_,
             EXCEPTION_STACK_ID_,
             EXCEPTION_MSG_,
             HANDLER_TYPE_,
@@ -634,9 +636,9 @@
             #{tenantId, jdbcType=VARCHAR}
     )
   </insert>
-  
+
   <!-- MESSAGE UPDATE -->
-  
+
   <update id="updateMessage" parameterType="org.activiti.engine.impl.persistence.entity.MessageEntity">
     update ${prefix}ACT_RU_JOB
     <set>
@@ -651,7 +653,7 @@
     where ID_= #{id, jdbcType=VARCHAR}
       and REV_ = #{revision, jdbcType=INTEGER}
   </update>
-  
+
   <update id="unacquireJob" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject">
     update ${prefix}ACT_RU_JOB
     set DUEDATE_ = #{dueDate,jdbcType=TIMESTAMP}, LOCK_OWNER_ = null, LOCK_EXP_TIME_ = null

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/ManagementServiceTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/mgmt/ManagementServiceTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,22 +13,22 @@
 
 package org.activiti.engine.test.api.mgmt;
 
-import java.util.Date;
-
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.ActivitiIllegalArgumentException;
-import org.activiti.engine.ActivitiObjectNotFoundException;
-import org.activiti.engine.JobNotFoundException;
+import org.activiti.engine.*;
 import org.activiti.engine.impl.ProcessEngineImpl;
 import org.activiti.engine.impl.cmd.AcquireTimerJobsCmd;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.activiti.engine.impl.persistence.entity.JobEntity;
+import org.activiti.engine.impl.test.JobTestHelper;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.management.TableMetaData;
 import org.activiti.engine.runtime.Job;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.test.Deployment;
+
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 
 /**
@@ -43,7 +43,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     TableMetaData metaData = managementService.getTableMetaData("unexistingtable");
     assertNull(metaData);
   }
-  
+
   public void testGetMetaDataNullTableName() {
     try {
       managementService.getTableMetaData(null);
@@ -52,7 +52,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertTextPresent("tableName is null", re.getMessage());
     }
   }
-  
+
   public void testExecuteJobNullJobId() {
     try {
       managementService.executeJob(null);
@@ -61,7 +61,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertTextPresent("jobId and job is null", re.getMessage());
     }
   }
-  
+
   public void testExecuteJobUnexistingJob() {
     try {
       managementService.executeJob("unexistingjob");
@@ -71,42 +71,42 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertEquals(Job.class, jnfe.getObjectClass());
     }
   }
-  
-  
+
+
   @Deployment
   public void testGetJobExceptionStacktrace() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
-    
+
     // The execution is waiting in the first usertask. This contains a boundry
     // timer event which we will execute manual for testing purposes.
     Job timerJob = managementService.createJobQuery()
       .processInstanceId(processInstance.getId())
       .singleResult();
-    
+
     assertNotNull("No job found for process instance", timerJob);
-    
+
     try {
       managementService.executeJob(timerJob.getId());
       fail("RuntimeException from within the script task expected");
     } catch(RuntimeException re) {
       assertTextPresent("This is an exception thrown from scriptTask", re.getCause().getMessage());
     }
-    
+
     // Fetch the task to see that the exception that occurred is persisted
     timerJob = managementService.createJobQuery()
     .processInstanceId(processInstance.getId())
     .singleResult();
-    
+
     assertNotNull(timerJob);
     assertNotNull(timerJob.getExceptionMessage());
     assertTextPresent("This is an exception thrown from scriptTask", timerJob.getExceptionMessage());
-    
+
     // Get the full stacktrace using the managementService
     String exceptionStack = managementService.getJobExceptionStacktrace(timerJob.getId());
     assertNotNull(exceptionStack);
-    assertTextPresent("This is an exception thrown from scriptTask", exceptionStack);    
+    assertTextPresent("This is an exception thrown from scriptTask", exceptionStack);
   }
-  
+
   public void testgetJobExceptionStacktraceUnexistingJobId() {
     try {
       managementService.getJobExceptionStacktrace("unexistingjob");
@@ -116,7 +116,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertEquals(Job.class, re.getObjectClass());
     }
   }
-  
+
   public void testgetJobExceptionStacktraceNullJobId() {
     try {
       managementService.getJobExceptionStacktrace(null);
@@ -125,7 +125,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertTextPresent("jobId is null", re.getMessage());
     }
   }
-  
+
   @Deployment(resources = {"org/activiti/engine/test/api/mgmt/ManagementServiceTest.testGetJobExceptionStacktrace.bpmn20.xml"})
   public void testSetJobRetries() {
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("exceptionInJobExecution");
@@ -149,7 +149,53 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     assertEquals(5, timerJob.getRetries());
     assertEquals(duedate, timerJob.getDuedate());
   }
-  
+
+  @Deployment(resources = {"org/activiti/engine/test/jobexecutor/AsyncExecutorTest.testAsyncFailingScript.bpmn20.xml"})
+  public void testSetJobRetriesOnFailedJob() {
+      // There is a back off mechanism for the retry, so need a bit of time
+      // But to be sure, we make the wait time small
+      processEngine.getProcessEngineConfiguration().setAsyncFailedJobWaitTime(1);
+
+      // Start process instance. Wait for all jobs to be done.
+      ProcessInstance processInstance = processEngine.getRuntimeService().startProcessInstanceByKey("asyncScript");
+
+
+    final ProcessEngine processEngineCopy = processEngine;
+    JobTestHelper.waitForJobExecutorOnCondition(processEngine.getProcessEngineConfiguration(), 30000L, 2000L, new Callable<Boolean>() {
+      @Override
+      public Boolean call() throws Exception {
+          List<Job> failedJobs = processEngineCopy.getManagementService().createJobQuery().withRetriesLeft().list();
+          if (failedJobs.isEmpty()) {
+              return true;
+          }
+        return false;
+      }
+    });
+
+    Job failedJob = managementService.createJobQuery()
+      .processInstanceId(processInstance.getId())
+      .noRetriesLeft()
+            .singleResult();
+
+    assertNotNull("No job found for process instance", failedJob);
+    assertEquals(0, failedJob.getRetries());
+
+      managementService.setJobRetries(failedJob.getId(), 1);
+
+      failedJob = managementService.createJobQuery()
+      .processInstanceId(processInstance.getId())
+      .singleResult();
+      assertEquals(1, failedJob.getRetries());
+
+    // wait to execute the failing process again
+      JobTestHelper.waitForJobExecutorOnCondition(processEngine.getProcessEngineConfiguration(), 30000L, 2000L, new Callable<Boolean>() {
+          @Override
+          public Boolean call() throws Exception {
+              return processEngineCopy.getManagementService().createJobQuery().withRetriesLeft().count() == 0;
+          }
+      });
+  }
+
   public void testSetJobRetriesUnexistingJobId() {
     try {
       managementService.setJobRetries("unexistingjob", 5);
@@ -159,7 +205,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertEquals(Job.class, re.getObjectClass());
     }
   }
-  
+
   public void testSetJobRetriesEmptyJobId() {
     try {
       managementService.setJobRetries("", 5);
@@ -168,7 +214,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
       assertTextPresent("The job id is mandatory, but '' has been provided.", re.getMessage());
     }
   }
-  
+
   public void testSetJobRetriesJobIdNull() {
     try {
       managementService.setJobRetries(null, 5);
@@ -213,18 +259,18 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
 
     assertNotNull("Task timer should be there", timerJob);
     managementService.deleteJob(timerJob.getId());
-    
+
     timerJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
     assertNull("There should be no job now. It was deleted", timerJob);
   }
-  
+
   @Deployment(resources = { "org/activiti/engine/test/api/mgmt/timerOnTask.bpmn20.xml" })
   public void testDeleteJobThatWasAlreadyAcquired() {
     processEngineConfiguration.getClock().setCurrentTime(new Date());
-    
+
     ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("timerOnTask");
     Job timerJob = managementService.createJobQuery().processInstanceId(processInstance.getId()).singleResult();
-    
+
     // We need to move time at least one hour to make the timer executable
     processEngineConfiguration.getClock().setCurrentTime(new Date(processEngineConfiguration.getClock().getCurrentTime().getTime() + 7200000L));
 
@@ -233,7 +279,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     AcquireTimerJobsCmd acquireJobsCmd = new AcquireTimerJobsCmd("testLockOwner", 60000, 5);
     CommandExecutor commandExecutor = processEngineImpl.getProcessEngineConfiguration().getCommandExecutor();
     commandExecutor.execute(acquireJobsCmd);
-    
+
     // Try to delete the job. This should fail.
     try {
       managementService.deleteJob(timerJob.getId());
@@ -241,11 +287,11 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     } catch (ActivitiException e) {
       // Exception is expected
     }
-    
+
     // Clean up
     managementService.executeJob(timerJob.getId());
   }
-  
+
   // https://activiti.atlassian.net/browse/ACT-1816:
   // ManagementService doesn't seem to give actual table Name for EventSubscriptionEntity.class
   public void testGetTableName() {


### PR DESCRIPTION
The jUnit test shows that after setting retries_ > 0 failed job is not fetched by the async job executor to be re-executed.
the fixed job.xml changes selectAsyncJobsDueToExecute to select all jobs without expiration time and due date null.

Another possibility is to set due date to now (there are still some test failing.). It could make sense too.
(?) which approach do you prefer?