### PR TITLE
Update history of inheritBusinessKey

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -115,9 +115,11 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
     if (!StringUtils.isEmpty(businessKey)) {
       Expression expression = expressionManager.createExpression(businessKey);
       subProcessInstance.setBusinessKey(expression.getValue(execution).toString());
+      Context.getCommandContext().getHistoryManager().updateProcessBusinessKeyInHistory((ExecutionEntity) subProcessInstance);
     } else if (inheritBusinessKey) {
       ExecutionEntity processInstance = executionEntityManager.findExecutionById(execution.getProcessInstanceId());
       subProcessInstance.setBusinessKey(processInstance.getBusinessKey());
+      Context.getCommandContext().getHistoryManager().updateProcessBusinessKeyInHistory((ExecutionEntity) subProcessInstance);
     }
 
     if (inheritVariables) {

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/CallActivityTest.java
@@ -23,6 +23,7 @@ import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.history.HistoricActivityInstance;
 import org.activiti.engine.history.HistoricActivityInstanceQuery;
+import org.activiti.engine.history.HistoricProcessInstance;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
@@ -268,10 +269,14 @@ public class CallActivityTest extends ResourceActivitiTestCase {
     pi = runtimeService.startProcessInstanceByKey("mainProcessBusinessKey", variables);
     subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
     assertEquals("123", subProcessInstance.getBusinessKey());
+    HistoricProcessInstance historicSubProcessInstance = historyService.createHistoricProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+    assertEquals("123", historicSubProcessInstance.getBusinessKey());
 
     // Inherit business key
     pi = runtimeService.startProcessInstanceByKey("mainProcessInheritBusinessKey", "123");
     subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
     assertEquals("123", subProcessInstance.getBusinessKey());
+    historicSubProcessInstance = historyService.createHistoricProcessInstanceQuery().superProcessInstanceId(pi.getId()).singleResult();
+    assertEquals("123", historicSubProcessInstance.getBusinessKey());
   }
 }


### PR DESCRIPTION
I fixed the bug that the history of businessKey cannot be updated in case of using inheritBusinessKey.
This bug is related to https://github.com/Activiti/Activiti/pull/1567.