### PR TITLE
Unnecessary 'null' check before 'equals()' call

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ShellActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ShellActivityBehavior.java
@@ -62,8 +62,8 @@ public class ShellActivityBehavior extends AbstractBpmnActivityBehavior {
     String cleanEnvStr = getStringFromField(cleanEnv, execution);
 
     waitFlag = waitStr == null || waitStr.equals("true");
-    redirectErrorFlag = redirectErrorStr != null && redirectErrorStr.equals("true");
-    cleanEnvBoolean = cleanEnvStr != null && cleanEnvStr.equals("true");
+    redirectErrorFlag = "true".equals(redirectErrorStr);
+    cleanEnvBoolean = "true".equals(cleanEnvStr);
     directoryStr = getStringFromField(directory, execution);
 
   }


### PR DESCRIPTION
Unnecessary 'null' which are followed by an 'equals()' call with a constant argument can be simplified.

For example:
    if (s != null && s.equals("literal")) {}
The fix is to replace that with:
    if ("literal".equals(s)) {}