### PR TITLE
ACT-4206: Webservice endpoint address should be customizable

### DIFF
--- a/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/CxfWebServiceClient.java
+++ b/modules/activiti-cxf/src/main/java/org/activiti/engine/impl/webservice/CxfWebServiceClient.java
@@ -16,10 +16,16 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.namespace.QName;
 
 import org.activiti.engine.ActivitiException;
 import org.apache.cxf.endpoint.Client;
 import org.apache.cxf.jaxws.endpoint.dynamic.JaxWsDynamicClientFactory;
+import org.apache.cxf.message.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -57,7 +63,13 @@ public class CxfWebServiceClient implements SyncWebServiceClient {
   /**
    * {@inheritDoc}}
    */
-  public Object[] send(String methodName, Object[] arguments) throws Exception {
+  public Object[] send(String methodName, Object[] arguments, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
+    // If needed, we override the endpoint address
+    final URL newEndpointAddress = overridenEndpointAddresses
+             .get(this.client.getEndpoint().getEndpointInfo().getName());
+    if (newEndpointAddress != null) {
+       this.client.getRequestContext().put(Message.ENDPOINT_ADDRESS, newEndpointAddress.toExternalForm());
+    }
     return client.invoke(methodName, arguments);
   }
 }

--- a/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/WebServiceTaskTest.java
+++ b/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/WebServiceTaskTest.java
@@ -12,10 +12,13 @@
  */
 package org.activiti.engine.impl.webservice;
 
+import java.net.URL;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+
+import javax.xml.namespace.QName;
 
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -60,6 +63,22 @@ public class WebServiceTaskTest extends PluggableActivitiTestCase {
     public void testWebServiceInvocation() throws Exception {
 
         assertEquals(-1, webServiceMock.getCount());
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("webServiceInvocation");
+        waitForJobExecutorToProcessAllJobs(10000L, 250L);
+
+        assertEquals(0, webServiceMock.getCount());
+        assertTrue(processInstance.isEnded());
+    }
+
+    @Deployment
+    public void testWebServiceInvocationWithEndpointAddressConfigured() throws Exception {
+
+        assertEquals(-1, webServiceMock.getCount());
+
+        processEngine.getProcessEngineConfiguration().addWsEndpointAddress(
+                new QName("http://webservice.impl.engine.activiti.org/", "CounterImplPort"),
+                new URL("http://localhost:63081/webservicemock"));
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("webServiceInvocation");
         waitForJobExecutorToProcessAllJobs(10000L, 250L);

--- a/modules/activiti-cxf/src/test/resources/org/activiti/engine/impl/webservice/WebServiceTaskTest.testWebServiceInvocationWithEndpointAddressConfigured.bpmn20.xml
+++ b/modules/activiti-cxf/src/test/resources/org/activiti/engine/impl/webservice/WebServiceTaskTest.testWebServiceInvocationWithEndpointAddressConfigured.bpmn20.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="org.activiti.enginge.impl.webservice"
+  xmlns:tns="org.activiti.enginge.impl.webservice"
+  xmlns:webservice="http://webservice.activiti.org/">
+
+  <import importType="http://schemas.xmlsoap.org/wsdl/"
+          location="webservicemock.wsdl"
+          namespace="http://webservice.activiti.org/" />
+
+  <process id="webServiceInvocation">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="webService" />
+
+    <serviceTask id="webService"
+                 name="Web service invocation"
+                 implementation="##WebService"
+                 operationRef="tns:incOperation" />
+
+    <sequenceFlow id="flow2" sourceRef="webService" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+
+  <itemDefinition id="incRequestItem" structureRef="webservice:inc" /><!-- QName of input element --> <!-- NEEDED FOR THE ARGUMENTS -->
+  <itemDefinition id="incResponseItem" structureRef="webservice:incResponse" /><!-- QName of output element -->
+
+  <message id="incRequestMessage" itemRef="tns:incRequestItem" name="incRequestMessage" />
+  <message id="incResponseMessage" itemRef="tns:incResponseItem" name="incResponseMessage" />
+
+
+  <!-- Interface: implementationRef = QName of WSDL Port Type -->
+  <interface name="Webservice Interface"> <!-- NEEDED FOR THE PORT -->
+    <!-- Operation: implementationRef = QName of WSDL Operation -->
+    <operation id="incOperation" name="Increase Operation" implementationRef="webservice:inc"> <!-- NEEDED FOR THE OPERATION NAME -->
+      <inMessageRef>tns:incRequestMessage</inMessageRef>
+      <outMessageRef>tns:incResponseMessage</outMessageRef>
+    </operation>
+  </interface>
+
+
+</definitions>

--- a/modules/activiti-cxf/src/test/resources/org/activiti/engine/impl/webservice/webservicemock.wsdl
+++ b/modules/activiti-cxf/src/test/resources/org/activiti/engine/impl/webservice/webservicemock.wsdl
@@ -1,0 +1,280 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions name="Counter" targetNamespace="http://webservice.impl.engine.activiti.org/"
+   xmlns:ns1="http://schemas.xmlsoap.org/soap/http" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://webservice.impl.engine.activiti.org/"
+   xmlns:tns1="http://impl.engine.activiti.org/test" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+   <wsdl:types>
+      <xs:schema attributeFormDefault="unqualified" elementFormDefault="unqualified"
+         targetNamespace="http://webservice.impl.engine.activiti.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+         <xs:element name="getCount" type="tns:getCount" />
+         <xs:element name="getCountResponse" type="tns:getCountResponse" />
+         <xs:element name="inc" type="tns:inc" />
+         <xs:element name="incResponse" type="tns:incResponse" />
+         <xs:element name="prettyPrintCount" type="tns:prettyPrintCount" />
+         <xs:element name="prettyPrintCountResponse" type="tns:prettyPrintCountResponse" />
+         <xs:element name="noNameResult" type="tns:noNameResult" />
+         <xs:element name="noNameResultResponse" type="tns:noNameResultResponse" />
+         <xs:element name="reservedWordAsName" type="tns:reservedWordAsName" />
+         <xs:element name="reservedWordAsNameResponse" type="tns:reservedWordAsNameResponse" />
+         <xs:element name="reset" type="tns:reset" />
+         <xs:element name="resetResponse" type="tns:resetResponse" />
+         <xs:element name="setTo" type="tns:setTo" />
+         <xs:element name="setToResponse" type="tns:setToResponse" />
+         <xs:complexType name="reset">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="resetResponse">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="setTo">
+            <xs:sequence>
+               <xs:element name="value" type="xs:int" />
+            </xs:sequence>
+         </xs:complexType>
+         <xs:complexType name="setToResponse">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="inc">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="incResponse">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="prettyPrintCount">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="prefix" type="xs:string" />
+               <xs:element minOccurs="0" name="suffix" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+         <xs:complexType name="prettyPrintCountResponse">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="prettyPrint" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+
+         <xs:complexType name="noNameResult">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="prefix" type="xs:string" />
+               <xs:element minOccurs="0" name="suffix" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+         <xs:complexType name="noNameResultResponse">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="return" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+
+         <xs:complexType name="reservedWordAsName">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="prefix" type="xs:string" />
+               <xs:element minOccurs="0" name="suffix" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+         <xs:complexType name="reservedWordAsNameResponse">
+            <xs:sequence>
+               <xs:element minOccurs="0" name="static" type="xs:string" />
+            </xs:sequence>
+         </xs:complexType>
+
+         <xs:complexType name="getCount">
+            <xs:sequence />
+         </xs:complexType>
+         <xs:complexType name="getCountResponse">
+            <xs:sequence>
+               <xs:element name="count" type="xs:int" />
+            </xs:sequence>
+         </xs:complexType>
+      </xs:schema>
+      <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:tns1="http://impl.engine.activiti.org/test"
+         attributeFormDefault="unqualified" elementFormDefault="unqualified" targetNamespace="http://impl.engine.activiti.org/test">
+         <xsd:element name="MaxValueReachedFault" type="tns1:MaxValueReachedFault" />
+         <xsd:complexType name="MaxValueReachedFault">
+            <xsd:sequence>
+               <xsd:element minOccurs="0" name="message" type="xsd:string" />
+            </xsd:sequence>
+         </xsd:complexType>
+      </xsd:schema>
+   </wsdl:types>
+   <wsdl:message name="getCount">
+      <wsdl:part element="tns:getCount" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="setTo">
+      <wsdl:part element="tns:setTo" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="prettyPrintCountResponse">
+      <wsdl:part element="tns:prettyPrintCountResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="noNameResultResponse">
+      <wsdl:part element="tns:noNameResultResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+
+   <wsdl:message name="reservedWordAsNameResponse">
+      <wsdl:part element="tns:reservedWordAsNameResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="resetResponse">
+      <wsdl:part element="tns:resetResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="reset">
+      <wsdl:part element="tns:reset" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="getCountResponse">
+      <wsdl:part element="tns:getCountResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="incResponse">
+      <wsdl:part element="tns:incResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="prettyPrintCount">
+      <wsdl:part element="tns:prettyPrintCount" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="noNameResult">
+      <wsdl:part element="tns:noNameResult" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="reservedWordAsName">
+      <wsdl:part element="tns:reservedWordAsName" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="inc">
+      <wsdl:part element="tns:inc" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="setToResponse">
+      <wsdl:part element="tns:setToResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="MaxValueReachedFault">
+      <wsdl:part element="tns1:MaxValueReachedFault" name="MaxValueReachedFault">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:portType name="Counter">
+      <wsdl:operation name="reset">
+         <wsdl:input message="tns:reset" name="reset">
+         </wsdl:input>
+         <wsdl:output message="tns:resetResponse" name="resetResponse">
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="setTo">
+         <wsdl:input message="tns:setTo" name="setTo">
+         </wsdl:input>
+         <wsdl:output message="tns:setToResponse" name="setToResponse">
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="inc">
+         <wsdl:input message="tns:inc" name="inc">
+         </wsdl:input>
+         <wsdl:output message="tns:incResponse" name="incResponse">
+         </wsdl:output>
+         <wsdl:fault message="tns:MaxValueReachedFault" name="MaxValueReachedFault">
+         </wsdl:fault>
+      </wsdl:operation>
+      <wsdl:operation name="prettyPrintCount">
+         <wsdl:input message="tns:prettyPrintCount" name="prettyPrintCount">
+         </wsdl:input>
+         <wsdl:output message="tns:prettyPrintCountResponse" name="prettyPrintCountResponse">
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="noNameResult">
+         <wsdl:input message="tns:noNameResult" name="noNameResult">
+         </wsdl:input>
+         <wsdl:output message="tns:noNameResultResponse" name="noNameResultResponse">
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="reservedWordAsName">
+         <wsdl:input message="tns:reservedWordAsName" name="reservedWordAsName">
+         </wsdl:input>
+         <wsdl:output message="tns:reservedWordAsNameResponse" name="reservedWordAsNameResponse">
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="getCount">
+         <wsdl:input message="tns:getCount" name="getCount">
+         </wsdl:input>
+         <wsdl:output message="tns:getCountResponse" name="getCountResponse">
+         </wsdl:output>
+      </wsdl:operation>
+   </wsdl:portType>
+   <wsdl:binding name="CounterSoapBinding" type="tns:Counter">
+      <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http" />
+      <wsdl:operation name="reset">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="reset">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="resetResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="setTo">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="setTo">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="setToResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="inc">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="inc">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="incResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+         <wsdl:fault name="MaxValueReachedFault">
+            <soap:fault name="MaxValueReachedFault" use="literal" />
+         </wsdl:fault>
+      </wsdl:operation>
+      <wsdl:operation name="prettyPrintCount">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="prettyPrintCount">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="prettyPrintCountResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="noNameResult">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="noNameResult">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="noNameResultResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+
+      <wsdl:operation name="reservedWordAsName">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="reservedWordAsName">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="reservedWordAsNameResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+      <wsdl:operation name="getCount">
+         <soap:operation soapAction="" style="document" />
+         <wsdl:input name="getCount">
+            <soap:body use="literal" />
+         </wsdl:input>
+         <wsdl:output name="getCountResponse">
+            <soap:body use="literal" />
+         </wsdl:output>
+      </wsdl:operation>
+   </wsdl:binding>
+   <wsdl:service name="Counter">
+      <wsdl:port binding="tns:CounterSoapBinding" name="CounterImplPort">
+         <!-- The endpoint address is configured at Activiti engine level -->
+         <soap:address location="http://localhost:8080/a-webservicemock" />
+      </wsdl:port>
+   </wsdl:service>
+</wsdl:definitions>

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/ProcessEngineConfiguration.java
@@ -14,10 +14,14 @@
 package org.activiti.engine;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import javax.sql.DataSource;
+import javax.xml.namespace.QName;
 
 import org.activiti.engine.cfg.MailServerInfo;
 import org.activiti.engine.impl.asyncexecutor.AsyncExecutor;
@@ -117,6 +121,8 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   protected String mailSessionJndi;
   protected Map<String,MailServerInfo> mailServers = new HashMap<String,MailServerInfo>();
   protected Map<String, String> mailSessionsJndi = new HashMap<String, String>();
+
+  protected ConcurrentMap<QName, URL> wsOverridenEndpointAddresses = new ConcurrentHashMap<QName, URL>();
 
   protected String databaseType;
   protected String databaseSchemaUpdate = DB_SCHEMA_UPDATE_FALSE;
@@ -382,6 +388,34 @@ public abstract class ProcessEngineConfiguration implements EngineServices {
   
   public ProcessEngineConfiguration setMailSessionsJndi(Map<String, String> mailSessionsJndi) {
     this.mailSessionsJndi.putAll(mailSessionsJndi);
+    return this;
+  }
+  
+  /**
+   * Add or replace the address of the given web-service endpoint with the given value
+   * @param endpointName The endpoint name for which a new address must be set
+   * @param address The new address of the endpoint
+   */
+  public ProcessEngineConfiguration addWsEndpointAddress(QName endpointName, URL address) {
+      this.wsOverridenEndpointAddresses.put(endpointName, address);
+      return this;
+  }
+  
+  /**
+   * Remove the address definition of the given web-service endpoint
+   * @param endpointName The endpoint name for which the address definition must be removed
+   */
+  public ProcessEngineConfiguration removeWsEndpointAddress(QName endpointName) {
+      this.wsOverridenEndpointAddresses.remove(endpointName);
+      return this;
+  }
+  
+  public ConcurrentMap<QName, URL> getWsOverridenEndpointAddresses() {
+      return this.wsOverridenEndpointAddresses;
+  }
+  
+  public ProcessEngineConfiguration setWsOverridenEndpointAddresses(final ConcurrentMap<QName, URL> wsOverridenEndpointAdress) {
+    this.wsOverridenEndpointAddresses.putAll(wsOverridenEndpointAdress);
     return this;
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/WebServiceActivityBehavior.java
@@ -15,6 +15,7 @@ package org.activiti.engine.impl.bpmn.behavior;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.activiti.engine.ProcessEngineConfiguration;
 import org.activiti.engine.impl.bpmn.data.AbstractDataAssociation;
 import org.activiti.engine.impl.bpmn.data.IOSpecification;
 import org.activiti.engine.impl.bpmn.data.ItemInstance;
@@ -72,7 +73,8 @@ public class WebServiceActivityBehavior extends AbstractBpmnActivityBehavior {
     
     this.fillMessage(message, execution);
     
-    MessageInstance receivedMessage = this.operation.sendMessage(message);
+    ProcessEngineConfiguration processEngineConfig = execution.getEngineServices().getProcessEngineConfiguration();
+    MessageInstance receivedMessage = this.operation.sendMessage(message, processEngineConfig.getWsOverridenEndpointAddresses());
 
     execution.setVariable(CURRENT_MESSAGE, receivedMessage);
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/webservice/Operation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/webservice/Operation.java
@@ -12,6 +12,11 @@
  */
 package org.activiti.engine.impl.bpmn.webservice;
 
+import java.net.URL;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.namespace.QName;
+
 /**
  * An Operation is part of an {@link BpmnInterface} and it defines Messages that are consumed and
  * (optionally) produced when the Operation is called.
@@ -46,8 +51,8 @@ public class Operation {
     setInMessage(inMessage);
   }
   
-  public MessageInstance sendMessage(MessageInstance message) {
-    return this.implementation.sendFor(message, this);
+  public MessageInstance sendMessage(MessageInstance message, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
+    return this.implementation.sendFor(message, this, overridenEndpointAddresses);
   }
   
   public String getId() {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/webservice/OperationImplementation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/webservice/OperationImplementation.java
@@ -12,6 +12,11 @@
  */
 package org.activiti.engine.impl.bpmn.webservice;
 
+import java.net.URL;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.namespace.QName;
+
 /**
  * Represents an implementation of a {@link Operation}
  * 
@@ -34,7 +39,8 @@ public interface OperationImplementation {
    * 
    * @param message the message to be sent
    * @param operation the operation that is interested on sending the message
+   * @param overridenEndpointAddresses a not null map of overriden enpoint addresses. The key is the endpoint qualified name.
    * @return the resulting message
    */
-  MessageInstance sendFor(MessageInstance message, Operation operation);
+  MessageInstance sendFor(MessageInstance message, Operation operation, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception;
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/webservice/SyncWebServiceClient.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/webservice/SyncWebServiceClient.java
@@ -12,6 +12,10 @@
  */
 package org.activiti.engine.impl.webservice;
 
+import java.net.URL;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.namespace.QName;
 
 /**
  * A dynamic web service client that allows to perform synchronous calls
@@ -26,7 +30,8 @@ public interface SyncWebServiceClient {
    * 
    * @param methodName a not null method name
    * @param arguments a not null list of arguments
+   * @param overridenEndpointAddresses a not null map of overriden enpoint addresses. The key is the endpoint qualified name.
    * @return the result of invoking the method of the web service
    */
-  Object[] send(String methodName, Object[] arguments) throws Exception;
+  Object[] send(String methodName, Object[] arguments, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception;
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/webservice/WSOperation.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/webservice/WSOperation.java
@@ -12,6 +12,11 @@
  */
 package org.activiti.engine.impl.webservice;
 
+import java.net.URL;
+import java.util.concurrent.ConcurrentMap;
+
+import javax.xml.namespace.QName;
+
 import org.activiti.engine.impl.bpmn.webservice.MessageDefinition;
 import org.activiti.engine.impl.bpmn.webservice.MessageInstance;
 import org.activiti.engine.impl.bpmn.webservice.Operation;
@@ -33,8 +38,8 @@ public class WSOperation implements OperationImplementation {
   protected String name;
   
   protected WSService service;
-  
-  public WSOperation(String id, String operationName, WSService service) {
+
+    public WSOperation(String id, String operationName, WSService service) {
     this.id = id;
     this.name = operationName;
     this.service = service;
@@ -57,9 +62,9 @@ public class WSOperation implements OperationImplementation {
   /**
    * {@inheritDoc}
    */
-  public MessageInstance sendFor(MessageInstance message, Operation operation) {
+  public MessageInstance sendFor(MessageInstance message, Operation operation, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
     Object[] arguments = this.getArguments(message);
-    Object[] results = this.safeSend(arguments);
+    Object[] results = this.safeSend(arguments, overridenEndpointAddresses);
     return this.createResponseMessage(results, operation);
   }
 
@@ -67,11 +72,11 @@ public class WSOperation implements OperationImplementation {
     return message.getStructureInstance().toArray();
   }
   
-  private Object[] safeSend(Object[] arguments) {
+  private Object[] safeSend(Object[] arguments, final ConcurrentMap<QName, URL> overridenEndpointAddresses) throws Exception {
     Object[] results = null;
     
     try {
-      results = this.service.getClient().send(this.name, arguments);
+      results = this.service.getClient().send(this.name, arguments, overridenEndpointAddresses);
     } catch (Exception e) {
       LOGGER.warn("Error calling WS {}", this.service.getName(), e);
     }


### PR DESCRIPTION
See [ACT-4206](https://activiti.atlassian.net/browse/ACT-4206):
> When using a service task implemented by a web-service, the endpoint address of the web-service is extracted from the WSDL imported into the process definition.
> Once you have deployed your process definition, it is possible to move the web-service, and its endpoint address changes. And now all new process instances will fail.
> To avoid this problem, we should be able to override the endpoint addresses at Activiti engine level, in its configuration for example.

Endpoint addresses are configured through a map where the key is the endpoint qualified name available in the WSDL, and the value its location
