### PR TITLE
Remaining optimizations for 'or queries' with multiple process variable values

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractVariableQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractVariableQueryImpl.java
@@ -224,4 +224,23 @@ public abstract class AbstractVariableQueryImpl<T extends Query<?,?>, U> extends
   public List<QueryVariableValue> getQueryVariableValues() {
     return queryVariableValues;
   }   
+
+  public boolean hasLocalQueryVariableValue() {
+    for (QueryVariableValue qvv : queryVariableValues) {
+        if (qvv.isLocal()) {
+            return true;
+        }
+    }
+    return false;
+  }
+
+  public boolean hasNonLocalQueryVariableValue() {
+    for (QueryVariableValue qvv : queryVariableValues) {
+        if (!qvv.isLocal()) {
+            return true;
+        }
+    }
+    return false;
+  }
+
 }

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -394,9 +394,9 @@
       <if test="orQueryObject.processDefinitionId != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionVersion != null || orQueryObject.processDefinitionCategory != null || orQueryObject.processDefinitionName != null || (orQueryObject.processDefinitionIds != null &amp;&amp; !orQueryObject.processDefinitionIds.isEmpty()) || (orQueryObject.processDefinitionKeys != null &amp;&amp; !orQueryObject.processDefinitionKeys.isEmpty())">
         inner join ${prefix}ACT_RE_PROCDEF P_OR${orIndex} on RES.PROC_DEF_ID_ = P_OR${orIndex}.ID_
       </if>
-      <foreach collection="orQueryObject.queryVariableValues" index="index" item="queryVariableValue">
-        left outer join ${prefix}ACT_RU_VARIABLE A_OR${orIndex}_${index} on RES.PROC_INST_ID_ = A_OR${orIndex}_${index}.PROC_INST_ID_
-      </foreach>
+      <if test="orQueryObject.queryVariableValues != null &amp;&amp; orQueryObject.queryVariableValues.size() &gt; 0">
+        left outer join ${prefix}ACT_RU_VARIABLE A_OR${orIndex} on RES.PROC_INST_ID_ = A_OR${orIndex}.PROC_INST_ID_
+      </if>
       <if test="orQueryObject.deploymentId != null || (orQueryObject.deploymentIds != null &amp;&amp; orQueryObject.deploymentIds.size() &gt; 0)">
         left outer join ${prefix}ACT_RE_PROCDEF DEPLOY_P_OR${orIndex} ON RES.PROC_DEF_ID_ = DEPLOY_P_OR${orIndex}.ID_
       </if>
@@ -698,23 +698,23 @@
             <trim prefix="(" prefixOverrides="AND" suffix=")">
               <if test="!queryVariableValue.local">
                 <!-- When process instance variable is queried for, only process variables are taken into account -->
-                and A_OR${orIndex}_${index}.EXECUTION_ID_ = A_OR${orIndex}_${index}.PROC_INST_ID_
+                and A_OR${orIndex}.EXECUTION_ID_ = A_OR${orIndex}.PROC_INST_ID_
               </if>
               <if test="queryVariableValue.name != null">
                 <!-- Match-all variable-names when name is null -->
-                and A_OR${orIndex}_${index}.NAME_= #{queryVariableValue.name}
+                and A_OR${orIndex}.NAME_= #{queryVariableValue.name}
               </if>
               <if test="!queryVariableValue.type.equals('null')">
               <!-- When operator is not-equals or type of value is null, type doesn't matter! -->
-                and A_OR${orIndex}_${index}.TYPE_ = #{queryVariableValue.type}
+                and A_OR${orIndex}.TYPE_ = #{queryVariableValue.type}
               </if>
               <if test="queryVariableValue.textValue != null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                 <choose>
                   <when test="queryVariableValue.operator.equals('EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVariableValue.operator.equals('LIKE_IGNORE_CASE')">
-                    and lower(A_OR${orIndex}_${index}.TEXT_)
+                    and lower(A_OR${orIndex}.TEXT_)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_
+                    and A_OR${orIndex}.TEXT_
                   </otherwise>
                 </choose>
               <choose>
@@ -727,7 +727,7 @@
               </choose>
               </if>
               <if test="queryVariableValue.textValue2 != null">
-              and A_OR${orIndex}_${index}.TEXT2_
+              and A_OR${orIndex}.TEXT2_
               <choose>
                 <when test="queryVariableValue.operator.equals('LIKE')">LIKE</when>
                 <otherwise><include refid="executionVariableOperator" /></otherwise>
@@ -738,12 +738,12 @@
                 </choose>
               </if>
               <if test="queryVariableValue.longValue != null">
