### PR TITLE
Allow the ExpressionManager to create an ELResolver without a variable scope

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/el/ExpressionManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/el/ExpressionManager.java
@@ -106,9 +106,16 @@ public class ExpressionManager {
     return new ActivitiElContext(elResolver);
   }
 
+  public ELResolver createElResolver() {
+    return createElResolver(null);
+  }
+
   protected ELResolver createElResolver(VariableScope variableScope) {
     CompositeELResolver elResolver = new CompositeELResolver();
-    elResolver.add(new VariableScopeElResolver(variableScope));
+
+    if (variableScope != null) {
+      elResolver.add(new VariableScopeElResolver(variableScope));
+    }
     
     if(beans != null) {
       // ACT-1102: Also expose all beans in configuration when using standalone activiti, not


### PR DESCRIPTION
Allow the ExpressionManager to create an ELResolver without a variableScope