### PR TITLE
 feat: add support for localization information conversion

### DIFF
--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
@@ -241,4 +241,6 @@ public interface StencilConstants {
   final String PROPERTY_DECISIONTABLE_REFERENCE_ID = "decisiontablereferenceid";
   final String PROPERTY_DECISIONTABLE_REFERENCE_NAME = "decisiontablereferencename";
   final String PROPERTY_DECISIONTABLE_REFERENCE_KEY = "decisionTableReferenceKey";
+
+  final String PROPERTY_LOCALIZATION = "localization";
 }

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -27,6 +27,7 @@ import org.activiti.bpmn.model.DataStoreReference;
 import org.activiti.bpmn.model.ErrorEventDefinition;
 import org.activiti.bpmn.model.Event;
 import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.ExtensionAttribute;
 import org.activiti.bpmn.model.ExtensionElement;
 import org.activiti.bpmn.model.FieldExtension;
 import org.activiti.bpmn.model.FlowElement;
@@ -62,6 +63,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import java.util.Iterator;
+
 /**
  * @author Tijs Rademakers
  */
@@ -70,6 +73,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
   protected static final Logger LOGGER = LoggerFactory.getLogger(BaseBpmnJsonConverter.class);
 
   public static final String NAMESPACE = "http://activiti.com/modeler";
+  public static final String ACTIVITI_EXTENSIONS_NAMESPACE = "http://activiti.org/bpmn";
 
   protected ObjectMapper objectMapper = new ObjectMapper();
   protected ActivityProcessor processor;
@@ -198,7 +202,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
         }
       }
     }
-    
+
     if (baseElement instanceof FlowElement) {
 		BpmnJsonConverterUtil.convertListenersToJson(((FlowElement) baseElement).getExecutionListeners(), true, propertiesNode);
 	}
@@ -504,6 +508,67 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
     }
   }
 
+  protected void addLocalizationProperties(BaseElement baseElement, ObjectNode propertiesNode) {
+    List<ExtensionElement> localizationElements = baseElement.getExtensionElements().get("localization");
+    if (localizationElements != null) {
+      ObjectNode localizationNode = objectMapper.createObjectNode();
+      ObjectNode nameNode = localizationNode.putObject("name");
+      ObjectNode descriptionNode = localizationNode.putObject("description");
+
+      for (ExtensionElement localizationElement : localizationElements) {
+        if (ACTIVITI_EXTENSIONS_NAMESPACE.equals(localizationElement.getNamespace())) {
+          String locale = localizationElement.getAttributeValue(null, "locale");
+          String name = localizationElement.getAttributeValue(null, "name");
+          String documentation = null;
+          List<ExtensionElement> documentationElements = localizationElement.getChildElements().get("documentation");
+          if (documentationElements != null) {
+            for (ExtensionElement documentationElement : documentationElements) {
+              documentation = StringUtils.trimToNull(documentationElement.getElementText());
+              break;
+            }
+          }
+          if (name != null && !name.trim().isEmpty()) {
+            nameNode.put(locale, name);
+          }
+          if (documentation != null && !documentation.trim().isEmpty()) {
+
+            descriptionNode.put(locale, documentation);
+          }
+        }
+      }
+      if (nameNode.fieldNames().hasNext() || descriptionNode.fieldNames().hasNext()) {
+        propertiesNode.set("localization", localizationNode);
+      }
+    }
+
+  }
+
+  protected void addLocalizationExtensionElement(JsonNode objectNode, BaseElement element) {
+    JsonNode localizationNode = getProperty(PROPERTY_LOCALIZATION, objectNode);
+    if (localizationNode != null) {
+      localizationNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(localizationNode);
+      final JsonNode nameNode = localizationNode.get("name");
+      Iterator<Map.Entry<String, JsonNode>> fields;
+      if (nameNode != null) {
+        fields = nameNode.fields();
+        while (fields.hasNext()) {
+          final Map.Entry<String, JsonNode> entry = fields.next();
+          setLocalizedName(entry.getKey(), entry.getValue().textValue(), element);
+        }
+      }
+      final JsonNode descriptionNode = localizationNode.get("description");
+      if (descriptionNode != null) {
+        fields = descriptionNode.fields();
+        while (fields.hasNext()) {
+          final Map.Entry<String, JsonNode> entry = fields.next();
+          setLocalizedDescription(entry.getKey(), entry.getValue().textValue(), element);
+        }
+      }
+
+    }
+
+  }
+
   protected void convertJsonToFormProperties(JsonNode objectNode, BaseElement element) {
 
     JsonNode formPropertiesNode = getProperty(PROPERTY_FORM_PROPERTIES, objectNode);
@@ -698,5 +763,67 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants, Sten
       resultString = expressionBuilder.toString();
     }
     return resultString;