-              and A_OR${orIndex}_${index}.LONG_
+              and A_OR${orIndex}.LONG_
               <include refid="executionVariableOperator" />
               #{queryVariableValue.longValue}
               </if>
               <if test="queryVariableValue.doubleValue != null">
-              and A_OR${orIndex}_${index}.DOUBLE_
+              and A_OR${orIndex}.DOUBLE_
               <include refid="executionVariableOperator" />
               #{queryVariableValue.doubleValue}
               </if>
@@ -751,10 +751,10 @@
               <if test="queryVariableValue.textValue == null &amp;&amp; queryVariableValue.textValue2 == null &amp;&amp; queryVariableValue.longValue == null &amp;&amp; queryVariableValue.doubleValue == null">
                 <choose>
                   <when test="queryVariableValue.operator.equals('NOT_EQUALS')">
-                    and (A_OR${orIndex}_${index}.TEXT_ is not null or A_OR${orIndex}_${index}.TEXT2_ is not null or A_OR${orIndex}_${index}.LONG_ is not null or A_OR${orIndex}_${index}.DOUBLE_ is not null or A_OR${orIndex}_${index}.BYTEARRAY_ID_ is not null)
+                    and (A_OR${orIndex}.TEXT_ is not null or A_OR${orIndex}.TEXT2_ is not null or A_OR${orIndex}.LONG_ is not null or A_OR${orIndex}.DOUBLE_ is not null or A_OR${orIndex}.BYTEARRAY_ID_ is not null)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_ is null and A_OR${orIndex}_${index}.TEXT2_ is null and A_OR${orIndex}_${index}.LONG_ is null and A_OR${orIndex}_${index}.DOUBLE_ is null and A_OR${orIndex}_${index}.BYTEARRAY_ID_ is null
+                    and A_OR${orIndex}.TEXT_ is null and A_OR${orIndex}.TEXT2_ is null and A_OR${orIndex}.LONG_ is null and A_OR${orIndex}.DOUBLE_ is null and A_OR${orIndex}.BYTEARRAY_ID_ is null
                   </otherwise>
                 </choose>
               </if>

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
@@ -392,16 +392,14 @@
       <if test="orQueryObject.deploymentId != null || (orQueryObject.deploymentIds != null &amp;&amp; orQueryObject.deploymentIds.size() &gt; 0)">
         left outer join ${prefix}ACT_RE_PROCDEF DEPLOY_P_OR${orIndex} ON RES.PROC_DEF_ID_ = DEPLOY_P_OR${orIndex}.ID_
       </if>
-      <foreach collection="orQueryObject.queryVariableValues" index="index" item="var">
-        <choose>
-          <when test="var.local">
-            left outer join ${prefix}ACT_HI_VARINST A_OR${orIndex}_${index} on RES.ID_ = A_OR${orIndex}_${index}.TASK_ID_ 
-          </when>
-          <otherwise>
-            left outer join ${prefix}ACT_HI_VARINST A_OR${orIndex}_${index} on RES.PROC_INST_ID_ = A_OR${orIndex}_${index}.PROC_INST_ID_ 
-          </otherwise>
-        </choose>       
-      </foreach>
+      <if test="orQueryObject.queryVariableValues.size() &gt; 0">
+        <if test="orQueryObject.hasLocalQueryVariableValue()">
+          left outer join ${prefix}ACT_HI_VARINST A_L_OR${orIndex} on RES.ID_ = A_L_OR${orIndex}.TASK_ID_ 
+        </if>
+        <if test="orQueryObject.hasNonLocalQueryVariableValue()">
+          left outer join ${prefix}ACT_HI_VARINST A_OR${orIndex} on RES.PROC_INST_ID_ = A_OR${orIndex}.PROC_INST_ID_ 
+        </if>
+      </if>
     </foreach>
     <where>
       <if test="taskId != null">
@@ -930,25 +928,31 @@
           <foreach item="queryVar" collection="orQueryObject.queryVariableValues" index="index">
             or
             <trim prefix="(" prefixOverrides="AND" suffix=")">
-              <if test="!queryVar.local">
-                <!-- When process instance variable is queried for, taskId should be null -->
-                and A_OR${orIndex}_${index}.TASK_ID_ is null
-              </if>
+              <choose>
+                <when test="!queryVar.local">
+                  <bind name="orLocal" value="''" />
+                  <!-- When process instance variable is queried for, taskId should be null -->
+                  and A_OR${orIndex}.TASK_ID_ is null
+                </when>
+                <otherwise>
+                  <bind name="orLocal" value="'L_'" />
+                </otherwise>
+              </choose>
               <if test="queryVar.name != null">
                 <!-- Match-all variable-names when name is null -->
