### PR TITLE
add activiti-rest and dependent modules to main modules list

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -634,6 +634,11 @@
     <module>modules/activiti-image-generator</module>
     <module>modules/activiti-bpmn-converter</module>
     <module>modules/activiti-engine</module>
+    <module>modules/activiti-common-rest</module>
+    <module>modules/activiti-simple-workflow</module>
+    <module>modules/activiti-spring</module>
+    <module>modules/activiti-spring-boot</module>
+    <module>modules/activiti-rest</module>
   </modules>
 
   <build>


### PR DESCRIPTION
this allows things like 'mvn install' to work, pushing rest api libraries
to the local maven repo.
