### PR TITLE
Unnecessary 'null' check before 'instanceof' expression

### DIFF
--- a/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/modules/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -471,7 +471,7 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
       } else if (flowElement instanceof BoundaryEvent) {
         BoundaryEvent boundaryEvent = (BoundaryEvent) flowElement;
         FlowElement attachedToElement = getFlowNodeFromScope(boundaryEvent.getAttachedToRefId(), parentScope);
-        if (attachedToElement != null && attachedToElement instanceof Activity) {
+        if (attachedToElement instanceof Activity) {
           Activity attachedActivity = (Activity) attachedToElement;
           boundaryEvent.setAttachedToRef(attachedActivity);
           attachedActivity.getBoundaryEvents().add(boundaryEvent);

--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/FlowElement.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/FlowElement.java
@@ -59,7 +59,7 @@ public abstract class FlowElement extends BaseElement implements HasExecutionLis
   @JsonIgnore
   public SubProcess getSubProcess() {
     SubProcess subProcess = null;
-    if (parentContainer != null && parentContainer instanceof SubProcess) {
+    if (parentContainer instanceof SubProcess) {
       subProcess = (SubProcess) parentContainer;
     }
     

--- a/modules/activiti-dmn-api/src/main/java/org/activiti/dmn/api/DecisionExecutionAuditContainer.java
+++ b/modules/activiti-dmn-api/src/main/java/org/activiti/dmn/api/DecisionExecutionAuditContainer.java
@@ -173,19 +173,19 @@ public class DecisionExecutionAuditContainer {
   }
 
   public static boolean isBoolean(Object obj) {
-    return obj != null && obj instanceof Boolean;
+    return obj instanceof Boolean;
   }
 
   public static boolean isDate(Object obj) {
-    return obj != null && (obj instanceof Date || obj instanceof DateTime);
+    return (obj instanceof Date || obj instanceof DateTime);
   }
 
   public static boolean isString(Object obj) {
-    return obj != null && obj instanceof String;
+    return obj instanceof String;
   }
 
   public static boolean isNumber(Object obj) {
-    return obj != null && obj instanceof Number;
+    return obj instanceof Number;
   }
 
   protected Map<String, Object> createDefensiveCopyInputVariables(Map<String, Object> inputVariables) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryCompensateEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryCompensateEventActivityBehavior.java
@@ -58,7 +58,7 @@ public class BoundaryCompensateEventActivityBehavior extends BoundaryEventActivi
     List<Association> associations = process.findAssociationsWithSourceRefRecursive(boundaryEvent.getId());
     for (Association association : associations) {
       FlowElement targetElement = process.getFlowElement(association.getTargetRef(), true);
-      if (targetElement != null && targetElement instanceof Activity) {
+      if (targetElement instanceof Activity) {
         Activity activity = (Activity) targetElement;
         if (activity.isForCompensation()) {
           compensationActivity = activity;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
@@ -66,7 +66,7 @@ public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivity
   
   protected EventGateway getPrecedingEventBasedGateway(DelegateExecution execution) {
     FlowElement currentFlowElement = execution.getCurrentFlowElement();
-    if (currentFlowElement != null && currentFlowElement instanceof IntermediateCatchEvent) {
+    if (currentFlowElement instanceof IntermediateCatchEvent) {
       IntermediateCatchEvent intermediateCatchEvent = (IntermediateCatchEvent) currentFlowElement;
       List<SequenceFlow> incomingSequenFlow = intermediateCatchEvent.getIncomingFlows();
       

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
@@ -210,7 +210,7 @@ public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior 
 
     // activity with message/signal boundary events
     FlowElement currentFlowElement = execution.getCurrentFlowElement();
-    if (currentFlowElement != null && currentFlowElement instanceof FlowNode) {
+    if (currentFlowElement instanceof FlowNode) {
       dispatchActivityCancelled(execution, terminateEndEvent);
     }
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ListenerNotificationHelper.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/listener/ListenerNotificationHelper.java
@@ -99,7 +99,7 @@ public class ListenerNotificationHelper {
     if (taskEntity.getProcessDefinitionId() != null) {
       org.activiti.bpmn.model.Process process = ProcessDefinitionUtil.getProcess(taskEntity.getProcessDefinitionId());
       FlowElement flowElement = process.getFlowElement(taskEntity.getTaskDefinitionKey(), true);
-      if (flowElement != null && flowElement instanceof UserTask) {
+      if (flowElement instanceof UserTask) {
         UserTask userTask = (UserTask) flowElement;
         executeTaskListeners(userTask, taskEntity, eventType);
       }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/BpmnParse.java
@@ -389,7 +389,7 @@ public class BpmnParse implements BpmnXMLConstants {
 
   public void createBPMNEdge(String key, List<GraphicInfo> graphicList) {
     FlowElement flowElement = bpmnModel.getFlowElement(key);
-    if (flowElement != null && flowElement instanceof SequenceFlow) {
+    if (flowElement instanceof SequenceFlow) {
       SequenceFlow sequenceFlow = (SequenceFlow) flowElement;
       List<Integer> waypoints = new ArrayList<Integer>();
       for (GraphicInfo waypointInfo : graphicList) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/el/JsonNodeELResolver.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/el/JsonNodeELResolver.java
@@ -327,6 +327,6 @@ public class JsonNodeELResolver extends ELResolver {
    * @return base != null
    */
   private final boolean isResolvable(Object base) {
-    return base != null && base instanceof JsonNode;
+    return base instanceof JsonNode;
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/AbstractEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/AbstractEventHandler.java
@@ -84,7 +84,7 @@ public abstract class AbstractEventHandler implements EventHandler {
 
     // activity with message/signal boundary events
     FlowElement flowElement = execution.getCurrentFlowElement();
-    if (flowElement != null && flowElement instanceof BoundaryEvent) {
+    if (flowElement instanceof BoundaryEvent) {
       BoundaryEvent boundaryEvent = (BoundaryEvent) flowElement;
       if (boundaryEvent.getAttachedToRef() != null) {
         dispatchActivityCancelled(eventSubscription, execution, boundaryEvent.getAttachedToRef(), commandContext);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
@@ -55,7 +55,7 @@ public class SignalEventHandler extends AbstractEventHandler {
       
       // Start process instance via that flow element
       Map<String, Object> variables = null;
-      if (payload != null && payload instanceof Map) {
+      if (payload instanceof Map) {
         variables = (Map<String, Object>) payload;
       }
       ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ExecutionGraphUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ExecutionGraphUtil.java
@@ -106,7 +106,7 @@ public class ExecutionGraphUtil {
       visitedElements.add(sourceElement.getId());
 
       FlowElementsContainer parentElement = process.findParent(sourceElement);
-      if (parentElement != null && parentElement instanceof SubProcess) {
+      if (parentElement instanceof SubProcess) {
         sourceElement = (SubProcess) parentElement;
       } else {
         return false;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/FormHandlerUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/FormHandlerUtil.java
@@ -57,7 +57,7 @@ public class FormHandlerUtil {
   public static TaskFormHandler getTaskFormHandlder(String processDefinitionId, String taskId) {
     org.activiti.bpmn.model.Process process = ProcessDefinitionUtil.getProcess(processDefinitionId);
     FlowElement flowElement = process.getFlowElement(taskId, true);
-    if (flowElement != null && flowElement instanceof UserTask) {
+    if (flowElement instanceof UserTask) {
       UserTask userTask = (UserTask) flowElement;
       
       ProcessDefinition processDefinitionEntity = ProcessDefinitionUtil.getProcessDefinition(processDefinitionId);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/TimerUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/TimerUtil.java
@@ -129,7 +129,7 @@ public class TimerUtil {
       // ACT-1951: intermediate catching timer events shouldn't repeat according to spec
       if (executionEntity != null) {
         FlowElement currentElement = executionEntity.getCurrentFlowElement();
-        if (currentElement != null && currentElement instanceof IntermediateCatchEvent) {
+        if (currentElement instanceof IntermediateCatchEvent) {
           repeat = false;
         }
       }


### PR DESCRIPTION
Since the instanceof operator always returns false for null, there is no need to have an additional null check.
Here is an example of a violation:
    if (x != null && x instanceof String) { ... }
The change to the code is:
    if (x instanceof String) { ... }