-                and A_OR${orIndex}_${index}.NAME_= #{queryVar.name}
+                and A_${orLocal}OR${orIndex}.NAME_= #{queryVar.name}
               </if>
               <if test="!queryVar.type.equals('null')">
-                and A_OR${orIndex}_${index}.VAR_TYPE_ = #{queryVar.type}
+                and A_${orLocal}OR${orIndex}.VAR_TYPE_ = #{queryVar.type}
               </if>
               <!-- Variable value -->
               <if test="queryVar.textValue != null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">
                 <choose>
                   <when test="queryVar.operator.equals('EQUALS_IGNORE_CASE') || queryVar.operator.equals('NOT_EQUALS_IGNORE_CASE') || queryVar.operator.equals('LIKE_IGNORE_CASE')">
-                    and lower(A_OR${orIndex}_${index}.TEXT_)
+                    and lower(A_${orLocal}OR${orIndex}.TEXT_)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_
+                    and A_${orLocal}OR${orIndex}.TEXT_
                   </otherwise>
                 </choose> 
                 <choose>
@@ -961,7 +965,7 @@
                 </choose>
               </if>
               <if test="queryVar.textValue2 != null">
-                and A_OR${orIndex}_${index}.TEXT2_ 
+                and A_${orLocal}OR${orIndex}.TEXT2_ 
                 <choose>
                   <when test="queryVar.operator.equals('LIKE')">LIKE</when>
                   <otherwise><include refid="executionVariableOperator" /></otherwise>
@@ -972,12 +976,12 @@
                 </choose>
               </if>
               <if test="queryVar.longValue != null">
-                and A_OR${orIndex}_${index}.LONG_
+                and A_${orLocal}OR${orIndex}.LONG_
                 <include refid="executionVariableOperator" />
                 #{queryVar.longValue}
               </if>
               <if test="queryVar.doubleValue != null">
-                and A_OR${orIndex}_${index}.DOUBLE_ 
+                and A_${orLocal}OR${orIndex}.DOUBLE_ 
                 <include refid="executionVariableOperator" />
                 #{queryVar.doubleValue}
               </if>
@@ -985,10 +989,10 @@
               <if test="queryVar.textValue == null &amp;&amp; queryVar.textValue2 == null &amp;&amp; queryVar.longValue == null &amp;&amp; queryVar.doubleValue == null">
                 <choose>
                   <when test="queryVar.operator.equals('NOT_EQUALS')">
-                    and (A_OR${orIndex}_${index}.TEXT_ is not null or A_OR${orIndex}_${index}.TEXT2_ is not null or A_OR${orIndex}_${index}.LONG_ is not null or A_OR${orIndex}_${index}.DOUBLE_ is not null or A_OR${orIndex}_${index}.BYTEARRAY_ID_ is not null)
+                    and (A_${orLocal}OR${orIndex}.TEXT_ is not null or A_${orLocal}OR${orIndex}.TEXT2_ is not null or A_${orLocal}OR${orIndex}.LONG_ is not null or A_${orLocal}OR${orIndex}.DOUBLE_ is not null or A_${orLocal}OR${orIndex}.BYTEARRAY_ID_ is not null)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_ is null and A_OR${orIndex}_${index}.TEXT2_ is null and A_OR${orIndex}_${index}.LONG_ is null and A_OR${orIndex}_${index}.DOUBLE_ is null and A_OR${orIndex}_${index}.BYTEARRAY_ID_ is null
+                    and A_${orLocal}OR${orIndex}.TEXT_ is null and A_${orLocal}OR${orIndex}.TEXT2_ is null and A_${orLocal}OR${orIndex}.LONG_ is null and A_${orLocal}OR${orIndex}.DOUBLE_ is null and A_${orLocal}OR${orIndex}.BYTEARRAY_ID_ is null
                   </otherwise>
                 </choose>          
               </if>

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -360,17 +360,15 @@
         </choose>
         join ${prefix}ACT_RU_IDENTITYLINK I_OR${orIndex} on I_OR${orIndex}.TASK_ID_ = RES.ID_
       </if>
