### PR TITLE
Add support for TIMER_SCHEDULED event.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEventType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEventType.java
@@ -59,6 +59,11 @@ public enum ActivitiEventType {
   ENTITY_ACTIVATED,
 
   /**
+   * A Timer has been scheduled.
+   */
+  TIMER_SCHEDULED,
+
+  /**
    * Timer has been fired successfully.
    */
   TIMER_FIRED,


### PR DESCRIPTION
Neither the ACTIVITY_STARTED OR ENTITY_CREATED/ENTITY_INITIALIZED events can be used as an event type for a callback hook in a listener to know when a timer is started. ACTIVITY_STARTED does not work since a timer is not an 'activity'. The ENTITY_CREATED/ENTITY_INITIALIZED event types do not help since they are sent multiple times (i.e when the process has reached the timer element and when the timer is fired). This pulls request adds a new event (TIMER_STARTED) that is sent after a timer is scheduled which a listener can use.
 
