### PR TITLE
app name injected to all events

### DIFF
--- a/activiti-services/activiti-services-audit/activiti-services-audit-jpa/src/test/java/org/activiti/services/audit/MockProcessEngineEvent.java
+++ b/activiti-services/activiti-services-audit/activiti-services-audit-jpa/src/test/java/org/activiti/services/audit/MockProcessEngineEvent.java
@@ -15,6 +15,7 @@
  */
 
 package org.activiti.services.audit;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
@@ -25,9 +26,24 @@ public class MockProcessEngineEvent implements ProcessEngineEvent {
 
     private Long timestamp;
     private String eventType;
+    private String applicationName;
     private String executionId;
     private String processDefinitionId;
     private String processInstanceId;
+
+    public MockProcessEngineEvent(Long timestamp,
+                                  String eventType,
+                                  String applicationName,
+                                  String executionId,
+                                  String processDefinitionId,
+                                  String processInstanceId) {
+        this.timestamp = timestamp;
+        this.eventType = eventType;
+        this.applicationName = applicationName;
+        this.executionId = executionId;
+        this.processDefinitionId = processDefinitionId;
+        this.processInstanceId = processInstanceId;
+    }
 
     public MockProcessEngineEvent(Long timestamp,
                                   String eventType,
@@ -36,6 +52,7 @@ public class MockProcessEngineEvent implements ProcessEngineEvent {
                                   String processInstanceId) {
         this.timestamp = timestamp;
         this.eventType = eventType;
+        this.applicationName = "mock-app-name";
         this.executionId = executionId;
         this.processDefinitionId = processDefinitionId;
         this.processInstanceId = processInstanceId;
@@ -64,5 +81,10 @@ public class MockProcessEngineEvent implements ProcessEngineEvent {
     @Override
     public String getProcessInstanceId() {
         return processInstanceId;
+    }
+
+    @Override
+    public String getApplicationName() {
+        return applicationName;
     }
 }

--- a/activiti-services/activiti-services-core-model/src/main/java/org/activiti/services/core/model/events/ProcessEngineEvent.java
+++ b/activiti-services/activiti-services-core-model/src/main/java/org/activiti/services/core/model/events/ProcessEngineEvent.java
@@ -33,4 +33,6 @@ public interface ProcessEngineEvent {
     String getProcessDefinitionId();
 
     String getProcessInstanceId();
+
+    String getApplicationName();
 }

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/AbstractProcessEngineEvent.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/AbstractProcessEngineEvent.java
@@ -20,6 +20,8 @@ package org.activiti.services.events;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
 
 public abstract class AbstractProcessEngineEvent implements ProcessEngineEvent {
+
+    private String applicationName;
     private String executionId;
     private String processDefinitionId;
     private String processInstanceId;
@@ -28,22 +30,32 @@ public abstract class AbstractProcessEngineEvent implements ProcessEngineEvent {
     public AbstractProcessEngineEvent() {
     }
 
-    public AbstractProcessEngineEvent(String executionId,
+    public AbstractProcessEngineEvent(String applicationName,
+                                      String executionId,
                                       String processDefinitionId,
                                       String processInstanceId) {
+        this.applicationName = applicationName;
         this.executionId = executionId;
         this.processDefinitionId = processDefinitionId;
         this.processInstanceId = processInstanceId;
         this.timestamp = System.currentTimeMillis();
     }
 
-    public AbstractProcessEngineEvent(String executionId,
+    public AbstractProcessEngineEvent(String applicationName,
+                                      String executionId,
                                       String processDefinitionId,
-                                      String processInstanceId, Long timestamp) {
+                                      String processInstanceId,
+                                      Long timestamp) {
+        this.applicationName = applicationName;
         this.executionId = executionId;
         this.processDefinitionId = processDefinitionId;
         this.processInstanceId = processInstanceId;
         this.timestamp = timestamp;
+    }
+
+    @Override
+    public String getApplicationName() {
+        return applicationName;
     }
 
     @Override
@@ -65,7 +77,7 @@ public abstract class AbstractProcessEngineEvent implements ProcessEngineEvent {
     public abstract String getEventType();
 
     @Override
-    public Long getTimestamp(){
+    public Long getTimestamp() {
         return timestamp;
     }
 }

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCancelledEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCancelledEventImpl.java
@@ -27,14 +27,16 @@ public class ActivityCancelledEventImpl extends AbstractProcessEngineEvent imple
     public ActivityCancelledEventImpl() {
     }
 
-    public ActivityCancelledEventImpl(String executionId,
+    public ActivityCancelledEventImpl(String applicationName,
+                                      String executionId,
                                       String processDefinitionId,
                                       String processInstanceId,
                                       String activityId,
                                       String activityName,
                                       String activityType,
                                       String cause) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.activityId = activityId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCompensateEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCompensateEventImpl.java
@@ -26,13 +26,15 @@ public class ActivityCompensateEventImpl extends AbstractProcessEngineEvent impl
     public ActivityCompensateEventImpl() {
     }
 
-    public ActivityCompensateEventImpl(String executionId,
+    public ActivityCompensateEventImpl(String applicationName,
+                                       String executionId,
                                        String processDefinitionId,
                                        String processInstanceId,
                                        String activityId,
                                        String activityName,
                                        String activityType) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.activityId = activityId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCompletedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityCompletedEventImpl.java
@@ -26,13 +26,15 @@ public class ActivityCompletedEventImpl extends AbstractProcessEngineEvent imple
     public ActivityCompletedEventImpl() {
     }
 
-    public ActivityCompletedEventImpl(String executionId,
+    public ActivityCompletedEventImpl(String applicationName,
+                                      String executionId,
                                       String processDefinitionId,
                                       String processInstanceId,
                                       String activityId,
                                       String activityName,
                                       String activityType) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.activityId = activityId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityStartedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ActivityStartedEventImpl.java
@@ -26,13 +26,15 @@ public class ActivityStartedEventImpl extends AbstractProcessEngineEvent impleme
     public ActivityStartedEventImpl() {
     }
 
-    public ActivityStartedEventImpl(String executionId,
+    public ActivityStartedEventImpl(String applicationName,
+                                    String executionId,
                                     String processDefinitionId,
                                     String processInstanceId,
                                     String activityId,
                                     String activityName,
                                     String activityType) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.activityId = activityId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/MessageProducerActivitiEventListener.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/MessageProducerActivitiEventListener.java
@@ -2,10 +2,9 @@ package org.activiti.services.events;
 
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventListener;
-import org.activiti.services.events.converter.EventConverterContext;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.converter.EventConverterContext;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/MessageProducerActivitiEventListener.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/MessageProducerActivitiEventListener.java
@@ -5,6 +5,7 @@ import org.activiti.engine.delegate.event.ActivitiEventListener;
 import org.activiti.services.events.converter.EventConverterContext;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessCancelledEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessCancelledEventImpl.java
@@ -20,14 +20,17 @@ package org.activiti.services.events;
 public class ProcessCancelledEventImpl extends AbstractProcessEngineEvent implements ProcessCancelledEvent {
 
     private String cause;
+
     public ProcessCancelledEventImpl() {
     }
 
-    public ProcessCancelledEventImpl(String executionId,
+    public ProcessCancelledEventImpl(String applicationName,
+                                     String executionId,
                                      String processDefinitionId,
                                      String processInstanceId,
                                      String cause) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.cause = cause;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessCompletedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessCompletedEventImpl.java
@@ -22,14 +22,17 @@ import org.activiti.services.core.model.ProcessInstance;
 public class ProcessCompletedEventImpl extends AbstractProcessEngineEvent implements ProcessCompletedEvent {
 
     private ProcessInstance processInstance;
+
     public ProcessCompletedEventImpl() {
     }
 
-    public ProcessCompletedEventImpl(String executionId,
+    public ProcessCompletedEventImpl(String applicationName,
+                                     String executionId,
                                      String processDefinitionId,
                                      String processInstanceId,
                                      ProcessInstance processInstance) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.processInstance = processInstance;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessStartedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/ProcessStartedEventImpl.java
@@ -25,12 +25,14 @@ public class ProcessStartedEventImpl  extends AbstractProcessEngineEvent impleme
     public ProcessStartedEventImpl() {
     }
 
-    public ProcessStartedEventImpl(String executionId,
+    public ProcessStartedEventImpl(String applicationName,
+                                   String executionId,
                                    String processDefinitionId,
                                    String processInstanceId,
                                    String nestedProcessDefinitionId,
                                    String nestedProcessInstanceId) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.nestedProcessDefinitionId = nestedProcessDefinitionId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/SequenceFlowTakenEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/SequenceFlowTakenEventImpl.java
@@ -26,7 +26,8 @@ public class SequenceFlowTakenEventImpl extends AbstractProcessEngineEvent imple
     private String targetActivityName;
     private String targetActivityType;
 
-    public SequenceFlowTakenEventImpl(String executionId,
+    public SequenceFlowTakenEventImpl(String applicatioName,
+                                      String executionId,
                                       String processDefinitionId,
                                       String processInstanceId,
                                       String sequenceFlowId,
@@ -36,7 +37,8 @@ public class SequenceFlowTakenEventImpl extends AbstractProcessEngineEvent imple
                                       String targetActivityId,
                                       String targetActivityName,
                                       String targetActivityType) {
-        super(executionId,
+        super(applicatioName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.sequenceFlowId = sequenceFlowId;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskAssignedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskAssignedEventImpl.java
@@ -26,11 +26,13 @@ public class TaskAssignedEventImpl extends AbstractProcessEngineEvent implements
     public TaskAssignedEventImpl() {
     }
 
-    public TaskAssignedEventImpl(String executionId,
+    public TaskAssignedEventImpl(String applicationName,
+                                 String executionId,
                                  String processDefinitionId,
                                  String processInstanceId,
                                  Task task) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.task = task;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskCompletedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskCompletedEventImpl.java
@@ -26,11 +26,13 @@ public class TaskCompletedEventImpl extends AbstractProcessEngineEvent implement
     public TaskCompletedEventImpl() {
     }
 
-    public TaskCompletedEventImpl(String executionId,
+    public TaskCompletedEventImpl(String applicationName,
+                                  String executionId,
                                   String processDefinitionId,
                                   String processInstanceId,
                                   Task task) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.task = task;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskCreatedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/TaskCreatedEventImpl.java
@@ -26,11 +26,13 @@ public class TaskCreatedEventImpl extends AbstractProcessEngineEvent implements 
     public TaskCreatedEventImpl() {
     }
 
-    public TaskCreatedEventImpl(String executionId,
+    public TaskCreatedEventImpl(String applicationName,
+                                String executionId,
                                 String processDefinitionId,
                                 String processInstanceId,
                                 Task task) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.task = task;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableCreatedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableCreatedEventImpl.java
@@ -27,14 +27,16 @@ public class VariableCreatedEventImpl extends AbstractProcessEngineEvent impleme
     public VariableCreatedEventImpl() {
     }
 
-    public VariableCreatedEventImpl(String executionId,
+    public VariableCreatedEventImpl(String applicationName,
+                                    String executionId,
                                     String processDefinitionId,
                                     String processInstanceId,
                                     String variableName,
                                     String variableValue,
                                     String variableType,
                                     String taskId) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.variableName = variableName;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableDeletedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableDeletedEventImpl.java
@@ -26,13 +26,15 @@ public class VariableDeletedEventImpl extends AbstractProcessEngineEvent impleme
     public VariableDeletedEventImpl() {
     }
 
-    public VariableDeletedEventImpl(String executionId,
+    public VariableDeletedEventImpl(String applicationName,
+                                    String executionId,
                                     String processDefinitionId,
                                     String processInstanceId,
                                     String variableName,
                                     String variableType,
                                     String taskId) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.variableName = variableName;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableUpdatedEventImpl.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/VariableUpdatedEventImpl.java
@@ -27,14 +27,16 @@ public class VariableUpdatedEventImpl extends AbstractProcessEngineEvent impleme
     public VariableUpdatedEventImpl() {
     }
 
-    public VariableUpdatedEventImpl(String executionId,
+    public VariableUpdatedEventImpl(String applicationName,
+                                    String executionId,
                                     String processDefinitionId,
                                     String processInstanceId,
                                     String variableName,
                                     String variableValue,
                                     String variableType,
                                     String taskId) {
-        super(executionId,
+        super(applicationName,
+              executionId,
               processDefinitionId,
               processInstanceId);
         this.variableName = variableName;

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/AbstractEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/AbstractEventConverter.java
@@ -1,0 +1,15 @@
+package org.activiti.services.events.converter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class AbstractEventConverter implements EventConverter{
+
+    @Value("${spring.application.name}")
+    protected String applicationName;
+
+    public String getApplicationName() {
+        return applicationName;
+    }
+}

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityCancelledEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityCancelledEventConverter.java
@@ -26,11 +26,12 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.ACTIVITY_CANCELLED;
 
 @Component
-public class ActivityCancelledEventConverter implements EventConverter {
+public class ActivityCancelledEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ActivityCancelledEventImpl(event.getExecutionId(),
+        return new ActivityCancelledEventImpl(getApplicationName(),
+                                              event.getExecutionId(),
                                               event.getProcessDefinitionId(),
                                               event.getProcessInstanceId(),
                                               ((ActivitiActivityCancelledEvent) event).getActivityId(),

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityCompletedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityCompletedEventConverter.java
@@ -19,24 +19,24 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiActivityEvent;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
-import org.activiti.services.events.ActivityCompletedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.ActivityCompletedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.ACTIVITY_COMPLETED;
 
 @Component
-public class ActivityCompletedEventConverter implements EventConverter {
+public class ActivityCompletedEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ActivityCompletedEventImpl(event.getExecutionId(),
-                                                  event.getProcessDefinitionId(),
-                                                  event.getProcessInstanceId(),
-                                                  ((ActivitiActivityEvent) event).getActivityId(),
-                                                  ((ActivitiActivityEvent) event).getActivityName(),
-                                                  ((ActivitiActivityEvent) event).getActivityType());
-
+        return new ActivityCompletedEventImpl(getApplicationName(),
+                                              event.getExecutionId(),
+                                              event.getProcessDefinitionId(),
+                                              event.getProcessInstanceId(),
+                                              ((ActivitiActivityEvent) event).getActivityId(),
+                                              ((ActivitiActivityEvent) event).getActivityName(),
+                                              ((ActivitiActivityEvent) event).getActivityType());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityStartedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ActivityStartedEventConverter.java
@@ -19,18 +19,19 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiActivityEventImpl;
-import org.activiti.services.events.ActivityStartedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.ActivityStartedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.ACTIVITY_STARTED;
 
 @Component
-public class ActivityStartedEventConverter implements EventConverter {
+public class ActivityStartedEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ActivityStartedEventImpl(event.getExecutionId(),
+        return new ActivityStartedEventImpl(getApplicationName(),
+                                            event.getExecutionId(),
                                             event.getProcessDefinitionId(),
                                             event.getProcessInstanceId(),
                                             ((ActivitiActivityEventImpl) event).getActivityId(),

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessCancelledEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessCancelledEventConverter.java
@@ -19,21 +19,22 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiCancelledEvent;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
-import org.activiti.services.events.ProcessCancelledEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.ProcessCancelledEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.PROCESS_CANCELLED;
 
 @Component
-public class ProcessCancelledEventConverter implements EventConverter {
+public class ProcessCancelledEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ProcessCancelledEventImpl(event.getExecutionId(),
-                                                        event.getProcessDefinitionId(),
-                                                        event.getProcessInstanceId(),
-                                                        ((ActivitiCancelledEvent) event).getCause().toString());
+        return new ProcessCancelledEventImpl(getApplicationName(),
+                                             event.getExecutionId(),
+                                             event.getProcessDefinitionId(),
+                                             event.getProcessInstanceId(),
+                                             ((ActivitiCancelledEvent) event).getCause().toString());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessCompletedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessCompletedEventConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.PROCESS_COMPLETED;
 
 @Component
-public class ProcessCompletedEventConverter implements EventConverter {
+public class ProcessCompletedEventConverter extends AbstractEventConverter {
 
     private final ProcessInstanceConverter processInstanceConverter;
 
@@ -40,7 +40,8 @@ public class ProcessCompletedEventConverter implements EventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ProcessCompletedEventImpl(event.getExecutionId(),
+        return new ProcessCompletedEventImpl(getApplicationName(),
+                                             event.getExecutionId(),
                                              event.getProcessDefinitionId(),
                                              event.getProcessInstanceId(),
                                              processInstanceConverter.from(((ExecutionEntityImpl) ((ActivitiEntityEvent) event).getEntity()).getProcessInstance()));

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessStartedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/ProcessStartedEventConverter.java
@@ -19,22 +19,23 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.ActivitiProcessStartedEvent;
-import org.activiti.services.events.ProcessStartedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.ProcessStartedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.PROCESS_STARTED;
 
 @Component
-public class ProcessStartedEventConverter implements EventConverter {
+public class ProcessStartedEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new ProcessStartedEventImpl(event.getExecutionId(),
-                                               event.getProcessDefinitionId(),
-                                               event.getProcessInstanceId(),
-                                               ((ActivitiProcessStartedEvent) event).getNestedProcessDefinitionId(),
-                                               ((ActivitiProcessStartedEvent) event).getNestedProcessInstanceId());
+        return new ProcessStartedEventImpl(getApplicationName(),
+                                           event.getExecutionId(),
+                                           event.getProcessDefinitionId(),
+                                           event.getProcessInstanceId(),
+                                           ((ActivitiProcessStartedEvent) event).getNestedProcessDefinitionId(),
+                                           ((ActivitiProcessStartedEvent) event).getNestedProcessInstanceId());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/SequenceFlowTakenEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/SequenceFlowTakenEventConverter.java
@@ -26,20 +26,21 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.SEQUENCEFLOW_TAKEN;
 
 @Component
-public class SequenceFlowTakenEventConverter implements EventConverter {
+public class SequenceFlowTakenEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new SequenceFlowTakenEventImpl(event.getExecutionId(),
+        return new SequenceFlowTakenEventImpl(getApplicationName(),
+                                              event.getExecutionId(),
                                               event.getProcessDefinitionId(),
                                               event.getProcessInstanceId(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getId(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getSourceActivityId(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getSourceActivityName(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getSourceActivityType(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getTargetActivityId(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getTargetActivityName(),
-                                              ((ActivitiSequenceFlowTakenEventImpl)event).getTargetActivityType());
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getId(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getSourceActivityId(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getSourceActivityName(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getSourceActivityType(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getTargetActivityId(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getTargetActivityName(),
+                                              ((ActivitiSequenceFlowTakenEventImpl) event).getTargetActivityType());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskAssignedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskAssignedEventConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.TASK_ASSIGNED;
 
 @Component
-public class TaskAssignedEventConverter implements EventConverter {
+public class TaskAssignedEventConverter extends AbstractEventConverter {
 
     private final TaskConverter taskConverter;
 
@@ -40,7 +40,8 @@ public class TaskAssignedEventConverter implements EventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new TaskAssignedEventImpl(event.getExecutionId(),
+        return new TaskAssignedEventImpl(getApplicationName(),
+                                         event.getExecutionId(),
                                          event.getProcessDefinitionId(),
                                          event.getProcessInstanceId(),
                                          taskConverter.from((Task) ((ActivitiEntityEvent) event).getEntity()));

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskCompletedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskCompletedEventConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.TASK_COMPLETED;
 
 @Component
-public class TaskCompletedEventConverter implements EventConverter {
+public class TaskCompletedEventConverter extends AbstractEventConverter {
 
     private final TaskConverter taskConverter;
 
@@ -40,7 +40,8 @@ public class TaskCompletedEventConverter implements EventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new TaskCompletedEventImpl(event.getExecutionId(),
+        return new TaskCompletedEventImpl(getApplicationName(),
+                                          event.getExecutionId(),
                                           event.getProcessDefinitionId(),
                                           event.getProcessInstanceId(),
                                           taskConverter.from((Task) ((ActivitiEntityEventImpl) event).getEntity()));

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskCreatedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/TaskCreatedEventConverter.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 import static org.activiti.engine.delegate.event.ActivitiEventType.TASK_CREATED;
 
 @Component
-public class TaskCreatedEventConverter implements EventConverter {
+public class TaskCreatedEventConverter extends AbstractEventConverter {
 
     private final TaskConverter taskConverter;
 
@@ -40,7 +40,8 @@ public class TaskCreatedEventConverter implements EventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new TaskCreatedEventImpl(event.getExecutionId(),
+        return new TaskCreatedEventImpl(getApplicationName(),
+                                        event.getExecutionId(),
                                         event.getProcessDefinitionId(),
                                         event.getProcessInstanceId(),
                                         taskConverter.from((Task) ((ActivitiEntityEventImpl) event).getEntity()));

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableCreatedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableCreatedEventConverter.java
@@ -19,24 +19,25 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
-import org.activiti.services.events.VariableCreatedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.VariableCreatedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.VARIABLE_CREATED;
 
 @Component
-public class VariableCreatedEventConverter implements EventConverter {
+public class VariableCreatedEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new VariableCreatedEventImpl(event.getExecutionId(),
-                                                       event.getProcessDefinitionId(),
-                                                       event.getProcessInstanceId(),
-                                                       ((ActivitiVariableEventImpl) event).getVariableName(),
-                                                       ((ActivitiVariableEventImpl) event).getVariableValue().toString(),
-                                                       ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
-                                                       ((ActivitiVariableEventImpl) event).getTaskId());
+        return new VariableCreatedEventImpl(getApplicationName(),
+                                            event.getExecutionId(),
+                                            event.getProcessDefinitionId(),
+                                            event.getProcessInstanceId(),
+                                            ((ActivitiVariableEventImpl) event).getVariableName(),
+                                            ((ActivitiVariableEventImpl) event).getVariableValue().toString(),
+                                            ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
+                                            ((ActivitiVariableEventImpl) event).getTaskId());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableDeletedEventConveter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableDeletedEventConveter.java
@@ -19,23 +19,24 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
-import org.activiti.services.events.VariableDeletedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.VariableDeletedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.VARIABLE_DELETED;
 
 @Component
-public class VariableDeletedEventConveter implements EventConverter {
+public class VariableDeletedEventConveter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new VariableDeletedEventImpl(event.getExecutionId(),
-                                                event.getProcessDefinitionId(),
-                                                event.getProcessInstanceId(),
-                                                ((ActivitiVariableEventImpl) event).getVariableName(),
-                                                ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
-                                                ((ActivitiVariableEventImpl) event).getTaskId());
+        return new VariableDeletedEventImpl(getApplicationName(),
+                                            event.getExecutionId(),
+                                            event.getProcessDefinitionId(),
+                                            event.getProcessInstanceId(),
+                                            ((ActivitiVariableEventImpl) event).getVariableName(),
+                                            ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
+                                            ((ActivitiVariableEventImpl) event).getTaskId());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableUpdatedEventConverter.java
+++ b/activiti-services/activiti-services-events/src/main/java/org/activiti/services/events/converter/VariableUpdatedEventConverter.java
@@ -19,24 +19,25 @@ package org.activiti.services.events.converter;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
-import org.activiti.services.events.VariableUpdatedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
+import org.activiti.services.events.VariableUpdatedEventImpl;
 import org.springframework.stereotype.Component;
 
 import static org.activiti.engine.delegate.event.ActivitiEventType.VARIABLE_UPDATED;
 
 @Component
-public class VariableUpdatedEventConverter implements EventConverter {
+public class VariableUpdatedEventConverter extends AbstractEventConverter {
 
     @Override
     public ProcessEngineEvent from(ActivitiEvent event) {
-        return new VariableUpdatedEventImpl(event.getExecutionId(),
-                                                event.getProcessDefinitionId(),
-                                                event.getProcessInstanceId(),
-                                                ((ActivitiVariableEventImpl) event).getVariableName(),
-                                                ((ActivitiVariableEventImpl) event).getVariableValue().toString(),
-                                                ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
-                                                ((ActivitiVariableEventImpl) event).getTaskId());
+        return new VariableUpdatedEventImpl(getApplicationName(),
+                                            event.getExecutionId(),
+                                            event.getProcessDefinitionId(),
+                                            event.getProcessInstanceId(),
+                                            ((ActivitiVariableEventImpl) event).getVariableName(),
+                                            ((ActivitiVariableEventImpl) event).getVariableValue().toString(),
+                                            ((ActivitiVariableEventImpl) event).getVariableType().getTypeName(),
+                                            ((ActivitiVariableEventImpl) event).getTaskId());
     }
 
     @Override

--- a/activiti-services/activiti-services-events/src/test/java/org/activiti/services/events/converter/EventConverterContextIT.java
+++ b/activiti-services/activiti-services-events/src/test/java/org/activiti/services/events/converter/EventConverterContextIT.java
@@ -19,18 +19,26 @@ package org.activiti.services.events.converter;
 import java.util.Map;
 
 import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.ActivitiProcessStartedEvent;
+import org.activiti.engine.delegate.event.impl.ActivitiEventImpl;
+import org.activiti.engine.delegate.event.impl.ActivitiProcessStartedEventImpl;
+import org.activiti.services.core.model.events.ProcessEngineEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = EventConverterContextIT.SpringConfig.class)
+@TestPropertySource("classpath:test-application.properties")
 public class EventConverterContextIT {
 
     @Autowired
@@ -62,5 +70,25 @@ public class EventConverterContextIT {
                                                 ActivitiEventType.VARIABLE_DELETED,
                                                 ActivitiEventType.VARIABLE_UPDATED);
     }
+
+    @Test
+    public void shouldIncludeApplicationNameInConvertedEvents() throws Exception {
+
+        //when
+        Map<ActivitiEventType, EventConverter> converters = converterContext.getConvertersMap();
+
+        //then
+        assertThat(converters).containsKey(ActivitiEventType.PROCESS_STARTED);
+        ActivitiProcessStartedEvent activitiEvent = mock(ActivitiProcessStartedEvent.class);
+
+        ProcessEngineEvent processEngineEvent = converters.get(ActivitiEventType.PROCESS_STARTED).from(activitiEvent);
+
+        assertThat(processEngineEvent).isNotNull();
+        assertThat(processEngineEvent.getApplicationName()).isNotEmpty();
+        // this comes from the application.properties (test-application.properties) spring app name configuration
+        assertThat(processEngineEvent.getApplicationName()).isEqualTo("test-app");
+
+    }
+
 
 }

--- a/activiti-services/activiti-services-events/src/test/java/org/activiti/services/events/converter/EventConverterContextIT.java
+++ b/activiti-services/activiti-services-events/src/test/java/org/activiti/services/events/converter/EventConverterContextIT.java
@@ -20,8 +20,6 @@ import java.util.Map;
 
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.ActivitiProcessStartedEvent;
-import org.activiti.engine.delegate.event.impl.ActivitiEventImpl;
-import org.activiti.engine.delegate.event.impl.ActivitiProcessStartedEventImpl;
 import org.activiti.services.core.model.events.ProcessEngineEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,8 +31,7 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 @ContextConfiguration(classes = EventConverterContextIT.SpringConfig.class)
@@ -87,8 +84,5 @@ public class EventConverterContextIT {
         assertThat(processEngineEvent.getApplicationName()).isNotEmpty();
         // this comes from the application.properties (test-application.properties) spring app name configuration
         assertThat(processEngineEvent.getApplicationName()).isEqualTo("test-app");
-
     }
-
-
 }

--- a/activiti-services/activiti-services-events/src/test/resources/test-application.properties
+++ b/activiti-services/activiti-services-events/src/test/resources/test-application.properties
@@ -1,0 +1,1 @@
+spring.application.name=test-app


### PR DESCRIPTION
Now events include the app name defined in the spring configurations.
@erdemedeiros @ryandawsonuk review and merge if appropriate. This is a requirement as filter for both query and audit services. Both should filter by app name as one of their basic filters. 