### PR TITLE
Setting dynamic hostname for swagger docs of activiti-rest

### DIFF
--- a/modules/activiti-webapp-rest2/src/main/webapp/docs/index.html
+++ b/modules/activiti-webapp-rest2/src/main/webapp/docs/index.html
@@ -68,6 +68,7 @@
           if(window.SwaggerTranslator) {
             window.SwaggerTranslator.translate();
           }
+          window.swaggerUi.api.setHost(getHost());
         },
         onFailure: function(data) {
           log("Unable to Load SwaggerUI");
@@ -87,6 +88,13 @@
           console.log.apply(console, arguments);
         }
       }
+      function getHost() {
+  	    var defaultPorts = {"http:":80,"https:":443};
+          return window.location.hostname
+                 + (((window.location.port)
+                 && (window.location.port != defaultPorts[window.location.protocol]))
+                 ? (":"+window.location.port) : "");
+        }
       
       
 


### PR DESCRIPTION
Hi,

By default swagger host set to "localhost:8080" in pom.xml. When there is any changes in host of activiti-rest other then "localhost:8080", then swagger docs host doesn't change dynamically. So that rest call can't be called successfully. Which is handled with this fix.