### PR TITLE
Fix signal events throw/catch race conditions in process instance scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target
 .DS_Store
 *.bpmn/
 /userguide/src/en/index.html
+/.metadata/
+/.recommenders/
+.factorypath

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.pvm.PvmTransition;
@@ -30,16 +31,19 @@ public class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
   
   protected boolean interrupting;
   protected String activityId;
+  protected BoundaryEvent boundaryEvent;
   
   public BoundaryEventActivityBehavior() {
     
   }
   
-  public BoundaryEventActivityBehavior(boolean interrupting, String activityId) {
+  public BoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, String activityId) {
     this.interrupting = interrupting;
     this.activityId = activityId;
+    this.boundaryEvent = boundaryEvent;
   }
   
+  @Override
   @SuppressWarnings("unchecked")
   public void execute(ActivityExecution execution) throws Exception {
     ExecutionEntity executionEntity = (ExecutionEntity) execution;
@@ -93,6 +97,16 @@ public class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
 
   public void setInterrupting(boolean interrupting) {
     this.interrupting = interrupting;
+  }
+
+  
+  public String getActivityId() {
+    return activityId;
+  }
+
+  
+  public BoundaryEvent getBoundaryEvent() {
+    return boundaryEvent;
   }
 
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundarySignalEventAwareStartEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundarySignalEventAwareStartEventActivityBehavior.java
@@ -1,0 +1,76 @@
+package org.activiti.engine.impl.bpmn.behavior;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.pvm.delegate.ActivityBehavior;
+import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
+import org.activiti.engine.impl.pvm.process.ActivityImpl;
+
+public class BoundarySignalEventAwareStartEventActivityBehavior extends FlowNodeActivityBehavior {
+  
+  private final ActivityBehavior initialActivity;
+  private final ActivityImpl activity;
+  
+  public BoundarySignalEventAwareStartEventActivityBehavior(ActivityImpl delegate) {
+    this.initialActivity = delegate.getActivityBehavior();
+    this.activity = delegate.getParentActivity();
+  }
+  
+  @Override
+  public void execute(ActivityExecution execution) throws Exception {
+
+    // Check any boundary event signal activity matching registered signal event in process instance execution scope
+    for(BoundaryEventActivityBehavior boundaryEventActivityBehavior: getBoundaryEventActivities(activity)) {
+      SignalEventDefinition signalEventDef = findSignalEventDefinition(boundaryEventActivityBehavior);
+      
+      if(signalEventDef != null) {
+        if(Context.getCommandContext().getSignalEventSessionManager()
+            .hasThrowSignalEventForExecution(execution, signalEventDef.getSignalRef())) 
+        {
+          // Execute outgoing boundary signal event activity
+          boundaryEventActivityBehavior.execute(execution);
+
+          return;
+        }
+      }
+    }        
+    
+    this.initialActivity.execute(execution);
+  }
+  
+  protected List<BoundaryEventActivityBehavior> getBoundaryEventActivities(ActivityImpl activity) {
+    List<BoundaryEventActivityBehavior> result = new ArrayList<BoundaryEventActivityBehavior>();
+
+    List<ActivityImpl> children = activity.getActivities();
+    
+    for(ActivityImpl child: children) {
+      if(child.getActivityBehavior() instanceof BoundaryEventActivityBehavior) {
+        BoundaryEventActivityBehavior boundaryEventActivity = (BoundaryEventActivityBehavior) child.getActivityBehavior();
+        result.add(boundaryEventActivity);
+      }
+    }
+    
+    return result;
+  }
+
+  protected SignalEventDefinition findSignalEventDefinition(BoundaryEventActivityBehavior boundaryEventActivityBehavior) {
+    SignalEventDefinition signalEventDef = null;
+    BoundaryEvent boundaryEvent = boundaryEventActivityBehavior.getBoundaryEvent();
+    
+    if(boundaryEvent != null) {
+      for(EventDefinition eventDef : boundaryEvent.getEventDefinitions()) {
+        if(eventDef instanceof SignalEventDefinition) {
+          signalEventDef = (SignalEventDefinition) eventDef;
+        }
+      }
+    }
+    
+    return signalEventDef;
+    
+  }      
+}

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundarySignalEventAwareStartEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundarySignalEventAwareStartEventActivityBehavior.java
@@ -35,7 +35,8 @@ public class BoundarySignalEventAwareStartEventActivityBehavior extends FlowNode
           // Execute outgoing boundary signal event activity
           boundaryEventActivityBehavior.execute(execution);
 
-          return;
+          if(boundaryEventActivityBehavior.isInterrupting())
+            return;
         }
       }
     }        

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
@@ -13,7 +13,13 @@
 
 package org.activiti.engine.impl.bpmn.behavior;
 
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.IntermediateCatchEvent;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
+import org.activiti.engine.impl.pvm.process.ActivityImpl;
 
 
 /**
@@ -23,8 +29,53 @@ public class EventBasedGatewayActivityBehavior extends FlowNodeActivityBehavior 
   
   @Override
   public void execute(ActivityExecution execution) throws Exception {
+
+    // Continue with signal catch event activities for signal events 
+    // already registered in process instance execution scope
+    ExecutionEntity executionEntity = (ExecutionEntity) execution;
+    ActivityImpl executionActivity = executionEntity.getActivity();
+    
+    for(ActivityImpl mayBeCatchEventActivity: executionActivity.getActivities()) {
+      if(mayBeCatchEventActivity.getActivityBehavior() instanceof IntermediateCatchEventActivityBehavior) {
+        IntermediateCatchEventActivityBehavior catchEventActivity = (IntermediateCatchEventActivityBehavior) mayBeCatchEventActivity.getActivityBehavior();
+
+        SignalEventDefinition signalEventDef = findSignalEventDefinition(catchEventActivity);
+        
+        // Find first matching registered event
+        if(signalEventDef != null) {
+          if(Context.getCommandContext().getSignalEventSessionManager()
+              .hasThrowSignalEventForExecution(execution, signalEventDef.getSignalRef())) 
+          {
+              // Switch execution context to signal catch event activity
+              executionEntity.setActivity(mayBeCatchEventActivity); 
+              
+              // Send signal
+              catchEventActivity.signal(execution, signalEventDef.getSignalRef(), null);
+              
+              return;
+          }
+        }
+      }
+    }
+    
+    // Otherwise
     // the event based gateway doesn't really do anything
     // ignoring outgoing sequence flows (they're only parsed for the diagram)
   }
-  
+ 
+  protected SignalEventDefinition findSignalEventDefinition(IntermediateCatchEventActivityBehavior catchEventActivityBehavior) {
+    SignalEventDefinition signalEventDefinition = null;
+    IntermediateCatchEvent catchEvent = catchEventActivityBehavior.intermediateCatchEvent;
+    
+    if(catchEvent != null) {
+      for(EventDefinition eventDef : catchEvent.getEventDefinitions()) {
+        if(eventDef instanceof SignalEventDefinition) {
+          signalEventDefinition = (SignalEventDefinition) eventDef;
+        }
+      }
+    }
+    
+    return signalEventDefinition;
+    
+  }  
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventBasedGatewayActivityBehavior.java
@@ -31,17 +31,17 @@ public class EventBasedGatewayActivityBehavior extends FlowNodeActivityBehavior 
   public void execute(ActivityExecution execution) throws Exception {
 
     // Continue with signal catch event activities for signal events 
-    // already registered in process instance execution scope
+    // already fired and registered in process instance execution scope
     ExecutionEntity executionEntity = (ExecutionEntity) execution;
     ActivityImpl executionActivity = executionEntity.getActivity();
     
     for(ActivityImpl mayBeCatchEventActivity: executionActivity.getActivities()) {
       if(mayBeCatchEventActivity.getActivityBehavior() instanceof IntermediateCatchEventActivityBehavior) {
-        IntermediateCatchEventActivityBehavior catchEventActivity = (IntermediateCatchEventActivityBehavior) mayBeCatchEventActivity.getActivityBehavior();
+        IntermediateCatchEventActivityBehavior catchEventActivityBehavior = (IntermediateCatchEventActivityBehavior) mayBeCatchEventActivity.getActivityBehavior();
 
-        SignalEventDefinition signalEventDef = findSignalEventDefinition(catchEventActivity);
+        SignalEventDefinition signalEventDef = findSignalEventDefinition(catchEventActivityBehavior);
         
-        // Find first matching registered event
+        // Find matching registered signal event
         if(signalEventDef != null) {
           if(Context.getCommandContext().getSignalEventSessionManager()
               .hasThrowSignalEventForExecution(execution, signalEventDef.getSignalRef())) 
@@ -49,8 +49,8 @@ public class EventBasedGatewayActivityBehavior extends FlowNodeActivityBehavior 
               // Switch execution context to signal catch event activity
               executionEntity.setActivity(mayBeCatchEventActivity); 
               
-              // Send signal
-              catchEventActivity.signal(execution, signalEventDef.getSignalRef(), null);
+              // Emit signal
+              catchEventActivityBehavior.signal(execution, signalEventDef.getSignalRef(), null);
               
               return;
           }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
@@ -12,14 +12,44 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
+import java.util.List;
+
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.IntermediateCatchEvent;
+import org.activiti.bpmn.model.SignalEventDefinition;
+import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
 
 
 public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
+  protected final IntermediateCatchEvent intermediateCatchEvent;
+    
+  public IntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent) {
+        this.intermediateCatchEvent = intermediateCatchEvent;
+  }
 
+  @Override
   public void execute(ActivityExecution execution) throws Exception {
-    // Do nothing: waitstate behavior
+      
+      // Use associated event definitions     
+      List<EventDefinition> events = intermediateCatchEvent.getEventDefinitions();
+
+      for(EventDefinition event : events) {
+        if(event instanceof SignalEventDefinition) {
+          SignalEventDefinition signalEventDefinition = (SignalEventDefinition) event;
+          
+          // Check already published signal events registered in the process instance context   
+          if(Context.getCommandContext().getSignalEventSessionManager()
+              .hasThrowSignalEventForExecution(execution, signalEventDefinition.getSignalRef()))
+          {
+              //Continue execution 
+              leave(execution);
+          }
+        }
+      }
+      
+     // Otherwise, do nothing: waitstate behavior
   }
 
   @Override

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SubProcessActivityBehavior.java
@@ -34,6 +34,7 @@ import org.activiti.engine.impl.pvm.process.ActivityImpl;
  */
 public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior implements CompositeActivityBehavior {
   
+  @Override
   public void execute(ActivityExecution execution) throws Exception {
     PvmActivity activity = execution.getActivity();
     ActivityImpl initialActivity = (ActivityImpl) activity.getProperty(BpmnParse.PROPERTYNAME_INITIAL);
@@ -51,10 +52,15 @@ public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior imp
     	((ExecutionEntity) execution).setActivity(initialActivity);
     	Context.getCommandContext().getHistoryManager().recordActivityStart((ExecutionEntity) execution);
     }
-
+    
+    initialActivity.setActivityBehavior(new BoundarySignalEventAwareStartEventActivityBehavior(initialActivity));
+    
+    // Start sub process activity    
     execution.executeActivity(initialActivity);
+  
   }
   
+  @Override
   public void lastExecutionEnded(ActivityExecution execution) {
     ScopeUtil.createEventScopeExecution((ExecutionEntity) execution);
     
@@ -73,4 +79,5 @@ public class SubProcessActivityBehavior extends AbstractBpmnActivityBehavior imp
       execution.setVariablesLocal(dataObjectVars);
     }
   }
+  
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -236,8 +236,9 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
           // Execute boundary event activity
           boundaryEventActivityBehavior.execute(execution);
           
-          // Leave
-          return;
+          // Leave only if interrupted
+          if(boundaryEventActivityBehavior.isInterrupting())
+            return;
         }
       }
     }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -225,16 +225,19 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
       task.complete(null, false);
     }
     
-    // Execute any interrupting boundary event activities 
-    // for any signal events registered in process instance execution scope
-    for(BoundaryEventActivityBehavior boundaryEventActivity: getInterruptingBoundaryEventActivities(execution)) {
-      SignalEventDefinition signalEventDef = findSignalEventDefinition(boundaryEventActivity);
+    // Execute any  boundary event signal activity if matching signal event is registered in process instance execution scope
+    for(BoundaryEventActivityBehavior boundaryEventActivityBehavior: getBoundaryEventActivityBehaviors(execution)) {
+      SignalEventDefinition signalEventDef = findSignalEventDefinition(boundaryEventActivityBehavior);
       
       if(signalEventDef != null) {
         if(Context.getCommandContext().getSignalEventSessionManager()
             .hasThrowSignalEventForExecution(execution, signalEventDef.getSignalRef())) 
         {
-          boundaryEventActivity.execute(execution);
+          // Execute boundary event activity
+          boundaryEventActivityBehavior.execute(execution);
+          
+          // Leave
+          return;
         }
       }
     }
@@ -394,7 +397,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
     return taskDefinition;
   }
   
