### PR TITLE
feat: add support for localization information conversion

### DIFF
--- a/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
+++ b/activiti-json-converter/src/main/java/org/activiti/editor/constants/StencilConstants.java
@@ -241,4 +241,6 @@ public interface StencilConstants {
   final String PROPERTY_DECISIONTABLE_REFERENCE_ID = "decisiontablereferenceid";
   final String PROPERTY_DECISIONTABLE_REFERENCE_NAME = "decisiontablereferencename";
   final String PROPERTY_DECISIONTABLE_REFERENCE_KEY = "decisionTableReferenceKey";
+
+  final String PROPERTY_LOCALIZATION = "localization";
 }

--- a/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
+++ b/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/BaseBpmnJsonConverter.java
@@ -13,6 +13,7 @@
 package org.activiti.editor.language.json.converter;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +32,7 @@ import org.activiti.bpmn.model.DataStoreReference;
 import org.activiti.bpmn.model.ErrorEventDefinition;
 import org.activiti.bpmn.model.Event;
 import org.activiti.bpmn.model.EventDefinition;
+import org.activiti.bpmn.model.ExtensionAttribute;
 import org.activiti.bpmn.model.ExtensionElement;
 import org.activiti.bpmn.model.FieldExtension;
 import org.activiti.bpmn.model.FlowElement;
@@ -70,6 +72,7 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants,
     protected static final Logger LOGGER = LoggerFactory.getLogger(BaseBpmnJsonConverter.class);
 
     public static final String NAMESPACE = "http://activiti.com/modeler";
+    public static final String ACTIVITI_EXTENSIONS_NAMESPACE = "http://activiti.org/bpmn";
 
     protected ObjectMapper objectMapper = new ObjectMapper();
     protected ActivityProcessor processor;
@@ -604,6 +607,77 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants,
         }
     }
 
+    protected void addLocalizationProperties(BaseElement baseElement,
+                                             ObjectNode propertiesNode) {
+        List<ExtensionElement> localizationElements = baseElement.getExtensionElements().get("localization");
+        if (localizationElements != null) {
+            ObjectNode localizationNode = objectMapper.createObjectNode();
+            ObjectNode nameNode = localizationNode.putObject("name");
+            ObjectNode descriptionNode = localizationNode.putObject("description");
+
+            for (ExtensionElement localizationElement : localizationElements) {
+                if (ACTIVITI_EXTENSIONS_NAMESPACE.equals(localizationElement.getNamespace())) {
+                    String locale = localizationElement.getAttributeValue(null,
+                                                                          "locale");
+                    String name = localizationElement.getAttributeValue(null,
+                                                                        "name");
+                    String documentation = null;
+                    List<ExtensionElement> documentationElements = localizationElement.getChildElements().get("documentation");
+                    if (documentationElements != null) {
+                        for (ExtensionElement documentationElement : documentationElements) {
+                            documentation = StringUtils.trimToNull(documentationElement.getElementText());
+                            break;
+                        }
+                    }
+                    if (name != null && !name.trim().isEmpty()) {
+                        nameNode.put(locale,
+                                     name);
+                    }
+                    if (documentation != null && !documentation.trim().isEmpty()) {
+
+                        descriptionNode.put(locale,
+                                            documentation);
+                    }
+                }
+            }
+            if (nameNode.fieldNames().hasNext() || descriptionNode.fieldNames().hasNext()) {
+                propertiesNode.set("localization",
+                                   localizationNode);
+            }
+        }
+    }
+
+    protected void addLocalizationExtensionElement(JsonNode objectNode,
+                                                   BaseElement element) {
+        JsonNode localizationNode = getProperty(PROPERTY_LOCALIZATION,
+                                                objectNode);
+        if (localizationNode != null) {
+            localizationNode = BpmnJsonConverterUtil.validateIfNodeIsTextual(localizationNode);
+            final JsonNode nameNode = localizationNode.get("name");
+            Iterator<Map.Entry<String, JsonNode>> fields;
+            if (nameNode != null) {
+                fields = nameNode.fields();
+                while (fields.hasNext()) {
+                    final Map.Entry<String, JsonNode> entry = fields.next();
+                    setLocalizedName(entry.getKey(),
+                                     entry.getValue().textValue(),
+                                     element);
+                }
+            }
+            final JsonNode descriptionNode = localizationNode.get("description");
+            if (descriptionNode != null) {
+                fields = descriptionNode.fields();
+                while (fields.hasNext()) {
+                    final Map.Entry<String, JsonNode> entry = fields.next();
+                    setLocalizedDescription(entry.getKey(),
+                                            entry.getValue().textValue(),
+                                            element);
+                }
+            }
+        }
+    }
+
+
     protected void convertJsonToFormProperties(JsonNode objectNode,
                                                BaseElement element) {
 
@@ -833,5 +907,82 @@ public abstract class BaseBpmnJsonConverter implements EditorJsonConstants,
             resultString = expressionBuilder.toString();
         }
         return resultString;
