### PR TITLE
ACT-4027 BaseBpmnXmlParser doesn't support endDate attribute

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
@@ -412,6 +412,11 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
 
     } else if (StringUtils.isNotEmpty(timerDefinition.getTimeCycle())) {
       xtw.writeStartElement(ATTRIBUTE_TIMER_CYCLE);
+
+      if (StringUtils.isNotEmpty(timerDefinition.getEndDate())) {
+        xtw.writeAttribute(ACTIVITI_EXTENSIONS_PREFIX, ACTIVITI_EXTENSIONS_NAMESPACE,ATTRIBUTE_END_DATE,timerDefinition.getEndDate());
+      }
+
       xtw.writeCharacters(timerDefinition.getTimeCycle());
       xtw.writeEndElement();
 

--- a/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/TimerDefinitionConverterTest.java
+++ b/modules/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/TimerDefinitionConverterTest.java
@@ -1,12 +1,16 @@
 package org.activiti.editor.language.xml;
 
-import org.activiti.bpmn.model.*;
-import org.junit.Test;
-
-import java.util.List;
-
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.IntermediateCatchEvent;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.TimerEventDefinition;
+import org.junit.Test;
 
 public class TimerDefinitionConverterTest extends AbstractConverterTest {
   
@@ -33,15 +37,19 @@ public class TimerDefinitionConverterTest extends AbstractConverterTest {
     assertNotNull(timer);
     TimerEventDefinition timerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
     assertThat(timerEvent.getCalendarName(), is("custom"));
+    assertEquals("PT5M", timerEvent.getTimeDuration());
 
     StartEvent start = (StartEvent) model.getMainProcess().getFlowElement("theStart");
     assertNotNull(start);
-    TimerEventDefinition startTimerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
+    TimerEventDefinition startTimerEvent = (TimerEventDefinition) start.getEventDefinitions().get(0);
     assertThat(startTimerEvent.getCalendarName(), is("custom"));
+    assertEquals("R2/PT5S", startTimerEvent.getTimeCycle());
+    assertEquals("${EndDate}", startTimerEvent.getEndDate());
 
     BoundaryEvent boundaryTimer = (BoundaryEvent) model.getMainProcess().getFlowElement("boundaryTimer");
     assertNotNull(boundaryTimer);
-    TimerEventDefinition boundaryTimerEvent = (TimerEventDefinition) timer.getEventDefinitions().get(0);
+    TimerEventDefinition boundaryTimerEvent = (TimerEventDefinition) boundaryTimer.getEventDefinitions().get(0);
     assertThat(boundaryTimerEvent.getCalendarName(), is("custom"));
+    assertEquals("PT10S", boundaryTimerEvent.getTimeDuration());
   }
 }

--- a/modules/activiti-bpmn-converter/src/test/resources/timerCalendarDefinition.bpmn
+++ b/modules/activiti-bpmn-converter/src/test/resources/timerCalendarDefinition.bpmn
@@ -8,7 +8,7 @@
 
     <startEvent id="theStart">
       <timerEventDefinition activiti:businessCalendarName="custom">
-        <timeCycle>R2/PT5S</timeCycle>
+        <timeCycle activiti:endDate="${EndDate}">R2/PT5S</timeCycle>
       </timerEventDefinition>
     </startEvent>
     <sequenceFlow id="flow1" sourceRef="theStart" targetRef="timer"/>


### PR DESCRIPTION
added support from master to activiti6 branch

also updated unit test to verify this value as well as the time duration
and cycle values