### PR TITLE
BDE-1243 Fix dependency of assertj-core in generator plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1084,6 +1084,13 @@
           <groupId>org.assertj</groupId>
           <artifactId>assertj-assertions-generator-maven-plugin</artifactId>
           <version>${assertions-generator-plugin.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj.version}</version>
+              </dependency>
+          </dependencies>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
Specifying the proper version of assertj-core in the Maven generator plugin.
Side effect: fixes the build on Bamboo...