### PR TITLE
Ignore unknown events

### DIFF
--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/AbstractProcessEngineEvent.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/AbstractProcessEngineEvent.java
@@ -27,7 +27,8 @@ import org.activiti.services.api.events.ProcessEngineEvent;
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
         include = JsonTypeInfo.As.PROPERTY,
-        property = "eventType")
+        property = "eventType",
+        defaultImpl = IgnoredProcessEngineEvent.class)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = ProcessStartedEvent.class, name = "ProcessStartedEvent"),
         @JsonSubTypes.Type(value = ProcessCompletedEvent.class, name = "ProcessCompletedEvent"),

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/IgnoredProcessEngineEvent.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/IgnoredProcessEngineEvent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.services.query.events;
+
+public class IgnoredProcessEngineEvent extends AbstractProcessEngineEvent {
+
+}


### PR DESCRIPTION
Closes #1428. Add a new type to map all the events to be ignored by the query service.
This avoid exceptions when jackson tries to deserialize events.