-  protected List<BoundaryEventActivityBehavior> getInterruptingBoundaryEventActivities(ActivityExecution execution) {
+  protected List<BoundaryEventActivityBehavior> getBoundaryEventActivityBehaviors(ActivityExecution execution) {
     List<BoundaryEventActivityBehavior> result = new ArrayList<BoundaryEventActivityBehavior>();
 
     ActivityImpl activity = ((ExecutionEntity)execution).getActivity();
@@ -404,8 +407,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
     for(ActivityImpl child: children) {
       if(child.getActivityBehavior() instanceof BoundaryEventActivityBehavior) {
         BoundaryEventActivityBehavior boundaryEventActivity = (BoundaryEventActivityBehavior) child.getActivityBehavior();
-        if(boundaryEventActivity.isInterrupting())
-          result.add(boundaryEventActivity);
+        result.add(boundaryEventActivity);
       }
     }
     

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/UserTaskActivityBehavior.java
@@ -12,6 +12,7 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
@@ -21,6 +22,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.SignalEventDefinition;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.DynamicBpmnConstants;
@@ -30,18 +36,15 @@ import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.bpmn.helper.SkipExpressionUtil;
 import org.activiti.engine.impl.calendar.BusinessCalendar;
-import org.activiti.engine.impl.calendar.DueDateBusinessCalendar;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.el.ExpressionManager;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;
 import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
+import org.activiti.engine.impl.pvm.process.ActivityImpl;
 import org.activiti.engine.impl.task.TaskDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * activity implementation for the user task.
@@ -62,6 +65,7 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
     this.taskDefinition = taskDefinition;
   }
 
+  @Override
   public void execute(ActivityExecution execution) throws Exception {
     TaskEntity task = TaskEntity.createAndInsert(execution);
     task.setExecution(execution);
@@ -220,8 +224,25 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
     if (skipUserTask) {
       task.complete(null, false);
     }
+    
+    // Execute any interrupting boundary event activities 
+    // for any signal events registered in process instance execution scope
+    for(BoundaryEventActivityBehavior boundaryEventActivity: getInterruptingBoundaryEventActivities(execution)) {
+      SignalEventDefinition signalEventDef = findSignalEventDefinition(boundaryEventActivity);
+      
+      if(signalEventDef != null) {
+        if(Context.getCommandContext().getSignalEventSessionManager()
+            .hasThrowSignalEventForExecution(execution, signalEventDef.getSignalRef())) 
+        {
+          boundaryEventActivity.execute(execution);
+        }
+      }
+    }
+    
   }
 
+  
+  @Override
   public void signal(ActivityExecution execution, String signalName, Object signalData) throws Exception {
     if (!((ExecutionEntity) execution).getTasks().isEmpty())
       throw new ActivitiException("UserTask should not be signalled before complete");
@@ -372,5 +393,40 @@ public class UserTaskActivityBehavior extends TaskActivityBehavior {
   public TaskDefinition getTaskDefinition() {
     return taskDefinition;
   }
+  
+  protected List<BoundaryEventActivityBehavior> getInterruptingBoundaryEventActivities(ActivityExecution execution) {
+    List<BoundaryEventActivityBehavior> result = new ArrayList<BoundaryEventActivityBehavior>();
+
+    ActivityImpl activity = ((ExecutionEntity)execution).getActivity();
+    
+    List<ActivityImpl> children = activity.getActivities();
+    
+    for(ActivityImpl child: children) {
+      if(child.getActivityBehavior() instanceof BoundaryEventActivityBehavior) {
+        BoundaryEventActivityBehavior boundaryEventActivity = (BoundaryEventActivityBehavior) child.getActivityBehavior();
+        if(boundaryEventActivity.isInterrupting())
+          result.add(boundaryEventActivity);
+      }
+    }
+    
+    return result;
+  }
+
+  protected SignalEventDefinition findSignalEventDefinition(BoundaryEventActivityBehavior boundaryEventActivityBehavior) {
+    SignalEventDefinition signalEventDef = null;
+    BoundaryEvent boundaryEvent = boundaryEventActivityBehavior.getBoundaryEvent();
+    
+    if(boundaryEvent != null) {
+      for(EventDefinition eventDef : boundaryEvent.getEventDefinitions()) {
+        if(eventDef instanceof SignalEventDefinition) {
+          signalEventDef = (SignalEventDefinition) eventDef;
+        }
+      }
+    }
+    
+    return signalEventDef;
+    
+  }
+  
   
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -14,70 +14,11 @@ package org.activiti.engine.impl.bpmn.parser.factory;
 
 import java.util.List;
 
-import org.activiti.bpmn.model.BoundaryEvent;
-import org.activiti.bpmn.model.BpmnModel;
-import org.activiti.bpmn.model.BusinessRuleTask;
-import org.activiti.bpmn.model.CallActivity;
-import org.activiti.bpmn.model.CancelEventDefinition;
-import org.activiti.bpmn.model.EndEvent;
-import org.activiti.bpmn.model.ErrorEventDefinition;
-import org.activiti.bpmn.model.EventGateway;
-import org.activiti.bpmn.model.ExclusiveGateway;
-import org.activiti.bpmn.model.FieldExtension;
-import org.activiti.bpmn.model.IOParameter;
-import org.activiti.bpmn.model.InclusiveGateway;
-import org.activiti.bpmn.model.IntermediateCatchEvent;
-import org.activiti.bpmn.model.ManualTask;
-import org.activiti.bpmn.model.MapExceptionEntry;
-import org.activiti.bpmn.model.ParallelGateway;
-import org.activiti.bpmn.model.ReceiveTask;
-import org.activiti.bpmn.model.ScriptTask;
-import org.activiti.bpmn.model.SendTask;
-import org.activiti.bpmn.model.ServiceTask;
-import org.activiti.bpmn.model.Signal;
-import org.activiti.bpmn.model.StartEvent;
-import org.activiti.bpmn.model.SubProcess;
-import org.activiti.bpmn.model.Task;
-import org.activiti.bpmn.model.TaskWithFieldExtensions;
-import org.activiti.bpmn.model.ThrowEvent;
-import org.activiti.bpmn.model.Transaction;
-import org.activiti.bpmn.model.UserTask;
+import org.activiti.bpmn.model.*;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.delegate.BusinessRuleTaskDelegate;
 import org.activiti.engine.delegate.Expression;
-import org.activiti.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.BoundaryEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.BusinessRuleTaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.CallActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.CancelBoundaryEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.CancelEndEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ErrorEndEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.EventBasedGatewayActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.EventSubProcessStartEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ExclusiveGatewayActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.InclusiveGatewayActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.IntermediateCatchEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowCompensationEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowNoneEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.MailActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ManualTaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.NoneEndEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ParallelGatewayActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ScriptTaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.SequentialMultiInstanceBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ServiceTaskExpressionActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.ShellActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.SubProcessActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.TaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.TerminateEndEventActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.TransactionActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
-import org.activiti.engine.impl.bpmn.behavior.WebServiceActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.*;
 import org.activiti.engine.impl.bpmn.data.SimpleDataInputAssociation;
 import org.activiti.engine.impl.bpmn.helper.ClassDelegate;
 import org.activiti.engine.impl.bpmn.parser.CompensateEventDefinition;
@@ -103,35 +44,42 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   // Start event
   public final static String EXCEPTION_MAP_FIELD = "mapExceptions";
 
-  public NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent) {
+  @Override
+public NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent) {
     return new NoneStartEventActivityBehavior();
   }
 
-  public EventSubProcessStartEventActivityBehavior createEventSubProcessStartEventActivityBehavior(StartEvent startEvent, String activityId) {
+  @Override
+public EventSubProcessStartEventActivityBehavior createEventSubProcessStartEventActivityBehavior(StartEvent startEvent, String activityId) {
     return new EventSubProcessStartEventActivityBehavior(activityId);
   }
   
   // Task
   
-  public TaskActivityBehavior createTaskActivityBehavior(Task task) {
+  @Override
+public TaskActivityBehavior createTaskActivityBehavior(Task task) {
     return new TaskActivityBehavior();
   }
   
-  public ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask) {
+  @Override
+public ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask) {
     return new ManualTaskActivityBehavior();
   }
   
-  public ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask) {
+  @Override
+public ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask) {
     return new ReceiveTaskActivityBehavior();
   }
   
-  public UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask, TaskDefinition taskDefinition) {
+  @Override
+public UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask, TaskDefinition taskDefinition) {
     return new UserTaskActivityBehavior(userTask.getId(), taskDefinition);
   }
 
   // Service task
   
-  public ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask) {
+  @Override
+public ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask) {
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
       skipExpression = expressionManager.createExpression(serviceTask.getSkipExpression());
@@ -142,7 +90,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
         createFieldDeclarations(serviceTask.getFieldExtensions()), skipExpression, serviceTask.getMapExceptions());
   }
   
-  public ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask) {
+  @Override
+public ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask) {
     Expression delegateExpression = expressionManager.createExpression(serviceTask.getImplementation());
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
@@ -154,7 +103,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
         skipExpression, createFieldDeclarations(serviceTask.getFieldExtensions()));
   }
   
-  public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask) {
+  @Override
+public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask) {
     Expression expression = expressionManager.createExpression(serviceTask.getImplementation());
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
@@ -165,19 +115,23 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
     return new ServiceTaskExpressionActivityBehavior(serviceTask.getId(), expression, skipExpression, serviceTask.getResultVariableName());
   }
   
-  public WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask) {
+  @Override
+public WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask) {
     return new WebServiceActivityBehavior();
   }
   
-  public WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask) {
+  @Override
+public WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask) {
     return new WebServiceActivityBehavior();
   }
   
-  public MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask) {
+  @Override
+public MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask) {
     return createMailActivityBehavior(serviceTask.getId(), serviceTask.getFieldExtensions());
   }
   
-  public MailActivityBehavior createMailActivityBehavior(SendTask sendTask) {
+  @Override
+public MailActivityBehavior createMailActivityBehavior(SendTask sendTask) {
     return createMailActivityBehavior(sendTask.getId(), sendTask.getFieldExtensions());  
   }
   
@@ -188,11 +142,13 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   
   // We do not want a hard dependency on Mule, hence we return ActivityBehavior and instantiate 
   // the delegate instance using a string instead of the Class itself.
-  public ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
+  @Override
+public ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
     return createMuleActivityBehavior(serviceTask, serviceTask.getFieldExtensions(), bpmnModel);
   }
   
-  public ActivityBehavior createMuleActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
+  @Override
+public ActivityBehavior createMuleActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
     return createMuleActivityBehavior(sendTask, sendTask.getFieldExtensions(), bpmnModel);
   }
   
@@ -210,11 +166,13 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   
   // We do not want a hard dependency on Camel, hence we return ActivityBehavior and instantiate 
   // the delegate instance using a string instead of the Class itself.
-  public ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
+  @Override
+public ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
     return createCamelActivityBehavior(serviceTask, serviceTask.getFieldExtensions(), bpmnModel);
   }
  
-  public ActivityBehavior createCamelActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
+  @Override
+public ActivityBehavior createCamelActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
     return createCamelActivityBehavior(sendTask, sendTask.getFieldExtensions(), bpmnModel);
   }
  
@@ -254,12 +212,14 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
     
   }
 
-  public ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask) {
+  @Override
+public ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask) {
     List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(serviceTask.getFieldExtensions());
     return (ShellActivityBehavior) ClassDelegate.defaultInstantiateDelegate(ShellActivityBehavior.class, fieldDeclarations);
   }
   
-  public ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask) {
+  @Override
+public ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask) {
     BusinessRuleTaskDelegate ruleActivity = null;
     if (StringUtils.isNotEmpty(businessRuleTask.getClassName())){
       try {
@@ -294,7 +254,8 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   
   // Script task
 
-  public ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask) {
+  @Override
+public ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask) {
     String language = scriptTask.getScriptFormat();
     if (language == null) {
       language = ScriptingEngines.DEFAULT_SCRIPTING_LANGUAGE;
@@ -304,41 +265,49 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
 
   // Gateways
 
-  public ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway) {
+  @Override
+public ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway) {
     return new ExclusiveGatewayActivityBehavior();
   }
 
-  public ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway) {
+  @Override
+public ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway) {
     return new ParallelGatewayActivityBehavior();
   }
 
-  public InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway) {
+  @Override
+public InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway) {
     return new InclusiveGatewayActivityBehavior();
   }
 
-  public EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway) {
+  @Override
+public EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway) {
     return new EventBasedGatewayActivityBehavior();
   }
 
   // Multi Instance
 
-  public SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
+  @Override
+public SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
     return new SequentialMultiInstanceBehavior(activity, innerActivityBehavior);
   }
 
-  public ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
+  @Override
+public ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
     return new ParallelMultiInstanceBehavior(activity, innerActivityBehavior);
   }
   
   // Subprocess
   
-  public SubProcessActivityBehavior createSubprocActivityBehavior(SubProcess subProcess) {
+  @Override
+public SubProcessActivityBehavior createSubprocActivityBehavior(SubProcess subProcess) {
     return new SubProcessActivityBehavior();
   }
   
   // Call activity
   
-  public CallActivityBehavior createCallActivityBehavior(CallActivity callActivity) {
+  @Override
+public CallActivityBehavior createCallActivityBehavior(CallActivity callActivity) {
     String expressionRegex = "\\$+\\{+.+\\}";
     
     CallActivityBehavior callActivityBehaviour = null;
@@ -372,55 +341,66 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   
   // Transaction
   
-  public TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction) {
+  @Override
+public TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction) {
     return new TransactionActivityBehavior();
   }
 
   // Intermediate Events
   
-  public IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent) {
-    return new IntermediateCatchEventActivityBehavior();
+  @Override
+public IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent) {
+    return new IntermediateCatchEventActivityBehavior(intermediateCatchEvent);
   }
 
-  public IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent) {
+  @Override
+public IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent) {
     return new IntermediateThrowNoneEventActivityBehavior();
   }
 
-  public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
+  @Override
+public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
           Signal signal, EventSubscriptionDeclaration eventSubscriptionDeclaration) {
     return new IntermediateThrowSignalEventActivityBehavior(throwEvent, signal, eventSubscriptionDeclaration);
   }
 
-  public IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent,
+  @Override
+public IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent,
           CompensateEventDefinition compensateEventDefinition) {
     return new IntermediateThrowCompensationEventActivityBehavior(compensateEventDefinition);
   }
   
   // End events
   
-  public NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent) {
+  @Override
+public NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent) {
     return new NoneEndEventActivityBehavior();
   }
   
-  public ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition) {
+  @Override
+public ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition) {
     return new ErrorEndEventActivityBehavior(errorEventDefinition.getErrorCode());
   }
   
-  public CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent) {
+  @Override
+public CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent) {
     return new CancelEndEventActivityBehavior();
   }
   
-  public TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent) {
+  @Override
+public TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent) {
     return new TerminateEndEventActivityBehavior(endEvent);
   }
 
   // Boundary Events
   
-  public BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, ActivityImpl activity) {
+  @Override
+public BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, ActivityImpl activity) {
     return new BoundaryEventActivityBehavior(interrupting, activity.getId());
   }
 