+    }
+
+    protected void setLocalizedName(String locale,
+                                    String name,
+                                    BaseElement element) {
+        upsertLocalizationExtensionElement(locale,
+                                           name,
+                                           null,
+                                           element);
+    }
+
+    protected void setLocalizedDescription(String locale,
+                                           String description,
+                                           BaseElement element) {
+        upsertLocalizationExtensionElement(locale,
+                                           null,
+                                           description,
+                                           element);
+    }
+
+    protected void upsertLocalizationExtensionElement(String locale,
+                                                      String name,
+                                                      String description,
+                                                      BaseElement element) {
+        final List<ExtensionElement> localizations = element.getExtensionElements().get("localization");
+        ExtensionElement localization = null;
+        ExtensionAttribute localeAttr = null;
+        ExtensionAttribute nameAttr = null;
+        if (localizations != null) {
+            for (ExtensionElement extensionElement : localizations) {
+                if ((locale.equals(extensionElement.getAttributeValue(null,
+                                                                      "locale"))) &&
+                        extensionElement.getAttributeValue(null,
+                                                           "name") != null) {
+                    localization = extensionElement;
+                    localeAttr = extensionElement.getAttributes().get("locale").get(0);
+                    nameAttr = extensionElement.getAttributes().get("name").get(0);
+                    break;
+                }
+            }
+        }
+        if (localization == null) {
+            localization = new ExtensionElement();
+            localization.setNamespace(ACTIVITI_EXTENSIONS_NAMESPACE);
+            localization.setName("localization");
+            element.addExtensionElement(localization);
+            localeAttr = new ExtensionAttribute("locale");
+            nameAttr = new ExtensionAttribute("name");
+            localization.addAttribute(localeAttr);
+            localization.addAttribute(nameAttr);
+        }
+        if (name == null) {
+            name = localization.getAttributeValue(null,
+                                                  "name");
+        }
+        ExtensionElement documentationElement = null;
+        if (description == null) {
+            List<ExtensionElement> documentationElements = localization.getChildElements().get("documentation");
+            if (documentationElements != null) {
+                for (ExtensionElement docElement : documentationElements) {
+                    documentationElement = docElement;
+                    description = StringUtils.trimToNull(docElement.getElementText());
+                    break;
+                }
+            }
+        }
+        if (description != null && !description.trim().isEmpty()) {
+            if (documentationElement == null) {
+                documentationElement = new ExtensionElement();
+                documentationElement.setNamespace(ACTIVITI_EXTENSIONS_NAMESPACE);
+                documentationElement.setName("documentation");
+                documentationElement.setElementText(description);
+                localization.addChildElement(documentationElement);
+            }
+        }
+        localeAttr.setValue(locale);
+        nameAttr.setValue(name);
     }
 }

--- a/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
+++ b/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
@@ -29,94 +29,119 @@ import org.activiti.editor.language.json.model.ModelInfo;
 /**
 
  */
