### PR TITLE
disabling discovery for tests

### DIFF
--- a/activiti-services/activiti-services-audit/activiti-services-audit-jpa/src/test/resources/application-producer-test.properties
+++ b/activiti-services/activiti-services-audit/activiti-services-audit-jpa/src/test/resources/application-producer-test.properties
@@ -22,3 +22,4 @@ keycloaktestuser=testuser
 keycloaktestpassword=password
 spring.rabbitmq.host=localhost
 keycloak.auth-server-url=http://localhost:8180/auth
+spring.cloud.discovery.enabled=false


### PR DESCRIPTION
@erdemedeiros @ryandawsonuk please review and merge. Notice that we will need this flag in tests for the query service and all the other services that doesn't require the registry to be tested. 