### PR TITLE
Set process definition version on process instance in rest api

### DIFF
--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/BaseProcessInstanceResource.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/BaseProcessInstanceResource.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.ManagementService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.impl.ProcessInstanceQueryProperty;
 import org.activiti.engine.query.QueryProperty;
@@ -34,6 +35,9 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Frederik Heremans
  */
 public class BaseProcessInstanceResource {
+
+  @Autowired
+  protected ManagementService managementService;
 
   private static Map<String, QueryProperty> allowedSortProperties = new HashMap<String, QueryProperty>();
 

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceActionRequest.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceActionRequest.java
@@ -22,4 +22,12 @@ public class ProcessInstanceActionRequest extends RestActionRequest {
 
   public static final String ACTION_SUSPEND = "suspend";
   public static final String ACTION_ACTIVATE = "activate";
+  private Integer processDefinitionVersion;
+
+  public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+  public Integer getProcessDefinitionVersion() {
+    return processDefinitionVersion;
+  }
 }

--- a/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceResource.java
+++ b/modules/activiti-rest/src/main/java/org/activiti/rest/service/api/runtime/process/ProcessInstanceResource.java
@@ -17,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.impl.cmd.SetProcessDefinitionVersionCmd;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.rest.exception.ActivitiConflictException;
 import org.springframework.http.HttpStatus;
@@ -54,8 +55,19 @@ public class ProcessInstanceResource extends BaseProcessInstanceResource {
       @RequestBody ProcessInstanceActionRequest actionRequest, HttpServletRequest request) {
     
     ProcessInstance processInstance = getProcessInstanceFromRequest(processInstanceId);
-    
-    if (ProcessInstanceActionRequest.ACTION_ACTIVATE.equals(actionRequest.getAction())) {
+
+    if (actionRequest.getProcessDefinitionVersion() != null) {
+
+      // Update of process definition version is required
+      SetProcessDefinitionVersionCmd cmd = new SetProcessDefinitionVersionCmd(processInstanceId, actionRequest.getProcessDefinitionVersion());
+      managementService.executeCommand(cmd);
+
+      // No need to re-fetch the ProcessInstance entity
+      ProcessInstanceResponse response = restResponseFactory.createProcessInstanceResponse(processInstance);
+      return response;
+
+
+    } else if (ProcessInstanceActionRequest.ACTION_ACTIVATE.equals(actionRequest.getAction())) {
       return activateProcessInstance(processInstance);
       
     } else if (ProcessInstanceActionRequest.ACTION_SUSPEND.equals(actionRequest.getAction())) {

--- a/userguide/src/en/ch14-REST.adoc
+++ b/userguide/src/en/ch14-REST.adoc
@@ -1475,6 +1475,37 @@ DELETE runtime/process-instances/{processInstanceId}
 |===============
 
 
+==== Update process definition version for a process instance
+
+----
+PUT runtime/process-instances/{processInstanceId}
+----
+
+
+*Body JSON:*
+
+[source,json,linenums]
+----
+{
+  "processDefinitionVersion" : "5"
+}
+----
+
+
+.Update process definition version for a process instance - Response codes
+[options="header"]
+|===============
+|Response code|Description
+|200|Indicates the process instance's process definition version was altered.
+|400|Indicates no process definition version was defined in the request body.
+|404|Indicates the requested process instance was not found.
+
+|===============
+
+*Success response body:* see response for +runtime/process-instances/{processInstanceId}+.
+
+
+
 ==== Activate or suspend a process instance
 
 


### PR DESCRIPTION
Use the management api to set the process definition version on a process instance in the rest api
