### PR TITLE
Add the inheritVariables option to callActivityBehavior task.

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/constants/BpmnXMLConstants.java
@@ -188,6 +188,7 @@ public interface BpmnXMLConstants {
   public static final String ATTRIBUTE_TASK_RULE_CLASS = "class";
   
   public static final String ATTRIBUTE_CALL_ACTIVITY_CALLEDELEMENT = "calledElement";
+  public static final String ATTRIBUTE_CALL_ACTIVITY_INHERITVARIABLES = "inheritVariables";
   public static final String ELEMENT_CALL_ACTIVITY_IN_PARAMETERS = "in";
   public static final String ELEMENT_CALL_ACTIVITY_OUT_PARAMETERS = "out";
   public static final String ATTRIBUTE_IOPARAMETER_SOURCE = "source";

--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/CallActivityXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/CallActivityXMLConverter.java
@@ -55,6 +55,7 @@ public class CallActivityXMLConverter extends BaseBpmnXMLConverter {
     CallActivity callActivity = new CallActivity();
     BpmnXMLUtil.addXMLLocation(callActivity, xtr);
     callActivity.setCalledElement(xtr.getAttributeValue(null, ATTRIBUTE_CALL_ACTIVITY_CALLEDELEMENT));
+    callActivity.setInheritVariables(Boolean.valueOf(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_CALL_ACTIVITY_INHERITVARIABLES)));
     parseChildElements(getXMLElementName(), callActivity, childParserMap, model, xtr);
     return callActivity;
   }
@@ -64,6 +65,7 @@ public class CallActivityXMLConverter extends BaseBpmnXMLConverter {
     CallActivity callActivity = (CallActivity) element;
     if (StringUtils.isNotEmpty(callActivity.getCalledElement())) {
       xtw.writeAttribute(ATTRIBUTE_CALL_ACTIVITY_CALLEDELEMENT, callActivity.getCalledElement());
+      xtw.writeAttribute(ACTIVITI_EXTENSIONS_NAMESPACE, ATTRIBUTE_CALL_ACTIVITY_INHERITVARIABLES, String.valueOf(callActivity.isInheritVariables()));
     }
   }
   

