### PR TITLE
admin user for keycloak docker container

### DIFF
--- a/activiti-spring-boot/spring-boot-samples/spring-boot-sample-hal-rest-api/README.md
+++ b/activiti-spring-boot/spring-boot-samples/spring-boot-sample-hal-rest-api/README.md
@@ -26,4 +26,4 @@ A reference dockerfile is also provided which applies the keycloak json configur
 
 To run it first have docker installed then go to the directory and do 'docker build . -t activitikeycloak' Then execute 'docker run -p 8180:8080 --name keycloak -i -t activitikeycloak'
 
-TODO: The reference docker is based upon https://github.com/dfranssen/docker-keycloak-import-realm but creation of admin user isn't working for master and no config of master realm is provided (could add as they can be put on comma-separated on keycloak.import). But the realm we need to run tests is there.
+If you get a container already in use error when running the docker container then do a docker rm with the id of the running container and try again. To access the admin console for the container go to http://localhost:8180/auth/admin/springboot/console/ and log in as admin/admin. (This reference docker is based upon reference docker is based upon https://github.com/dfranssen/docker-keycloak-import-realm. Note that the admin user has been included in the springboot-realm.json.)

--- a/activiti-spring-boot/spring-boot-samples/spring-boot-sample-hal-rest-api/springboot-realm.json
+++ b/activiti-spring-boot/spring-boot-samples/spring-boot-sample-hal-rest-api/springboot-realm.json
@@ -1537,6 +1537,34 @@
       "account" : [ "manage-account", "view-profile" ]
     },
     "groups" : [ "/testgroup" ]
-  } ],
+  }, {
+    "id" : "e24cf342-fc50-4cb1-a0c0-57daedb82749",
+    "createdTimestamp" : 1498137163228,
+    "username" : "admin",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "credentials" : [ {
+      "type" : "password",
+      "hashedSaltedValue" : "HuTLxSTg7sB62oK0MEkE0Wd+GubUfKV2zAPIsyLqjGPwiNt6bm/KF6klDA4b1QuRfBVvoHLOOgIx2gFEPUGXFw==",
+      "salt" : "4uyMaFvyJCRwso0up6hapQ==",
+      "hashIterations" : 20000,
+      "counter" : 0,
+      "algorithm" : "pbkdf2",
+      "digits" : 0,
+      "period" : 0,
+      "createdDate" : 1498137163347,
+      "config" : { }
+    } ],
+    "disableableCredentialTypes" : [ "password" ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "uma_authorization", "admin", "offline_access" ],
+    "clientRoles" : {
+      "realm-management" : [ "manage-users", "manage-clients", "manage-authorization", "manage-events", "manage-realm", "create-client", "impersonation", "realm-admin", "manage-identity-providers" ],
+      "broker" : [ "read-token" ],
+      "account" : [ "manage-account", "view-profile" ]
+    },
+    "groups" : [ ]
+  }],
   "keycloakVersion" : "3.1.0.Final"
 }


### PR DESCRIPTION
Small addition to keycloak config that provides an admin user for the docker container and update to README to say how to access container's admin console.