### PR TITLE
Process Definition Id was null

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/VariableInstanceEntity.java
@@ -107,8 +107,9 @@ public class VariableInstanceEntity implements VariableInstance, BulkDeleteable,
   }
   
   protected static ActivitiVariableEvent createVariableDeleteEvent(VariableInstanceEntity variableInstance) {
+	  String procDefinitionId = Context.getExecutionContext().getExecution().getProcessDefinitionId();
     return ActivitiEventBuilder.createVariableEvent(ActivitiEventType.VARIABLE_DELETED, variableInstance.getName(), null, variableInstance.getType(),
-        variableInstance.getTaskId(), variableInstance.getExecutionId(), variableInstance.getProcessInstanceId(), null);
+        variableInstance.getTaskId(), variableInstance.getExecutionId(), variableInstance.getProcessInstanceId(), procDefinitionId);
   }
 
   public Object getPersistentState() {


### PR DESCRIPTION
null processDefinitionId passed while creating new VARIABLE_DELETE event. processDefinitionId is require to get tenant Id. Without processDefinitionId VARIABLE_DELETE event will not have tenant Id