### PR TITLE
Add dependency to AssertJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,13 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
+				<groupId>org.assertj</groupId>
+				<artifactId>assertj-core</artifactId>
+				<!-- using version 2.x because version 3.x requires Java 8 -->
+				<version>2.6.0</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
 				<version>5.1.27</version>


### PR DESCRIPTION
AssertJ will replace classic JUnit assertions when writing tests.
It should be added as dependency in each maven module when it is used for the first time.