### PR TITLE
added fix for class loader not handling primitive types

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/util/ReflectUtil.java
@@ -38,7 +38,22 @@ public abstract class ReflectUtil {
 
   private static final Pattern GETTER_PATTERN = Pattern.compile("(get|is)[A-Z].*");
   private static final Pattern SETTER_PATTERN = Pattern.compile("set[A-Z].*");
+  private static final String[] PRIMITIVE_NAMES = new String[] { "boolean",
+          "byte", "char", "double", "float", "int", "long", "short", "void" };
 
+  private static final Class<?>[] PRIMITIVES = new Class[] { boolean.class,
+          byte.class, char.class, double.class, float.class, int.class,
+          long.class, short.class, Void.TYPE };
+
+  private static Class<?> forNamePrimitive(String name) {
+    if (name.length() <= 8) {
+      int p = Arrays.binarySearch(PRIMITIVE_NAMES, name);
+      if (p >= 0) {
+        return PRIMITIVES[p];
+      }
+    }
+    return null;
+  }
   public static ClassLoader getClassLoader() {
     ClassLoader loader = getCustomClassLoader();
     if(loader == null) {
@@ -49,6 +64,12 @@ public abstract class ReflectUtil {
   
   public static Class<?> loadClass(String className) {
    Class<?> clazz = null;
+
+   clazz = forNamePrimitive(className);
+   if(clazz!=null){
+     return clazz;
+   }
+
    ClassLoader classLoader = getCustomClassLoader();
    
    // First exception in chain of classloaders will be used as cause when no class is found in any of them

--- a/modules/activiti-engine/src/test/java/org/activiti/engine/impl/util/ReflectUtilTest.java
+++ b/modules/activiti-engine/src/test/java/org/activiti/engine/impl/util/ReflectUtilTest.java
@@ -1,0 +1,16 @@
+package org.activiti.engine.impl.util;
+
+import junit.framework.TestCase;
+
+public class ReflectUtilTest extends TestCase {
+
+    public void testLoadNonPrimitiveClass() {
+        Class<?> aClass = ReflectUtil.loadClass("java.lang.Integer");
+        assertNotNull(aClass);
+    }
+
+    public void testLoadPrimitiveClass() {
+        Class<?> aClass = ReflectUtil.loadClass("int");
+        assertNotNull(aClass);
+    }
+}


### PR DESCRIPTION
In regards to issue #1905 

I added  a new private method `forNamePrimitive()` which checks if the class to be loaded is a primitive type. 

The code has been ported from tomcat-embedded project `org.apache.el.util.ReflectionUtil.java`. [Similar workaround is done in similar way in many other popular frameworks like spring.](https://stackoverflow.com/a/11284822/2557818) .