### PR TITLE
ACT-4144 - fixed search variables by activityInstanceID in HistoricDetailQuery. Added unit test.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -654,10 +654,14 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
   			} else {
   				
   				VariableScopeImpl parent = getParentVariableScope();
-  				if (parent != null) {
-  					parent.setVariable(variableName, value, sourceActivityExecution, fetchAllVariables);
-  					return;
-  				} 
+          if (parent != null) {
+            if (sourceActivityExecution == null) {
+              parent.setVariable(variableName, value, fetchAllVariables);
+            } else {
+              parent.setVariable(variableName, value, sourceActivityExecution, fetchAllVariables);
+            }
+            return;
+          }
 
   				variable = createVariableInstance(variableName, value, sourceActivityExecution);
   				usedVariablesCache.put(variableName, variable);


### PR DESCRIPTION
ACT-4144 - fixed search variables by activityInstanceID in HistoricDetailQuery. Added unit test.

More details in the comments of the Jira bug:
https://activiti.atlassian.net/browse/ACT-4144

Signed-off-by: Vlad Stan <stan.v.vlad@gmail.com>