-public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements FormAwareConverter, FormKeyAwareConverter, 
-    DecisionTableAwareConverter, DecisionTableKeyAwareConverter {
-  
-  protected Map<String, String> formMap;
-  protected Map<String, ModelInfo> formKeyMap;
-  protected Map<String, String> decisionTableMap;
-  protected Map<String, ModelInfo> decisionTableKeyMap;
-  
-  public static void fillTypes(Map<String, Class<? extends BaseBpmnJsonConverter>> convertersToBpmnMap,
-          Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
-  
-    fillJsonTypes(convertersToBpmnMap);
-    fillBpmnTypes(convertersToJsonMap);
-  }
+public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements FormAwareConverter,
+                                                                              FormKeyAwareConverter,
+                                                                              DecisionTableAwareConverter,
+                                                                              DecisionTableKeyAwareConverter {
 
-  public static void fillJsonTypes(Map<String, Class<? extends BaseBpmnJsonConverter>> convertersToBpmnMap) {
-    convertersToBpmnMap.put(STENCIL_SUB_PROCESS, SubProcessJsonConverter.class);
-  }
+    protected Map<String, String> formMap;
+    protected Map<String, ModelInfo> formKeyMap;
+    protected Map<String, String> decisionTableMap;
+    protected Map<String, ModelInfo> decisionTableKeyMap;
 
-  public static void fillBpmnTypes(Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
-    convertersToJsonMap.put(SubProcess.class, SubProcessJsonConverter.class);
-    convertersToJsonMap.put(Transaction.class, SubProcessJsonConverter.class);
-  }
-  
-  protected String getStencilId(BaseElement baseElement) {
-    return STENCIL_SUB_PROCESS;
-  }
+    public static void fillTypes(Map<String, Class<? extends BaseBpmnJsonConverter>> convertersToBpmnMap,
+                                 Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
 
-  protected void convertElementToJson(ObjectNode propertiesNode, BaseElement baseElement) {
-    SubProcess subProcess = (SubProcess) baseElement;
-  
-    propertiesNode.put("activitytype", "Sub-Process");
-    propertiesNode.put("subprocesstype", "Embedded");
-    ArrayNode subProcessShapesArrayNode = objectMapper.createArrayNode();
-    GraphicInfo graphicInfo = model.getGraphicInfo(subProcess.getId());
-    processor.processFlowElements(subProcess, model, subProcessShapesArrayNode, formKeyMap,
-        decisionTableKeyMap, graphicInfo.getX(), graphicInfo.getY());
-    flowElementNode.set("childShapes", subProcessShapesArrayNode);
-    
-    if (subProcess instanceof Transaction) {
-      propertiesNode.put("istransaction", true);
+        fillJsonTypes(convertersToBpmnMap);
+        fillBpmnTypes(convertersToJsonMap);
     }
 
-    BpmnJsonConverterUtil.convertDataPropertiesToJson(subProcess.getDataObjects(), propertiesNode);
-    addLocalizationProperties(subProcess,
-                              propertiesNode);
-  }
+    public static void fillJsonTypes(Map<String, Class<? extends BaseBpmnJsonConverter>> convertersToBpmnMap) {
+        convertersToBpmnMap.put(STENCIL_SUB_PROCESS,
+                                SubProcessJsonConverter.class);
+    }
 
-  protected FlowElement convertJsonToElement(JsonNode elementNode, JsonNode modelNode, Map<String, JsonNode> shapeMap) {
-    SubProcess subProcess = null;
-    if (getPropertyValueAsBoolean("istransaction", elementNode)) {
-      subProcess = new Transaction();
-      
-    } else {
-      subProcess = new SubProcess();
+    public static void fillBpmnTypes(Map<Class<? extends BaseElement>, Class<? extends BaseBpmnJsonConverter>> convertersToJsonMap) {
+        convertersToJsonMap.put(SubProcess.class,
+                                SubProcessJsonConverter.class);
+        convertersToJsonMap.put(Transaction.class,
+                                SubProcessJsonConverter.class);
     }
-    
-    JsonNode childShapesArray = elementNode.get(EDITOR_CHILD_SHAPES);
-    processor.processJsonElements(childShapesArray, modelNode, subProcess, shapeMap, formMap, decisionTableMap, model);
-    
-    JsonNode processDataPropertiesNode = elementNode.get(EDITOR_SHAPE_PROPERTIES).get(PROPERTY_DATA_PROPERTIES);
-    if (processDataPropertiesNode != null) {
-      List<ValuedDataObject> dataObjects = BpmnJsonConverterUtil.convertJsonToDataProperties(processDataPropertiesNode, subProcess);
-      subProcess.setDataObjects(dataObjects);
-      subProcess.getFlowElements().addAll(dataObjects);
+
+    protected String getStencilId(BaseElement baseElement) {
+        return STENCIL_SUB_PROCESS;
     }
-    addLocalizationExtensionElement(elementNode,
-                                    subProcess);
-    return subProcess;
-  }
-  
-  @Override
-  public void setFormMap(Map<String, String> formMap) {
-    this.formMap = formMap;
-  }
-  
-  @Override
-  public void setFormKeyMap(Map<String, ModelInfo> formKeyMap) {
-    this.formKeyMap = formKeyMap;
-  }
-  
-  @Override
-  public void setDecisionTableMap(Map<String, String> decisionTableMap) {
-    this.decisionTableMap = decisionTableMap;
-  }
-  
-  @Override
-  public void setDecisionTableKeyMap(Map<String, ModelInfo> decisionTableKeyMap) {
-    this.decisionTableKeyMap = decisionTableKeyMap;
-  }
+
+    protected void convertElementToJson(ObjectNode propertiesNode,
+                                        BaseElement baseElement) {
+        SubProcess subProcess = (SubProcess) baseElement;
+
+        propertiesNode.put("activitytype",
+                           "Sub-Process");
+        propertiesNode.put("subprocesstype",
+                           "Embedded");
+        ArrayNode subProcessShapesArrayNode = objectMapper.createArrayNode();
+        GraphicInfo graphicInfo = model.getGraphicInfo(subProcess.getId());
+        processor.processFlowElements(subProcess,
+                                      model,
+                                      subProcessShapesArrayNode,
+                                      formKeyMap,
+                                      decisionTableKeyMap,
+                                      graphicInfo.getX(),
+                                      graphicInfo.getY());
+        flowElementNode.set("childShapes",
+                            subProcessShapesArrayNode);
+
+        if (subProcess instanceof Transaction) {
+            propertiesNode.put("istransaction",
+                               true);
+        }
+
+        BpmnJsonConverterUtil.convertDataPropertiesToJson(subProcess.getDataObjects(),
+                                                          propertiesNode);
+        addLocalizationProperties(subProcess,
+                                  propertiesNode);
+    }
+
+    protected FlowElement convertJsonToElement(JsonNode elementNode,
+                                               JsonNode modelNode,
+                                               Map<String, JsonNode> shapeMap) {
+        SubProcess subProcess = null;
+        if (getPropertyValueAsBoolean("istransaction",
+                                      elementNode)) {
+            subProcess = new Transaction();
+        } else {
+            subProcess = new SubProcess();
+        }
+
+        JsonNode childShapesArray = elementNode.get(EDITOR_CHILD_SHAPES);
+        processor.processJsonElements(childShapesArray,
+                                      modelNode,
+                                      subProcess,
+                                      shapeMap,
+                                      formMap,
+                                      decisionTableMap,
+                                      model);
+
+        JsonNode processDataPropertiesNode = elementNode.get(EDITOR_SHAPE_PROPERTIES).get(PROPERTY_DATA_PROPERTIES);
+        if (processDataPropertiesNode != null) {
+            List<ValuedDataObject> dataObjects = BpmnJsonConverterUtil.convertJsonToDataProperties(processDataPropertiesNode,
+                                                                                                   subProcess);
+            subProcess.setDataObjects(dataObjects);
+            subProcess.getFlowElements().addAll(dataObjects);
+        }
+        addLocalizationExtensionElement(elementNode,
+                                        subProcess);
+        return subProcess;
+    }
+
+    @Override
+    public void setFormMap(Map<String, String> formMap) {
+        this.formMap = formMap;
+    }
+
+    @Override
+    public void setFormKeyMap(Map<String, ModelInfo> formKeyMap) {
+        this.formKeyMap = formKeyMap;
+    }
+
+    @Override
+    public void setDecisionTableMap(Map<String, String> decisionTableMap) {
+        this.decisionTableMap = decisionTableMap;
+    }
+
+    @Override
+    public void setDecisionTableKeyMap(Map<String, ModelInfo> decisionTableKeyMap) {
+        this.decisionTableKeyMap = decisionTableKeyMap;
+    }
 }

--- a/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
+++ b/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/SubProcessJsonConverter.java
@@ -15,6 +15,9 @@ package org.activiti.editor.language.json.converter;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.GraphicInfo;
@@ -22,10 +25,6 @@ import org.activiti.bpmn.model.SubProcess;
 import org.activiti.bpmn.model.Transaction;
 import org.activiti.bpmn.model.ValuedDataObject;
 import org.activiti.editor.language.json.model.ModelInfo;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
 
@@ -72,8 +71,10 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements Fo
     if (subProcess instanceof Transaction) {
       propertiesNode.put("istransaction", true);
     }
-    
+
     BpmnJsonConverterUtil.convertDataPropertiesToJson(subProcess.getDataObjects(), propertiesNode);
+    addLocalizationProperties(subProcess,
+                              propertiesNode);
   }
 
   protected FlowElement convertJsonToElement(JsonNode elementNode, JsonNode modelNode, Map<String, JsonNode> shapeMap) {
@@ -94,7 +95,8 @@ public class SubProcessJsonConverter extends BaseBpmnJsonConverter implements Fo
       subProcess.setDataObjects(dataObjects);
       subProcess.getFlowElements().addAll(dataObjects);
     }
-    
+    addLocalizationExtensionElement(elementNode,
+                                    subProcess);
     return subProcess;
   }
   

--- a/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/UserTaskJsonConverter.java
+++ b/activiti-json-converter/src/main/java/org/activiti/editor/language/json/converter/UserTaskJsonConverter.java
@@ -16,6 +16,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.activiti.bpmn.model.BaseElement;
 import org.activiti.bpmn.model.ExtensionElement;
 import org.activiti.bpmn.model.FlowElement;
@@ -24,10 +27,6 @@ import org.activiti.editor.language.json.converter.util.CollectionUtils;
 import org.activiti.editor.language.json.model.ModelInfo;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
 
@@ -270,6 +269,8 @@ public class UserTaskJsonConverter extends BaseBpmnJsonConverter implements Form
     setPropertyValue(PROPERTY_USERTASK_CATEGORY, userTask.getCategory(), propertiesNode);
 
     addFormProperties(userTask.getFormProperties(), propertiesNode);
+    addLocalizationProperties(userTask,
+                              propertiesNode);
   }
 
   protected int getExtensionElementValueAsInt(String name, UserTask userTask) {
@@ -364,6 +365,8 @@ public class UserTaskJsonConverter extends BaseBpmnJsonConverter implements Form
       }
     }
     convertJsonToFormProperties(elementNode, task);