-  public CancelBoundaryEventActivityBehavior createCancelBoundaryEventActivityBehavior(CancelEventDefinition cancelEventDefinition) {
+  @Override
+public CancelBoundaryEventActivityBehavior createCancelBoundaryEventActivityBehavior(CancelEventDefinition cancelEventDefinition) {
     return new CancelBoundaryEventActivityBehavior();
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -417,7 +417,7 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   // Boundary Events
   
   public BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, ActivityImpl activity) {
-    return new BoundaryEventActivityBehavior(interrupting, activity.getId());
+    return new BoundaryEventActivityBehavior(boundaryEvent, interrupting, activity.getId());
   }
 
   public CancelBoundaryEventActivityBehavior createCancelBoundaryEventActivityBehavior(CancelEventDefinition cancelEventDefinition) {

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultActivityBehaviorFactory.java
@@ -14,11 +14,70 @@ package org.activiti.engine.impl.bpmn.parser.factory;
 
 import java.util.List;
 
-import org.activiti.bpmn.model.*;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.BusinessRuleTask;
+import org.activiti.bpmn.model.CallActivity;
+import org.activiti.bpmn.model.CancelEventDefinition;
+import org.activiti.bpmn.model.EndEvent;
+import org.activiti.bpmn.model.ErrorEventDefinition;
+import org.activiti.bpmn.model.EventGateway;
+import org.activiti.bpmn.model.ExclusiveGateway;
+import org.activiti.bpmn.model.FieldExtension;
+import org.activiti.bpmn.model.IOParameter;
+import org.activiti.bpmn.model.InclusiveGateway;
+import org.activiti.bpmn.model.IntermediateCatchEvent;
+import org.activiti.bpmn.model.ManualTask;
+import org.activiti.bpmn.model.MapExceptionEntry;
+import org.activiti.bpmn.model.ParallelGateway;
+import org.activiti.bpmn.model.ReceiveTask;
+import org.activiti.bpmn.model.ScriptTask;
+import org.activiti.bpmn.model.SendTask;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.bpmn.model.Signal;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.Task;
+import org.activiti.bpmn.model.TaskWithFieldExtensions;
+import org.activiti.bpmn.model.ThrowEvent;
+import org.activiti.bpmn.model.Transaction;
+import org.activiti.bpmn.model.UserTask;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.delegate.BusinessRuleTaskDelegate;
 import org.activiti.engine.delegate.Expression;
-import org.activiti.engine.impl.bpmn.behavior.*;
+import org.activiti.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.BoundaryEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.BusinessRuleTaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.CallActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.CancelBoundaryEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.CancelEndEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ErrorEndEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.EventBasedGatewayActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.EventSubProcessStartEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ExclusiveGatewayActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.InclusiveGatewayActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateCatchEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowCompensationEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowNoneEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.MailActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ManualTaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.NoneEndEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.NoneStartEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ParallelGatewayActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ReceiveTaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ScriptTaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.SequentialMultiInstanceBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ServiceTaskExpressionActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.ShellActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.SubProcessActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.TaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.TerminateEndEventActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.TransactionActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.UserTaskActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.WebServiceActivityBehavior;
 import org.activiti.engine.impl.bpmn.data.SimpleDataInputAssociation;
 import org.activiti.engine.impl.bpmn.helper.ClassDelegate;
 import org.activiti.engine.impl.bpmn.parser.CompensateEventDefinition;
@@ -44,42 +103,35 @@ public class DefaultActivityBehaviorFactory extends AbstractBehaviorFactory impl
   // Start event
   public final static String EXCEPTION_MAP_FIELD = "mapExceptions";
 
-  @Override
-public NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent) {
+  public NoneStartEventActivityBehavior createNoneStartEventActivityBehavior(StartEvent startEvent) {
     return new NoneStartEventActivityBehavior();
   }
 
-  @Override
-public EventSubProcessStartEventActivityBehavior createEventSubProcessStartEventActivityBehavior(StartEvent startEvent, String activityId) {
+  public EventSubProcessStartEventActivityBehavior createEventSubProcessStartEventActivityBehavior(StartEvent startEvent, String activityId) {
     return new EventSubProcessStartEventActivityBehavior(activityId);
   }
   
   // Task
   
-  @Override
-public TaskActivityBehavior createTaskActivityBehavior(Task task) {
+  public TaskActivityBehavior createTaskActivityBehavior(Task task) {
     return new TaskActivityBehavior();
   }
   
-  @Override
-public ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask) {
+  public ManualTaskActivityBehavior createManualTaskActivityBehavior(ManualTask manualTask) {
     return new ManualTaskActivityBehavior();
   }
   
-  @Override
-public ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask) {
+  public ReceiveTaskActivityBehavior createReceiveTaskActivityBehavior(ReceiveTask receiveTask) {
     return new ReceiveTaskActivityBehavior();
   }
   
-  @Override
-public UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask, TaskDefinition taskDefinition) {
+  public UserTaskActivityBehavior createUserTaskActivityBehavior(UserTask userTask, TaskDefinition taskDefinition) {
     return new UserTaskActivityBehavior(userTask.getId(), taskDefinition);
   }
 
   // Service task
   
-  @Override
-public ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask) {
+  public ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask) {
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
       skipExpression = expressionManager.createExpression(serviceTask.getSkipExpression());
@@ -90,8 +142,7 @@ public ClassDelegate createClassDelegateServiceTask(ServiceTask serviceTask) {
         createFieldDeclarations(serviceTask.getFieldExtensions()), skipExpression, serviceTask.getMapExceptions());
   }
   
-  @Override
-public ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask) {
+  public ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateExpressionActivityBehavior(ServiceTask serviceTask) {
     Expression delegateExpression = expressionManager.createExpression(serviceTask.getImplementation());
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
@@ -103,8 +154,7 @@ public ServiceTaskDelegateExpressionActivityBehavior createServiceTaskDelegateEx
         skipExpression, createFieldDeclarations(serviceTask.getFieldExtensions()));
   }
   
-  @Override
-public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask) {
+  public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivityBehavior(ServiceTask serviceTask) {
     Expression expression = expressionManager.createExpression(serviceTask.getImplementation());
     Expression skipExpression;
     if (StringUtils.isNotEmpty(serviceTask.getSkipExpression())) {
@@ -115,23 +165,19 @@ public ServiceTaskExpressionActivityBehavior createServiceTaskExpressionActivity
     return new ServiceTaskExpressionActivityBehavior(serviceTask.getId(), expression, skipExpression, serviceTask.getResultVariableName());
   }
   
-  @Override
-public WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask) {
+  public WebServiceActivityBehavior createWebServiceActivityBehavior(ServiceTask serviceTask) {
     return new WebServiceActivityBehavior();
   }
   
-  @Override
-public WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask) {
+  public WebServiceActivityBehavior createWebServiceActivityBehavior(SendTask sendTask) {
     return new WebServiceActivityBehavior();
   }
   
-  @Override
-public MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask) {
+  public MailActivityBehavior createMailActivityBehavior(ServiceTask serviceTask) {
     return createMailActivityBehavior(serviceTask.getId(), serviceTask.getFieldExtensions());
   }
   
-  @Override
-public MailActivityBehavior createMailActivityBehavior(SendTask sendTask) {
+  public MailActivityBehavior createMailActivityBehavior(SendTask sendTask) {
     return createMailActivityBehavior(sendTask.getId(), sendTask.getFieldExtensions());  
   }
   
@@ -142,13 +188,11 @@ public MailActivityBehavior createMailActivityBehavior(SendTask sendTask) {
   
   // We do not want a hard dependency on Mule, hence we return ActivityBehavior and instantiate 
   // the delegate instance using a string instead of the Class itself.
-  @Override
-public ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
+  public ActivityBehavior createMuleActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
     return createMuleActivityBehavior(serviceTask, serviceTask.getFieldExtensions(), bpmnModel);
   }
   
-  @Override
-public ActivityBehavior createMuleActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
+  public ActivityBehavior createMuleActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
     return createMuleActivityBehavior(sendTask, sendTask.getFieldExtensions(), bpmnModel);
   }
   
@@ -166,13 +210,11 @@ public ActivityBehavior createMuleActivityBehavior(SendTask sendTask, BpmnModel 
   
   // We do not want a hard dependency on Camel, hence we return ActivityBehavior and instantiate 
   // the delegate instance using a string instead of the Class itself.
-  @Override
-public ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
+  public ActivityBehavior createCamelActivityBehavior(ServiceTask serviceTask, BpmnModel bpmnModel) {
     return createCamelActivityBehavior(serviceTask, serviceTask.getFieldExtensions(), bpmnModel);
   }
  
-  @Override
-public ActivityBehavior createCamelActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
+  public ActivityBehavior createCamelActivityBehavior(SendTask sendTask, BpmnModel bpmnModel) {
     return createCamelActivityBehavior(sendTask, sendTask.getFieldExtensions(), bpmnModel);
   }
  
@@ -212,14 +254,12 @@ public ActivityBehavior createCamelActivityBehavior(SendTask sendTask, BpmnModel
     
   }
 
-  @Override
-public ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask) {
+  public ShellActivityBehavior createShellActivityBehavior(ServiceTask serviceTask) {
     List<FieldDeclaration> fieldDeclarations = createFieldDeclarations(serviceTask.getFieldExtensions());
     return (ShellActivityBehavior) ClassDelegate.defaultInstantiateDelegate(ShellActivityBehavior.class, fieldDeclarations);
   }
   
-  @Override
-public ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask) {
+  public ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask businessRuleTask) {
     BusinessRuleTaskDelegate ruleActivity = null;
     if (StringUtils.isNotEmpty(businessRuleTask.getClassName())){
       try {
@@ -254,8 +294,7 @@ public ActivityBehavior createBusinessRuleTaskActivityBehavior(BusinessRuleTask 
   
   // Script task
 
-  @Override
-public ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask) {
+  public ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask scriptTask) {
     String language = scriptTask.getScriptFormat();
     if (language == null) {
       language = ScriptingEngines.DEFAULT_SCRIPTING_LANGUAGE;
@@ -265,49 +304,41 @@ public ScriptTaskActivityBehavior createScriptTaskActivityBehavior(ScriptTask sc
 
   // Gateways
 
-  @Override
-public ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway) {
+  public ExclusiveGatewayActivityBehavior createExclusiveGatewayActivityBehavior(ExclusiveGateway exclusiveGateway) {
     return new ExclusiveGatewayActivityBehavior();
   }
 
-  @Override
-public ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway) {
+  public ParallelGatewayActivityBehavior createParallelGatewayActivityBehavior(ParallelGateway parallelGateway) {
     return new ParallelGatewayActivityBehavior();
   }
 
-  @Override
-public InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway) {
+  public InclusiveGatewayActivityBehavior createInclusiveGatewayActivityBehavior(InclusiveGateway inclusiveGateway) {
     return new InclusiveGatewayActivityBehavior();
   }
 
-  @Override
-public EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway) {
+  public EventBasedGatewayActivityBehavior createEventBasedGatewayActivityBehavior(EventGateway eventGateway) {
     return new EventBasedGatewayActivityBehavior();
   }
 
   // Multi Instance
 
-  @Override
-public SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
+  public SequentialMultiInstanceBehavior createSequentialMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
     return new SequentialMultiInstanceBehavior(activity, innerActivityBehavior);
   }
 
-  @Override
-public ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
+  public ParallelMultiInstanceBehavior createParallelMultiInstanceBehavior(ActivityImpl activity, AbstractBpmnActivityBehavior innerActivityBehavior) {
     return new ParallelMultiInstanceBehavior(activity, innerActivityBehavior);
   }
   
   // Subprocess
   
-  @Override
-public SubProcessActivityBehavior createSubprocActivityBehavior(SubProcess subProcess) {
+  public SubProcessActivityBehavior createSubprocActivityBehavior(SubProcess subProcess) {
     return new SubProcessActivityBehavior();
   }
   
   // Call activity
   
-  @Override
-public CallActivityBehavior createCallActivityBehavior(CallActivity callActivity) {
+  public CallActivityBehavior createCallActivityBehavior(CallActivity callActivity) {
     String expressionRegex = "\\$+\\{+.+\\}";
     
     CallActivityBehavior callActivityBehaviour = null;
@@ -341,66 +372,55 @@ public CallActivityBehavior createCallActivityBehavior(CallActivity callActivity
   
   // Transaction
   
-  @Override
-public TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction) {
+  public TransactionActivityBehavior createTransactionActivityBehavior(Transaction transaction) {
     return new TransactionActivityBehavior();
   }
 
   // Intermediate Events
   
-  @Override
-public IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent) {
+  public IntermediateCatchEventActivityBehavior createIntermediateCatchEventActivityBehavior(IntermediateCatchEvent intermediateCatchEvent) {
     return new IntermediateCatchEventActivityBehavior(intermediateCatchEvent);
   }
 
-  @Override
-public IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent) {
+  public IntermediateThrowNoneEventActivityBehavior createIntermediateThrowNoneEventActivityBehavior(ThrowEvent throwEvent) {
     return new IntermediateThrowNoneEventActivityBehavior();
   }
 
-  @Override
-public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
+  public IntermediateThrowSignalEventActivityBehavior createIntermediateThrowSignalEventActivityBehavior(ThrowEvent throwEvent,
           Signal signal, EventSubscriptionDeclaration eventSubscriptionDeclaration) {
     return new IntermediateThrowSignalEventActivityBehavior(throwEvent, signal, eventSubscriptionDeclaration);
   }
 
-  @Override
-public IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent,
+  public IntermediateThrowCompensationEventActivityBehavior createIntermediateThrowCompensationEventActivityBehavior(ThrowEvent throwEvent,
           CompensateEventDefinition compensateEventDefinition) {
     return new IntermediateThrowCompensationEventActivityBehavior(compensateEventDefinition);
   }
   
   // End events
   
-  @Override
-public NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent) {
+  public NoneEndEventActivityBehavior createNoneEndEventActivityBehavior(EndEvent endEvent) {
     return new NoneEndEventActivityBehavior();
   }
   
-  @Override
-public ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition) {
+  public ErrorEndEventActivityBehavior createErrorEndEventActivityBehavior(EndEvent endEvent, ErrorEventDefinition errorEventDefinition) {
     return new ErrorEndEventActivityBehavior(errorEventDefinition.getErrorCode());
   }
   
-  @Override
-public CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent) {
+  public CancelEndEventActivityBehavior createCancelEndEventActivityBehavior(EndEvent endEvent) {
     return new CancelEndEventActivityBehavior();
   }
   
-  @Override
-public TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent) {
+  public TerminateEndEventActivityBehavior createTerminateEndEventActivityBehavior(EndEvent endEvent) {
     return new TerminateEndEventActivityBehavior(endEvent);
   }
 
   // Boundary Events
   
-  @Override
-public BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, ActivityImpl activity) {
+  public BoundaryEventActivityBehavior createBoundaryEventActivityBehavior(BoundaryEvent boundaryEvent, boolean interrupting, ActivityImpl activity) {
     return new BoundaryEventActivityBehavior(interrupting, activity.getId());
   }
 
-  @Override
-public CancelBoundaryEventActivityBehavior createCancelBoundaryEventActivityBehavior(CancelEventDefinition cancelEventDefinition) {
+  public CancelBoundaryEventActivityBehavior createCancelBoundaryEventActivityBehavior(CancelEventDefinition cancelEventDefinition) {
     return new CancelBoundaryEventActivityBehavior();
   }
   

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -40,6 +40,7 @@ import javax.naming.InitialContext;
 import javax.sql.DataSource;
 import javax.xml.namespace.QName;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.DynamicBpmnService;
@@ -192,6 +193,7 @@ import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntityManage
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntityManager;
 import org.activiti.engine.impl.persistence.entity.PropertyEntityManager;
 import org.activiti.engine.impl.persistence.entity.ResourceEntityManager;
+import org.activiti.engine.impl.persistence.entity.SignalEventSessionManager;
 import org.activiti.engine.impl.persistence.entity.TableDataManager;
 import org.activiti.engine.impl.persistence.entity.TaskEntityManager;
 import org.activiti.engine.impl.persistence.entity.VariableInstanceEntityManager;
@@ -243,8 +245,6 @@ import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 
 /**
@@ -1036,6 +1036,7 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       addSessionFactory(new GenericManagerFactory(VariableInstanceEntityManager.class));
       addSessionFactory(new GenericManagerFactory(EventSubscriptionEntityManager.class));
       addSessionFactory(new GenericManagerFactory(EventLogEntryEntityManager.class));
+      addSessionFactory(new GenericManagerFactory(SignalEventSessionManager.class)); 
       
       addSessionFactory(new DefaultHistoryManagerSessionFactory());
       

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -52,6 +52,7 @@ import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntityManage
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionInfoEntityManager;
 import org.activiti.engine.impl.persistence.entity.PropertyEntityManager;
 import org.activiti.engine.impl.persistence.entity.ResourceEntityManager;
+import org.activiti.engine.impl.persistence.entity.SignalEventSessionManager;
 import org.activiti.engine.impl.persistence.entity.TableDataManager;
 import org.activiti.engine.impl.persistence.entity.TaskEntityManager;
 import org.activiti.engine.impl.persistence.entity.UserIdentityManager;
@@ -376,6 +377,10 @@ public class CommandContext {
     return getSession(EventSubscriptionEntityManager.class);
   }
 
+  public SignalEventSessionManager getSignalEventSessionManager() {
+    return getSession(SignalEventSessionManager.class); 
+  }
+  
   public Map<Class< ? >, SessionFactory> getSessionFactories() {
     return sessionFactories;
   }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SignalEventSessionManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SignalEventSessionManager.java
@@ -82,7 +82,8 @@ public class SignalEventSessionManager extends AbstractManager {
 
     HistoricActivityInstanceQueryImpl activityInstanceQuery = new HistoricActivityInstanceQueryImpl(commandContext)
      .processInstanceId(execution.getProcessInstanceId())
-     .activityType("intermediateSignalThrow");
+     .activityType("intermediateSignalThrow")
+     .orderByHistoricActivityInstanceStartTime();
 
     List<HistoricActivityInstance> thrownSignalActivities = commandContext.getHistoricActivityInstanceEntityManager()
       .findHistoricActivityInstancesByQueryCriteria(activityInstanceQuery, null);

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SignalEventSessionManager.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/SignalEventSessionManager.java
@@ -1,0 +1,112 @@
+package org.activiti.engine.impl.persistence.entity;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.activiti.engine.history.HistoricActivityInstance;
+import org.activiti.engine.impl.HistoricActivityInstanceQueryImpl;
+import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowSignalEventActivityBehavior;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.AbstractManager;
+import org.activiti.engine.impl.pvm.delegate.ActivityBehavior;
+import org.activiti.engine.impl.pvm.delegate.ActivityExecution;
+
+/**
+ * Keep track of fired events for process instance execution 
+ * in the current command context session and historic activity instance 
+ *
+ */
+public class SignalEventSessionManager extends AbstractManager {
+
+  /** collect fired events in process instance scope in the current command context session */
+  protected Map<String,Set<String>> firedSignalEventsInCurrentSesssion = new HashMap<String, Set<String>>();
+  
+  /**
+   * Registers thrown signal events for execution in current session 
+   * 
+   * @param execution current execution
+   * @param eventName name of the event
+   */
+  public void registerThrowSignalEventByExecution(ActivityExecution execution, String eventName) {
+    String processInstanceId = execution.getProcessInstanceId();
+    
+    synchronized (firedSignalEventsInCurrentSesssion) {
+      Set<String> events = firedSignalEventsInCurrentSesssion
+          .getOrDefault(processInstanceId, new LinkedHashSet<String>());
+
+      events.add(eventName);
+
+      firedSignalEventsInCurrentSesssion.put(processInstanceId, events);
+    }
+    
+  }
+  
+  /**
+   * Check signal events already registered in current session command context 
+   * or recorded history for the process instance scope. 
+   * Requires full audit level to query historic activity events 
+   * 
+   * @param execution current execution instance
+   * @param eventName event name
+   * @return true if event has been fired in the execution context
+   * @throws Exception
+   */
+  public boolean hasThrowSignalEventForExecution(ActivityExecution execution, String eventName) throws Exception {
+  
+    // Check signal events already registered in current session command context 
+    if(mayBeHasThrowSignalEventsInCurrentSession(execution.getProcessInstanceId(), eventName)) {
+      return true;
+    } // Then check signal events in recorded history for the process instance scope
+    else if(mayBeHasThrowSignalEventsInHistoricActivityInstance(execution, eventName)) {
+      return true;
+    }
+
+    return false;
+  }
+    
+  protected boolean mayBeHasThrowSignalEventsInCurrentSession(String processInstanceId, String eventName) {
+    return firedSignalEventsInCurrentSesssion
+      .getOrDefault(processInstanceId, new LinkedHashSet<String>(0))
+      .contains(eventName);
+  }
+
+  protected boolean mayBeHasThrowSignalEventsInHistoricActivityInstance(ActivityExecution execution, String eventName) {
+    // Then check signal events in recorded history for the process instance scope 
+    CommandContext commandContext = Context.getCommandContext();
+
+    HistoricActivityInstanceQueryImpl activityInstanceQuery = new HistoricActivityInstanceQueryImpl(commandContext)
+     .processInstanceId(execution.getProcessInstanceId())
+     .activityType("intermediateSignalThrow");
+
+    List<HistoricActivityInstance> thrownSignalActivities = commandContext.getHistoricActivityInstanceEntityManager()
+      .findHistoricActivityInstancesByQueryCriteria(activityInstanceQuery, null);
+
+    for(HistoricActivityInstance thrownSignal : thrownSignalActivities) {
+      if(execution instanceof ExecutionEntity) {
+        ExecutionEntity executionEntity = (ExecutionEntity) execution;
+
+        ActivityBehavior activityBehavior = executionEntity.getProcessDefinition()
+         .findActivity(thrownSignal.getActivityId())
+         .getActivityBehavior();
+
+        if(activityBehavior != null && activityBehavior instanceof IntermediateThrowSignalEventActivityBehavior) {
+          IntermediateThrowSignalEventActivityBehavior intermediateThrowSignalEventBehavior = 
+              (IntermediateThrowSignalEventActivityBehavior) activityBehavior;
+
+          if(intermediateThrowSignalEventBehavior.isProcessInstanceScope() &&
+              intermediateThrowSignalEventBehavior.getSignalDefinition().getEventName().equals(eventName)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+  
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
@@ -1,0 +1,82 @@
+package org.activiti.engine.test.bpmn.event.signal;
+
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.test.Deployment;
+
+public class SignalEventSessionManagerTest extends PluggableActivitiTestCase {
+
+  @Deployment
+  public void testSignalRaceConditionsAfterParallelGateway() {
+    runtimeService.startProcessInstanceByKey("testSignalRaceConditionsAfterParallelGateway");
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }
+  
+  @Deployment
+  public void testSignalRaceConditionsAfterParallelGatewayAsync() {
+    runtimeService.startProcessInstanceByKey("testSignalRaceConditionsAfterParallelGatewayAsync");
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }  
+
+  
+  @Deployment
+  public void testSignalRaceConditionsThrowCatchSequence() {
+    runtimeService.startProcessInstanceByKey("testSignalRaceConditionsThrowCatchSequence");
+
+    taskService.complete(taskService.createTaskQuery().taskName("Task 3").singleResult().getId());
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }  
+  
+  @Deployment
+  public void testSignalRaceConditionsThrowCatchAfterUserTask() {
+    runtimeService.startProcessInstanceByKey("testSignalRaceConditionsThrowCatchAfterUserTask");
+    
+    taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId());
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }    
+  
+  @Deployment
+  public void testSignalRaceConditionsCatchThrowWithSubProcesses() {
+    runtimeService.startProcessInstanceByKey("testSignalRaceConditionsCatchThrowWithSubProcesses");
+
+    taskService.complete(taskService.createTaskQuery().taskName("Task B").singleResult().getId());
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }      
+  
+  @Deployment
+  public void testSignalThrowCatchUserTask() {
+    runtimeService.startProcessInstanceByKey("testSignalThrowCatchUserTask");
+
+    taskService.complete(taskService.createTaskQuery().taskName("User Task").singleResult().getId());
+    
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }      
+  
+  @Deployment
+  public void testSignalThrowCatchUserTaskGlobal() {
+    runtimeService.startProcessInstanceByKey("testSignalThrowCatchUserTaskGlobal");
+
+    taskService.complete(taskService.createTaskQuery().taskName("User Task").singleResult().getId());
+    
+    // Should wait on global signal catch event activity execution
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(2, runtimeService.createExecutionQuery().count());
+  }       
+
+}

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
@@ -88,18 +88,25 @@ public class SignalEventSessionManagerTest extends PluggableActivitiTestCase {
 
     
   @Deployment
-  public void testSignalThrowCatchEventGateway() throws InterruptedException {
+  public void testSignalThrowCatchBoundarySubProcess() throws InterruptedException {
     // Set the clock fixed
     Date startTime = new Date();
+
+    runtimeService.startProcessInstanceByKey("testSignalThrowCatchBoundarySubProcess");
+
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }      
+
+  
+  @Deployment
+  public void testSignalThrowCatchEventGateway() throws InterruptedException {
 
     runtimeService.startProcessInstanceByKey("testSignalThrowCatchEventGateway");
 
     taskService.complete(taskService.createTaskQuery().taskName("User Task").singleResult().getId());
     
-//    // After setting the clock to startTime + '2 seconds', the timer should fire
-//    processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 2000));
-//    waitForJobExecutorToProcessAllJobs(5000L, 25L);
-     
     // No tasks should be open then and process should have ended
     assertEquals(0, taskService.createTaskQuery().count());
     assertEquals(0, runtimeService.createExecutionQuery().count());

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
@@ -85,7 +85,26 @@ public class SignalEventSessionManagerTest extends PluggableActivitiTestCase {
     assertEquals(0, taskService.createTaskQuery().count());
     assertEquals(0, runtimeService.createExecutionQuery().count());
   }      
-  
+
+    
+  @Deployment
+  public void testSignalThrowCatchEventGateway() throws InterruptedException {
+    // Set the clock fixed
+    Date startTime = new Date();
+
+    runtimeService.startProcessInstanceByKey("testSignalThrowCatchEventGateway");
+
+    taskService.complete(taskService.createTaskQuery().taskName("User Task").singleResult().getId());
+    
+//    // After setting the clock to startTime + '2 seconds', the timer should fire
+//    processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 2000));
+//    waitForJobExecutorToProcessAllJobs(5000L, 25L);
+     
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }      
+
   @Deployment
   public void testSignalThrowCatchUserTaskGlobal() {
     runtimeService.startProcessInstanceByKey("testSignalThrowCatchUserTaskGlobal");

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java
@@ -1,5 +1,7 @@
 package org.activiti.engine.test.bpmn.event.signal;
 
+import java.util.Date;
+
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.test.Deployment;
 
@@ -63,6 +65,22 @@ public class SignalEventSessionManagerTest extends PluggableActivitiTestCase {
 
     taskService.complete(taskService.createTaskQuery().taskName("User Task").singleResult().getId());
     
+    // No tasks should be open then and process should have ended
+    assertEquals(0, taskService.createTaskQuery().count());
+    assertEquals(0, runtimeService.createExecutionQuery().count());
+  }      
+
+  @Deployment
+  public void testSignalThrowCatchBoundaryUserTask() throws InterruptedException {
+    // Set the clock fixed
+    Date startTime = new Date();
+
+    runtimeService.startProcessInstanceByKey("testSignalThrowCatchBoundaryUserTask");
+
+    // After setting the clock to startTime + '2 seconds', the timer should fire
+    processEngineConfiguration.getClock().setCurrentTime(new Date(startTime.getTime() + 2000));
+    waitForJobExecutorToProcessAllJobs(5000L, 25L);
+     
     // No tasks should be open then and process should have ended
     assertEquals(0, taskService.createTaskQuery().count());
     assertEquals(0, runtimeService.createExecutionQuery().count());

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsAfterParallelGateway.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsAfterParallelGateway.bpmn20.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <signal id="signal1" activiti:scope="processInstance" name="Signal1"/>
+  <process id="testSignalRaceConditionsAfterParallelGateway" name="Racing Event Signals After Parallel Gateway" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</outgoing>
+    </startEvent>
+    <parallelGateway id="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>ExclusiveGateway_025l4wk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</incoming>
+      <outgoing>SequenceFlow_1wzkv9g</outgoing>
+      <outgoing>SequenceFlow_1kvzl0v</outgoing>
+      <outgoing>SequenceFlow_5</outgoing>
+      <outgoing>SequenceFlow_8</outgoing>
+    </parallelGateway>
+    <manualTask id="Task_2" name="Task 2">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1mlavmk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1gdnqtq</incoming>
+      <outgoing>SequenceFlow_01wekde</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_01wekde" sourceRef="Task_2" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_01wekde</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_17lberr</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_17lberr" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_17lberr</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1gdnqtq" sourceRef="IntermediateCatchEvent_1" targetRef="Task_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1gdnqtq</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Catch Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-CFE04485-5B67-4A15-BD33-BF172C9A1585</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1kvzl0v</incoming>
+      <outgoing>SequenceFlow_1gdnqtq</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1wzkv9g" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1wzkv9g</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1kvzl0v" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1kvzl0v</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <parallelGateway id="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-17ECCDD5-2343-489B-A517-3AB7A03801CF</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_01wekde</incoming>
+      <incoming>SequenceFlow_0lwprnk</incoming>
+      <incoming>SequenceFlow_7</incoming>
+      <incoming>SequenceFlow_10</incoming>
+      <outgoing>SequenceFlow_17lberr</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_2"/>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_2"/>
+    <manualTask id="ManualTask_3" name="Task B">
+      <incoming>SequenceFlow_9</incoming>
+      <outgoing>SequenceFlow_10</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_10" name="" sourceRef="ManualTask_3" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_2" name="Catch Signal1">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_9</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_4" signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_9" name="" sourceRef="IntermediateCatchEvent_2" targetRef="ManualTask_3"/>
+    <manualTask id="Task_1" name="Task 1">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1ywy9qe</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1dh3sax</incoming>
+      <outgoing>SequenceFlow_0lwprnk</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_0lwprnk" sourceRef="Task_1" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_0lwprnk</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Throw Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0B6D28DC-133E-4840-B6DB-44687AFCD0A1</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1wzkv9g</incoming>
+      <outgoing>SequenceFlow_1dh3sax</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_1dh3sax" sourceRef="IntermediateThrowEvent_1" targetRef="Task_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1dh3sax</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <manualTask id="ManualTask_2" name="Task A">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_7</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_7" name="" sourceRef="ManualTask_2" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateThrowEvent_2" name="Catch Signal1">
+      <incoming>SequenceFlow_5</incoming>
+      <outgoing>SequenceFlow_6</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_3" signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="IntermediateThrowEvent_2" targetRef="ManualTask_2"/>
+  </process>
+  <signal id="Signal_2" activiti:scope="processInstance" name="Signal2"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalRaceConditionsAfterParallelGateway">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="270.0" y="223.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_025l4wk" bpmnElement="ExclusiveGateway_1">
+        <omgdc:Bounds height="40.0" width="40.0" x="362.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1ywy9qe" bpmnElement="Task_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="36.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1mlavmk" bpmnElement="Task_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="290.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="958.0" y="224.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_04sj5fb" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="61.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="96.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_0lm80py" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="315.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_0pu7trk" bpmnElement="ExclusiveGateway_2">
+        <omgdc:Bounds height="40.0" width="40.0" x="825.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_01wekde" bpmnElement="SequenceFlow_01wekde">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="842.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="844.3684" y="257.3684"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" bpmnElement="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="300.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="362.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1wzkv9g" bpmnElement="SequenceFlow_1wzkv9g">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="218.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="76.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="382.0" y="122.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_0lwprnk" bpmnElement="SequenceFlow_0lwprnk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="218.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="830.0" y="76.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1gdnqtq" bpmnElement="SequenceFlow_1gdnqtq">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="330.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1kvzl0v" bpmnElement="SequenceFlow_1kvzl0v">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="330.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17lberr" bpmnElement="SequenceFlow_17lberr">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="865.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="958.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1dh3sax" bpmnElement="SequenceFlow_1dh3sax">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="76.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="597.0" y="76.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_5" bpmnElement="IntermediateThrowEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="183.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="218.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateThrowEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="402.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="198.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="424.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="158.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_IntermediateThrowEvent_5" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="198.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="562.0" y="186.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_ManualTask_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="789.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="789.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="825.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="786.0" y="231.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="451.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="486.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateCatchEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="466.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="283.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_4" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="425.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="_BPMNShape_ManualTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="596.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="596.0" y="465.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="465.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="562.0" y="466.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_ManualTask_4" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="465.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="464.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="842.0" y="402.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsAfterParallelGatewayAsync.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsAfterParallelGatewayAsync.bpmn20.xml
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <signal id="signal1" activiti:scope="processInstance" name="Signal1"/>
+  <process id="testSignalRaceConditionsAfterParallelGatewayAsync" name="Racing Event Signals After Parallel Gateway" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</outgoing>
+    </startEvent>
+    <parallelGateway id="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>ExclusiveGateway_025l4wk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</incoming>
+      <outgoing>SequenceFlow_1wzkv9g</outgoing>
+      <outgoing>SequenceFlow_1kvzl0v</outgoing>
+      <outgoing>SequenceFlow_5</outgoing>
+      <outgoing>SequenceFlow_8</outgoing>
+    </parallelGateway>
+    <manualTask id="Task_2" name="Task 2">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1mlavmk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1gdnqtq</incoming>
+      <outgoing>SequenceFlow_01wekde</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_01wekde" sourceRef="Task_2" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_01wekde</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_17lberr</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_17lberr" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_17lberr</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1gdnqtq" sourceRef="IntermediateCatchEvent_1" targetRef="Task_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1gdnqtq</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Catch Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-CFE04485-5B67-4A15-BD33-BF172C9A1585</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1kvzl0v</incoming>
+      <outgoing>SequenceFlow_1gdnqtq</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1wzkv9g" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1wzkv9g</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1kvzl0v" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1kvzl0v</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <parallelGateway id="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-17ECCDD5-2343-489B-A517-3AB7A03801CF</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_01wekde</incoming>
+      <incoming>SequenceFlow_0lwprnk</incoming>
+      <incoming>SequenceFlow_7</incoming>
+      <incoming>SequenceFlow_10</incoming>
+      <outgoing>SequenceFlow_17lberr</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_2"/>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_2"/>
+    <manualTask id="ManualTask_3" name="Task B">
+      <incoming>SequenceFlow_9</incoming>
+      <outgoing>SequenceFlow_10</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_10" name="" sourceRef="ManualTask_3" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_2" name="Catch Signal1">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_9</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_4" signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_9" name="" sourceRef="IntermediateCatchEvent_2" targetRef="ManualTask_3"/>
+    <manualTask id="Task_1" name="Task 1">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1ywy9qe</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1dh3sax</incoming>
+      <outgoing>SequenceFlow_0lwprnk</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_0lwprnk" sourceRef="Task_1" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_0lwprnk</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Throw Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0B6D28DC-133E-4840-B6DB-44687AFCD0A1</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1wzkv9g</incoming>
+      <outgoing>SequenceFlow_1dh3sax</outgoing>
+      <signalEventDefinition activiti:async="true" signalRef="signal1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_1dh3sax" sourceRef="IntermediateThrowEvent_1" targetRef="Task_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1dh3sax</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <manualTask id="ManualTask_2" name="Task A">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_7</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_7" name="" sourceRef="ManualTask_2" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateThrowEvent_2" name="Catch Signal1">
+      <incoming>SequenceFlow_5</incoming>
+      <outgoing>SequenceFlow_6</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_3" signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="IntermediateThrowEvent_2" targetRef="ManualTask_2"/>
+  </process>
+  <signal id="Signal_2" activiti:scope="processInstance" name="Signal2"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalRaceConditionsAfterParallelGatewayAsync">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="270.0" y="223.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_025l4wk" bpmnElement="ExclusiveGateway_1">
+        <omgdc:Bounds height="40.0" width="40.0" x="362.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1ywy9qe" bpmnElement="Task_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="36.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1mlavmk" bpmnElement="Task_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="290.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="958.0" y="224.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_04sj5fb" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="61.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="96.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_0lm80py" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="315.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_0pu7trk" bpmnElement="ExclusiveGateway_2">
+        <omgdc:Bounds height="40.0" width="40.0" x="825.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_01wekde" bpmnElement="SequenceFlow_01wekde">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="842.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="844.3684" y="257.3684"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" bpmnElement="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="300.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="362.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1wzkv9g" bpmnElement="SequenceFlow_1wzkv9g">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="218.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="76.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="382.0" y="122.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_0lwprnk" bpmnElement="SequenceFlow_0lwprnk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="218.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="830.0" y="76.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1gdnqtq" bpmnElement="SequenceFlow_1gdnqtq">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="330.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1kvzl0v" bpmnElement="SequenceFlow_1kvzl0v">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="330.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="330.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17lberr" bpmnElement="SequenceFlow_17lberr">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="865.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="958.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1dh3sax" bpmnElement="SequenceFlow_1dh3sax">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="76.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="76.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="597.0" y="76.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_5" bpmnElement="IntermediateThrowEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="183.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="218.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateThrowEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="402.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="198.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="424.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="158.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_IntermediateThrowEvent_5" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="198.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="562.0" y="186.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_ManualTask_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="789.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="789.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="825.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="786.0" y="231.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="451.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="486.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateCatchEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="466.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="283.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_4" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="653.0" y="425.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="_BPMNShape_ManualTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="596.0" y="466.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="596.0" y="465.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="653.0" y="465.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="562.0" y="466.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_ManualTask_4" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="753.0" y="465.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="464.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="842.0" y="402.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsCatchThrowWithSubProcesses.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsCatchThrowWithSubProcesses.bpmn20.xml
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <signal id="signal1" activiti:scope="processInstance" name="Signal1"/>
+  <process id="testSignalRaceConditionsCatchThrowWithSubProcesses" name="SS Signals" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</outgoing>
+    </startEvent>
+    <parallelGateway id="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>ExclusiveGateway_025l4wk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</incoming>
+      <outgoing>SequenceFlow_5</outgoing>
+      <outgoing>SequenceFlow_3</outgoing>
+      <outgoing>SequenceFlow_14</outgoing>
+      <outgoing>SequenceFlow_18</outgoing>
+    </parallelGateway>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_17lberr</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_17lberr" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_17lberr</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <parallelGateway id="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-17ECCDD5-2343-489B-A517-3AB7A03801CF</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_7</incoming>
+      <incoming>SequenceFlow_4</incoming>
+      <incoming>SequenceFlow_15</incoming>
+      <incoming>SequenceFlow_16</incoming>
+      <outgoing>SequenceFlow_17lberr</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_2"/>
+    <subProcess id="SubProcess_2">
+      <incoming>SequenceFlow_3</incoming>
+      <outgoing>SequenceFlow_4</outgoing>
+      <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Signal1">
+        <extensionElements>
+          <modeler:editor-resource-id>sid-0B6D28DC-133E-4840-B6DB-44687AFCD0A1</modeler:editor-resource-id>
+        </extensionElements>
+        <incoming>SequenceFlow_1</incoming>
+        <outgoing>SequenceFlow_1dh3sax</outgoing>
+        <signalEventDefinition signalRef="signal1"/>
+      </intermediateThrowEvent>
+      <sequenceFlow id="SequenceFlow_1dh3sax" sourceRef="IntermediateThrowEvent_1" targetRef="Task_1">
+        <extensionElements>
+          <modeler:editor-resource-id>SequenceFlow_1dh3sax</modeler:editor-resource-id>
+        </extensionElements>
+      </sequenceFlow>
+      <manualTask id="Task_1" name="Task 1">
+        <extensionElements>
+          <modeler:editor-resource-id>Task_1ywy9qe</modeler:editor-resource-id>
+        </extensionElements>
+        <incoming>SequenceFlow_1dh3sax</incoming>
+        <outgoing>SequenceFlow_2</outgoing>
+      </manualTask>
+      <sequenceFlow id="SequenceFlow_2" name="" sourceRef="Task_1" targetRef="EndEvent_2"/>
+      <endEvent id="EndEvent_2">
+        <incoming>SequenceFlow_2</incoming>
+      </endEvent>
+      <startEvent id="StartEvent_2">
+        <outgoing>SequenceFlow_1</outgoing>
+      </startEvent>
+      <sequenceFlow id="SequenceFlow_1" name="" sourceRef="StartEvent_2" targetRef="IntermediateThrowEvent_1"/>
+    </subProcess>
+    <sequenceFlow id="SequenceFlow_3" name="" sourceRef="ExclusiveGateway_1" targetRef="SubProcess_2"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_2" name="Signal2">
+      <incoming>SequenceFlow_5</incoming>
+      <outgoing>SequenceFlow_6</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_3" signalRef="Signal_2"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="IntermediateThrowEvent_2" targetRef="ManualTask_2"/>
+    <sequenceFlow id="SequenceFlow_4" name="" sourceRef="SubProcess_2" targetRef="ExclusiveGateway_2"/>
+    <sequenceFlow id="SequenceFlow_14" name="" sourceRef="ExclusiveGateway_1" targetRef="SubProcess_3"/>
+    <subProcess id="SubProcess_3">
+      <incoming>SequenceFlow_14</incoming>
+      <outgoing>SequenceFlow_15</outgoing>
+      <endEvent id="EndEvent_3">
+        <incoming>SequenceFlow_13</incoming>
+      </endEvent>
+      <startEvent id="StartEvent_3">
+        <outgoing>SequenceFlow_10</outgoing>
+      </startEvent>
+      <sequenceFlow id="SequenceFlow_10" name="" sourceRef="StartEvent_3" targetRef="ManualTask_3"/>
+      <userTask id="ManualTask_3" name="Task B">
+        <incoming>SequenceFlow_10</incoming>
+        <outgoing>SequenceFlow_8</outgoing>
+      </userTask>
+      <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ManualTask_3" targetRef="IntermediateCatchEvent_2"/>
+      <intermediateCatchEvent id="IntermediateCatchEvent_2" name="Signal2">
+        <incoming>SequenceFlow_8</incoming>
+        <outgoing>SequenceFlow_13</outgoing>
+        <signalEventDefinition id="_SignalEventDefinition_4" signalRef="Signal_2"/>
+      </intermediateCatchEvent>
+      <sequenceFlow id="SequenceFlow_13" name="" sourceRef="IntermediateCatchEvent_2" targetRef="EndEvent_3"/>
+    </subProcess>
+    <sequenceFlow id="SequenceFlow_15" name="" sourceRef="SubProcess_3" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-CFE04485-5B67-4A15-BD33-BF172C9A1585</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_12</incoming>
+      <outgoing>SequenceFlow_16</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_16" name="" sourceRef="IntermediateCatchEvent_1" targetRef="ExclusiveGateway_2"/>
+    <sequenceFlow id="SequenceFlow_18" name="" sourceRef="ExclusiveGateway_1" targetRef="Task_2"/>
+    <manualTask id="ManualTask_2" name="Task A">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_7</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_7" name="" sourceRef="ManualTask_2" targetRef="ExclusiveGateway_2"/>
+    <manualTask id="Task_2" name="Task 2">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1mlavmk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_18</incoming>
+      <outgoing>SequenceFlow_12</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_12" name="" sourceRef="Task_2" targetRef="IntermediateCatchEvent_1"/>
+  </process>
+  <signal id="Signal_2" activiti:scope="processInstance" name="Signal2"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalRaceConditionsCatchThrowWithSubProcesses">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="270.0" y="223.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_025l4wk" bpmnElement="ExclusiveGateway_1">
+        <omgdc:Bounds height="40.0" width="40.0" x="362.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1ywy9qe" bpmnElement="Task_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="600.0" y="50.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1mlavmk" bpmnElement="Task_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="486.0" y="300.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="958.0" y="224.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_04sj5fb" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="528.0" y="75.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="519.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_0lm80py" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="711.0" y="325.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="702.0" y="360.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_0pu7trk" bpmnElement="ExclusiveGateway_2">
+        <omgdc:Bounds height="40.0" width="40.0" x="825.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" bpmnElement="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="300.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="362.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17lberr" bpmnElement="SequenceFlow_17lberr">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="865.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="958.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1dh3sax" bpmnElement="SequenceFlow_1dh3sax">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="558.0" y="90.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="600.0" y="90.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="579.0" y="90.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_5" bpmnElement="IntermediateThrowEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="510.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="501.0" y="259.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateThrowEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="402.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="239.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="424.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="658.0" y="198.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_IntermediateThrowEvent_5" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="540.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="658.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="549.0" y="239.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_ManualTask_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="758.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="825.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="789.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="684.0" y="472.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="675.0" y="507.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_4" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="514.0" y="447.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_3" bpmnElement="SubProcess_2" isExpanded="true">
+        <omgdc:Bounds height="145.0" width="410.0" x="409.0" y="24.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="444.0" y="75.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="459.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_StartEvent_2" targetElement="BPMNShape_IntermediateThrowEvent_04sj5fb">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="474.0" y="90.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="528.0" y="90.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="486.0" y="90.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_2" bpmnElement="EndEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="743.0" y="75.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="758.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_Task_1ywy9qe" targetElement="_BPMNShape_EndEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="700.0" y="90.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="743.0" y="90.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="719.0" y="90.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_SubProcess_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="218.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="96.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="409.0" y="96.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="120.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_SubProcess_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="819.0" y="96.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="96.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="218.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="842.0" y="163.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_4" bpmnElement="SubProcess_3" isExpanded="true">
+        <omgdc:Bounds height="150.0" width="410.0" x="409.0" y="411.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_3" bpmnElement="StartEvent_3">
+        <omgdc:Bounds height="30.0" width="30.0" x="432.0" y="472.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="447.0" y="507.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_3" bpmnElement="EndEvent_3">
+        <omgdc:Bounds height="30.0" width="30.0" x="764.0" y="472.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="779.0" y="507.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_13" bpmnElement="SequenceFlow_13" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="_BPMNShape_EndEvent_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="714.0" y="487.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="764.0" y="487.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="736.0" y="487.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_14" bpmnElement="SequenceFlow_14" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_SubProcess_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="486.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="409.0" y="486.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="392.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_15" bpmnElement="SequenceFlow_15" sourceElement="_BPMNShape_SubProcess_4" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="819.0" y="486.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="486.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="333.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="842.0" y="329.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="_BPMNShape_ManualTask_4" targetElement="_BPMNShape_IntermediateCatchEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="614.0" y="487.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="684.0" y="487.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="647.0" y="487.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_StartEvent_3" targetElement="_BPMNShape_ManualTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="462.0" y="487.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="514.0" y="487.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="511.0" y="487.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="BPMNShape_Task_1mlavmk" targetElement="BPMNShape_IntermediateThrowEvent_0lm80py">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="586.0" y="340.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="711.0" y="340.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="612.0" y="340.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_16" bpmnElement="SequenceFlow_16" sourceElement="BPMNShape_IntermediateThrowEvent_0lm80py" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="741.0" y="340.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="783.0" y="340.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="340.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="831.0" y="340.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_18" bpmnElement="SequenceFlow_18" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="BPMNShape_Task_1mlavmk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="340.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="486.0" y="340.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="424.0" y="340.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsThrowCatchAfterUserTask.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsThrowCatchAfterUserTask.bpmn20.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <signal id="signal1" activiti:scope="processInstance" name="Signal1"/>
+  <process id="testSignalRaceConditionsThrowCatchAfterUserTask" name="SS Signals" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</outgoing>
+    </startEvent>
+    <parallelGateway id="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>ExclusiveGateway_025l4wk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</incoming>
+      <outgoing>SequenceFlow_5</outgoing>
+      <outgoing>SequenceFlow_8</outgoing>
+    </parallelGateway>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_17lberr</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_17lberr" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_17lberr</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <parallelGateway id="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-17ECCDD5-2343-489B-A517-3AB7A03801CF</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_7</incoming>
+      <incoming>SequenceFlow_10</incoming>
+      <outgoing>SequenceFlow_17lberr</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_2"/>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ExclusiveGateway_1" targetRef="ManualTask_3"/>
+    <userTask id="ManualTask_3" name="Task B">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_2</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_2" name="" sourceRef="ManualTask_3" targetRef="IntermediateCatchEvent_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_2" name="Catch Signal2">
+      <incoming>SequenceFlow_2</incoming>
+      <outgoing>SequenceFlow_10</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_4" signalRef="Signal_2"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_10" name="" sourceRef="IntermediateCatchEvent_2" targetRef="ExclusiveGateway_2"/>
+    <manualTask id="ManualTask_2" name="Task A">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_7</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_7" name="" sourceRef="ManualTask_2" targetRef="ExclusiveGateway_2"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_2" name="Throw Signal2">
+      <incoming>SequenceFlow_5</incoming>
+      <outgoing>SequenceFlow_6</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_3" signalRef="Signal_2"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="IntermediateThrowEvent_2" targetRef="ManualTask_2"/>
+  </process>
+  <signal id="Signal_2" activiti:scope="processInstance" name="Signal2"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalRaceConditionsThrowCatchAfterUserTask">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="270.0" y="223.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_025l4wk" bpmnElement="ExclusiveGateway_1">
+        <omgdc:Bounds height="40.0" width="40.0" x="362.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="958.0" y="224.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_0pu7trk" bpmnElement="ExclusiveGateway_2">
+        <omgdc:Bounds height="40.0" width="40.0" x="825.0" y="218.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" bpmnElement="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="300.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="362.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17lberr" bpmnElement="SequenceFlow_17lberr">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="865.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="958.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_5" bpmnElement="IntermediateThrowEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="480.0" y="144.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="471.0" y="179.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateThrowEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="383.0" y="218.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="383.0" y="198.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="383.0" y="159.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="480.0" y="159.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="380.0" y="193.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="600.0" y="119.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_IntermediateThrowEvent_5" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="510.0" y="159.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="600.0" y="159.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="544.0" y="159.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_ManualTask_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="700.0" y="159.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="844.0" y="159.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="218.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="766.0" y="159.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="699.0" y="361.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="690.0" y="396.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_ManualTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="376.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="539.0" y="376.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="283.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_4" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="539.0" y="336.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="729.0" y="376.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="376.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="842.0" y="338.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="_BPMNShape_ManualTask_4" targetElement="_BPMNShape_IntermediateCatchEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="639.0" y="376.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="699.0" y="376.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="664.0" y="376.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsThrowCatchSequence.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalRaceConditionsThrowCatchSequence.bpmn20.xml
@@ -1,0 +1,353 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <signal id="signal1" activiti:scope="processInstance" name="Signal1"/>
+  <process id="testSignalRaceConditionsThrowCatchSequence" name="SS Signals" isExecutable="true">
+    <sequenceFlow id="SequenceFlow_0lwprnk" sourceRef="Task_1" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_0lwprnk</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <parallelGateway id="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-17ECCDD5-2343-489B-A517-3AB7A03801CF</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_0lwprnk</incoming>
+      <incoming>SequenceFlow_01wekde</incoming>
+      <incoming>SequenceFlow_7</incoming>
+      <incoming>SequenceFlow_10</incoming>
+      <incoming>SequenceFlow_17</incoming>
+      <outgoing>SequenceFlow_17lberr</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_17lberr" sourceRef="ExclusiveGateway_2" targetRef="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_17lberr</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_17lberr</incoming>
+    </endEvent>
+    <parallelGateway id="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>ExclusiveGateway_025l4wk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</incoming>
+      <outgoing>SequenceFlow_1wzkv9g</outgoing>
+      <outgoing>SequenceFlow_1kvzl0v</outgoing>
+      <outgoing>SequenceFlow_5</outgoing>
+      <outgoing>SequenceFlow_8</outgoing>
+      <outgoing>SequenceFlow_14</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_1wzkv9g" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1wzkv9g</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_1kvzl0v" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1kvzl0v</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="SequenceFlow_5" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateThrowEvent_2"/>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ExclusiveGateway_1" targetRef="IntermediateCatchEvent_2"/>
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</outgoing>
+    </startEvent>
+    <sequenceFlow id="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" sourceRef="StartEvent_1" targetRef="ExclusiveGateway_1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <manualTask id="Task_1" name="Task 1">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1ywy9qe</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_3</incoming>
+      <outgoing>SequenceFlow_0lwprnk</outgoing>
+    </manualTask>
+    <manualTask id="ManualTask_3" name="Task B">
+      <incoming>SequenceFlow_4</incoming>
+      <outgoing>SequenceFlow_10</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_10" name="" sourceRef="ManualTask_3" targetRef="ExclusiveGateway_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_2" name="Signal2">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_4</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_4" signalRef="Signal_2"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_4" name="" sourceRef="IntermediateCatchEvent_2" targetRef="ManualTask_3"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-0B6D28DC-133E-4840-B6DB-44687AFCD0A1</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1wzkv9g</incoming>
+      <outgoing>SequenceFlow_3</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_3" name="" sourceRef="IntermediateThrowEvent_1" targetRef="Task_1"/>
+    <manualTask id="ManualTask_2" name="Task A">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_7</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_7" name="" sourceRef="ManualTask_2" targetRef="ExclusiveGateway_2"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_2" name="Signal2">
+      <incoming>SequenceFlow_5</incoming>
+      <outgoing>SequenceFlow_6</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_3" signalRef="Signal_2"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="IntermediateThrowEvent_2" targetRef="ManualTask_2"/>
+    <manualTask id="Task_2" name="Task 2">
+      <extensionElements>
+        <modeler:editor-resource-id>Task_1mlavmk</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1gdnqtq</incoming>
+      <outgoing>SequenceFlow_01wekde</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_01wekde" sourceRef="Task_2" targetRef="ExclusiveGateway_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_01wekde</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Signal1">
+      <extensionElements>
+        <modeler:editor-resource-id>sid-CFE04485-5B67-4A15-BD33-BF172C9A1585</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_1kvzl0v</incoming>
+      <outgoing>SequenceFlow_1gdnqtq</outgoing>
+      <signalEventDefinition signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_1gdnqtq" sourceRef="IntermediateCatchEvent_1" targetRef="Task_2">
+      <extensionElements>
+        <modeler:editor-resource-id>SequenceFlow_1gdnqtq</modeler:editor-resource-id>
+      </extensionElements>
+    </sequenceFlow>
+    <intermediateCatchEvent id="IntermediateCatchEvent_3" name="Signal 1">
+      <incoming>SequenceFlow_15</incoming>
+      <outgoing>SequenceFlow_16</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_5" signalRef="signal1"/>
+    </intermediateCatchEvent>
+    <intermediateCatchEvent id="IntermediateCatchEvent_4" name="Signal 2">
+      <incoming>SequenceFlow_16</incoming>
+      <outgoing>SequenceFlow_17</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_6" signalRef="Signal_2"/>
+    </intermediateCatchEvent>
+    <userTask id="ManualTask_1" name="Task 3">
+      <incoming>SequenceFlow_14</incoming>
+      <outgoing>SequenceFlow_15</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_14" name="" sourceRef="ExclusiveGateway_1" targetRef="ManualTask_1"/>
+    <sequenceFlow id="SequenceFlow_15" name="" sourceRef="ManualTask_1" targetRef="IntermediateCatchEvent_3"/>
+    <sequenceFlow id="SequenceFlow_16" name="" sourceRef="IntermediateCatchEvent_3" targetRef="IntermediateCatchEvent_4"/>
+    <sequenceFlow id="SequenceFlow_17" name="" sourceRef="IntermediateCatchEvent_4" targetRef="ExclusiveGateway_2"/>
+  </process>
+  <signal id="Signal_2" activiti:scope="processInstance" name="Signal2"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalRaceConditionsThrowCatchSequence">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="271.0" y="242.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="286.0" y="277.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_025l4wk" bpmnElement="ExclusiveGateway_1">
+        <omgdc:Bounds height="40.0" width="40.0" x="362.0" y="236.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="382.0" y="281.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1ywy9qe" bpmnElement="Task_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="578.0" y="24.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1mlavmk" bpmnElement="Task_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="624.0" y="322.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="959.0" y="243.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="973.0" y="276.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_04sj5fb" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="472.0" y="49.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="463.0" y="84.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_0lm80py" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="468.0" y="347.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="459.0" y="382.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ExclusiveGateway_0pu7trk" bpmnElement="ExclusiveGateway_2">
+        <omgdc:Bounds height="40.0" width="40.0" x="825.0" y="237.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="845.0" y="282.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_01wekde" bpmnElement="SequenceFlow_01wekde">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="724.0" y="362.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="362.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="277.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="804.0" y="362.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA" bpmnElement="sid-0A4A04CE-9653-4B46-B81C-FE8BC3B2E2AA">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="301.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="331.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="331.0" y="256.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="362.0" y="256.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="331.0" y="256.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1wzkv9g" bpmnElement="SequenceFlow_1wzkv9g" targetElement="BPMNShape_IntermediateThrowEvent_04sj5fb">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="236.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="64.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="472.0" y="64.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="382.0" y="140.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_0lwprnk" bpmnElement="SequenceFlow_0lwprnk" sourceElement="BPMNShape_Task_1ywy9qe">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="678.0" y="64.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="751.0" y="64.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="64.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="237.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="755.0" y="64.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1gdnqtq" bpmnElement="SequenceFlow_1gdnqtq">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="498.0" y="362.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="624.0" y="362.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="555.0" y="362.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1kvzl0v" bpmnElement="SequenceFlow_1kvzl0v">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="276.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="362.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="468.0" y="362.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="396.0" y="362.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17lberr" bpmnElement="SequenceFlow_17lberr">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="865.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="959.0" y="257.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="912.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_5" bpmnElement="IntermediateThrowEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="472.0" y="150.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="463.0" y="185.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateThrowEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="236.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="383.0" y="165.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="472.0" y="165.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="211.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="600.0" y="125.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="_BPMNShape_IntermediateThrowEvent_5" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="502.0" y="165.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="600.0" y="165.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="536.0" y="165.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_7" bpmnElement="SequenceFlow_7" sourceElement="_BPMNShape_ManualTask_3" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="700.0" y="165.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="165.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="237.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="766.0" y="165.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="30.0" width="30.0" x="472.0" y="445.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="49.0" x="463.0" y="480.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_IntermediateCatchEvent_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="276.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="382.0" y="460.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="472.0" y="460.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="379.0" y="301.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_4" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="564.0" y="420.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_ManualTask_4" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="664.0" y="460.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="744.0" y="460.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="460.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="845.0" y="277.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="815.0" y="460.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="BPMNShape_IntermediateThrowEvent_04sj5fb" targetElement="BPMNShape_Task_1ywy9qe">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="502.0" y="64.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="578.0" y="64.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="533.0" y="64.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_IntermediateCatchEvent_2" targetElement="_BPMNShape_ManualTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="502.0" y="460.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="564.0" y="460.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_4" bpmnElement="IntermediateCatchEvent_3">
+        <omgdc:Bounds height="30.0" width="30.0" x="677.0" y="242.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="53.0" x="666.0" y="277.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_5" bpmnElement="IntermediateCatchEvent_4">
+        <omgdc:Bounds height="30.0" width="30.0" x="757.0" y="242.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="53.0" x="746.0" y="277.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_5" bpmnElement="ManualTask_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="486.0" y="217.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_14" bpmnElement="SequenceFlow_14" sourceElement="BPMNShape_ExclusiveGateway_025l4wk" targetElement="_BPMNShape_ManualTask_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="402.0" y="256.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="444.0" y="256.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="444.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="486.0" y="257.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_15" bpmnElement="SequenceFlow_15" sourceElement="_BPMNShape_ManualTask_5" targetElement="_BPMNShape_IntermediateCatchEvent_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="586.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="677.0" y="257.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_16" bpmnElement="SequenceFlow_16" sourceElement="_BPMNShape_IntermediateCatchEvent_4" targetElement="_BPMNShape_IntermediateCatchEvent_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="707.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="757.0" y="257.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_17" bpmnElement="SequenceFlow_17" sourceElement="_BPMNShape_IntermediateCatchEvent_5" targetElement="BPMNShape_ExclusiveGateway_0pu7trk">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="787.0" y="257.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="825.0" y="257.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchBoundarySubProcess.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchBoundarySubProcess.bpmn20.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="testSignalThrowCatchBoundarySubProcess" isExecutable="true">
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Publish Event">
+      <incoming>SequenceFlow_9</incoming>
+      <outgoing>SequenceFlow_11</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_7" signalRef="Signal_1"/>
+    </intermediateThrowEvent>
+    <parallelGateway id="ParallelGateway_2">
+      <incoming>SequenceFlow_11</incoming>
+      <incoming>SequenceFlow_4</incoming>
+      <outgoing>SequenceFlow_12</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_11" name="" sourceRef="IntermediateThrowEvent_1" targetRef="ParallelGateway_2"/>
+    <sequenceFlow id="SequenceFlow_12" name="" sourceRef="ParallelGateway_2" targetRef="EndEvent_1"/>
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>SequenceFlow_6</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="StartEvent_1" targetRef="ParallelGateway_1"/>
+    <subProcess id="SubProcess_1">
+      <incoming>SequenceFlow_1</incoming>
+      <startEvent id="StartEvent_2">
+        <outgoing>SequenceFlow_13</outgoing>
+      </startEvent>
+      <endEvent id="EndEvent_2">
+        <incoming>SequenceFlow_16</incoming>
+      </endEvent>
+      <userTask id="UserTask_2" name="User Task">
+        <incoming>SequenceFlow_13</incoming>
+        <outgoing>SequenceFlow_16</outgoing>
+      </userTask>
+      <sequenceFlow id="SequenceFlow_13" name="" sourceRef="StartEvent_2" targetRef="UserTask_2"/>
+      <sequenceFlow id="SequenceFlow_16" name="" sourceRef="UserTask_2" targetRef="EndEvent_2"/>
+    </subProcess>
+    <boundaryEvent id="BoundaryEvent_2" name="Event Received" attachedToRef="SubProcess_1">
+      <outgoing>SequenceFlow_4</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_11" signalRef="Signal_1"/>
+    </boundaryEvent>
+    <sequenceFlow id="SequenceFlow_4" name="" sourceRef="BoundaryEvent_2" targetRef="ParallelGateway_2"/>
+    <parallelGateway id="ParallelGateway_1">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_8</outgoing>
+      <outgoing>SequenceFlow_1</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ParallelGateway_1" targetRef="ManualTask_1"/>
+    <sequenceFlow id="SequenceFlow_1" name="" sourceRef="ParallelGateway_1" targetRef="SubProcess_1"/>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_12</incoming>
+    </endEvent>
+    <manualTask id="ManualTask_1" name="Fast Task">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_9</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_9" name="" sourceRef="ManualTask_1" targetRef="IntermediateThrowEvent_1"/>
+  </process>
+  <signal id="Signal_1" activiti:scope="processInstance" name="Event"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalThrowCatchBoundarySubProcess">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="401.0" y="225.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="416.0" y="260.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="968.0" y="213.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="982.0" y="246.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_6" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="805.0" y="96.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="85.0" x="777.0" y="129.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_2" bpmnElement="ParallelGateway_1">
+        <omgdc:Bounds height="50.0" width="50.0" x="456.0" y="214.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="481.0" y="269.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="BPMNShape_StartEvent_1" targetElement="_BPMNShape_ParallelGateway_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="431.0" y="240.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="456.0" y="239.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="349.0" y="239.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_5" bpmnElement="ManualTask_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="606.0" y="70.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_ManualTask_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="481.0" y="214.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="481.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="606.0" y="110.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="499.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="_BPMNShape_ManualTask_5" targetElement="_BPMNShape_IntermediateThrowEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="706.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="805.0" y="110.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="732.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_3" bpmnElement="ParallelGateway_2">
+        <omgdc:Bounds height="50.0" width="50.0" x="888.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="913.0" y="256.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_11" bpmnElement="SequenceFlow_11" sourceElement="_BPMNShape_IntermediateThrowEvent_6" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="833.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="860.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="910.0" y="116.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="BPMNShape_EndEvent_1t6khkd">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="938.0" y="226.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="968.0" y="227.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="965.0" y="227.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_SubProcess_5" bpmnElement="SubProcess_1" isExpanded="true">
+        <omgdc:Bounds height="150.0" width="346.0" x="525.0" y="289.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_SubProcess_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="481.0" y="264.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="481.0" y="364.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="525.0" y="364.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="478.0" y="289.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_4" bpmnElement="StartEvent_2">
+        <omgdc:Bounds height="28.0" width="28.0" x="552.0" y="351.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="566.0" y="384.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_EndEvent_4" bpmnElement="EndEvent_2">
+        <omgdc:Bounds height="28.0" width="28.0" x="792.0" y="351.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="806.0" y="384.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_BoundaryEvent_5" bpmnElement="BoundaryEvent_2">
+        <omgdc:Bounds height="28.0" width="28.0" x="802.0" y="425.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_BoundaryEvent_5" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="816.0" y="453.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="816.0" y="483.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="483.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="251.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_UserTask_4" bpmnElement="UserTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="630.0" y="325.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_13" bpmnElement="SequenceFlow_13" sourceElement="_BPMNShape_StartEvent_4" targetElement="_BPMNShape_UserTask_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="580.0" y="365.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="630.0" y="365.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_16" bpmnElement="SequenceFlow_16" sourceElement="_BPMNShape_UserTask_4" targetElement="_BPMNShape_EndEvent_4">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="730.0" y="365.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="792.0" y="365.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchBoundaryUserTask.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchBoundaryUserTask.bpmn20.xml
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="testSignalThrowCatchBoundaryUserTask" isExecutable="true">
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Publish Event">
+      <incoming>SequenceFlow_9</incoming>
+      <outgoing>SequenceFlow_11</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_7" signalRef="Signal_1"/>
+    </intermediateThrowEvent>
+    <manualTask id="ManualTask_1" name="Fast Task">
+      <incoming>SequenceFlow_8</incoming>
+      <outgoing>SequenceFlow_9</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_9" name="" sourceRef="ManualTask_1" targetRef="IntermediateThrowEvent_1"/>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_12</incoming>
+    </endEvent>
+    <parallelGateway id="ParallelGateway_2">
+      <incoming>SequenceFlow_10</incoming>
+      <incoming>SequenceFlow_11</incoming>
+      <outgoing>SequenceFlow_12</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_11" name="" sourceRef="IntermediateThrowEvent_1" targetRef="ParallelGateway_2"/>
+    <sequenceFlow id="SequenceFlow_12" name="" sourceRef="ParallelGateway_2" targetRef="EndEvent_1"/>
+    <boundaryEvent id="BoundaryEvent_1" name="Event Published" attachedToRef="ManualTask_2">
+      <outgoing>SequenceFlow_10</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_9" signalRef="Signal_1"/>
+    </boundaryEvent>
+    <sequenceFlow id="SequenceFlow_10" name="" sourceRef="BoundaryEvent_1" targetRef="ParallelGateway_2"/>
+    <userTask id="ManualTask_2" name="Slow Task">
+      <incoming>SequenceFlow_15</incoming>
+    </userTask>
+    <intermediateCatchEvent id="IntermediateCatchEvent_2" name="PT1S">
+      <incoming>SequenceFlow_14</incoming>
+      <outgoing>SequenceFlow_15</outgoing>
+      <timerEventDefinition id="_TimerEventDefinition_2">
+        <timeDuration xsi:type="tFormalExpression">PT1S</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_15" name="" sourceRef="IntermediateCatchEvent_2" targetRef="ManualTask_2"/>
+    <parallelGateway id="ParallelGateway_1">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_8</outgoing>
+      <outgoing>SequenceFlow_14</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_8" name="" sourceRef="ParallelGateway_1" targetRef="ManualTask_1"/>
+    <sequenceFlow id="SequenceFlow_14" name="" sourceRef="ParallelGateway_1" targetRef="IntermediateCatchEvent_2"/>
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>SequenceFlow_6</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="StartEvent_1" targetRef="ParallelGateway_1"/>
+  </process>
+  <signal id="Signal_1" activiti:scope="processInstance" name="Event"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalThrowCatchBoundaryUserTask">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="401.0" y="225.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="416.0" y="260.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="996.0" y="213.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="1010.0" y="246.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="679.0" y="198.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_6" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="805.0" y="96.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="85.0" x="777.0" y="129.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_BoundaryEvent_2" bpmnElement="BoundaryEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="738.0" y="264.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="99.0" x="703.0" y="297.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_2" bpmnElement="ParallelGateway_1">
+        <omgdc:Bounds height="50.0" width="50.0" x="480.0" y="214.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="505.0" y="269.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="BPMNShape_StartEvent_1" targetElement="_BPMNShape_ParallelGateway_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="431.0" y="240.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="455.0" y="240.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="455.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="480.0" y="239.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="349.0" y="239.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_5" bpmnElement="ManualTask_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="648.0" y="70.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_8" bpmnElement="SequenceFlow_8" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_ManualTask_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="214.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="648.0" y="110.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="523.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="_BPMNShape_ManualTask_5" targetElement="_BPMNShape_IntermediateThrowEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="748.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="805.0" y="110.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_3" bpmnElement="ParallelGateway_2">
+        <omgdc:Bounds height="50.0" width="50.0" x="888.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="913.0" y="256.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_10" bpmnElement="SequenceFlow_10" sourceElement="_BPMNShape_BoundaryEvent_2" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="752.0" y="292.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="752.0" y="322.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="322.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="251.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="788.0" y="322.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_11" bpmnElement="SequenceFlow_11" sourceElement="_BPMNShape_IntermediateThrowEvent_6" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="833.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="860.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="913.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="910.0" y="116.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="BPMNShape_EndEvent_1t6khkd">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="938.0" y="226.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="967.0" y="226.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="967.0" y="227.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="996.0" y="227.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_7" bpmnElement="IntermediateCatchEvent_2">
+        <omgdc:Bounds height="28.0" width="28.0" x="580.0" y="225.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="38.0" x="575.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_14" bpmnElement="SequenceFlow_14" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_7">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="530.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="580.0" y="239.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="552.0" y="239.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_15" bpmnElement="SequenceFlow_15" sourceElement="_BPMNShape_IntermediateCatchEvent_7" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="608.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="646.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="646.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="679.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="643.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchEventGateway.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchEventGateway.bpmn20.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="testSignalThrowCatchEventGateway" name="Wait 1S" isExecutable="true">
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Publish Event">
+      <incoming>SequenceFlow_9</incoming>
+      <outgoing>SequenceFlow_11</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_7" signalRef="Signal_1"/>
+    </intermediateThrowEvent>
+    <manualTask id="ManualTask_1" name="Fast Task">
+      <incoming>SequenceFlow_21</incoming>
+      <outgoing>SequenceFlow_9</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_9" name="" sourceRef="ManualTask_1" targetRef="IntermediateThrowEvent_1"/>
+    <sequenceFlow id="SequenceFlow_11" name="" sourceRef="IntermediateThrowEvent_1" targetRef="ParallelGateway_2"/>
+    <parallelGateway id="ParallelGateway_1">
+      <incoming>SequenceFlow_6</incoming>
+      <outgoing>SequenceFlow_21</outgoing>
+      <outgoing>SequenceFlow_26</outgoing>
+    </parallelGateway>
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>SequenceFlow_6</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_6" name="" sourceRef="StartEvent_1" targetRef="ParallelGateway_1"/>
+    <sequenceFlow id="SequenceFlow_21" name="" sourceRef="ParallelGateway_1" targetRef="ManualTask_1"/>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_12</incoming>
+    </endEvent>
+    <parallelGateway id="ParallelGateway_2">
+      <incoming>SequenceFlow_11</incoming>
+      <incoming>SequenceFlow_24</incoming>
+      <outgoing>SequenceFlow_12</outgoing>
+    </parallelGateway>
+    <sequenceFlow id="SequenceFlow_12" name="" sourceRef="ParallelGateway_2" targetRef="EndEvent_1"/>
+    <sequenceFlow id="SequenceFlow_26" name="" sourceRef="ParallelGateway_1" targetRef="UserTask_1"/>
+    <manualTask id="ManualTask_3" name="End Task">
+      <incoming>SequenceFlow_23</incoming>
+      <incoming>SequenceFlow_29</incoming>
+      <outgoing>SequenceFlow_24</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_24" name="" sourceRef="ManualTask_3" targetRef="ParallelGateway_2"/>
+    <eventBasedGateway id="EventBasedGateway_1">
+      <incoming>SequenceFlow_27</incoming>
+      <outgoing>SequenceFlow_3</outgoing>
+      <outgoing>SequenceFlow_28</outgoing>
+    </eventBasedGateway>
+    <sequenceFlow id="SequenceFlow_3" name="" sourceRef="EventBasedGateway_1" targetRef="IntermediateCatchEvent_3"/>
+    <sequenceFlow id="SequenceFlow_28" name="" sourceRef="EventBasedGateway_1" targetRef="IntermediateCatchEvent_7"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_7" name="PT1S">
+      <incoming>SequenceFlow_28</incoming>
+      <outgoing>SequenceFlow_29</outgoing>
+      <timerEventDefinition id="_TimerEventDefinition_7">
+        <timeDuration xsi:type="tFormalExpression">PT1S</timeDuration>
+      </timerEventDefinition>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_29" name="" sourceRef="IntermediateCatchEvent_7" targetRef="ManualTask_3"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_3" name="Event Published">
+      <incoming>SequenceFlow_3</incoming>
+      <outgoing>SequenceFlow_23</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_10" signalRef="Signal_1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_23" name="" sourceRef="IntermediateCatchEvent_3" targetRef="ManualTask_3"/>
+    <userTask id="UserTask_1" name="User Task">
+      <incoming>SequenceFlow_26</incoming>
+      <outgoing>SequenceFlow_27</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_27" name="" sourceRef="UserTask_1" targetRef="EventBasedGateway_1"/>
+  </process>
+  <signal id="Signal_1" activiti:scope="processInstance" name="Event"/>
+  <signal id="Signal_2" name="Another"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalThrowCatchEventGateway">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="401.0" y="225.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="416.0" y="260.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="1032.0" y="213.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="1046.0" y="246.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_6" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="805.0" y="96.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="85.0" x="777.0" y="129.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_2" bpmnElement="ParallelGateway_1">
+        <omgdc:Bounds height="50.0" width="50.0" x="480.0" y="214.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="505.0" y="269.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_6" bpmnElement="SequenceFlow_6" sourceElement="BPMNShape_StartEvent_1" targetElement="_BPMNShape_ParallelGateway_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="431.0" y="240.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="455.0" y="240.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="455.0" y="239.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="480.0" y="239.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="349.0" y="239.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_5" bpmnElement="ManualTask_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="648.0" y="70.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_9" bpmnElement="SequenceFlow_9" sourceElement="_BPMNShape_ManualTask_5" targetElement="_BPMNShape_IntermediateThrowEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="748.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="805.0" y="110.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ParallelGateway_3" bpmnElement="ParallelGateway_2">
+        <omgdc:Bounds height="50.0" width="50.0" x="936.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="961.0" y="256.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_11" bpmnElement="SequenceFlow_11" sourceElement="_BPMNShape_IntermediateThrowEvent_6" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="833.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="860.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="201.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="916.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_12" bpmnElement="SequenceFlow_12" sourceElement="_BPMNShape_ParallelGateway_3" targetElement="BPMNShape_EndEvent_1t6khkd">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="986.0" y="226.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="1032.0" y="227.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="994.0" y="226.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_EventBasedGateway_2" bpmnElement="EventBasedGateway_1">
+        <omgdc:Bounds height="50.0" width="50.0" x="672.0" y="300.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="697.0" y="355.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_9" bpmnElement="IntermediateCatchEvent_3">
+        <omgdc:Bounds height="28.0" width="28.0" x="773.0" y="386.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="99.0" x="738.0" y="419.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_EventBasedGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_9">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="697.0" y="350.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="697.0" y="400.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="773.0" y="400.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="706.0" y="400.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_21" bpmnElement="SequenceFlow_21" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_ManualTask_5">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="214.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="589.0" y="110.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="648.0" y="110.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="521.0" y="110.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_6" bpmnElement="ManualTask_3">
+        <omgdc:Bounds height="80.0" width="100.0" x="832.0" y="286.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_23" bpmnElement="SequenceFlow_23" sourceElement="_BPMNShape_IntermediateCatchEvent_9" targetElement="_BPMNShape_ManualTask_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="801.0" y="400.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="882.0" y="400.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="882.0" y="366.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="849.0" y="400.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_24" bpmnElement="SequenceFlow_24" sourceElement="_BPMNShape_ManualTask_6" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="932.0" y="326.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="326.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="251.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="958.0" y="284.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_UserTask_2" bpmnElement="UserTask_1">
+        <omgdc:Bounds height="80.0" width="100.0" x="530.0" y="286.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_26" bpmnElement="SequenceFlow_26" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_UserTask_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="264.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="326.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="530.0" y="326.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="502.0" y="285.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_27" bpmnElement="SequenceFlow_27" sourceElement="_BPMNShape_UserTask_2" targetElement="_BPMNShape_EventBasedGateway_2">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="630.0" y="326.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="672.0" y="325.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="643.0" y="326.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_13" bpmnElement="IntermediateCatchEvent_7">
+        <omgdc:Bounds height="28.0" width="28.0" x="773.0" y="244.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="22.0" width="38.0" x="768.0" y="286.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_28" bpmnElement="SequenceFlow_28" sourceElement="_BPMNShape_EventBasedGateway_2" targetElement="_BPMNShape_IntermediateCatchEvent_13">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="697.0" y="300.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="697.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="773.0" y="258.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="696.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_29" bpmnElement="SequenceFlow_29" sourceElement="_BPMNShape_IntermediateCatchEvent_13" targetElement="_BPMNShape_ManualTask_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="801.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="881.0" y="258.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="881.0" y="286.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="875.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchEventGateway.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchEventGateway.bpmn20.xml
@@ -16,6 +16,7 @@
       <incoming>SequenceFlow_6</incoming>
       <outgoing>SequenceFlow_21</outgoing>
       <outgoing>SequenceFlow_26</outgoing>
+      <outgoing>SequenceFlow_30</outgoing>
     </parallelGateway>
     <startEvent id="StartEvent_1">
       <extensionElements>
@@ -34,6 +35,7 @@
     <parallelGateway id="ParallelGateway_2">
       <incoming>SequenceFlow_11</incoming>
       <incoming>SequenceFlow_24</incoming>
+      <incoming>SequenceFlow_31</incoming>
       <outgoing>SequenceFlow_12</outgoing>
     </parallelGateway>
     <sequenceFlow id="SequenceFlow_12" name="" sourceRef="ParallelGateway_2" targetRef="EndEvent_1"/>
@@ -70,6 +72,12 @@
       <outgoing>SequenceFlow_27</outgoing>
     </userTask>
     <sequenceFlow id="SequenceFlow_27" name="" sourceRef="UserTask_1" targetRef="EventBasedGateway_1"/>
+    <sequenceFlow id="SequenceFlow_30" name="" sourceRef="ParallelGateway_1" targetRef="ManualTask_4"/>
+    <manualTask id="ManualTask_4" name="Parallel Task">
+      <incoming>SequenceFlow_30</incoming>
+      <outgoing>SequenceFlow_31</outgoing>
+    </manualTask>
+    <sequenceFlow id="SequenceFlow_31" name="" sourceRef="ManualTask_4" targetRef="ParallelGateway_2"/>
   </process>
   <signal id="Signal_1" activiti:scope="processInstance" name="Event"/>
   <signal id="Signal_2" name="Another"/>
@@ -223,6 +231,26 @@
         <omgdi:waypoint xsi:type="omgdc:Point" x="881.0" y="286.0"/>
         <bpmndi:BPMNLabel>
           <omgdc:Bounds height="6.0" width="6.0" x="875.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_7" bpmnElement="ManualTask_4">
+        <omgdc:Bounds height="80.0" width="100.0" x="679.0" y="480.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_30" bpmnElement="SequenceFlow_30" sourceElement="_BPMNShape_ParallelGateway_2" targetElement="_BPMNShape_ManualTask_7">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="264.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="505.0" y="520.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="679.0" y="520.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="502.0" y="289.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_31" bpmnElement="SequenceFlow_31" sourceElement="_BPMNShape_ManualTask_7" targetElement="_BPMNShape_ParallelGateway_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="779.0" y="520.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="857.0" y="520.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="520.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="961.0" y="251.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="958.0" y="477.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchUserTask.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchUserTask.bpmn20.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="testSignalThrowCatchUserTask" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>SequenceFlow_2</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_2" name="" sourceRef="StartEvent_1" targetRef="IntermediateThrowEvent_1"/>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_4</incoming>
+    </endEvent>
+    <userTask id="ManualTask_2" name="User Task">
+      <incoming>SequenceFlow_3</incoming>
+      <outgoing>SequenceFlow_1</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_1" name="" sourceRef="ManualTask_2" targetRef="IntermediateCatchEvent_1"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Publish Event">
+      <incoming>SequenceFlow_2</incoming>
+      <outgoing>SequenceFlow_3</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_7" signalRef="Signal_1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_3" name="" sourceRef="IntermediateThrowEvent_1" targetRef="ManualTask_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Event Published">
+      <incoming>SequenceFlow_1</incoming>
+      <outgoing>SequenceFlow_4</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_8" signalRef="Signal_1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_4" name="" sourceRef="IntermediateCatchEvent_1" targetRef="EndEvent_1"/>
+  </process>
+  <signal id="Signal_1" activiti:scope="processInstance" name="Event"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalThrowCatchUserTask">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="504.0" y="223.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="519.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="924.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="938.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="684.0" y="198.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_ManualTask_3" targetElement="_BPMNShape_IntermediateCatchEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="784.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="852.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="821.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_StartEvent_1" targetElement="_BPMNShape_IntermediateThrowEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="534.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="588.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="546.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_6" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="588.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="602.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_IntermediateThrowEvent_6" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="616.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="684.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_6" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="852.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="866.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_IntermediateCatchEvent_6" targetElement="BPMNShape_EndEvent_1t6khkd">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="880.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="924.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="912.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchUserTaskGlobal.bpmn20.xml
+++ b/modules/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.testSignalThrowCatchUserTaskGlobal.bpmn20.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:modeler="http://activiti.com/modeler" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd" modeler:version="1.0en" modeler:exportDateTime="20171201010336345" modeler:modelId="33" modeler:modelVersion="7" modeler:modelLastUpdated="1512090194573" exporter="Camunda Modeler" exporterVersion="1.11.2" targetNamespace="http://bpmn.io/schema/bpmn">
+  <process id="testSignalThrowCatchUserTaskGlobal" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>StartEvent_1</modeler:editor-resource-id>
+      </extensionElements>
+      <outgoing>SequenceFlow_2</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_2" name="" sourceRef="StartEvent_1" targetRef="IntermediateThrowEvent_1"/>
+    <endEvent id="EndEvent_1">
+      <extensionElements>
+        <modeler:editor-resource-id>EndEvent_1t6khkd</modeler:editor-resource-id>
+      </extensionElements>
+      <incoming>SequenceFlow_4</incoming>
+    </endEvent>
+    <userTask id="ManualTask_2" name="User Task">
+      <incoming>SequenceFlow_3</incoming>
+      <outgoing>SequenceFlow_1</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_1" name="" sourceRef="ManualTask_2" targetRef="IntermediateCatchEvent_1"/>
+    <intermediateThrowEvent id="IntermediateThrowEvent_1" name="Publish Event">
+      <incoming>SequenceFlow_2</incoming>
+      <outgoing>SequenceFlow_3</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_7" signalRef="Signal_1"/>
+    </intermediateThrowEvent>
+    <sequenceFlow id="SequenceFlow_3" name="" sourceRef="IntermediateThrowEvent_1" targetRef="ManualTask_2"/>
+    <intermediateCatchEvent id="IntermediateCatchEvent_1" name="Event Published">
+      <incoming>SequenceFlow_1</incoming>
+      <outgoing>SequenceFlow_4</outgoing>
+      <signalEventDefinition id="_SignalEventDefinition_8" signalRef="Signal_1"/>
+    </intermediateCatchEvent>
+    <sequenceFlow id="SequenceFlow_4" name="" sourceRef="IntermediateCatchEvent_1" targetRef="EndEvent_1"/>
+  </process>
+  <signal id="Signal_1" activiti:scope="global" name="Event"/>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_Process_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="testSignalThrowCatchUserTaskGlobal">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds height="30.0" width="30.0" x="504.0" y="223.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="519.0" y="258.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1t6khkd" bpmnElement="EndEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="924.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="938.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_ManualTask_3" bpmnElement="ManualTask_2">
+        <omgdc:Bounds height="80.0" width="100.0" x="684.0" y="198.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="_BPMNShape_ManualTask_3" targetElement="_BPMNShape_IntermediateCatchEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="784.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="852.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="821.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_StartEvent_1" targetElement="_BPMNShape_IntermediateThrowEvent_6">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="534.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="588.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="546.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateThrowEvent_6" bpmnElement="IntermediateThrowEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="588.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="602.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_3" bpmnElement="SequenceFlow_3" sourceElement="_BPMNShape_IntermediateThrowEvent_6" targetElement="_BPMNShape_ManualTask_3">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="616.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="684.0" y="238.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_IntermediateCatchEvent_6" bpmnElement="IntermediateCatchEvent_1">
+        <omgdc:Bounds height="28.0" width="28.0" x="852.0" y="224.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="0.0" width="0.0" x="866.0" y="257.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_4" bpmnElement="SequenceFlow_4" sourceElement="_BPMNShape_IntermediateCatchEvent_6" targetElement="BPMNShape_EndEvent_1t6khkd">
+        <omgdi:waypoint xsi:type="omgdc:Point" x="880.0" y="238.0"/>
+        <omgdi:waypoint xsi:type="omgdc:Point" x="924.0" y="238.0"/>
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds height="6.0" width="6.0" x="912.0" y="238.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Currently, throw/catch signal event handling in Activiti engine causes race conditions behavior to occur when throw/catch signals are used to synchronize parallel activities in the same process instance scope.

For example, after a parallel gateway, due to various task execution timings or non-deterministic execution path by Activiti engine, a signal on one path is emitted before subscribers on parallel paths can subscribe to it, causing subscribers to block and wait indefinitely:

![image](https://user-images.githubusercontent.com/20428629/33520617-6c719170-d773-11e7-8ad8-f3d578f1f4cb.png)

To fix this problem, the PR introduces throw signal event registration in the process instance session execution context. This will allow subscribers to receive events at any time after the signal has been published, so the  execution can proceed if the signal has been registered in the current session or, has already been recorded in the historic activity instance audit log in the previous sessions. 

Global events handling stays the same as before, i.e. non-deterministic, because it requires global persistent event registration/cleanup mechanism in the command execution session to properly synchronize between parallel process instances for each tenant.

See test cases in Activiti Engine module for details: [SignalEventSessionManagerTest.java](Activiti/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/signal/SignalEventSessionManagerTest.java)

![image](https://user-images.githubusercontent.com/20428629/33520748-ddc00ddc-d775-11e7-803e-53525a338599.png)

![image](https://user-images.githubusercontent.com/20428629/33520752-efacb7c0-d775-11e7-9298-7ee9fb0bd4b7.png)

![image](https://user-images.githubusercontent.com/20428629/33520755-fbd0cbcc-d775-11e7-8d5e-203089f9d1a6.png)

![image](https://user-images.githubusercontent.com/20428629/33529521-c2c4adb0-d826-11e7-995f-ffd8b6cdd875.png)

![image](https://user-images.githubusercontent.com/20428629/33536678-5e6fe2b8-d86b-11e7-92c3-a03bd501a95e.png)

![image](https://user-images.githubusercontent.com/20428629/33536667-4a312622-d86b-11e7-9a48-1b3e220d394e.png)

