### PR TITLE
Fix multi instance

### DIFF
--- a/modules/activiti-engine/pom.xml
+++ b/modules/activiti-engine/pom.xml
@@ -72,6 +72,10 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.codehaus.groovy</groupId>
 			<artifactId>groovy-all</artifactId>
 			<scope>provided</scope>

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ScopeUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ScopeUtil.java
@@ -17,8 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.impl.context.Context;
@@ -96,10 +94,7 @@ public class ScopeUtil {
 
       // copy local variables to eventScopeExecution by value. This way,
       // the eventScopeExecution references a 'snapshot' of the local variables
-      Map<String, Object> variables = subProcessExecution.getVariablesLocal();
-      for (Entry<String, Object> variable : variables.entrySet()) {
-        eventScopeExecution.setVariableLocal(variable.getKey(), variable.getValue());
-      }
+      new SubProcessVariableSnapshotter().setVariablesSnapshots(subProcessExecution, eventScopeExecution);
 
       // set event subscriptions to the event scope execution:
       for (CompensateEventSubscriptionEntity eventSubscriptionEntity : compensateEventSubscriptions) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotter.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotter.java
@@ -1,0 +1,20 @@
+package org.activiti.engine.impl.bpmn.helper;
+
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class SubProcessVariableSnapshotter {
+
+    public void setVariablesSnapshots(ExecutionEntity sourceExecution, ExecutionEntity snapshotHolder) {
+        snapshotHolder.setVariablesLocal(sourceExecution.getVariablesLocal());
+
+        ExecutionEntity parentExecution = sourceExecution.getParent();
+        if (parentExecution != null && parentExecution.isMultiInstanceRoot()) {
+            snapshotHolder.setVariablesLocal(parentExecution.getVariablesLocal());
+        }
+
+    }
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotterTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotterTest.java
@@ -1,0 +1,89 @@
+package org.activiti.engine.impl.bpmn.helper;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.junit.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Elias Ricken de Medeiros
+ */
+public class SubProcessVariableSnapshotterTest {
+
+    private SubProcessVariableSnapshotter snapshotter = new SubProcessVariableSnapshotter();
+
+    @Test
+    public void setVariablesSnapshots_should_set_all_source_local_variables_in_the_snapshot_holder() throws Exception {
+        //given
+        Map<String, Object> variables = Collections.<String, Object>singletonMap("subCount", 1L);
+        ExecutionEntity subProcessExecution = buildExecutionEntity(variables);
+
+        ExecutionEntity snapshotHolderExecution = mock(ExecutionEntity.class);
+
+        //when
+        snapshotter.setVariablesSnapshots(subProcessExecution, snapshotHolderExecution);
+
+        //then
+        verify(snapshotHolderExecution).setVariablesLocal(variables);
+    }
+
+    private ExecutionEntity buildExecutionEntity(Map<String, Object> variables) {
+        ExecutionEntity subProcessExecution = mock(ExecutionEntity.class);
+        when(subProcessExecution.getVariablesLocal()).thenReturn(variables);
+        return subProcessExecution;
+    }
+
+    @Test
+    public void setVariablesSnapshots_should_set_parent_variables_in_the_snapshot_holder_when_parent_is_multi_instance() throws Exception {
+        //given
+        Map<String, Object> parentVariables = Collections.<String, Object>singletonMap("parentCount", 1L);
+        ExecutionEntity parentExecution = buildExecutionEntity(parentVariables);
+        when(parentExecution.isMultiInstanceRoot()).thenReturn(true);
+
+        Map<String, Object> localVariables = Collections.<String, Object>singletonMap("subCount", 1L);
+        ExecutionEntity subProcessExecution = buildExecutionEntity(parentExecution, localVariables);
+
+        ExecutionEntity snapshotHolderExecution = mock(ExecutionEntity.class);
+
+        //when
+        snapshotter.setVariablesSnapshots(subProcessExecution, snapshotHolderExecution);
+
+        //then
+        verify(snapshotHolderExecution).setVariablesLocal(localVariables);
+        verify(snapshotHolderExecution).setVariablesLocal(parentVariables);
+    }
+
+    private ExecutionEntity buildExecutionEntity(ExecutionEntity parentExecution, Map<String, Object> localVariables) {
+        ExecutionEntity subProcessExecution = buildExecutionEntity(localVariables);
+        when(subProcessExecution.getParent()).thenReturn(parentExecution);
+        return subProcessExecution;
+    }
+
+    @Test
+    public void setVariablesSnapshots_should_not_set_parent_variables_in_the_snapshot_holder_when_parent_is_not_multi_instance() throws Exception {
+        //given
+        Map<String, Object> parentVariables = Collections.<String, Object>singletonMap("parentCount", 1L);
+        ExecutionEntity parentExecution = buildExecutionEntity(parentVariables);
+        when(parentExecution.isMultiInstanceRoot()).thenReturn(false);
+
+        Map<String, Object> localVariables = Collections.<String, Object>singletonMap("subCount", 1L);
+        ExecutionEntity subProcessExecution = buildExecutionEntity(parentExecution, localVariables);
+
+        ExecutionEntity snapshotHolderExecution = mock(ExecutionEntity.class);
+
+        //when
+        snapshotter.setVariablesSnapshots(subProcessExecution, snapshotHolderExecution);
+
+        //then
+        verify(snapshotHolderExecution).setVariablesLocal(localVariables);
+        verify(snapshotHolderExecution, never()).setVariablesLocal(parentVariables);
+    }
+
+
+}


### PR DESCRIPTION
 - The variables nrOfInstances, nrOfCompletedInstances and nrOfActiveInstances are only created for the outer instance.
 They are, however, still available in the context of the inner instances when using the method getVariables instead of getVariablesLocal
 - The variable loopCounter is only created for the inner instances