### PR TITLE
Added taskAssigneeIds method,

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -73,6 +73,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected String taskAssignee;
   protected String taskAssigneeLike;
   protected String taskAssigneeLikeIgnoreCase;
+  protected List<String> taskAssigneeIds;
   protected String taskDefinitionKey;
   protected String taskDefinitionKeyLike;
   protected String candidateUser;
@@ -520,6 +521,38 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
      }
      return this;
   }
+  
+  @Override
+  public HistoricTaskInstanceQuery taskAssigneeIds(List<String> assigneeIds) {
+    if (assigneeIds == null) {
+      throw new ActivitiIllegalArgumentException("Task assignee list is null");
+    }
+    if (assigneeIds.isEmpty()) {
+      throw new ActivitiIllegalArgumentException("Task assignee list is empty");
+    }
+    for (String assignee : assigneeIds) {
+      if (assignee == null) {
+        throw new ActivitiIllegalArgumentException("None of the given task assignees can be null");
+      }
+    }
+
+    if (taskAssignee != null) {
+      throw new ActivitiIllegalArgumentException("Invalid query usage: cannot set both taskAssigneeIds and taskAssignee");
+    }
+    if (taskAssigneeLike != null) {
+      throw new ActivitiIllegalArgumentException("Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLike");
+    }
+    if (taskAssigneeLikeIgnoreCase != null) {
+      throw new ActivitiIllegalArgumentException("Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLikeIgnoreCase");
+    }
+
+    if (inOrStatement) {
+      currentOrQueryObject.taskAssigneeIds = assigneeIds;
+    } else {
+      this.taskAssigneeIds = assigneeIds;
+    }
+    return this;
+}
 
   public HistoricTaskInstanceQuery taskOwner(String taskOwner) {
     if (inOrStatement) {
@@ -1445,6 +1478,10 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   public String getTaskDeleteReasonLike() {
     return taskDeleteReasonLike;
   }
+  
+  public List<String> getTaskAssigneeIds() {
+	    return taskAssigneeIds;
+	}
 
   public String getTaskAssignee() {
     return taskAssignee;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/TaskQueryImpl.java
@@ -57,6 +57,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String assignee;
   protected String assigneeLike;
   protected String assigneeLikeIgnoreCase;
+  protected List<String> assigneeIds;
   protected String involvedUser;
   protected String owner;
   protected String ownerLike;
@@ -357,17 +358,52 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
      return this;
   }
 
-  public TaskQueryImpl taskOwner(String owner) {
-    if (owner == null) {
-      throw new ActivitiIllegalArgumentException("Owner is null");
-    }
-    if(orActive) {
-      currentOrQueryObject.owner = owner;
-    } else {
-      this.owner = owner;
-    }
-    return this;
-  }
+	@Override
+	public TaskQuery taskAssigneeIds(List<String> assigneeIds) {
+		if (assigneeIds == null) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is null");
+		}
+		if (assigneeIds.isEmpty()) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is empty");
+		}
+		for (String assignee : assigneeIds) {
+			if (assignee == null) {
+				throw new ActivitiIllegalArgumentException("None of the given task assignees can be null");
+			}
+		}
+
+		if (assignee != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssignee");
+		}
+		if (assigneeLike != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLike");
+		}
+		if (assigneeLikeIgnoreCase != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLikeIgnoreCase");
+		}
+
+		if (orActive) {
+			currentOrQueryObject.assigneeIds = assigneeIds;
+		} else {
+			this.assigneeIds = assigneeIds;
+		}
+		return this;
+	}
+  
+	public TaskQueryImpl taskOwner(String owner) {
+		if (owner == null) {
+			throw new ActivitiIllegalArgumentException("Owner is null");
+		}
+		if (orActive) {
+			currentOrQueryObject.owner = owner;
+		} else {
+			this.owner = owner;
+		}
+		return this;
+	}
 
   public TaskQueryImpl taskOwnerLike(String ownerLike) {
     if (ownerLike == null) {
@@ -1443,6 +1479,10 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   public String getAssigneeLike() {
     return assigneeLike;
   }
+  
+  public List<String> getAssigneeIds() {
+	    return assigneeIds;
+	}
 
   public String getInvolvedUser() {
     return involvedUser;

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
@@ -106,6 +106,14 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
    */
   T taskAssigneeLikeIgnoreCase(String assigneeLikeIgnoreCase);
 
+  /**
+   *Only select tasks with an assignee that is in the given list
+   * 
+   * @throws FlowableIllegalArgumentException
+   *           When passed name list is empty or <code>null</code> or contains <code>null String</code>.
+   */
+  T taskAssigneeIds(List<String> assigneeListIds);
+  
   /** Only select tasks for which the given user is the owner. */
   T taskOwner(String owner);
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/task/TaskInfoQuery.java
@@ -109,7 +109,7 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
   /**
    *Only select tasks with an assignee that is in the given list
    * 
-   * @throws FlowableIllegalArgumentException
+   * @throws ActivitiIllegalArgumentException
    *           When passed name list is empty or <code>null</code> or contains <code>null String</code>.
    */
   T taskAssigneeIds(List<String> assigneeListIds);

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricTaskInstance.xml
@@ -541,6 +541,13 @@
       <if test="taskAssigneeLikeIgnoreCase != null">
         and lower(RES.ASSIGNEE_) like #{taskAssigneeLikeIgnoreCase}${wildcardEscapeClause}
       </if>
+      <if test="taskAssigneeIds != null &amp;&amp; taskAssigneeIds.size() &gt; 0">
+        and RES.ASSIGNEE_ IN
+        <foreach item="assigneeId" index="index" collection="taskAssigneeIds" 
+                 open="(" separator="," close=")">
+          #{assigneeId}
+        </foreach>
+	  </if>
       <if test="taskPriority != null">
         and RES.PRIORITY_ = #{taskPriority}
       </if>
@@ -836,6 +843,13 @@
            <if test="orQueryObject.taskAssigneeLikeIgnoreCase != null">
             or RES.ASSIGNEE_ like #{orQueryObject.taskAssigneeLikeIgnoreCase}${wildcardEscapeClause}
           </if>
+          <if test="orQueryObject.taskAssigneeIds != null &amp;&amp; orQueryObject.taskAssigneeIds.size() &gt; 0">
+	        or RES.ASSIGNEE_ IN
+	        <foreach item="assigneeId" index="index" collection="orQueryObject.taskAssigneeIds" 
+	                 open="(" separator="," close=")">
+	          #{assigneeId}
+	        </foreach>
+		  </if>
           <if test="orQueryObject.taskPriority != null">
             or RES.PRIORITY_ = #{orQueryObject.taskPriority}
           </if>

--- a/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/modules/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -453,6 +453,13 @@
       <if test="assigneeLikeIgnoreCase != null">
         and lower(RES.ASSIGNEE_) like #{assigneeLikeIgnoreCase}${wildcardEscapeClause}
       </if>
+      <if test="assigneeIds != null &amp;&amp; assigneeIds.size() &gt; 0">
+        and RES.ASSIGNEE_ IN
+        <foreach item="assigneeId" index="index" collection="assigneeIds" 
+                 open="(" separator="," close=")">
+          #{assigneeId}
+        </foreach>
+	  </if>
       <if test="owner != null">
         and RES.OWNER_ = #{owner}
       </if>
@@ -770,6 +777,13 @@
             <if test="orQueryObject.assigneeLikeIgnoreCase != null">
               or lower(RES.ASSIGNEE_) like #{orQueryObject.assigneeLikeIgnoreCase}${wildcardEscapeClause}
             </if>
+             <if test="orQueryObject.assigneeIds != null &amp;&amp; orQueryObject.assigneeIds.size() &gt; 0">
+		      or RES.ASSIGNEE_ IN
+		      <foreach item="assigneeId" index="index" collection="orQueryObject.assigneeIds" 
+		               open="(" separator="," close=")">
+		        #{assigneeId}
+		      </foreach>
+			</if>
             <if test="orQueryObject.owner != null">
               or RES.OWNER_ = #{orQueryObject.owner}
             </if>

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -551,6 +551,72 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
     assertEquals(0, query.list().size());
     assertNull(query.singleResult());
   }
+  
+  public void testQueryByAssigneeIds() {
+	    TaskQuery query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
+	    assertEquals(1, query.count());
+	    assertEquals(1, query.list().size());
+	    assertNotNull(query.singleResult());
+
+	    query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
+	    assertEquals(0, query.count());
+	    assertEquals(0, query.list().size());
+	    assertNull(query.singleResult());
+	    
+	    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+	      // History
+	      assertEquals(1, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count());
+	      assertEquals(0, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count());
+	    }
+	    
+	    Task adhocTask = taskService.newTask();
+	    adhocTask.setName("test");
+	    adhocTask.setAssignee("testAssignee");
+	    taskService.saveTask(adhocTask);
+	    
+	    query = taskService.createTaskQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
+	    assertEquals(2, query.count());
+	    assertEquals(2, query.list().size());
+	    
+	    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+	      // History
+	      assertEquals(2, historyService.createHistoricTaskInstanceQuery().taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count());
+	    }
+	    
+	    taskService.deleteTask(adhocTask.getId(), true);
+	  }
+	  
+	  public void testQueryByAssigneeIdsOr() {
+	    TaskQuery query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit"));
+	    assertEquals(1, query.count());
+	    assertEquals(1, query.list().size());
+	    assertNotNull(query.singleResult());
+
+	    query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2"));
+	    assertEquals(0, query.count());
+	    assertEquals(0, query.list().size());
+	    assertNull(query.singleResult());
+	    
+	    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+	      assertEquals(1, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "kermit")).count());
+	      assertEquals(0, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("kermit", "kermit2")).count());
+	    }
+	    
+	    Task adhocTask = taskService.newTask();
+	    adhocTask.setName("test");
+	    adhocTask.setAssignee("testAssignee");
+	    taskService.saveTask(adhocTask);
+	    
+	    query = taskService.createTaskQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee"));
+	    assertEquals(2, query.count());
+	    assertEquals(2, query.list().size());
+	    
+	    if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.AUDIT)) {
+	      assertEquals(2, historyService.createHistoricTaskInstanceQuery().or().taskId("invalid").taskAssigneeIds(Arrays.asList("gonzo", "testAssignee")).count());
+	    }
+	    
+	    taskService.deleteTask(adhocTask.getId(), true);
+	}
 
   public void testQueryByInvolvedUser() {
     try {

--- a/modules/activiti5-engine/src/main/java/org/activiti5/engine/impl/HistoricTaskInstanceQueryImpl.java
+++ b/modules/activiti5-engine/src/main/java/org/activiti5/engine/impl/HistoricTaskInstanceQueryImpl.java
@@ -73,6 +73,7 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   protected String taskAssignee;
   protected String taskAssigneeLike;
   protected String taskAssigneeLikeIgnoreCase;
+  protected List<String> taskAssigneeIds;
   protected String taskDefinitionKey;
   protected String taskDefinitionKeyLike;
   protected String candidateUser;
@@ -518,6 +519,41 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
      }
      return this;
   }
