### PR TITLE
Added missing class name in the exception message

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -265,8 +265,9 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 			Class<?> clazz=Class.forName(businessRuleTask.getClassName());
 			ruleActivity=(BusinessRuleTaskActivityBehavior)clazz.newInstance();
 		} catch (Exception e) {
+            String clazzName = StringUtils.isNotEmpty (businessRuleTask.getClassName()) ? businessRuleTask.getClassName() : "<null>";
 			throw new ActivitiException(
-					"Could not instiate businessRuleTask class: ", e);
+					"Could not instantiate businessRuleTask class: " + clazzName, e);
 		}
 	}else{
 		ruleActivity=new BusinessRuleTaskActivityBehavior();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -267,7 +267,7 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 		} catch (Exception e) {
             String clazzName = StringUtils.isNotEmpty (businessRuleTask.getClassName()) ? businessRuleTask.getClassName() : "<null>";
 			throw new ActivitiException(
-					"Could not instantiate businessRuleTask class: " + clazzName, e);
+					"Could not instantiate businessRuleTask (id:" + businessRuleTask.getId()  + ") class: " + clazzName, e);
 		}
 	}else{
 		ruleActivity=new BusinessRuleTaskActivityBehavior();


### PR DESCRIPTION
Improved the exception message in case the businessRuleTask is configured with the invalid class name. Adding a class name to the exception messages makes the message more readable.