+  }
+
+  protected void setLocalizedName(String locale, String name, BaseElement element) {
+    upsertLocalizationExtensionElement(locale, name, null, element);
+  }
+
+  protected void setLocalizedDescription(String locale, String description, BaseElement element) {
+    upsertLocalizationExtensionElement(locale, null, description, element);
+  }
+
+  protected void upsertLocalizationExtensionElement(String locale, String name, String description, BaseElement element) {
+    final List<ExtensionElement> localizations = element.getExtensionElements().get("localization");
+    ExtensionElement localization = null;
+    ExtensionAttribute localeAttr = null;
+    ExtensionAttribute nameAttr = null;
+    if (localizations != null) {
+      for (ExtensionElement extensionElement : localizations) {
+        if ((locale.equals(extensionElement.getAttributeValue(null, "locale"))) &&
+                extensionElement.getAttributeValue(null, "name") != null) {
+          localization = extensionElement;
+          localeAttr = extensionElement.getAttributes().get("locale").get(0);
+          nameAttr = extensionElement.getAttributes().get("name").get(0);
+          break;
+        }
+      }
+    }
+    if (localization == null) {
+      localization = new ExtensionElement();
+      localization.setNamespace(ACTIVITI_EXTENSIONS_NAMESPACE);
+      localization.setName("localization");
+      element.addExtensionElement(localization);
+      localeAttr = new ExtensionAttribute("locale");
+      nameAttr = new ExtensionAttribute("name");
+      localization.addAttribute(localeAttr);
+      localization.addAttribute(nameAttr);
+    }
+    if (name == null) {
+      name = localization.getAttributeValue(null, "name");
+    }
+    ExtensionElement documentationElement = null;
+    if (description == null) {
+      List<ExtensionElement> documentationElements = localization.getChildElements().get("documentation");
+      if (documentationElements != null) {
+        for (ExtensionElement docElement : documentationElements) {
+          documentationElement = docElement;
+          description = StringUtils.trimToNull(docElement.getElementText());
+          break;
+        }
+      }
+    }
+    if (description != null && !description.trim().isEmpty()) {
+      if (documentationElement == null) {
+        documentationElement = new ExtensionElement();
+        documentationElement.setNamespace(ACTIVITI_EXTENSIONS_NAMESPACE);
+        documentationElement.setName("documentation");
+        documentationElement.setElementText(description);
+        localization.addChildElement(documentationElement);
+      }
+    }
+    localeAttr.setValue(locale);
+    nameAttr.setValue(name);
+
   }
 }

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
@@ -74,6 +74,7 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements Fo
     }
     
     BpmnJsonConverterUtil.convertDataPropertiesToJson(subProcess.getDataObjects(), propertiesNode);
+    addLocalizationProperties(subProcess, propertiesNode);
   }
 
   protected FlowElement convertJsonToElement(JsonNode elementNode, JsonNode modelNode, Map<String, JsonNode> shapeMap) {
@@ -94,7 +95,7 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements Fo
       subProcess.setDataObjects(dataObjects);
       subProcess.getFlowElements().addAll(dataObjects);
     }
