### PR TITLE
identitylinks user & group docs did not match implementation

### DIFF
--- a/userguide/src/en/ch14-REST.adoc
+++ b/userguide/src/en/ch14-REST.adoc
@@ -911,7 +911,7 @@ POST repository/process-definitions/{processDefinitionId}/identitylinks
 [source,json,linenums]
 ----
 {
-  "groupId" : "sales"
+  "group" : "sales"
 }
 ----
 
@@ -952,7 +952,7 @@ DELETE repository/process-definitions/{processDefinitionId}/identitylinks/{famil
 |Parameter|Required|Value|Description
 |processDefinitionId|Yes|String|The id of the process definition.
 |family|Yes|String|Either +users+ or +groups+, depending on the type of identity link.
-|identityId|Yes|String|Either the userId or groupId of the identity to remove as candidate starter.
+|identityId|Yes|String|Either the user or group of the identity to remove as candidate starter.
 
 |===============
 
@@ -994,7 +994,7 @@ GET repository/process-definitions/{processDefinitionId}/identitylinks/{family}/
 |Parameter|Required|Value|Description
 |processDefinitionId|Yes|String|The id of the process definition.
 |family|Yes|String|Either +users+ or +groups+, depending on the type of identity link.
-|identityId|Yes|String|Either the userId or groupId of the identity to get as candidate starter.
+|identityId|Yes|String|Either the user or group of the identity to get as candidate starter.
 
 |===============
 
@@ -1834,7 +1834,7 @@ GET runtime/process-instances/{processInstanceId}/identitylinks
 ----
 
 
-Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
+Note that the +group+ will always be null, as it's only possible to involve users with a process-instance.
 
 
 ==== Add an involved user to a process instance
@@ -1858,13 +1858,13 @@ POST runtime/process-instances/{processInstanceId}/identitylinks
 [source,json,linenums]
 ----
 {
-  "userId":"kermit",
+  "user":"kermit",
   "type":"participant"
 }
 ----
 
 
-Both +userId+ and +type+ are required.
+Both +user+ and +type+ are required.
 
 
 .Add an involved user to a process instance - Response codes
@@ -1872,7 +1872,7 @@ Both +userId+ and +type+ are required.
 |===============
 |Response code|Description
 |201|Indicates the process instance was found and the link is created.
-|400|Indicates the requested body did not contain a userId or a type.
+|400|Indicates the requested body did not contain a user or a type.
 |404|Indicates the requested process instance was not found.
 
 |===============
@@ -1891,7 +1891,7 @@ Both +userId+ and +type+ are required.
 ----
 
 
-Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
+Note that the +group+ will always be null, as it's only possible to involve users with a process-instance.
 
 
 ==== Remove an involved user to from process instance
@@ -1934,7 +1934,7 @@ DELETE runtime/process-instances/{processInstanceId}/identitylinks/users/{userId
 ----
 
 
-Note that the +groupId+ will always be null, as it's only possible to involve users with a process-instance.
+Note that the +group+ will always be null, as it's only possible to involve users with a process-instance.
 
 
 ==== List of variables for a process instance
@@ -3793,14 +3793,14 @@ GET runtime/tasks/{taskId}/identitylinks
 ----
 [
   {
-    "userId" : "kermit",
-    "groupId" : null,
+    "user" : "kermit",
+    "group" : null,
     "type" : "candidate",
     "url" : "http://localhost:8081/activiti-rest/service/runtime/tasks/100/identitylinks/users/kermit/candidate"
   },
   {
-    "userId" : null,
-    "groupId" : "sales",
+    "user" : null,
+    "group" : "sales",
     "type" : "candidate",
     "url" : "http://localhost:8081/activiti-rest/service/runtime/tasks/100/identitylinks/groups/sales/candidate"
   },
@@ -3858,8 +3858,8 @@ GET runtime/tasks/{taskId}/identitylinks/{family}/{identityId}/{type}
 [source,json,linenums]
 ----
 {
-  "userId" : null,
-  "groupId" : "sales",
+  "user" : null,
+  "group" : "sales",
   "type" : "candidate",
   "url" : "http://localhost:8081/activiti-rest/service/runtime/tasks/100/identitylinks/groups/sales/candidate"
 }
@@ -3889,7 +3889,7 @@ POST runtime/tasks/{taskId}/identitylinks
 [source,json,linenums]
 ----
 {
-  "userId" : "kermit",
+  "user" : "kermit",
   "type" : "candidate",
 }
 ----
@@ -3900,7 +3900,7 @@ POST runtime/tasks/{taskId}/identitylinks
 [source,json,linenums]
 ----
 {
-  "groupId" : "sales",
+  "group" : "sales",
   "type" : "candidate",
 }
 ----
@@ -3921,8 +3921,8 @@ POST runtime/tasks/{taskId}/identitylinks
 [source,json,linenums]
 ----
 {
-  "userId" : null,
-  "groupId" : "sales",
+  "user" : null,
+  "group" : "sales",
   "type" : "candidate",
   "url" : "http://localhost:8081/activiti-rest/service/runtime/tasks/100/identitylinks/groups/sales/candidate"
 }
@@ -4764,8 +4764,8 @@ GET history/historic-process-instance/{processInstanceId}/identitylinks
 [
  {
   "type" : "participant",
-  "userId" : "kermit",
-  "groupId" : null,
+  "user" : "kermit",
+  "group" : null,
   "taskId" : null,
   "taskUrl" : null,
   "processInstanceId" : "5",
@@ -5286,8 +5286,8 @@ GET history/historic-task-instance/{taskId}/identitylinks
 [
  {
   "type" : "assignee",
-  "userId" : "kermit",
-  "groupId" : null,
+  "user" : "kermit",
+  "group" : null,
   "taskId" : "6",
   "taskUrl" : "http://localhost:8182/history/historic-task-instances/5",
   "processInstanceId" : null,
@@ -7140,7 +7140,7 @@ POST identity/groups/{groupId}/members
 [source,json,linenums]
 ----
 {
-   "userId":"kermit"
+   "user":"kermit"
 }
 ----
 
@@ -7150,7 +7150,7 @@ POST identity/groups/{groupId}/members
 |===============
 |Response code|Description
 |201|Indicates the group was found and the member has been added.
-|404|Indicates the userId was not included in the request body.
+|404|Indicates the user was not included in the request body.
 |404|Indicates the requested group was not found.
 |409|Indicates the requested user is already a member of the group.
 
@@ -7162,8 +7162,8 @@ POST identity/groups/{groupId}/members
 [source,json,linenums]
 ----
 {
-   "userId":"kermit",
-   "groupId":"sales",
+   "user":"kermit",
+   "group":"sales",
     "url":"http://localhost:8182/identity/groups/sales/members/kermit"
 }
 ----
@@ -7202,8 +7202,8 @@ DELETE identity/groups/{groupId}/members/{userId}
 [source,json,linenums]
 ----
 {
-   "userId":"kermit",
-   "groupId":"sales",
+   "user":"kermit",
+   "group":"sales",
     "url":"http://localhost:8182/identity/groups/sales/members/kermit"
 }
 ----


### PR DESCRIPTION
The RestIdentityLink class, which is being used for serialization
in identity link creation and retrieval, has the properties,
"group", and "user".  The doc used "groupId" and "userId" instead.
Creating identity links using the exact doc sample syntax resulted
in the error,
"A group or a user is required to create an identity link."

Note: I left "groupId" and "userId" when it was part of a URL, for example:
"GET identity/users/{userId}"  since this makes more sense.  I could be
wrong in having left these.
