### PR TITLE
fixes issues with formbuilder item placement

### DIFF
--- a/modules/activiti-ui/activiti-app/src/main/webapp/editor/styles/style-editor.css
+++ b/modules/activiti-ui/activiti-app/src/main/webapp/editor/styles/style-editor.css
@@ -308,7 +308,7 @@ ul.filter-list li.current a:hover, ul.filter-list li.current a:focus {
     box-shadow:        inset  0  3px 3px -4px #ababab;
     margin: 15px 7px 0 7px;
     z-index: 0;
-    padding: 0 20px;
+    padding: 0px 20px 0px 20px;
     background-color: #f9f9f9;
 }
 .content-canvas-wrapper li.form-field-wrapper {
@@ -335,6 +335,11 @@ ul.filter-list li.current a:hover, ul.filter-list li.current a:focus {
 .content-canvas-wrapper > ul > li.dndPlaceholder {
     width: calc(100% - 10px);
 
+}
+
+.content-canvas-wrapper ul[dnd-list],
+.content-canvas-wrapper ul[dnd-list] > li {
+	position: relative;
 }
 
 .content-canvas-wrapper .form-group {
@@ -421,6 +426,16 @@ ul.filter-list li.current a:hover, ul.filter-list li.current a:focus {
 
 .content-canvas .item-wrapper {
     margin: 5px 10px;
+}
+
+.content-canvas .canvas-element {
+	margin: 8px;
+	padding: 8px;
+	position:relative;
+	z-index:0;
+	border: 1px dashed #ddd;
+	/* padding-left: 0; */
+	min-height: 100%;
 }
 
 /* History */
@@ -1027,6 +1042,8 @@ table.history tr.current td {
 .form-canvas .checkbox.inline:last-child {
     float: none;
 }
+
+
 
 .palette {
     padding-bottom: 10px;

--- a/modules/activiti-ui/activiti-app/src/main/webapp/editor/views/form-builder.html
+++ b/modules/activiti-ui/activiti-app/src/main/webapp/editor/views/form-builder.html
@@ -78,8 +78,8 @@
                                 dnd-effect-allowed="move"
                                 dnd-type="'width-1'"
                                 dnd-moved="onFieldMoved(field, formItems)">
-                                <div id="{{field._guid}}" form-builder-element form-element="field" edit-state="editState"
-                                     drop="onFieldDrop(item, list, event, index)" moved="onFieldMoved(item, list)">
+                                <div draggable="true" id="{{field._guid}}" form-builder-element form-element="field" edit-state="editState"
+                                     drop="onFieldDrop(item, list, event, index)" moved="onFieldMoved(item, list)" class="canvas-element">
                                 </div>
                             </li>
                         </ul>


### PR DESCRIPTION
there were issues with dragging palette items onto the form builder canvas.
especially adding them from the bottom of the canvas.
these are fixed.

in additional I've added some more spacing between the elements (and added a dotted border)