-    
+    addLocalizationExtensionElement(elementNode, subProcess);
     return subProcess;
   }
   

--- a/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/UserTaskJsonConverter.java
+++ b/modules/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/UserTaskJsonConverter.java
@@ -270,6 +270,7 @@ public class UserTaskJsonConverter extends BaseBpmnJsonConverter implements Form
     setPropertyValue(PROPERTY_USERTASK_CATEGORY, userTask.getCategory(), propertiesNode);
 
     addFormProperties(userTask.getFormProperties(), propertiesNode);
+    addLocalizationProperties(userTask, propertiesNode);
   }
 
   protected int getExtensionElementValueAsInt(String name, UserTask userTask) {
@@ -364,6 +365,7 @@ public class UserTaskJsonConverter extends BaseBpmnJsonConverter implements Form
       }
     }
     convertJsonToFormProperties(elementNode, task);
+    addLocalizationExtensionElement(elementNode, task);
     return task;
   }
 

--- a/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
+++ b/modules/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
@@ -1,0 +1,57 @@
+package org.activiti.editor.language;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.ExtensionElement;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class LocalizationConverterTest extends AbstractConverterTest {
+
+    @Test
+    public void convertJsonToModel() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void doubleConversionValidation() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        bpmnModel = convertToJsonAndBack(bpmnModel);
+        validateModel(bpmnModel);
+    }
+
+    protected String getResource() {
+        return "test.usertaskmodel.json";
+    }
+
+    private void validateModel(BpmnModel model) {
+        final UserTask userTask = model.getMainProcess().findFlowElementsOfType(UserTask.class).get(0);
+        final List<ExtensionElement> localization = userTask.getExtensionElements().get("localization");
+        assertNotNull(localization);
+        for (ExtensionElement extensionElement : localization) {
+            final String locale = extensionElement.getAttributeValue(null, "locale");
+            final String name = extensionElement.getAttributeValue(null, "name");
+            final List<ExtensionElement> docs = extensionElement.getChildElements().get("documentation");
+            assertNotNull(name);
+            assertNotNull(docs);
+            assertEquals(docs.size(), 1);
+            if(locale.equals("fa")){
+                assertEquals(name, "ثبت نام");
+            }
+            if(locale.equals("en")){
+                assertEquals(name, "registration");
+            }
+            if(locale.equals("fa")){
+                assertEquals(docs.get(0).getElementText(), "توضیحات ثبت نام");
+            }
+            if(locale.equals("en")){
+                assertEquals(docs.get(0).getElementText(), "registration description");
+            }
+        }
+    }
+}

--- a/modules/activiti-json-converter/src/test/resources/test.usertaskmodel.json
+++ b/modules/activiti-json-converter/src/test/resources/test.usertaskmodel.json
@@ -64,6 +64,16 @@
             	{"event": "complete", "className": "", "expression": "", "delegateExpression": "${someDelegateExpression}", "fields": "undefined"}]},
             "usertaskassignment" : { "assignment" : { "assignee" : "kermit", "owner": "gonzo", 
             		"candidateUsers": [{"value":"kermit"},{"value":"fozzie"}], "candidateGroups": [{"value":"management"},{"value":"sales"}] }
+            },
+            "localization": {
+              "name": {
+                "fa": "ثبت نام",
+                "en": "registration"
+              },
+              "description": {
+                "fa": "توضیحات ثبت نام",
+                "en": "registration description"
+              }
             }
           },
         "resourceId" : "usertask",


### PR DESCRIPTION
This pull request adds support for converting localization extension elements to/from json. Localization information are stored under `properties.localization` (currently for UserTask and SubProcess shapes) in the following format:

```json
{
  "name": {
    "someLocale": "translation of name in someLocale",
    "anotherLocale": "translation of name in anotherLocale"
  },
  "description": {
    "someLocale": "translation of description in someLocale",
    "anotherLocale": "translation of description in anotherLocale"
  }
}
```