### PR TITLE
Optimization for HistoricProcessInstance queries for 'or queries' with multiple process variable values

### DIFF
--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -355,9 +355,9 @@
       <if test="orQueryObject.deploymentId != null || (orQueryObject.deploymentIds != null &amp;&amp; orQueryObject.deploymentIds.size() &gt; 0)">
         left outer join ${prefix}ACT_RE_PROCDEF DEPLOY_P_OR${orIndex} ON RES.PROC_DEF_ID_ = DEPLOY_P_OR${orIndex}.ID_
       </if>
-      <foreach collection="orQueryObject.queryVariableValues" index="index" item="queryVariableValue">
-        left outer join ${prefix}ACT_HI_VARINST A_OR${orIndex}_${index} on RES.PROC_INST_ID_ = A_OR${orIndex}_${index}.PROC_INST_ID_
-      </foreach>
+      <if test="orQueryObject.queryVariableValues != null &amp;&amp; orQueryObject.queryVariableValues.size() &gt; 0">
+        left outer join ${prefix}ACT_HI_VARINST A_OR${orIndex} on RES.PROC_INST_ID_ = A_OR${orIndex}.PROC_INST_ID_
+      </if>
     </foreach>
     <if test="deploymentId != null || (deploymentIds != null &amp;&amp; deploymentIds.size() &gt; 0)">
       left outer join ${prefix}ACT_RE_PROCDEF DEPLOY_P ON RES.PROC_DEF_ID_ = DEPLOY_P.ID_
@@ -641,19 +641,19 @@
             <trim prefix="(" prefixOverrides="AND" suffix=")">
               <if test="queryVariableValue.name != null">
                 <!-- Match-all variable-names when name is null -->
-                and A_OR${orIndex}_${index}.NAME_= #{queryVariableValue.name}
+                and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
               </if>
               <if test="!queryVariableValue.type.equals('null')">
               <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
-                and A_OR${orIndex}_${index}.VAR_TYPE_ = #{queryVariableValue.type}
+                and A_OR${orIndex}.VAR_TYPE_ = #{queryVariableValue.type}
               </if>
               <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                 <choose>
                   <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                    and lower(A_OR${orIndex}_${index}.TEXT_)
+                    and lower(A_OR${orIndex}.TEXT_)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_
+                    and A_OR${orIndex}.TEXT_
                   </otherwise>
                 </choose>
                 <choose>
@@ -663,7 +663,7 @@
                 #{queryVariableValue.textValue}
               </if>
               <if test="queryVariableValue.textValue2 != null">
-                and A_OR${orIndex}_${index}.TEXT2_
+                and A_OR${orIndex}.TEXT2_
                 <choose>
                   <when test="queryVariableValue.operator.equals('LIKE')">LIKE</when>
                   <otherwise><include refid="executionVariableOperator" /></otherwise>
@@ -671,12 +671,12 @@
                 #{queryVariableValue.textValue2}
               </if>
               <if test="queryVariableValue.longValue != null">
-                and A_OR${orIndex}_${index}.LONG_
+                and A_OR${orIndex}.LONG_
                 <include refid="executionVariableOperator" />
                 #{queryVariableValue.longValue}
               </if>
               <if test="queryVariableValue.doubleValue != null">
-                and A_OR${orIndex}_${index}.DOUBLE_
+                and A_OR${orIndex}.DOUBLE_
                 <include refid="executionVariableOperator" />
                 #{queryVariableValue.doubleValue}
               </if>
@@ -684,10 +684,10 @@
               <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                 <choose>
                   <when test="queryVariableValue.operator.equals('NOT_EQUALS')">
-                    and (A_OR${orIndex}_${index}.TEXT_ is not null or A_OR${orIndex}_${index}.TEXT2_ is not null or A_OR${orIndex}_${index}.LONG_ is not null or A_OR${orIndex}_${index}.DOUBLE_ is not null or A_OR${orIndex}_${index}.BYTEARRAY_ID_ is not null)
+                    and (A_OR${orIndex}.TEXT_ is not null or A_OR${orIndex}.TEXT2_ is not null or A_OR${orIndex}.LONG_ is not null or A_OR${orIndex}.DOUBLE_ is not null or A_OR${orIndex}.BYTEARRAY_ID_ is not null)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_ is null and A_OR${orIndex}_${index}.TEXT2_ is null and A_OR${orIndex}_${index}.LONG_ is null and A_OR${orIndex}_${index}.DOUBLE_ is null and A_OR${orIndex}_${index}.BYTEARRAY_ID_ is null
+                    and A_OR${orIndex}.TEXT_ is null and A_OR${orIndex}.TEXT2_ is null and A_OR${orIndex}.LONG_ is null and A_OR${orIndex}.DOUBLE_ is null and A_OR${orIndex}.BYTEARRAY_ID_ is null
                   </otherwise>
                 </choose>
               </if>

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceAndVariablesQueryTest.java
@@ -388,6 +388,60 @@ public class HistoricProcessInstanceAndVariablesQueryTest extends PluggableActiv
       assertEquals(4, instanceList.size());
     }
   }
+
+  public void testOrQueryMultipleVariableValues() {
+    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+      HistoricProcessInstanceQuery query0 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or();
+      for (int i = 0; i < 20; i++) {
+          query0 = query0.variableValueEquals("anothertest", i);
+      }
+      query0 = query0.processDefinitionId("undefined").endOr();
+
+      assertNull(query0.singleResult());
+
+      HistoricProcessInstanceQuery query1 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables().or().variableValueEquals("anothertest", 123);
+      for (int i = 0; i < 20; i++) {
+          query1 = query1.variableValueEquals("anothertest", i);
+      }
+      query1 = query1.processDefinitionId("undefined").endOr();
+
+      HistoricProcessInstance processInstance = query1.singleResult();
+      Map<String, Object> variableMap = processInstance.getProcessVariables();
+      assertEquals(1, variableMap.size());
+      assertEquals(123, variableMap.get("anothertest"));
+
+      HistoricProcessInstanceQuery query2 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+              .or();
+      for (int i = 0; i < 20; i++) {
+          query2 = query2.variableValueEquals("anothertest", i);
+      }
+      query2 = query2.processDefinitionId("undefined")
+              .endOr()
+              .or()
+                .processDefinitionKey(PROCESS_DEFINITION_KEY_2)
+                .processDefinitionId("undefined")
+              .endOr();
+      assertNull(query2.singleResult());
+
+      HistoricProcessInstanceQuery query3 = historyService.createHistoricProcessInstanceQuery().includeProcessVariables()
+              .or().variableValueEquals("anothertest", 123);
+      for (int i = 0; i < 20; i++) {
+          query3 = query3.variableValueEquals("anothertest", i);
+      }
+      query3 = query3.processDefinitionId("undefined")
+              .endOr()
+              .or()
+                .processDefinitionKey(PROCESS_DEFINITION_KEY_2)
+                .processDefinitionId("undefined")
+              .endOr();
+      variableMap = query3.singleResult().getProcessVariables();
+      assertEquals(1, variableMap.size());
+      assertEquals(123, variableMap.get("anothertest"));
+      variableMap = processInstance.getProcessVariables();
+      assertEquals(1, variableMap.size());
+      assertEquals(123, variableMap.get("anothertest"));
+    }
+  }
   
   public void testOrQueryByprocessDefinition() {
     if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {


### PR DESCRIPTION
Changed mybatis mapper for HistoricProcessInstance.
Added some test cases.