### PR TITLE
fix intermittent TooManyResultsException

### DIFF
--- a/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextsCmd.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextsCmd.java
@@ -20,16 +20,18 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 
-public class RetrieveIntegrationContextCmd implements Command<IntegrationContextEntity> {
+import java.util.List;
+
+public class RetrieveIntegrationContextsCmd implements Command<List<IntegrationContextEntity>> {
 
     private String executionId;
 
-    public RetrieveIntegrationContextCmd(String executionId) {
+    public RetrieveIntegrationContextsCmd(String executionId) {
         this.executionId = executionId;
     }
 
     @Override
-    public IntegrationContextEntity execute(CommandContext commandContext) {
+    public List<IntegrationContextEntity> execute(CommandContext commandContext) {
         return commandContext.getProcessEngineConfiguration().getIntegrationContextManager().findIntegrationContextByExecutionId(executionId);
     }
 }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/data/integration/IntegrationContextDataManager.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/data/integration/IntegrationContextDataManager.java
@@ -19,8 +19,10 @@ package org.activiti.engine.impl.persistence.entity.data.integration;
 import org.activiti.engine.impl.persistence.entity.data.DataManager;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 
+import java.util.List;
+
 public interface IntegrationContextDataManager extends DataManager<IntegrationContextEntity> {
 
-    IntegrationContextEntity findIntegrationContextByExecutionId(final String executionId);
+    List<IntegrationContextEntity> findIntegrationContextByExecutionId(final String executionId);
 
 }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/data/integration/MybatisIntegrationContextDataManager.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/data/integration/MybatisIntegrationContextDataManager.java
@@ -21,6 +21,8 @@ import org.activiti.engine.impl.persistence.entity.data.AbstractDataManager;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
 
+import java.util.List;
+
 public class MybatisIntegrationContextDataManager extends AbstractDataManager<IntegrationContextEntity> implements IntegrationContextDataManager {
 
     public MybatisIntegrationContextDataManager(ProcessEngineConfigurationImpl processEngineConfiguration) {
@@ -38,8 +40,8 @@ public class MybatisIntegrationContextDataManager extends AbstractDataManager<In
     }
 
     @Override
-    public IntegrationContextEntity findIntegrationContextByExecutionId(String executionId) {
-        return (IntegrationContextEntity) getDbSqlSession().selectOne("selectIntegrationContextByExecutionId",
+    public List<IntegrationContextEntity> findIntegrationContextByExecutionId(String executionId) {
+        return (List<IntegrationContextEntity>) getDbSqlSession().selectList("selectIntegrationContextByExecutionId",
                                                                       executionId);
 
     }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManager.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManager.java
@@ -18,8 +18,10 @@ package org.activiti.engine.impl.persistence.entity.integration;
 
 import org.activiti.engine.impl.persistence.entity.EntityManager;
 
+import java.util.List;
+
 public interface IntegrationContextManager extends EntityManager<IntegrationContextEntity> {
 
-    IntegrationContextEntity findIntegrationContextByExecutionId(final String executionId);
+    List<IntegrationContextEntity> findIntegrationContextByExecutionId(final String executionId);
 
 }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImpl.java
@@ -21,6 +21,8 @@ import org.activiti.engine.impl.persistence.entity.AbstractEntityManager;
 import org.activiti.engine.impl.persistence.entity.data.DataManager;
 import org.activiti.engine.impl.persistence.entity.data.integration.IntegrationContextDataManager;
 
+import java.util.List;
+
 public class IntegrationContextManagerImpl extends AbstractEntityManager<IntegrationContextEntity> implements IntegrationContextManager {
 
     private final IntegrationContextDataManager dataManager;
@@ -36,7 +38,7 @@ public class IntegrationContextManagerImpl extends AbstractEntityManager<Integra
     }
 
     @Override
-    public IntegrationContextEntity findIntegrationContextByExecutionId(String executionId) {
+    public List<IntegrationContextEntity> findIntegrationContextByExecutionId(String executionId) {
         return dataManager.findIntegrationContextByExecutionId(executionId);
     }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/integration/IntegrationContextService.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/integration/IntegrationContextService.java
@@ -18,9 +18,11 @@ package org.activiti.engine.integration;
 
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 
+import java.util.List;
+
 public interface IntegrationContextService {
 
-    IntegrationContextEntity findIntegrationContextByExecutionId(String executionId);
+    List<IntegrationContextEntity> findIntegrationContextByExecutionId(String executionId);
 
     void deleteIntegrationContext(IntegrationContextEntity integrationContextEntity);
 

--- a/activiti-engine/src/main/java/org/activiti/engine/integration/IntegrationContextServiceImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/integration/IntegrationContextServiceImpl.java
@@ -17,9 +17,11 @@
 package org.activiti.engine.integration;
 
 import org.activiti.engine.impl.cmd.integration.DeleteIntegrationContextCmd;
-import org.activiti.engine.impl.cmd.integration.RetrieveIntegrationContextCmd;
+import org.activiti.engine.impl.cmd.integration.RetrieveIntegrationContextsCmd;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
+
+import java.util.List;
 
 public class IntegrationContextServiceImpl implements IntegrationContextService {
 
@@ -30,8 +32,8 @@ public class IntegrationContextServiceImpl implements IntegrationContextService 
     }
 
     @Override
-    public IntegrationContextEntity findIntegrationContextByExecutionId(String executionId) {
-        return commandExecutor.execute(new RetrieveIntegrationContextCmd(executionId));
+    public List<IntegrationContextEntity> findIntegrationContextByExecutionId(String executionId) {
+        return commandExecutor.execute(new RetrieveIntegrationContextsCmd(executionId));
     }
 
     @Override

--- a/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextCmdTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextCmdTest.java
@@ -24,6 +24,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -51,16 +54,17 @@ public class RetrieveIntegrationContextCmdTest {
     public void executeShouldReturnResultOfIntegrationContextManager() throws Exception {
         //given
         String executionId = "executionId";
-        RetrieveIntegrationContextCmd command = new RetrieveIntegrationContextCmd(executionId);
+        RetrieveIntegrationContextsCmd command = new RetrieveIntegrationContextsCmd(executionId);
 
         IntegrationContextEntity contextEntity = mock(IntegrationContextEntity.class);
-        given(integrationContextManager.findIntegrationContextByExecutionId(executionId)).willReturn(contextEntity);
+        given(integrationContextManager.findIntegrationContextByExecutionId(executionId)).willReturn(Arrays.asList(contextEntity));
 
         //when
-        IntegrationContextEntity executeResult = command.execute(commandContext);
+        Collection<IntegrationContextEntity> executeResult = command.execute(commandContext);
 
         //then
-        assertThat(executeResult).isEqualTo(contextEntity);
+        assertThat(executeResult).contains(contextEntity);
+        assertThat(executeResult).hasSize(1);
     }
 
 }

--- a/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/data/MybatisIntegrationContextDataManagerTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/data/MybatisIntegrationContextDataManagerTest.java
@@ -26,6 +26,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -68,13 +71,14 @@ public class MybatisIntegrationContextDataManagerTest {
         //given
         String executionId = "executionId";
         IntegrationContextEntity entity = mock(IntegrationContextEntity.class);
-        doReturn(entity).when(dbSqlSession).selectOne("selectIntegrationContextByExecutionId", executionId);
+        doReturn(Arrays.asList(entity)).when(dbSqlSession).selectList("selectIntegrationContextByExecutionId", executionId);
 
         //when
-        IntegrationContextEntity retrievedValue = manager.findIntegrationContextByExecutionId(executionId);
+        Collection<IntegrationContextEntity> retrievedValues = manager.findIntegrationContextByExecutionId(executionId);
 
         //then
-        assertThat(retrievedValue).isEqualTo(entity);
+        assertThat(retrievedValues).contains(entity);
+        assertThat(retrievedValues).hasSize(1);
     }
 
 }

--- a/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImplTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImplTest.java
@@ -23,6 +23,9 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -54,13 +57,14 @@ public class IntegrationContextManagerImplTest {
     public void findIntegrationContextByExecutionIdShouldReturnResultFromDataManager() throws Exception {
         //given
         IntegrationContextEntity entity = mock(IntegrationContextEntity.class);
-        given(dataManager.findIntegrationContextByExecutionId("execId")).willReturn(entity);
+        given(dataManager.findIntegrationContextByExecutionId("execId")).willReturn(Arrays.asList(entity));
 
         //when
-        IntegrationContextEntity retrievedEntity = manager.findIntegrationContextByExecutionId("execId");
+        List<IntegrationContextEntity> retrievedResults = manager.findIntegrationContextByExecutionId("execId");
 
         //then
-        assertThat(retrievedEntity).isEqualTo(entity);
+        assertThat(retrievedResults).contains(entity);
+        assertThat(retrievedResults).hasSize(1);
     }
 
 }

--- a/activiti-engine/src/test/java/org/activiti/engine/integration/IntegrationContextServiceImplTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/integration/IntegrationContextServiceImplTest.java
@@ -17,13 +17,16 @@
 package org.activiti.engine.integration;
 
 import org.activiti.engine.impl.cmd.integration.DeleteIntegrationContextCmd;
-import org.activiti.engine.impl.cmd.integration.RetrieveIntegrationContextCmd;
+import org.activiti.engine.impl.cmd.integration.RetrieveIntegrationContextsCmd;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -49,13 +52,14 @@ public class IntegrationContextServiceImplTest {
     public void findIntegrationContextByExecutionIdShouldExecuteRetrieveIntegrationContextCmd() throws Exception {
         //given
         IntegrationContextEntity entity = mock(IntegrationContextEntity.class);
-        given(commandExecutor.execute(any(RetrieveIntegrationContextCmd.class))).willReturn(entity);
+        given(commandExecutor.execute(any(RetrieveIntegrationContextsCmd.class))).willReturn(Arrays.asList(entity));
 
         //when
-        IntegrationContextEntity commandResult = integrationContextService.findIntegrationContextByExecutionId("execId");
+        Collection<IntegrationContextEntity> commandResult = integrationContextService.findIntegrationContextByExecutionId("execId");
 
         //then
-        assertThat(commandResult).isEqualTo(entity);
+        assertThat(commandResult).contains(entity);
+        assertThat(commandResult).hasSize(1);
     }
 
     @Test


### PR DESCRIPTION
Fix the rare and intermittent org.apache.ibatis.exceptions.TooManyResultsException: Expected one result (or null) to be returned by selectOne(), but found: 2 error

org.activiti.engine.integration.IntegrationContextServiceImpl.findIntegrationContextByExecutionId(IntegrationContextServiceImpl.java:34)
org.activiti.services.connectors.channel.ServiceTaskIntegrationResultEventHandler.receive(ServiceTaskIntegrationResultEventHandler.java:60)
org.activiti.engine.impl.persistence.entity.data.integration.MybatisIntegrationContextDataManager.findIntegrationContextByExecutionId(MybatisIntegrationContextDataManager.java:42)