### PR TITLE
changes recommended by sonar for possible null pointer dereference

### DIFF
--- a/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/BaseElement.java
+++ b/modules/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/BaseElement.java
@@ -85,7 +85,7 @@ public abstract class BaseElement implements HasExtensionAttributes {
     if (attributes != null && !attributes.isEmpty()) {
       for (ExtensionAttribute attribute : attributes) {
         if ( (namespace == null && attribute.getNamespace() == null)
-            || namespace.equals(attribute.getNamespace()) )
+            || (namespace!=null && namespace.equals(attribute.getNamespace())) )
           return attribute.getValue();
       }
     }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -164,10 +164,12 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
        
       Object value = null;
       int index = 0;
-      Iterator it = collection.iterator();
-      while (index <= loopCounter) {
-        value = it.next();
-        index++;
+      if(collection!=null) {
+        Iterator it = collection.iterator();
+        while (index <= loopCounter) {
+          value = it.next();
+          index++;
+        }
       }
       setLoopVariable(execution, collectionElementVariable, value);
     }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteJobsCmd.java
@@ -93,8 +93,9 @@ public class ExecuteJobsCmd implements Command<Object>, Serializable {
       }
       
     } catch (Throwable exception) {
-      failedJobListener.setException(exception);
-      
+        if(failedJobListener!=null) {
+            failedJobListener.setException(exception);
+        }
       // Dispatch an event, indicating job execution failed in a try-catch block, to prevent the original
       // exception to be swallowed
       if (commandContext.getEventDispatcher().isEnabled()) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/juel/ExpressionFactoryImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/juel/ExpressionFactoryImpl.java
@@ -254,7 +254,9 @@ public class ExpressionFactoryImpl extends ExpressionFactory {
 				throw new ELException("Cannot read default EL properties", e);
 			} finally {
 				try {
-					input.close();
+					if(input!=null) {
+						input.close();
+					}
 				} catch (IOException e) {
 					// ignore...
 				}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntityManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/AttachmentEntityManager.java
@@ -56,19 +56,18 @@ public class AttachmentEntityManager extends AbstractManager {
               processDefinitionId = processInstance.getProcessDefinitionId();
               executionId = processInstance.getId();
           }
-      }
-
-      for (AttachmentEntity attachment : attachments) {
-          if (attachment.getTaskId() != null) {
-              continue;
-          }
-          String contentId = attachment.getContentId();
-          if (contentId != null) {
-              getByteArrayManager().deleteByteArrayById(contentId);
-          }
-          getDbSqlSession().delete(attachment);
-          if (dispatchEvents) {
-              getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_DELETED, attachment, executionId, processInstanceId, processDefinitionId));
+          for (AttachmentEntity attachment : attachments) {
+              if (attachment.getTaskId() != null) {
+                  continue;
+              }
+              String contentId = attachment.getContentId();
+              if (contentId != null) {
+                  getByteArrayManager().deleteByteArrayById(contentId);
+              }
+              getDbSqlSession().delete(attachment);
+              if (dispatchEvents) {
+                  getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_DELETED, attachment, executionId, processInstanceId, processDefinitionId));
+              }
           }
       }
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableScopeImpl.java
@@ -822,7 +822,7 @@ public abstract class VariableScopeImpl implements Serializable, VariableScope {
       variableInstance.setType(newType);
       variableInstance.forceUpdate();
       variableInstance.setValue(value);
-    } else {
+    } else if(variableInstance!=null) {
       variableInstance.setValue(value);
     }
 


### PR DESCRIPTION
These items were all flagged by the sonar report as points where a null check was needed. Hopefully it is clear that in each a null check has been added, except for the change to AttachmentEntityManager where the change was to move the for-block inside of an existing null check that preceded it ("if (dispatchEvents && attachments != null && !attachments.isEmpty())").