### PR TITLE
retrofitting to main repo change done under starters

### DIFF
--- a/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-audit-starter/pom.xml
+++ b/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-audit-starter/pom.xml
@@ -227,27 +227,30 @@
              your docker containers during integration tests -->
         <executions>
           <execution>
+            <id>build</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>start</id>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
             <phase>pre-integration-test</phase>
             <goals>
-              <!-- "build" should be used to create the images with the
-                   artifact -->
-              <goal>build</goal>
               <goal>start</goal>
             </goals>
           </execution>
           <execution>
             <id>stop</id>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>build</id>
-            <phase>install</phase>
-            <goals>
-              <goal>build</goal>
             </goals>
           </execution>
         </executions>

--- a/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter/pom.xml
+++ b/activiti-spring-boot/spring-boot-starters/activiti-spring-boot-starter/pom.xml
@@ -230,27 +230,30 @@
              your docker containers during integration tests -->
         <executions>
           <execution>
+            <id>build</id>
+            <phase>package</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+          </execution>
+          <execution>
             <id>start</id>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
             <phase>pre-integration-test</phase>
             <goals>
-              <!-- "build" should be used to create the images with the
-                   artifact -->
-              <goal>build</goal>
               <goal>start</goal>
             </goals>
           </execution>
           <execution>
             <id>stop</id>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
             <phase>post-integration-test</phase>
             <goals>
               <goal>stop</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>build</id>
-            <phase>install</phase>
-            <goals>
-              <goal>build</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Change in starter repo -  Activiti/activiti-spring-boot-starters#1 in this commit - Activiti/activiti-spring-boot-starters@bc042f9

Just including for main repo to keep in sync until we remove. Alternatively we could just remove the activiti-spring-boot directory. But note that we should have a bamboo job set up for the new repo first as examples repo depends on starter artefacts getting published. 