### PR TITLE
Added message waiting event type

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEventType.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEventType.java
@@ -127,6 +127,11 @@ public enum ActivitiEventType {
    * An activity is about to be executed as a compensation for another activity. The event targets the activity that is about to be executed for compensation.
    */
   ACTIVITY_COMPENSATE,
+  
+  /**
+   * A boundary, intermediate, or subprocess start message catching event has started and it is waiting for message.
+   */
+  ACTIVITY_MESSAGE_WAITING,
 
   /**
    * An activity has received a message event. Dispatched before the actual message has been received by the activity. This event will be either followed by a {@link #ACTIVITY_SIGNALLED} event or

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryMessageEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryMessageEventActivityBehavior.java
@@ -18,6 +18,8 @@ import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.MessageEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
@@ -55,6 +57,12 @@ public class BoundaryMessageEventActivityBehavior extends BoundaryEventActivityB
     }
     
     commandContext.getEventSubscriptionEntityManager().insertMessageEvent(messageName, executionEntity);
+    
+    if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
+        commandContext.getProcessEngineConfiguration().getEventDispatcher()
+                .dispatchEvent(ActivitiEventBuilder.createMessageEvent(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, executionEntity.getActivityId(), messageName,
+                        null, executionEntity.getId(), executionEntity.getProcessInstanceId(), executionEntity.getProcessDefinitionId()));
+      }
   }
 
   @Override

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchMessageEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchMessageEventActivityBehavior.java
@@ -17,6 +17,8 @@ import java.util.List;
 import org.activiti.bpmn.model.MessageEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.history.DeleteReason;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -50,6 +52,12 @@ public class IntermediateCatchMessageEventActivityBehavior extends IntermediateC
     }
     
     commandContext.getEventSubscriptionEntityManager().insertMessageEvent(messageName, executionEntity);
+    
+    if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
+        commandContext.getProcessEngineConfiguration().getEventDispatcher()
+                .dispatchEvent(ActivitiEventBuilder.createMessageEvent(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, executionEntity.getActivityId(), messageName,
+                        null, executionEntity.getId(), executionEntity.getProcessInstanceId(), executionEntity.getProcessDefinitionId()));
+      }
   }
 
   @Override

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ActivityEventsTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/api/event/ActivityEventsTest.java
@@ -302,11 +302,22 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     assertNotNull(executionWithMessage);
 
     runtimeService.messageEventReceived("messageName", executionWithMessage.getId());
-    assertEquals(1, listener.getEventsReceived().size());
+    assertEquals(2, listener.getEventsReceived().size());
 
-    // First, a message-event is expected
+    // First, an ACTIVITY_MESSAGE_WAITING event is expected
     assertTrue(listener.getEventsReceived().get(0) instanceof ActivitiMessageEvent);
     ActivitiMessageEvent messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
+    assertEquals("shipOrder", messageEvent.getActivityId());
+    assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
+    assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
+    assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
+    assertEquals("messageName", messageEvent.getMessageName());
+    assertNull(messageEvent.getMessageData());
+
+    // Second, an ACTIVITY_MESSAGE_RECEIVED event is expected
+    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiMessageEvent);
+    messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(1);
     assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
     assertEquals("shipOrder", messageEvent.getActivityId());
     assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
@@ -333,11 +344,22 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
 
     // Only a message-event should be present, no signal-event, since the event-subprocess is
     // not signaled, but executed instead
-    assertEquals(1, listener.getEventsReceived().size());
+    assertEquals(2, listener.getEventsReceived().size());
 
-    // A message-event is expected
+    // An ACTIVITY_MESSAGE_WAITING event is expected
     assertTrue(listener.getEventsReceived().get(0) instanceof ActivitiMessageEvent);
     ActivitiMessageEvent messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
+    assertEquals("catchMessage", messageEvent.getActivityId());
+    assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
+    assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
+    assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
+    assertEquals("messageName", messageEvent.getMessageName());
+    assertNull(messageEvent.getMessageData());
+
+    // An ACTIVITY_MESSAGE_RECEIVED event is expected
+    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiMessageEvent);
+    messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(1);
     assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
     assertEquals("catchMessage", messageEvent.getActivityId());
     assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
@@ -536,11 +558,23 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     assertNotNull(executionWithMessage);
 
     runtimeService.messageEventReceived("message_1", executionWithMessage.getId());
-    assertEquals(2, listener.getEventsReceived().size());
+    assertEquals(3, listener.getEventsReceived().size());
 
-    // First, a message-event is expected
+    // First, an ACTIVITY_MESSAGE_WAITING event is expected
     assertTrue(listener.getEventsReceived().get(0) instanceof ActivitiMessageEvent);
     ActivitiMessageEvent messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
+    assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
+    assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
+    assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
+    assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
+    assertEquals("message_1", messageEvent.getMessageName());
+    assertNull(messageEvent.getMessageData());
+
+    // Second, an ACTIVITY_MESSAGE_RECEIVED event is expected
+    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiMessageEvent);
+    messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(1);
+    assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
     assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
     assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
     assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
@@ -550,8 +584,8 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     assertNull(messageEvent.getMessageData());
 
     // Next, an signal-event is expected, as a result of the message
-    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiActivityCancelledEvent);
-    ActivitiActivityCancelledEvent signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(1);
+    assertTrue(listener.getEventsReceived().get(2) instanceof ActivitiActivityCancelledEvent);
+    ActivitiActivityCancelledEvent signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(2);
     assertEquals(ActivitiEventType.ACTIVITY_CANCELLED, signalEvent.getType());
     assertEquals("cloudformtask1", signalEvent.getActivityId());
     assertEquals(executionWithMessage.getId(), signalEvent.getExecutionId());
@@ -577,11 +611,22 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     assertNotNull(executionWithMessage);
 
     runtimeService.messageEventReceived("message_1", executionWithMessage.getId());
-    assertEquals(3, listener.getEventsReceived().size());
+    assertEquals(4, listener.getEventsReceived().size());
 
-    // First, a message-event is expected
+    // First, an ACTIVITY_MESSAGE_WAITING event is expected
     assertTrue(listener.getEventsReceived().get(0) instanceof ActivitiMessageEvent);
     ActivitiMessageEvent messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(0);
+    assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_WAITING, messageEvent.getType());
+    assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
+    assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
+    assertEquals(executionWithMessage.getProcessInstanceId(), messageEvent.getProcessInstanceId());
+    assertEquals(processInstance.getProcessDefinitionId(), messageEvent.getProcessDefinitionId());
+    assertEquals("message_1", messageEvent.getMessageName());
+    assertNull(messageEvent.getMessageData());
+
+    // Second, an ACTIVITY_MESSAGE_RECEIVED event is expected
+    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiMessageEvent);
+    messageEvent = (ActivitiMessageEvent) listener.getEventsReceived().get(1);
     assertEquals(ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED, messageEvent.getType());
     assertEquals("boundaryMessageEventCatching", messageEvent.getActivityId());
     assertEquals(executionWithMessage.getId(), messageEvent.getExecutionId());
@@ -590,9 +635,9 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     assertEquals("message_1", messageEvent.getMessageName());
     assertNull(messageEvent.getMessageData());
 
-    // Next, an signal-event is expected, as a result of the message
-    assertTrue(listener.getEventsReceived().get(1) instanceof ActivitiActivityCancelledEvent);
-    ActivitiActivityCancelledEvent signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(1);
+    // Next, a signal-event is expected, as a result of the message
+    assertTrue(listener.getEventsReceived().get(2) instanceof ActivitiActivityCancelledEvent);
+    ActivitiActivityCancelledEvent signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(2);
     assertEquals(ActivitiEventType.ACTIVITY_CANCELLED, signalEvent.getType());
     assertEquals("subProcess", signalEvent.getActivityId());
     assertEquals(executionWithMessage.getProcessInstanceId(), signalEvent.getProcessInstanceId());
@@ -602,8 +647,8 @@ public class ActivityEventsTest extends PluggableActivitiTestCase {
     MessageEventSubscriptionEntity cause = (MessageEventSubscriptionEntity) signalEvent.getCause();
     assertEquals("message_1", cause.getEventName());
     
-    assertTrue(listener.getEventsReceived().get(2) instanceof ActivitiActivityCancelledEvent);
-    signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(2);
+    assertTrue(listener.getEventsReceived().get(3) instanceof ActivitiActivityCancelledEvent);
+    signalEvent = (ActivitiActivityCancelledEvent) listener.getEventsReceived().get(3);
     assertEquals(ActivitiEventType.ACTIVITY_CANCELLED, signalEvent.getType());
     assertEquals("cloudformtask1", signalEvent.getActivityId());
     assertEquals(executionWithMessage.getProcessInstanceId(), signalEvent.getProcessInstanceId());


### PR DESCRIPTION
Added message waiting event type for intermediate or boundary or sub-process start message catching event. Whenever any activity creates message event subscription, this event will be dispatched to indicate that activity is waiting for message.