### PR TITLE
Implement setOperation for serialization purposes

### DIFF
--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/engine/variable/QueryVariable.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/engine/variable/QueryVariable.java
@@ -39,7 +39,11 @@ public class QueryVariable {
     }
     return QueryVariableOperation.forFriendlyName(operation);
   }
-  
+
+  public String getOperation() {
+    return operation;
+  }
+
   public void setOperation(String operation) {
     this.operation = operation;
   }


### PR DESCRIPTION
Otherwise, serializing the QueryRequest object using
JSONNode ends up creating a "variableOperation" property
instead of an "operation" property, causing an error
on the server side.