+  
+	@Override
+	public HistoricTaskInstanceQuery taskAssigneeIds(List<String> assigneeIds) {
+		if (assigneeIds == null) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is null");
+		}
+		if (assigneeIds.isEmpty()) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is empty");
+		}
+		for (String assignee : assigneeIds) {
+			if (assignee == null) {
+				throw new ActivitiIllegalArgumentException("None of the given task assignees can be null");
+			}
+		}
+
+		if (taskAssignee != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssignee");
+		}
+		if (taskAssigneeLike != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLike");
+		}
+		if (taskAssigneeLikeIgnoreCase != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLikeIgnoreCase");
+		}
+
+		if (inOrStatement) {
+			currentOrQueryObject.taskAssigneeIds = assigneeIds;
+		} else {
+			this.taskAssigneeIds = assigneeIds;
+		}
+		return this;
+	}
   
   public HistoricTaskInstanceQuery taskOwner(String taskOwner) {
     if (inOrStatement) {
@@ -1427,7 +1463,11 @@ public class HistoricTaskInstanceQueryImpl extends AbstractVariableQueryImpl<His
   public String getTaskAssigneeLike() {
     return taskAssigneeLike;
   }
-  public String getTaskId() {
+  public List<String> getTaskAssigneeIds() {
+	return taskAssigneeIds;
+}
+
+public String getTaskId() {
     return taskId;
   }
   public String getTaskDefinitionKey() {

--- a/modules/activiti5-engine/src/main/java/org/activiti5/engine/impl/TaskQueryImpl.java
+++ b/modules/activiti5-engine/src/main/java/org/activiti5/engine/impl/TaskQueryImpl.java
@@ -57,6 +57,7 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
   protected String assignee;
   protected String assigneeLike;
   protected String assigneeLikeIgnoreCase;
+  protected List<String> assigneeIds;
   protected String involvedUser;
   protected String owner;
   protected String ownerLike;
@@ -356,6 +357,41 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
      }
      return this;
   }
+  
+	@Override
+	public TaskQuery taskAssigneeIds(List<String> assigneeIds) {
+		if (assigneeIds == null) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is null");
+		}
+		if (assigneeIds.isEmpty()) {
+			throw new ActivitiIllegalArgumentException("Task assignee list is empty");
+		}
+		for (String assignee : assigneeIds) {
+			if (assignee == null) {
+				throw new ActivitiIllegalArgumentException("None of the given task assignees can be null");
+			}
+		}
+
+		if (assignee != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssignee");
+		}
+		if (assigneeLike != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLike");
+		}
+		if (assigneeLikeIgnoreCase != null) {
+			throw new ActivitiIllegalArgumentException(
+					"Invalid query usage: cannot set both taskAssigneeIds and taskAssigneeLikeIgnoreCase");
+		}
+
+		if (orActive) {
+			currentOrQueryObject.assigneeIds = assigneeIds;
+		} else {
+			this.assigneeIds = assigneeIds;
+		}
+		return this;
+	}
   
   public TaskQueryImpl taskOwner(String owner) {
     if (owner == null) {
@@ -1424,7 +1460,11 @@ public class TaskQueryImpl extends AbstractVariableQueryImpl<TaskQuery, Task> im
     return assigneeLike;
   }
 
-  public String getInvolvedUser() {
+  public List<String> getAssigneeIds() {
+	return assigneeIds;
+}
+
+public String getInvolvedUser() {
     return involvedUser;
   }
 

--- a/modules/activiti5-engine/src/main/java/org/activiti5/engine/task/TaskInfoQuery.java
+++ b/modules/activiti5-engine/src/main/java/org/activiti5/engine/task/TaskInfoQuery.java
@@ -114,6 +114,14 @@ public interface TaskInfoQuery<T extends TaskInfoQuery<?, ?>, V extends TaskInfo
    */
   T taskAssigneeLikeIgnoreCase(String assigneeLikeIgnoreCase);
   
+	/**
+	 * Only select tasks with an assignee that is in the given list
+	 * 
+	 * @throws FlowableIllegalArgumentException
+	 *             When passed name list is empty or <code>null</code> or
+	 *             contains <code>null String</code>.
+	 */
+	T taskAssigneeIds(List<String> assigneeListIds);
   
   /** Only select tasks for which the given user is the owner. */
   T taskOwner(String owner);

--- a/modules/activiti5-engine/src/main/resources/org/activiti5/db/mapping/entity/HistoricTaskInstance.xml
+++ b/modules/activiti5-engine/src/main/resources/org/activiti5/db/mapping/entity/HistoricTaskInstance.xml
@@ -542,6 +542,13 @@
       <if test="taskAssigneeLikeIgnoreCase != null">
         and lower(RES.ASSIGNEE_) like #{taskAssigneeLikeIgnoreCase}${wildcardEscapeClause}
       </if>
+      <if test="taskAssigneeIds != null &amp;&amp; taskAssigneeIds.size() &gt; 0">
+        and RES.ASSIGNEE_ IN
+        <foreach item="assigneeId" index="index" collection="taskAssigneeIds" 
+                 open="(" separator="," close=")">
+          #{assigneeId}
+        </foreach>
+	  </if>
       <if test="taskPriority != null">
         and RES.PRIORITY_ = #{taskPriority}
       </if>
@@ -837,6 +844,13 @@
            <if test="orQueryObject.taskAssigneeLikeIgnoreCase != null">
             or RES.ASSIGNEE_ like #{orQueryObject.taskAssigneeLikeIgnoreCase}${wildcardEscapeClause}
           </if>
+          <if test="taskAssigneeIds != null &amp;&amp; taskAssigneeIds.size() &gt; 0">
+        	or RES.ASSIGNEE_ IN
+        	<foreach item="assigneeId" index="index" collection="taskAssigneeIds" 
+                 	 open="(" separator="," close=")">
+          	  #{assigneeId}
+        	</foreach>
+		  </if>
           <if test="orQueryObject.taskPriority != null">
             or RES.PRIORITY_ = #{orQueryObject.taskPriority}
           </if>

--- a/modules/activiti5-engine/src/main/resources/org/activiti5/db/mapping/entity/Task.xml
+++ b/modules/activiti5-engine/src/main/resources/org/activiti5/db/mapping/entity/Task.xml
@@ -447,6 +447,13 @@
       <if test="assigneeLikeIgnoreCase != null">
         and lower(RES.ASSIGNEE_) like #{assigneeLikeIgnoreCase}${wildcardEscapeClause}
       </if>
+      <if test="assigneeIds != null &amp;&amp; assigneeIds.size() &gt; 0">
+        and RES.ASSIGNEE_ IN
+        <foreach item="assigneeId" index="index" collection="assigneeIds" 
+                 open="(" separator="," close=")">
+          #{assigneeId}
+        </foreach>
+	  </if>
       <if test="owner != null">
         and RES.OWNER_ = #{owner}
       </if>
@@ -764,6 +771,13 @@
             <if test="orQueryObject.assigneeLikeIgnoreCase != null">
               or lower(RES.ASSIGNEE_) like #{orQueryObject.assigneeLikeIgnoreCase}${wildcardEscapeClause}
             </if>
+            <if test="assigneeIds != null &amp;&amp; assigneeIds.size() &gt; 0">
+	          or RES.ASSIGNEE_ IN
+		      <foreach item="assigneeId" index="index" collection="assigneeIds" 
+		               open="(" separator="," close=")">
+		        #{assigneeId}
+		      </foreach>
+			</if>
             <if test="orQueryObject.owner != null">
               or RES.OWNER_ = #{orQueryObject.owner}
             </if>


### PR DESCRIPTION
It takes a list of users as parameter and returns tasks with an assignee in the list. Currently, TaskInfoQuery interface provides methods for querying or filtering tasks assigned to a specific user. If one would like to query for tasks assigned to several users, he has to query for individual users and then merge them to create the complete list. This method solves this problem.
Similar method "taskCandidateGroupIn" for querying tasks of groups is already there in activiti. This will add similar functionality for querying tasks of users as well. 