### PR TITLE
Error in DB2 create and update scripts

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
@@ -74,7 +74,7 @@ create table ACT_RU_EXECUTION (
     START_TIME_ timestamp,
     START_USER_ID_ varchar(255),
     LOCK_TIME_ timestamp,
-    IS_COUNT_ENABLED_ smallint check(IS_ACTIVE_ in (1,0)),
+    IS_COUNT_ENABLED_ smallint check(IS_COUNT_ENABLED_ in (1,0)),
     EVT_SUBSCR_COUNT_ integer, 
     TASK_COUNT_ integer, 
     JOB_COUNT_ integer, 

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.6001.to.6002.engine.sql
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.6001.to.6002.engine.sql
@@ -201,7 +201,7 @@ alter table ACT_RE_DEPLOYMENT add column KEY_ varchar(255);
 update ACT_RU_EVENT_SUBSCR set PROC_DEF_ID_ = CONFIGURATION_ where EVENT_TYPE_ = 'message' and PROC_INST_ID_ is null and EXECUTION_ID_ is null and PROC_DEF_ID_ is null;
 
 -- Adding count columns for execution relationship count feature
-alter table ACT_RU_EXECUTION add column IS_COUNT_ENABLED_ smallint check(IS_ACTIVE_ in (1,0));
+alter table ACT_RU_EXECUTION add column IS_COUNT_ENABLED_ smallint check(IS_COUNT_ENABLED_ in (1,0));
 alter table ACT_RU_EXECUTION add column EVT_SUBSCR_COUNT_ integer; 
 alter table ACT_RU_EXECUTION add column TASK_COUNT_ integer; 
 alter table ACT_RU_EXECUTION add column JOB_COUNT_ integer; 


### PR DESCRIPTION
In create and update scripts for  the table ACT_RU_EXECUTION, the column  IS_COUNT_ENABLED_  specified the incorrect check() constraint variable.  Very simple change.