### PR TITLE
DatabaseTablePrefixTest in v5 compatibility

### DIFF
--- a/modules/activiti5-test/src/test/java/org/activiti5/engine/test/db/DatabaseTablePrefixTest.java
+++ b/modules/activiti5-test/src/test/java/org/activiti5/engine/test/db/DatabaseTablePrefixTest.java
@@ -52,6 +52,7 @@ public class DatabaseTablePrefixTest extends TestCase {
             .setDatabaseSchemaUpdate("NO_CHECK"); // disable auto create/drop schema
     config1.setDatabaseTablePrefix("SCHEMA1.");
     config1.setActiviti5CompatibilityEnabled(true);
+    config1.getPerformanceSettings().setValidateExecutionRelationshipCountConfigOnBoot(false);
     ProcessEngine engine1 = config1.buildProcessEngine();
     
     ProcessEngineConfigurationImpl config2 = (ProcessEngineConfigurationImpl) ProcessEngineConfigurationImpl
@@ -60,6 +61,7 @@ public class DatabaseTablePrefixTest extends TestCase {
             .setDatabaseSchemaUpdate("NO_CHECK"); // disable auto create/drop schema        
     config2.setDatabaseTablePrefix("SCHEMA2.");
     config2.setActiviti5CompatibilityEnabled(true);
+    config2.getPerformanceSettings().setValidateExecutionRelationshipCountConfigOnBoot(false);
     ProcessEngine engine2 = config2.buildProcessEngine();
     
     // create the tables in SCHEMA1


### PR DESCRIPTION
Fix DatabaseTablePrefixTest in v5 compatibility tests by setting `setValidateExecutionRelationshipCountConfigOnBoot(false);` as is done in the v6 test version.