### PR TITLE
Fix Query Model ProcessInstance @Id attribute to use String data type

### DIFF
--- a/activiti-services/activiti-services-query/activiti-services-query-graphql/src/test/java/org/activiti/services/query/qraphql/autoconfigure/ActivitiGraphQLSchemaBuildTest.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-graphql/src/test/java/org/activiti/services/query/qraphql/autoconfigure/ActivitiGraphQLSchemaBuildTest.java
@@ -18,6 +18,9 @@ package org.activiti.services.query.qraphql.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
+import graphql.Scalars;
+import graphql.schema.GraphQLSchema;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,11 +28,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import com.introproventures.graphql.jpa.query.schema.impl.GraphQLJpaSchemaBuilder;
-
-import graphql.Scalars;
-import graphql.schema.GraphQLSchema;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
@@ -70,7 +68,7 @@ public class ActivitiGraphQLSchemaBuildTest {
         //then
         assertThat(schema.getQueryType().getFieldDefinition("ProcessInstance")
             .getArgument("processInstanceId").getType())
-            .isEqualTo(Scalars.GraphQLLong);
+            .isEqualTo(Scalars.GraphQLString);
 
         //then
         assertThat(schema.getQueryType().getFieldDefinition("ProcessInstance")

--- a/activiti-services/activiti-services-query/activiti-services-query-model/src/main/java/org/activiti/services/query/model/ProcessInstance.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-model/src/main/java/org/activiti/services/query/model/ProcessInstance.java
@@ -19,16 +19,12 @@ package org.activiti.services.query.model;
 import java.util.Date;
 import java.util.Set;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.Transient;
-
-import org.springframework.format.annotation.DateTimeFormat;
+import javax.persistence.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.introproventures.graphql.jpa.query.annotation.GraphQLDescription;
+import org.springframework.format.annotation.DateTimeFormat;
 
 @GraphQLDescription("Process Instance Entity Model")
 
@@ -39,7 +35,7 @@ public class ProcessInstance {
 
     @Id
     @GraphQLDescription("Unique process instance identity attribute")
-    private Long processInstanceId;
+    private String processInstanceId;
     private String processDefinitionId;
     private String status;
 
@@ -63,17 +59,17 @@ public class ProcessInstance {
     public ProcessInstance() {
     }
 
-    public ProcessInstance(Long processInstanceId,
+    public ProcessInstance(String processInstanceId,
                            String processDefinitionId,
                            String status,
                            Date lastModified) {
         this.processInstanceId = processInstanceId;
         this.processDefinitionId = processDefinitionId;
-        this.status = status;
+        this.status = status; 
         this.lastModified = lastModified;
     }
 
-    public Long getProcessInstanceId() {
+    public String getProcessInstanceId() {
         return processInstanceId;
     }
 
@@ -89,7 +85,7 @@ public class ProcessInstance {
         return lastModified;
     }
 
-    public void setProcessInstanceId(Long processInstanceId) {
+    public void setProcessInstanceId(String processInstanceId) {
         this.processInstanceId = processInstanceId;
     }
 

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/ProcessStartedHandler.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/ProcessStartedHandler.java
@@ -19,9 +19,9 @@ package org.activiti.services.query.events.handlers;
 import java.util.Date;
 
 import org.activiti.services.api.events.ProcessEngineEvent;
-import org.activiti.services.query.model.ProcessInstance;
 import org.activiti.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.services.query.events.ProcessStartedEvent;
+import org.activiti.services.query.model.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,7 +44,7 @@ public class ProcessStartedHandler implements QueryEventHandler {
         LOGGER.debug("Handling start of process Instance " + event.getProcessInstanceId());
 
         processInstanceRepository.save(
-                new ProcessInstance(Long.parseLong(event.getProcessInstanceId()),
+                new ProcessInstance(event.getProcessInstanceId(),
                                     event.getProcessDefinitionId(),
                                     "RUNNING",
                                     new Date(event.getTimestamp())));

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/TaskCreatedEventHandler.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/TaskCreatedEventHandler.java
@@ -48,7 +48,7 @@ public class TaskCreatedEventHandler implements QueryEventHandler {
         
         // Get processInstance reference proxy without database query
         ProcessInstance processInstance = entityManager
-        	.getReference(ProcessInstance.class, Long.valueOf(taskCreatedEvent.getProcessInstanceId()));
+        	.getReference(ProcessInstance.class, taskCreatedEvent.getProcessInstanceId());
 
         // Associate task with parent reference
         task.setProcessInstance(processInstance);

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/VariableCreatedEventHandler.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/main/java/org/activiti/services/query/events/handlers/VariableCreatedEventHandler.java
@@ -72,7 +72,7 @@ public class VariableCreatedEventHandler implements QueryEventHandler {
         
     	// Set required parent processInstance reference
         ProcessInstance processInstance = entityManager
-        		.getReference(ProcessInstance.class, Long.valueOf(variableCreatedEvent.getProcessInstanceId()));
+        		.getReference(ProcessInstance.class, variableCreatedEvent.getProcessInstanceId());
 
     	variable.setProcessInstance(processInstance);
         

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/test/java/org/activiti/services/query/events/handlers/ProcessStartedHandlerTest.java
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/test/java/org/activiti/services/query/events/handlers/ProcessStartedHandlerTest.java
@@ -16,20 +16,20 @@
 
 package org.activiti.services.query.events.handlers;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.activiti.services.api.events.ProcessEngineEvent;
-import org.activiti.services.query.model.ProcessInstance;
 import org.activiti.services.query.app.repository.ProcessInstanceRepository;
 import org.activiti.services.query.events.ProcessStartedEvent;
+import org.activiti.services.query.model.ProcessInstance;
 import org.activiti.test.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ProcessStartedHandlerTest {
 
@@ -64,7 +64,7 @@ public class ProcessStartedHandlerTest {
 
         ProcessInstance processInstance = argumentCaptor.getValue();
         Assertions.assertThat(processInstance)
-                .hasProcessInstanceId(200L)
+                .hasProcessInstanceId("200")
                 .hasProcessDefinitionId("100")
                 .hasStatus("RUNNING");
     }

--- a/activiti-services/activiti-services-query/activiti-services-query-rest/src/test/resources/jpa-test.sql
+++ b/activiti-services/activiti-services-query/activiti-services-query-rest/src/test/resources/jpa-test.sql
@@ -1,20 +1,20 @@
 insert into process_instance (process_instance_id, last_modified, last_modified_from, last_modified_to, process_definition_id, status) values
-  (0, null, null, null, 'process_definition_id', 'Running'),
-  (1, null, null, null, 'process_definition_id', 'Running');
+  ('0', CURRENT_TIMESTAMP, null, null, 'process_definition_id', 'Running'),
+  ('1', CURRENT_TIMESTAMP, null, null, 'process_definition_id', 'Running');
 
 insert into task (id, assignee, category, create_time, description, due_date, last_modified, last_modified_from, last_modified_to, name, priority, process_definition_id, process_instance_id, status) values
-  ('1', 'assignee', 'category', null, 'description', null, null, null, null, 'task1', 'Normal', 'process_definition_id', 0, 'Completed' ),
-  ('2', 'assignee', 'category', null, 'description', null, null, null, null, 'task2', 'High', 'process_definition_id', 0, 'Running' ),
-  ('3', 'assignee', 'category', null, 'description', null, null, null, null, 'task3', 'Normal', 'process_definition_id', 0, 'Running' ),
-  ('4', 'assignee', 'category', null, 'description', null, null, null, null, 'task4', 'High', 'process_definition_id', 1, 'Running' ),
-  ('5', 'assignee', 'category', null, 'description', null, null, null, null, 'task5', 'Normal', 'process_definition_id', 1, 'Completed' );
+  ('1', 'assignee', 'category', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task1', 'Normal', 'process_definition_id', 0, 'Completed' ),
+  ('2', 'assignee', 'category', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task2', 'High', 'process_definition_id', 0, 'Running' ),
+  ('3', 'assignee', 'category', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task3', 'Normal', 'process_definition_id', 0, 'Running' ),
+  ('4', 'assignee', 'category', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task4', 'High', 'process_definition_id', 1, 'Running' ),
+  ('5', 'assignee', 'category', CURRENT_TIMESTAMP, 'description', null, null, null, null, 'task5', 'Normal', 'process_definition_id', 1, 'Completed' );
 
-insert into variable (id, create_time, execution_id, last_updated_time, name, process_instance_id, task_id, type, value) values
-  (0, null, 'execution_id', null, 'variable1', 0, '1', 'String', 'value1'),
-  (1, null, 'execution_id', null, 'variable2', 0, '1', 'String', 'value2'),
-  (2, null, 'execution_id', null, 'variable3', 0, '2', 'String', 'value3'),
-  (3, null, 'execution_id', null, 'variable4', 0, '2', 'String', 'value4'),
-  (4, null, 'execution_id', null, 'variable5', 1, '4', 'String', 'value5'),
-  (5, null, 'execution_id', null, 'variable6', 1, '4', 'String', 'value6'),
-  (6, null, 'execution_id', null, 'initiator', 1, null, 'String', 'admin');
+insert into variable (create_time, execution_id, last_updated_time, name, process_instance_id, task_id, type, value) values
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable1', 0, '1', 'String', 'value1'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable2', 0, '1', 'String', 'value2'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable3', 0, '2', 'String', 'value3'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable4', 0, '2', 'String', 'value4'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable5', 1, '4', 'String', 'value5'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'variable6', 1, '4', 'String', 'value6'),
+  (CURRENT_TIMESTAMP, 'execution_id', CURRENT_TIMESTAMP, 'initiator', 1, null, 'String', 'admin');
 


### PR DESCRIPTION
This PR fixes attribute data type inconsistencies in query entities. For example, @Id field processInstanceId in ProcessInstance is declared as Long type, and  as String in Task and Variable entities. It creates inconsistency in GraphQL and Rest API schemas visible to end-user.  

I have also fixed tests to verify correct data type are used in generated Rest and GraphQL schemas