-      <foreach collection="orQueryObject.queryVariableValues" index="index" item="var">
-        <choose>
-          <when test="var.local">
-            left outer join ${prefix}ACT_RU_VARIABLE A_OR${orIndex}_${index} on RES.ID_ = A_OR${orIndex}_${index}.TASK_ID_ 
-          </when>
-          <otherwise>
-            left outer join ${prefix}ACT_RU_VARIABLE A_OR${orIndex}_${index} on RES.PROC_INST_ID_ = A_OR${orIndex}_${index}.PROC_INST_ID_ 
-          </otherwise>
-        </choose>       
-      </foreach>
-      
+      <if test="orQueryObject.queryVariableValues.size() &gt; 0">
+        <if test="orQueryObject.hasLocalQueryVariableValue()">
+          left outer join ${prefix}ACT_RU_VARIABLE A_L_OR${orIndex} on RES.ID_ = A_L_OR${orIndex}.TASK_ID_
+        </if>
+        <if test="orQueryObject.hasNonLocalQueryVariableValue()">
+          left outer join ${prefix}ACT_RU_VARIABLE A_OR${orIndex} on RES.PROC_INST_ID_ = A_OR${orIndex}.PROC_INST_ID_
+        </if>
+      </if>
+
       <if test="orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionKeyLike != null || orQueryObject.processDefinitionKeyLikeIgnoreCase != null || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionNameLike != null || (orQueryObject.processCategoryInList != null &amp;&amp; orQueryObject.processCategoryInList.size() &gt; 0) || (orQueryObject.processCategoryNotInList != null &amp;&amp; orQueryObject.processCategoryNotInList.size() &gt; 0) || (orQueryObject.processDefinitionKeys != null &amp;&amp; orQueryObject.processDefinitionKeys.size() &gt; 0)">
         left outer join ${prefix}ACT_RE_PROCDEF D_OR${orIndex} on RES.PROC_DEF_ID_ = D_OR${orIndex}.ID_
       </if>
@@ -916,28 +914,34 @@
             <foreach item="var" collection="orQueryObject.queryVariableValues" index="index">
               or 
               <trim prefix="(" prefixOverrides="AND" suffix=")">
-              <if test="!var.local">
-                <!-- When process instance variable is queried for, taskId should be null -->
-                and A_OR${orIndex}_${index}.TASK_ID_ is null
-              </if>
+              <choose>
+                <when test="!var.local">
+                  <bind name="orLocal" value="''" />
+                  <!-- When process instance variable is queried for, taskId should be null -->
+                  and A_OR${orIndex}.TASK_ID_ is null
+                </when>
+                <otherwise>
+                  <bind name="orLocal" value="'L_'" />
+                </otherwise>
+              </choose>
               <if test="var.name != null">
                 <!-- Match-all variable-names when name is null -->
-                and A_OR${orIndex}_${index}.NAME_= #{var.name}
+                and A_${orLocal}OR${orIndex}.NAME_= #{var.name}
               </if>
               <if test="var.name == null">
-          		and A_OR${orIndex}_${index}.NAME_ is not null
+                and A_${orLocal}OR${orIndex}.NAME_ is not null
         	  </if>
               <if test="!var.type.equals('null')">
-                and A_OR${orIndex}_${index}.TYPE_ = #{var.type}
+                and A_${orLocal}OR${orIndex}.TYPE_ = #{var.type}
               </if>
               <!-- Variable value -->
               <if test="var.textValue != null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">
                 <choose>
                   <when test="var.operator.equals('EQUALS_IGNORE_CASE') || var.operator.equals('NOT_EQUALS_IGNORE_CASE') || var.operator.equals('LIKE_IGNORE_CASE')">
-                    and lower(A_OR${orIndex}_${index}.TEXT_)
+                    and lower(A_${orLocal}OR${orIndex}.TEXT_)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_
+                    and A_${orLocal}OR${orIndex}.TEXT_
                   </otherwise>
                 </choose> 
                 <choose>
@@ -950,7 +954,7 @@
                 </choose>
               </if>
               <if test="var.textValue2 != null">
-                and A_OR${orIndex}_${index}.TEXT2_ 
+                and A_${orLocal}OR${orIndex}.TEXT2_
                 <choose>
                   <when test="var.operator.equals('LIKE')">LIKE</when>
                   <otherwise><include refid="executionVariableOperator" /></otherwise>
@@ -961,12 +965,12 @@
                 </choose>
               </if>
               <if test="var.longValue != null">
-                and A_OR${orIndex}_${index}.LONG_
+                and A_${orLocal}OR${orIndex}.LONG_
                 <include refid="executionVariableOperator" />
                 #{var.longValue}
               </if>
               <if test="var.doubleValue != null">
-                and A_OR${orIndex}_${index}.DOUBLE_ 
+                and A_${orLocal}OR${orIndex}.DOUBLE_
                 <include refid="executionVariableOperator" />
                 #{var.doubleValue}
               </if>
