### PR TITLE
Fix problems found using terminateEndEvent in subprocess.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
@@ -181,8 +181,14 @@ public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior 
 
   protected void sendProcessInstanceCancelledEvent(DelegateExecution execution, FlowElement terminateEndEvent) {
     if (Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
-      Context.getProcessEngineConfiguration().getEventDispatcher()
-          .dispatchEvent(ActivitiEventBuilder.createCancelledEvent(execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(), execution.getCurrentFlowElement()));
+      // do not send Process Cancelled event if this is a SubProcess
+      if (null == execution.getParent()) {
+        Context.getProcessEngineConfiguration()
+            .getEventDispatcher()
+            .dispatchEvent(
+                ActivitiEventBuilder.createCancelledEvent(execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(),
+                    execution.getCurrentFlowElement()));
+      }
     }
 
     dispatchExecutionCancelled(execution, terminateEndEvent);
@@ -211,14 +217,13 @@ public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior 
   }
 
   protected void dispatchActivityCancelled(DelegateExecution execution, FlowElement terminateEndEvent) {
-    Context
-        .getProcessEngineConfiguration()
+    Context.getProcessEngineConfiguration()
         .getEventDispatcher()
         .dispatchEvent(
-            ActivitiEventBuilder.createActivityCancelledEvent(execution.getCurrentFlowElement().getId(), execution.getCurrentFlowElement().getName(), execution.getId(),
-                execution.getProcessInstanceId(), execution.getProcessDefinitionId(), execution.getCurrentFlowElement().getClass().getName(), ((FlowNode) execution.getCurrentFlowElement())
-                    .getBehavior().getClass().getCanonicalName(), terminateEndEvent));
-  }
+            ActivitiEventBuilder.createActivityCancelledEvent(execution.getCurrentFlowElement().getId(), execution.getCurrentFlowElement().getName(),
+                execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId(),
+                    parseActivityType((FlowNode) execution.getCurrentFlowElement()), ((FlowNode) execution.getCurrentFlowElement()).getBehavior()
+                        .getClass().getCanonicalName(), terminateEndEvent));}
   
   protected String createDeleteReason(String activityId) {
     return DeleteReason.TERMINATE_END_EVENT + " (" + activityId + ")";

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/JobEventsTest.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.activiti.engine.delegate.event.ActivitiActivityEvent;
 import org.activiti.engine.delegate.event.ActivitiEntityEvent;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
@@ -361,6 +362,57 @@ public class JobEventsTest extends PluggableActivitiTestCase {
     assertEquals(ActivitiEventType.JOB_RETRIES_DECREMENTED, event.getType());
     assertEquals(0, ((Job) ((ActivitiEntityEvent) event).getEntity()).getRetries());
     checkEventContext(event, theJob);
+  }
+  
+  @Deployment
+  public void testTerminateEndEvent() throws Exception {
+    Clock previousClock = processEngineConfiguration.getClock();
+
+    TestActivitiEventListener activitiEventListener = new TestActivitiEventListener();
+    processEngineConfiguration.getEventDispatcher().addEventListener(activitiEventListener);
+    Clock testClock = new DefaultClockImpl();
+
+    processEngineConfiguration.setClock(testClock);
+
+    testClock.setCurrentTime(new Date());
+    runtimeService.startProcessInstanceByKey("testTerminateEndEvent");
+    listener.clearEventsReceived();
+
+    Task task = taskService.createTaskQuery().singleResult();
+    assertEquals("Inside Task", task.getName());
+
+    // Force timer to trigger so that subprocess will flow to terminate end
+    // event
+    Calendar later = Calendar.getInstance();
+    later.add(Calendar.YEAR, 1);
+    processEngineConfiguration.getClock().setCurrentTime(later.getTime());
+    waitForJobExecutorToProcessAllJobs(12000, 100);
+
+    // Process Cancelled event should not be sent for the subprocess
+    List<ActivitiEvent> eventsReceived = activitiEventListener.getEventsReceived();
+    for (ActivitiEvent eventReceived : eventsReceived) {
+      if (ActivitiEventType.PROCESS_CANCELLED.equals(eventReceived.getType())) {
+        fail("Should not have received PROCESS_CANCELLED event");
+      }
+    }
+
+    // validate the activityType string
+    for (ActivitiEvent eventReceived : eventsReceived) {
+      if (ActivitiEventType.ACTIVITY_CANCELLED.equals(eventReceived.getType())) {
+        ActivitiActivityEvent event = (ActivitiActivityEvent) eventReceived;
+        String activityType = event.getActivityType();
+        if (!"userTask".equals(activityType) && (!"subProcess".equals(activityType)) && (!"endEvent".equals(activityType))) {
+          fail("Unexpected activity type: " + activityType);
+        }
+      }
+    }
+
+    task = taskService.createTaskQuery().singleResult();
+    assertEquals("Outside Task", task.getName());
+
+    taskService.complete(task.getId());
+
+    processEngineConfiguration.setClock(previousClock);
   }
 
   protected void checkEventContext(ActivitiEvent event, Job entity) {

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/event/JobEventsTest.testTerminateEndEvent.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/event/JobEventsTest.testTerminateEndEvent.bpmn20.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions 
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="testTerminateEndEvent">
+  
+    <startEvent id="theStart" />
+    
+    <sequenceFlow sourceRef="theStart" targetRef="subProcess1" />
+      
+    <userTask id="task" name="Outside Task" />
+    <subProcess id="subProcess1" name="SubProcess">
+        <startEvent id="subStart" name="Start"></startEvent>
+        <endEvent id="subEnd" name="End">
+            <terminateEventDefinition></terminateEventDefinition>
+        </endEvent>
+        
+        <intermediateCatchEvent id="timer">
+            <timerEventDefinition>
+              <timeDuration>PT5M</timeDuration>
+            </timerEventDefinition>
+        </intermediateCatchEvent>
+        
+        <userTask id="inTask" name="Inside Task"/>
+        
+        <sequenceFlow id="subFlow1" sourceRef="subStart" targetRef="timer"/>
+        <sequenceFlow id="subFlow2" sourceRef="subStart" targetRef="inTask"/>
+        <sequenceFlow id="subDone1" sourceRef="timer" targetRef="subEnd"/>
+        <sequenceFlow id="subDone2" sourceRef="inTask" targetRef="subEnd"/>
+    </subProcess>
+    
+    <sequenceFlow id="subToTask" sourceRef="subProcess1" targetRef="task" />
+    <sequenceFlow id="taskToEnd" sourceRef="task" targetRef="theEnd" />
+        
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
A timer intermediate catch event within a subprocess is causing an
invalid process cancelled event to be sent. It should not be sent in this
case. Additionally, the Activity cancelled events are setting the wrong
activity Type.

