### PR TITLE
Attachment entity attached to the process instance is not deleted when process instance is deleted.

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/HistoricProcessInstanceEntityManager.java
@@ -79,6 +79,10 @@ public class HistoricProcessInstanceEntityManager extends AbstractManager {
         .getCommentEntityManager()
         .deleteCommentsByProcessInstanceId(historicProcessInstanceId);
       
+      commandContext
+      .getAttachmentEntityManager()
+      .deleteAttachmentsByProcessInstanceId(historicProcessInstanceId);
+      
       getDbSqlSession().delete(historicProcessInstance);
       
       // Also delete any sub-processes that may be active (ACT-821)


### PR DESCRIPTION
## Attachment entity attached to the process instance is not deleted when process instance is deleted.

We fixed that attachment entity attached to the process instance is deleted when deleting historic process instance.

If we specify null as taskId when using TaskService.createAttachment method, we can attach file to not task but process instance.
https://www.activiti.org/javadocs/org/activiti/engine/TaskService.html#createAttachment-java.lang.String-java.lang.String-java.lang.String-java.lang.String-java.lang.String-java.io.InputStream-

In this case, we cannot delete attachment entity by deleting historic process instance.

## Attachment entity event on historicTaskDelete doesn't contain processDefinitionId and processInstanceId and executionId.

We fixed that attachment entity event on historicTaskDelete contains processDefinitionId and processInstanceId and executionId by using history data.