@@ -974,10 +978,10 @@
               <if test="var.textValue == null &amp;&amp; var.textValue2 == null &amp;&amp; var.longValue == null &amp;&amp; var.doubleValue == null">
                 <choose>
                   <when test="var.operator.equals('NOT_EQUALS')">
-                    and (A_OR${orIndex}_${index}.TEXT_ is not null or A_OR${orIndex}_${index}.TEXT2_ is not null or A_OR${orIndex}_${index}.LONG_ is not null or A_OR${orIndex}_${index}.DOUBLE_ is not null or A_OR${orIndex}_${index}.BYTEARRAY_ID_ is not null)
+                    and (A_${orLocal}OR${orIndex}.TEXT_ is not null or A_${orLocal}OR${orIndex}.TEXT2_ is not null or A_${orLocal}OR${orIndex}.LONG_ is not null or A_${orLocal}OR${orIndex}.DOUBLE_ is not null or A_${orLocal}OR${orIndex}.BYTEARRAY_ID_ is not null)
                   </when>
                   <otherwise>
-                    and A_OR${orIndex}_${index}.TEXT_ is null and A_OR${orIndex}_${index}.TEXT2_ is null and A_OR${orIndex}_${index}.LONG_ is null and A_OR${orIndex}_${index}.DOUBLE_ is null and A_OR${orIndex}_${index}.BYTEARRAY_ID_ is null
+                    and A_${orLocal}OR${orIndex}.TEXT_ is null and A_${orLocal}OR${orIndex}.TEXT2_ is null and A_${orLocal}OR${orIndex}.LONG_ is null and A_${orLocal}OR${orIndex}.DOUBLE_ is null and A_${orLocal}OR${orIndex}.BYTEARRAY_ID_ is null
                   </otherwise>
                 </choose>          
               </if>

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricTaskAndVariablesQueryTest.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.activiti.engine.history.HistoricTaskInstance;
+import org.activiti.engine.history.HistoricTaskInstanceQuery;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -350,6 +351,34 @@ public class HistoricTaskAndVariablesQueryTest extends PluggableActivitiTestCase
       assertNotNull(variableMap.get("testVar2"));
       assertEquals(123, variableMap.get("testVar2"));
     }
+  }
+
+  @Deployment
+  public void testOrQueryMultipleVariableValues() {
+      Map<String, Object> startMap = new HashMap<String, Object>();
+      startMap.put("processVar", true);
+      startMap.put("anotherProcessVar", 123);
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
+
+      startMap.put("anotherProcessVar", 999);
+      runtimeService.startProcessInstanceByKey("oneTaskProcess", startMap);
+
+      HistoricTaskInstanceQuery query0 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or();
+      for (int i = 0; i < 20; i++) {
+          query0 = query0.processVariableValueEquals("anotherProcessVar", i);
+      }
+      query0 = query0.endOr();
+      assertNull(query0.singleResult());
+
+      HistoricTaskInstanceQuery query1 = historyService.createHistoricTaskInstanceQuery().includeProcessVariables().or().processVariableValueEquals("anotherProcessVar", 123);
+      for (int i = 0; i < 20; i++) {
+          query1 = query1.processVariableValueEquals("anotherProcessVar", i);
+      }
+      query1 = query1.endOr();
+      HistoricTaskInstance task = query1.singleResult();
+      assertEquals(2, task.getProcessVariables().size());
+      assertEquals(true, task.getProcessVariables().get("processVar"));
+      assertEquals(123, task.getProcessVariables().get("anotherProcessVar"));
   }
   
   @Deployment

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testOrQueryMultipleVariableValues.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/history/HistoricTaskAndVariablesQueryTest.testOrQueryMultipleVariableValues.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess" name="The One Task Process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theProcessTask" />
+    <userTask id="theProcessTask" name="my process task" activiti:assignee="kermit" />    
+    <sequenceFlow id="flow2" sourceRef="theProcessTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskAndVariablesQueryTest.testOrQuery.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskAndVariablesQueryTest.testOrQuery.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess" name="The One Task Process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theProcessTask" />
+    <userTask id="theProcessTask" name="my process task" activiti:assignee="kermit" />    
+    <sequenceFlow id="flow2" sourceRef="theProcessTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskAndVariablesQueryTest.testOrQueryMultipleVariableValues.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/api/task/TaskAndVariablesQueryTest.testOrQueryMultipleVariableValues.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="oneTaskProcess" name="The One Task Process">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theProcessTask" />
+    <userTask id="theProcessTask" name="my process task" activiti:assignee="kermit" />    
+    <sequenceFlow id="flow2" sourceRef="theProcessTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
I addressed the same problem of #989 for Process Instance, Task and Historic Task queries.