### PR TITLE
Fix for ui issue related to list of groups in idm-group-management page

### DIFF
--- a/modules/activiti-ui/activiti-app/src/main/webapp/idm/views/idm-group-mgmt.html
+++ b/modules/activiti-ui/activiti-app/src/main/webapp/idm/views/idm-group-mgmt.html
@@ -9,7 +9,7 @@
 
         <span loading="model.loading"></span>
 
-        <div class="list-wrapper" ng-show="!model.loading" auto-height>
+        <div class="list-wrapper" ng-show="!model.loading">
 
             <ul class="full-list" offset-top="100">
                 <li ng-repeat="group in model.groups" ng-class="{'active': model.selectedGroup.id == group.id}" ng-click="selectGroup(group.id)">


### PR DESCRIPTION
Hi,

When adding a new group to the identity management,  group list ui getting scroll instead of showing created group below even if it has enough space to show. for the reference i have attached the screenshot and issue highlighted with red mark below . 

Before
![before-bug-fix](https://cloud.githubusercontent.com/assets/5857354/25649840/5de79156-2ff6-11e7-9e73-1fde68dbbfa4.png)

After
![after-bug-fix](https://cloud.githubusercontent.com/assets/5857354/25649668/0b37357a-2ff5-11e7-933a-96358e942ecf.png)


Which is handled with this fix.


Thanks,
Ravi kumar Tadela