+    addLocalizationExtensionElement(elementNode,
+                                    task);
     return task;
   }
 

--- a/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
+++ b/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
@@ -1,0 +1,63 @@
+package org.activiti.editor.language;
+
+import java.util.List;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.ExtensionElement;
+import org.activiti.bpmn.model.UserTask;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class LocalizationConverterTest extends AbstractConverterTest {
+
+    @Test
+    public void convertJsonToModel() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void doubleConversionValidation() throws Exception {
+        BpmnModel bpmnModel = readJsonFile();
+        bpmnModel = convertToJsonAndBack(bpmnModel);
+        validateModel(bpmnModel);
+    }
+
+    protected String getResource() {
+        return "test.usertaskmodel.json";
+    }
+
+    private void validateModel(BpmnModel model) {
+        final UserTask userTask = model.getMainProcess().findFlowElementsOfType(UserTask.class).get(0);
+        final List<ExtensionElement> localization = userTask.getExtensionElements().get("localization");
+        assertNotNull(localization);
+        for (ExtensionElement extensionElement : localization) {
+            final String locale = extensionElement.getAttributeValue(null,
+                                                                     "locale");
+            final String name = extensionElement.getAttributeValue(null,
+                                                                   "name");
+            final List<ExtensionElement> docs = extensionElement.getChildElements().get("documentation");
+            assertNotNull(name);
+            assertNotNull(docs);
+            assertEquals(docs.size(),
+                         1);
+            if (locale.equals("fa")) {
+                assertEquals(name,
+                             "ثبت نام");
+            }
+            if (locale.equals("en")) {
+                assertEquals(name,
+                             "registration");
+            }
+            if (locale.equals("fa")) {
+                assertEquals(docs.get(0).getElementText(),
+                             "توضیحات ثبت نام");
+            }
+            if (locale.equals("en")) {
+                assertEquals(docs.get(0).getElementText(),
+                             "registration description");
+            }
+        }
+    }
+}

