### PR TITLE
Improve unit tests of activiti-cxf introducing a constant for the webservice URL

### DIFF
--- a/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/AbstractWebServiceTaskTest.java
+++ b/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/AbstractWebServiceTaskTest.java
@@ -26,6 +26,8 @@ import org.apache.cxf.jaxws.JaxWsServerFactoryBean;
  */
 public abstract class AbstractWebServiceTaskTest extends PluggableActivitiTestCase {
 
+    public final static String WEBSERVICE_MOCK_ADDRESS = "http://localhost:63081/webservicemock";
+
     protected WebServiceMock webServiceMock;
 
     protected Server server;
@@ -37,7 +39,7 @@ public abstract class AbstractWebServiceTaskTest extends PluggableActivitiTestCa
         webServiceMock = new WebServiceMockImpl();
         JaxWsServerFactoryBean svrFactory = new JaxWsServerFactoryBean();
         svrFactory.setServiceClass(WebServiceMock.class);
-        svrFactory.setAddress("http://localhost:63081/webservicemock");
+        svrFactory.setAddress(WEBSERVICE_MOCK_ADDRESS);
         svrFactory.setServiceBean(webServiceMock);
         svrFactory.getInInterceptors().add(new LoggingInInterceptor());
         svrFactory.getOutInterceptors().add(new LoggingOutInterceptor());
@@ -49,6 +51,7 @@ public abstract class AbstractWebServiceTaskTest extends PluggableActivitiTestCa
     protected void tearDown() throws Exception {
         super.tearDown();
         server.stop();
+        server.destroy();
     }
 
 }

--- a/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/WebServiceTaskTest.java
+++ b/modules/activiti-cxf/src/test/java/org/activiti/engine/impl/webservice/WebServiceTaskTest.java
@@ -54,7 +54,7 @@ public class WebServiceTaskTest extends AbstractWebServiceTaskTest {
 
         processEngineConfiguration.addWsEndpointAddress(
                 new QName("http://webservice.impl.engine.activiti.org/", "CounterImplPort"),
-                new URL("http://localhost:63081/webservicemock"));
+                new URL(WEBSERVICE_MOCK_ADDRESS));
 
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("webServiceInvocation");
         waitForJobExecutorToProcessAllJobs(10000L, 250L);


### PR DESCRIPTION
Improve unit tests of `WebServiceTask` provided by `activiti-cxf` introducing a constant for the web-service URL. This constant is used to locate the test web-service on the server and client sides.