### PR TITLE
Fix for process instance created via signal from a suspended process …

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
@@ -55,7 +55,10 @@ public class SignalEventHandler extends AbstractEventHandler {
   		if (processDefinition == null) {
   			throw new ActivitiObjectNotFoundException("No process definition found for id '" + processDefinitionId + "'", ProcessDefinition.class);
   		}
- 
+  		if (processDefinition.isSuspended()) {
+  			throw new ActivitiException("Could not handle signal: process definition with id: " + processDefinitionId + " is suspended");
+  		}
+  		
   		ActivityImpl startActivity = processDefinition.findActivity(eventSubscription.getActivityId());
   		if (startActivity == null) {
   			throw new ActivitiException("Could no handle signal: no start activity found with id " + eventSubscription.getActivityId());


### PR DESCRIPTION
Process instance cannot be created from suspended process definition using message or runtime methods. However, this was possible using signal and therefore is not correct. The pull request here is to fix that unwanted behavior.