--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/CallActivity.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/CallActivity.java
@@ -21,6 +21,7 @@ import java.util.List;
 public class CallActivity extends Activity {
 
   protected String calledElement;
+  protected boolean inheritVariables;
   protected List<IOParameter> inParameters = new ArrayList<IOParameter>();
   protected List<IOParameter> outParameters = new ArrayList<IOParameter>();
 
@@ -29,6 +30,12 @@ public class CallActivity extends Activity {
   }
   public void setCalledElement(String calledElement) {
     this.calledElement = calledElement;
+  }
+  public boolean isInheritVariables() {
+    return inheritVariables;
+  }
+  public void setInheritVariables(boolean inheritVariables) {
+    this.inheritVariables = inheritVariables;
   }
   public List<IOParameter> getInParameters() {
     return inParameters;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -15,6 +15,7 @@ package org.activiti.engine.impl.bpmn.behavior;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.activiti.bpmn.model.MapExceptionEntry;
 import org.activiti.engine.ActivitiException;
@@ -44,6 +45,7 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
   private List<AbstractDataAssociation> dataOutputAssociations = new ArrayList<AbstractDataAssociation>();
   private Expression processDefinitionExpression;
   protected List<MapExceptionEntry> mapExceptions;
+  protected boolean inheritVariables;
 
   public CallActivityBehavior(String processDefinitionKey, List<MapExceptionEntry> mapExceptions) {
     this.processDefinitonKey = processDefinitionKey;
@@ -62,6 +64,10 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
 
   public void addDataOutputAssociation(AbstractDataAssociation dataOutputAssociation) {
     this.dataOutputAssociations.add(dataOutputAssociation);
+  }
+
+  public void setInheritVariables(boolean inheritVariables) {
+    this.inheritVariables = inheritVariables;
   }
 
   public void execute(ActivityExecution execution) throws Exception {
@@ -87,17 +93,24 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
     }
     
     PvmProcessInstance subProcessInstance = execution.createSubProcessInstance(processDefinition);
-    
-    // copy process variables
-    for (AbstractDataAssociation dataInputAssociation : dataInputAssociations) {
-      Object value = null;
-      if (dataInputAssociation.getSourceExpression()!=null) {
-        value = dataInputAssociation.getSourceExpression().getValue(execution);
+
+    if (inheritVariables) {
+      Map<String, Object> variables = execution.getVariables();
+      for (Map.Entry<String, Object> entry : variables.entrySet()) {
+        subProcessInstance.setVariable(entry.getKey(), entry.getValue());
       }
-      else {
-        value = execution.getVariable(dataInputAssociation.getSource());
+    } else {
+      // copy process variables
+      for (AbstractDataAssociation dataInputAssociation : dataInputAssociations) {
+        Object value = null;
+        if (dataInputAssociation.getSourceExpression()!=null) {
+          value = dataInputAssociation.getSourceExpression().getValue(execution);
+        }
+        else {
+          value = execution.getVariable(dataInputAssociation.getSource());
+        }
+        subProcessInstance.setVariable(dataInputAssociation.getTarget(), value);
       }
-      subProcessInstance.setVariable(dataInputAssociation.getTarget(), value);
     }
     
     try {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -347,6 +347,7 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
     } else {
       callActivityBehaviour = new CallActivityBehavior(callActivity.getCalledElement(), callActivity.getMapExceptions());
     }
+    callActivityBehaviour.setInheritVariables(callActivity.isInheritVariables());
 
     for (IOParameter ioParameter : callActivity.getInParameters()) {
       if (StringUtils.isNotEmpty(ioParameter.getSourceExpression())) {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -13,9 +13,19 @@
 
 package org.activiti.engine.test.bpmn.subprocess;
 
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.activiti.bpmn.converter.BpmnXMLConverter;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ActivitiException;
+import org.activiti.engine.history.HistoricActivityInstance;
+import org.activiti.engine.history.HistoricActivityInstanceQuery;
+import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.history.HistoricVariableInstance;
+import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
 import org.activiti.engine.impl.util.io.InputStreamSource;
 import org.activiti.engine.impl.util.io.StreamSource;
@@ -23,14 +33,14 @@ import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.ProcessInstance;
 
-import java.io.InputStream;
-import java.util.List;
-
 public class CallActivityTest extends ResourceActivitiTestCase {
 
   private static String MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_mainProcess.bpmn.xml";
   private static String CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_childProcess.bpmn.xml";
   private static String MESSAGE_TRIGGERED_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testSuspendedProcessCallActivity_messageTriggeredProcess.bpmn.xml";
+  private static String INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml";
+  private static String INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml";
+  private static String NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE = "org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml";
 
   public CallActivityTest() {
     super("org/activiti/standalone/parsing/encoding.activiti.cfg.xml");
@@ -122,6 +132,78 @@ public class CallActivityTest extends ResourceActivitiTestCase {
       assertTextPresent("Cannot start process instance. Process definition Child Process", ae.getMessage());
     }
 
+  }
+
+  public void testInheritVariablesSubprocess() throws Exception {
+    BpmnModel mainBpmnModel = loadBPMNModel(INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE);
+    BpmnModel childBpmnModel = loadBPMNModel(INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE);
+
+    processEngine.getRepositoryService()
+        .createDeployment()
+        .name("mainProcessDeployment")
+        .addBpmnModel("mainProcess.bpmn20.xml", mainBpmnModel).deploy();
+
+    processEngine.getRepositoryService()
+        .createDeployment()
+        .name("childProcessDeployment")
+        .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("var1", "String test value");
+    variables.put("var2", true);
+    variables.put("var3", 12345);
+    variables.put("var4", 67890);
+
+    ProcessInstance mainProcessInstance = runtimeService.startProcessInstanceByKey("mainProcess", variables);
+
+    HistoricActivityInstanceQuery activityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
+    activityInstanceQuery.processInstanceId(mainProcessInstance.getId());
+    activityInstanceQuery.activityId("childProcessCall");
+    HistoricActivityInstance activityInstance = activityInstanceQuery.singleResult();
+    String calledInstanceId = activityInstance.getCalledProcessInstanceId();
+
+    HistoricVariableInstanceQuery variableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
+    List<HistoricVariableInstance> variableInstances = variableInstanceQuery.processInstanceId(calledInstanceId).list();
+
+    assertEquals(4, variableInstances.size());
+    for (HistoricVariableInstance variable : variableInstances) {
+      assertEquals(variables.get(variable.getVariableName()), variable.getValue());
+    }
+  }
+
+  public void testNotInheritVariablesSubprocess() throws Exception {
+    BpmnModel mainBpmnModel = loadBPMNModel(NOT_INHERIT_VARIABLES_MAIN_PROCESS_RESOURCE);
+    BpmnModel childBpmnModel = loadBPMNModel(INHERIT_VARIABLES_CHILD_PROCESS_RESOURCE);
+
+    processEngine.getRepositoryService()
+        .createDeployment()
+        .name("childProcessDeployment")
+        .addBpmnModel("childProcess.bpmn20.xml", childBpmnModel).deploy();
+    
+    processEngine.getRepositoryService()
+        .createDeployment()
+        .name("mainProcessDeployment")
+        .addBpmnModel("mainProcess.bpmn20.xml", mainBpmnModel).deploy();
+    
+    Map<String, Object> variables = new HashMap<>();
+    variables.put("var1", "String test value");
+    variables.put("var2", true);
+    variables.put("var3", 12345);
+    variables.put("var4", 67890);
+
+    ProcessInstance mainProcessInstance = runtimeService.startProcessInstanceByKey("mainProcess", variables);
+
+    HistoricActivityInstanceQuery activityInstanceQuery = historyService.createHistoricActivityInstanceQuery();
+    activityInstanceQuery.processInstanceId(mainProcessInstance.getId());
+    activityInstanceQuery.activityId("childProcessCall");
+    HistoricActivityInstance activityInstance = activityInstanceQuery.singleResult();
+    String calledInstanceId = activityInstance.getCalledProcessInstanceId();
+
+    HistoricVariableInstanceQuery variableInstanceQuery = historyService.createHistoricVariableInstanceQuery();
+    variableInstanceQuery.processInstanceId(calledInstanceId);
+    List<HistoricVariableInstance> variableInstances = variableInstanceQuery.list();
+
+    assertEquals(0, variableInstances.size());
   }
 
   private void suspendProcessDefinitions(Deployment childDeployment) {

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_childProcess.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="childProcess" name="Child Process" isExecutable="true">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <userTask id="usertask1" name="User Task"></userTask>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow2" sourceRef="usertask1" targetRef="endevent1"></sequenceFlow>
+    <sequenceFlow id="flow3" sourceRef="startevent1" targetRef="usertask1"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_childProcess">
+    <bpmndi:BPMNPlane bpmnElement="childProcess" id="BPMNPlane_childProcess">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="50.0" y="110.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="usertask1" id="BPMNShape_usertask1">
+        <omgdc:Bounds height="75.0" width="105.0" x="130.0" y="90.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="280.0" y="110.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="235.0" y="127.0"></omgdi:waypoint>
+        <omgdi:waypoint x="280.0" y="127.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow3" id="BPMNEdge_flow3">
+        <omgdi:waypoint x="85.0" y="127.0"></omgdi:waypoint>
+        <omgdi:waypoint x="130.0" y="127.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testInheritVariablesCallActivity_mainProcess.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="mainProcess" name="Main Process" isExecutable="true">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <callActivity id="childProcessCall" name="Child Process Call" calledElement="childProcess" activiti:inheritVariables="true" activiti:async="false"></callActivity>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="childProcessCall" targetRef="endevent1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="startevent1" targetRef="childProcessCall"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_mainProcess">
+    <bpmndi:BPMNPlane bpmnElement="mainProcess" id="BPMNPlane_mainProcess">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="150.0" y="100.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="childProcessCall" id="BPMNShape_childProcessCall">
+        <omgdc:Bounds height="55.0" width="105.0" x="231.0" y="90.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="370.0" y="100.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="336.0" y="117.0"></omgdi:waypoint>
+        <omgdi:waypoint x="370.0" y="117.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="185.0" y="117.0"></omgdi:waypoint>
+        <omgdi:waypoint x="231.0" y="117.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testNotInheritVariablesCallActivity_mainProcess.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/test">
+  <process id="mainProcess" name="Main Process" isExecutable="true">
+    <startEvent id="startevent1" name="Start"></startEvent>
+    <callActivity id="childProcessCall" name="Child Process Call" calledElement="childProcess"></callActivity>
+    <endEvent id="endevent1" name="End"></endEvent>
+    <sequenceFlow id="flow1" sourceRef="childProcessCall" targetRef="endevent1"></sequenceFlow>
+    <sequenceFlow id="flow2" sourceRef="startevent1" targetRef="childProcessCall"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_mainProcess">
+    <bpmndi:BPMNPlane bpmnElement="mainProcess" id="BPMNPlane_mainProcess">
+      <bpmndi:BPMNShape bpmnElement="startevent1" id="BPMNShape_startevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="150.0" y="100.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="childProcessCall" id="BPMNShape_childProcessCall">
+        <omgdc:Bounds height="55.0" width="105.0" x="231.0" y="90.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endevent1" id="BPMNShape_endevent1">
+        <omgdc:Bounds height="35.0" width="35.0" x="370.0" y="100.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="flow1" id="BPMNEdge_flow1">
+        <omgdi:waypoint x="336.0" y="117.0"></omgdi:waypoint>
+        <omgdi:waypoint x="370.0" y="117.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="flow2" id="BPMNEdge_flow2">
+        <omgdi:waypoint x="185.0" y="117.0"></omgdi:waypoint>
+        <omgdi:waypoint x="231.0" y="117.0"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
We add the inheritVariables option to callActivityBehavior task.

If this option is true, sub process inherit all variables from parent process.