--- a/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
+++ b/activiti-json-converter/src/test/java/org/activiti/editor/language/LocalizationConverterTest.java
@@ -42,19 +42,19 @@ public class LocalizationConverterTest extends AbstractConverterTest {
             assertNotNull(docs);
             assertEquals(docs.size(),
                          1);
-            if (locale.equals("fa")) {
+            if ("fa".equals(locale)) {
                 assertEquals(name,
                              "ثبت نام");
             }
-            if (locale.equals("en")) {
+            if ("en".equals(locale)) {
                 assertEquals(name,
                              "registration");
             }
-            if (locale.equals("fa")) {
+            if ("fa".equals(locale)) {
                 assertEquals(docs.get(0).getElementText(),
                              "توضیحات ثبت نام");
             }
-            if (locale.equals("en")) {
+            if ("en".equals(locale)) {
                 assertEquals(docs.get(0).getElementText(),
                              "registration description");
             }

--- a/activiti-json-converter/src/test/resources/test.usertaskmodel.json
+++ b/activiti-json-converter/src/test/resources/test.usertaskmodel.json
@@ -64,6 +64,16 @@
             	{"event": "complete", "className": "", "expression": "", "delegateExpression": "${someDelegateExpression}", "fields": "undefined"}]},
             "usertaskassignment" : { "assignment" : { "assignee" : "kermit", "owner": "gonzo", 
             		"candidateUsers": [{"value":"kermit"},{"value":"fozzie"}], "candidateGroups": [{"value":"management"},{"value":"sales"}] }
+            },
+          "localization": {
+            "name": {
+              "fa": "ثبت نام",
+              "en": "registration"
+            },
+            "description": {
+              "fa": "توضیحات ثبت نام",
+              "en": "registration description"
+            }
             }
           },
         "resourceId" : "usertask",


### PR DESCRIPTION
Activiti currently supports localized **name** and **documentation** for a couple of things such as `UserTask` and `SubProcess`. This support for specifying name and documentation in different locales is done via a special **localization** extension element, and is handled inside [`BpmnDeployer#createLocalizationValues()`][1]. 
However `ActivitiJsonConverter` doesn't care about this localization information and it's not retained when converting to/from json.

This pull request adds support for converting localization information when converting `BpmnModel` to/from json via `ActivitiJsonConverter`.

[1]: https://github.com/Activiti/Activiti/blob/f1526dba92702aa07a0dcffb0144436d45074c7a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java#L261