### PR TITLE
Avoid failure when process definitions folder is not found

### DIFF
--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -215,6 +215,8 @@ public class BpmnDeployer implements Deployer {
     protected void dispatchProcessDefinitionEntityInitializedEvent(ParsedDeployment parsedDeployment) {
         CommandContext commandContext = Context.getCommandContext();
         for (ProcessDefinitionEntity processDefinitionEntity : parsedDeployment.getAllProcessDefinitions()) {
+            log.info("Process deployed: {id: " + processDefinitionEntity.getId() +
+                ", key: " + processDefinitionEntity.getKey() + "}");
             if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
                 commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                         ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_INITIALIZED,

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -54,12 +54,20 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
   protected boolean isProcessValidationEnabled = true;
   protected boolean isDuplicateFilterEnabled;
   protected Date processDefinitionsActivationDate;
-  protected Map<String, Object> deploymentProperties = new HashMap<String, Object>();
+  protected Map<String, Object> deploymentProperties = new HashMap<>();
 
   public DeploymentBuilderImpl(RepositoryServiceImpl repositoryService) {
+    this(repositoryService,
+         Context.getProcessEngineConfiguration().getDeploymentEntityManager().create(),
+         Context.getProcessEngineConfiguration().getResourceEntityManager());
+  }
+
+  public DeploymentBuilderImpl(RepositoryServiceImpl repositoryService,
+                               DeploymentEntity deployment,
+                               ResourceEntityManager resourceEntityManager) {
     this.repositoryService = repositoryService;
-    this.deployment = Context.getProcessEngineConfiguration().getDeploymentEntityManager().create();
-    this.resourceEntityManager = Context.getProcessEngineConfiguration().getResourceEntityManager();
+    this.deployment = deployment;
+    this.resourceEntityManager = resourceEntityManager;
   }
 
   public DeploymentBuilder addInputStream(String resourceName, InputStream inputStream) {
@@ -89,7 +97,7 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
         }
       }
     } catch (IOException e) {
-      throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
+      throw new ActivitiException("Couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
     }
     return this;
   }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/repository/DeploymentBuilderImpl.java
@@ -12,6 +12,7 @@
  */
 package org.activiti.engine.impl.repository;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
@@ -34,6 +35,7 @@ import org.activiti.engine.impl.util.IoUtil;
 import org.activiti.engine.impl.util.ReflectUtil;
 import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.repository.DeploymentBuilder;
+import org.springframework.core.io.Resource;
 
 /**
 
@@ -69,6 +71,26 @@ public class DeploymentBuilderImpl implements DeploymentBuilder, Serializable {
     resource.setName(resourceName);
     resource.setBytes(bytes);
     deployment.addResource(resource);
+    return this;
+  }
+
+  @Override
+  public DeploymentBuilder addInputStream(String resourceName,
+                                          Resource resource) {
+    try {
+      if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
+        try(ZipInputStream inputStream = new ZipInputStream(resource.getInputStream())) {
+          addZipInputStream(inputStream);
+        }
+      } else {
+        try(InputStream inputStream = resource.getInputStream()) {
+          addInputStream(resourceName,
+                         inputStream);
+        }
+      }
+    } catch (IOException e) {
+      throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
+    }
     return this;
   }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentBuilder.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentBuilder.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.zip.ZipInputStream;
 
 import org.activiti.bpmn.model.BpmnModel;
+import org.springframework.core.io.Resource;
 
 /**
  * Builder for creating new deployments.
@@ -33,6 +34,9 @@ import org.activiti.bpmn.model.BpmnModel;
 public interface DeploymentBuilder {
 
   DeploymentBuilder addInputStream(String resourceName, InputStream inputStream);
+
+  DeploymentBuilder addInputStream(String resourceName,
+                                   Resource resource);
 
   DeploymentBuilder addClasspathResource(String resource);
 

--- a/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.repository;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.activiti.engine.ActivitiException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.springframework.core.io.Resource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class DeploymentBuilderImplTest {
+
+    @Spy
+    @InjectMocks
+    private DeploymentBuilderImpl deploymentBuilder;
+
+    @Mock(answer = Answers.RETURNS_MOCKS)
+    private Resource resource;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+    }
+
+    @Test
+    public void addInputStreamShouldAddZipInputStreamWhenItsAZipLike() {
+        //given
+        doReturn(deploymentBuilder).when(deploymentBuilder).addZipInputStream(any());
+
+        //when
+        deploymentBuilder.addInputStream("my.bar",
+                                         resource);
+
+        //then
+        verify(deploymentBuilder).addZipInputStream(any());
+    }
+
+    @Test
+    public void addInputStreamShouldAddNormalImportStreamWhenITsNotAZipLike() throws Exception {
+        //given
+        String resourceName = "any.xml";
+        InputStream inputStream = mock(InputStream.class);
+        given(resource.getInputStream()).willReturn(inputStream);
+
+        doReturn(deploymentBuilder).when(deploymentBuilder).addInputStream(resourceName,
+                                                                           inputStream);
+
+        //when
+        deploymentBuilder.addInputStream(resourceName, resource);
+
+        //then
+        verify(deploymentBuilder).addInputStream(resourceName, inputStream);
+    }
+
+    @Test
+    public void ShouldThrowActivitiExceptionWhenIOExceptionIsThrown() throws Exception {
+        //given
+        given(resource.getInputStream()).willThrow(new IOException());
+
+        //when
+        Throwable thrown = catchThrowable(() ->
+                                                     deploymentBuilder.addInputStream("any.xml",
+                                                                                      resource));
+
+        //then
+        assertThat(thrown)
+                .isInstanceOf(ActivitiException.class)
+                .hasMessageContaining("Couldn't auto deploy resource");
+    }
+}

--- a/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
@@ -75,21 +75,23 @@ public class DeploymentBuilderImplTest {
                                                                            inputStream);
 
         //when
-        deploymentBuilder.addInputStream(resourceName, resource);
+        deploymentBuilder.addInputStream(resourceName,
+                                         resource);
 
         //then
-        verify(deploymentBuilder).addInputStream(resourceName, inputStream);
+        verify(deploymentBuilder).addInputStream(resourceName,
+                                                 inputStream);
     }
 
     @Test
-    public void ShouldThrowActivitiExceptionWhenIOExceptionIsThrown() throws Exception {
+    public void addInputStreamShouldThrowActivitiExceptionWhenIOExceptionIsThrown() throws Exception {
         //given
         given(resource.getInputStream()).willThrow(new IOException());
 
         //when
         Throwable thrown = catchThrowable(() ->
-                                                     deploymentBuilder.addInputStream("any.xml",
-                                                                                      resource));
+                                                  deploymentBuilder.addInputStream("any.xml",
+                                                                                   resource));
 
         //then
         assertThat(thrown)

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,20 +12,16 @@
  */
 package org.activiti.spring.boot;
 
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import javax.sql.DataSource;
 
-import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.engine.HistoryService;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.TaskService;
-import org.activiti.engine.impl.persistence.StrongUuidGenerator;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
 import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.spring.ProcessEngineFactoryBean;
@@ -33,197 +29,98 @@ import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringCallerRunsRejectedJobsHandler;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.activiti.spring.SpringRejectedJobsHandler;
-import org.activiti.spring.bpmn.parser.CloudActivityBehaviorFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.util.StringUtils;
 
 /**
  * Provides sane definitions for the various beans required to be productive with Activiti in Spring.
+ *
  */
 public abstract class AbstractProcessEngineAutoConfiguration
         extends AbstractProcessEngineConfiguration {
 
-    private ActivitiProperties activitiProperties;
+  @Bean
+  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor taskExecutor) {
+    return new SpringAsyncExecutor(taskExecutor, springRejectedJobsHandler());
+  }
+  
+  @Bean 
+  public SpringRejectedJobsHandler springRejectedJobsHandler() {
+    return new SpringCallerRunsRejectedJobsHandler();
+  }
 
-    @Autowired
-    private ResourcePatternResolver resourceLoader;
-
-    @Autowired(required = false)
-    private ProcessEngineConfigurationConfigurer processEngineConfigurationConfigurer;
-
-    @Bean
-    public SpringAsyncExecutor springAsyncExecutor(TaskExecutor taskExecutor) {
-        return new SpringAsyncExecutor(taskExecutor,
-                                       springRejectedJobsHandler());
+  protected Set<Class<?>> getCustomMybatisMapperClasses(List<String> customMyBatisMappers) {
+    Set<Class<?>> mybatisMappers = new HashSet<>();
+    for (String customMybatisMapperClassName : customMyBatisMappers) {
+      try {
+        Class customMybatisClass = Class.forName(customMybatisMapperClassName);
+        mybatisMappers.add(customMybatisClass);
+      } catch (ClassNotFoundException e) {
+        throw new IllegalArgumentException("Class " + customMybatisMapperClassName + " has not been found.", e);
+      }
     }
+    return mybatisMappers;
+  }
 
-    @Bean
-    public SpringRejectedJobsHandler springRejectedJobsHandler() {
-        return new SpringCallerRunsRejectedJobsHandler();
-    }
+  @Bean
+  public ProcessEngineFactoryBean processEngine(SpringProcessEngineConfiguration configuration) {
+    return super.springProcessEngineBean(configuration);
+  }
 
-    protected SpringProcessEngineConfiguration baseSpringProcessEngineConfiguration(DataSource dataSource,
-                                                                                    PlatformTransactionManager platformTransactionManager,
-                                                                                    SpringAsyncExecutor springAsyncExecutor,
-                                                                                    UserGroupManager userGroupManager) throws IOException {
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public RuntimeService runtimeServiceBean(ProcessEngine processEngine) {
+    return super.runtimeServiceBean(processEngine);
+  }
 
-        List<Resource> procDefResources = this.discoverProcessDefinitionResources(
-                this.resourceLoader,
-                this.activitiProperties.getProcessDefinitionLocationPrefix(),
-                this.activitiProperties.getProcessDefinitionLocationSuffixes(),
-                this.activitiProperties.isCheckProcessDefinitions());
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public RepositoryService repositoryServiceBean(ProcessEngine processEngine) {
+    return super.repositoryServiceBean(processEngine);
+  }
 
-        SpringProcessEngineConfiguration conf = super.processEngineConfigurationBean(
-                procDefResources.toArray(new Resource[procDefResources.size()]),
-                dataSource,
-                platformTransactionManager,
-                springAsyncExecutor);
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public TaskService taskServiceBean(ProcessEngine processEngine) {
+    return super.taskServiceBean(processEngine);
+  }
 
-        conf.setDeploymentName(defaultText(activitiProperties.getDeploymentName(),
-                                           conf.getDeploymentName()));
-        conf.setDatabaseSchema(defaultText(activitiProperties.getDatabaseSchema(),
-                                           conf.getDatabaseSchema()));
-        conf.setDatabaseSchemaUpdate(defaultText(activitiProperties.getDatabaseSchemaUpdate(),
-                                                 conf.getDatabaseSchemaUpdate()));
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public HistoryService historyServiceBean(ProcessEngine processEngine) {
+    return super.historyServiceBean(processEngine);
+  }
 
-        conf.setDbHistoryUsed(activitiProperties.isDbHistoryUsed());
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public ManagementService managementServiceBeanBean(ProcessEngine processEngine) {
+    return super.managementServiceBeanBean(processEngine);
+  }
 
-        conf.setAsyncExecutorActivate(activitiProperties.isAsyncExecutorActivate());
+  @Bean
+  @ConditionalOnMissingBean
+  public TaskExecutor taskExecutor() {
+    return new SimpleAsyncTaskExecutor();
+  }
 
-        conf.setMailServerHost(activitiProperties.getMailServerHost());
-        conf.setMailServerPort(activitiProperties.getMailServerPort());
-        conf.setMailServerUsername(activitiProperties.getMailServerUserName());
-        conf.setMailServerPassword(activitiProperties.getMailServerPassword());
-        conf.setMailServerDefaultFrom(activitiProperties.getMailServerDefaultFrom());
-        conf.setMailServerUseSSL(activitiProperties.isMailServerUseSsl());
-        conf.setMailServerUseTLS(activitiProperties.isMailServerUseTls());
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public IntegrationContextManager integrationContextManagerBean(ProcessEngine processEngine) {
+    return super.integrationContextManagerBean(processEngine);
+  }
 
-        if (userGroupManager != null) {
-            conf.setUserGroupManager(userGroupManager);
-        }
-
-        conf.setHistoryLevel(activitiProperties.getHistoryLevel());
-
-        if (activitiProperties.getCustomMybatisMappers() != null) {
-            conf.setCustomMybatisMappers(getCustomMybatisMapperClasses(activitiProperties.getCustomMybatisMappers()));
-        }
-
-        if (activitiProperties.getCustomMybatisXMLMappers() != null) {
-            conf.setCustomMybatisXMLMappers(new HashSet<>(activitiProperties.getCustomMybatisXMLMappers()));
-        }
-
-        if (activitiProperties.getCustomMybatisXMLMappers() != null) {
-            conf.setCustomMybatisXMLMappers(new HashSet<>(activitiProperties.getCustomMybatisXMLMappers()));
-        }
-
-        if (activitiProperties.isUseStrongUuids()) {
-            conf.setIdGenerator(new StrongUuidGenerator());
-        }
-
-        conf.setActivityBehaviorFactory(new CloudActivityBehaviorFactory());
-
-        if (processEngineConfigurationConfigurer != null) {
-            processEngineConfigurationConfigurer.configure(conf);
-        }
-
-        return conf;
-    }
-
-    protected Set<Class<?>> getCustomMybatisMapperClasses(List<String> customMyBatisMappers) {
-        Set<Class<?>> mybatisMappers = new HashSet<>();
-        for (String customMybatisMapperClassName : customMyBatisMappers) {
-            try {
-                Class customMybatisClass = Class.forName(customMybatisMapperClassName);
-                mybatisMappers.add(customMybatisClass);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalArgumentException("Class " + customMybatisMapperClassName + " has not been found.",
-                                                   e);
-            }
-        }
-        return mybatisMappers;
-    }
-
-    protected String defaultText(String deploymentName,
-                                 String deploymentName1) {
-        if (StringUtils.hasText(deploymentName)) {
-            return deploymentName;
-        }
-        return deploymentName1;
-    }
-
-    @Autowired
-    protected void setActivitiProperties(ActivitiProperties activitiProperties) {
-        this.activitiProperties = activitiProperties;
-    }
-
-    protected ActivitiProperties getActivitiProperties() {
-        return this.activitiProperties;
-    }
-
-    @Bean
-    public ProcessEngineFactoryBean processEngine(SpringProcessEngineConfiguration configuration) {
-        return super.springProcessEngineBean(configuration);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public RuntimeService runtimeServiceBean(ProcessEngine processEngine) {
-        return super.runtimeServiceBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public RepositoryService repositoryServiceBean(ProcessEngine processEngine) {
-        return super.repositoryServiceBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public TaskService taskServiceBean(ProcessEngine processEngine) {
-        return super.taskServiceBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public HistoryService historyServiceBean(ProcessEngine processEngine) {
-        return super.historyServiceBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public ManagementService managementServiceBeanBean(ProcessEngine processEngine) {
-        return super.managementServiceBeanBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    public TaskExecutor taskExecutor() {
-        return new SimpleAsyncTaskExecutor();
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public IntegrationContextManager integrationContextManagerBean(ProcessEngine processEngine) {
-        return super.integrationContextManagerBean(processEngine);
-    }
-
-    @Bean
-    @ConditionalOnMissingBean
-    @Override
-    public IntegrationContextService integrationContextServiceBean(ProcessEngine processEngine) {
-        return super.integrationContextServiceBean(processEngine);
-    }
+  @Bean
+  @ConditionalOnMissingBean
+  @Override
+  public IntegrationContextService integrationContextServiceBean(ProcessEngine processEngine) {
+    return super.integrationContextServiceBean(processEngine);
+  }
 }

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
@@ -22,8 +22,6 @@ import org.activiti.engine.impl.persistence.entity.integration.IntegrationContex
 import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.spring.ProcessEngineFactoryBean;
 import org.activiti.spring.SpringProcessEngineConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Provides sane definitions for the various beans required to be productive with Activiti in Spring.
@@ -31,8 +29,6 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class AbstractProcessEngineConfiguration {
 	
-	private static final Logger logger = LoggerFactory.getLogger(AbstractProcessEngineConfiguration.class);
-
   public ProcessEngineFactoryBean springProcessEngineBean(SpringProcessEngineConfiguration configuration) {
     ProcessEngineFactoryBean processEngineFactoryBean = new ProcessEngineFactoryBean();
     processEngineFactoryBean.setProcessEngineConfiguration(configuration);

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineConfiguration.java
@@ -12,11 +12,6 @@
  */
 package org.activiti.spring.boot;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import javax.sql.DataSource;
-
 import org.activiti.engine.HistoryService;
 import org.activiti.engine.ManagementService;
 import org.activiti.engine.ProcessEngine;
@@ -26,13 +21,9 @@ import org.activiti.engine.TaskService;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
 import org.activiti.engine.integration.IntegrationContextService;
 import org.activiti.spring.ProcessEngineFactoryBean;
-import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.support.ResourcePatternResolver;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * Provides sane definitions for the various beans required to be productive with Activiti in Spring.
@@ -46,49 +37,6 @@ public abstract class AbstractProcessEngineConfiguration {
     ProcessEngineFactoryBean processEngineFactoryBean = new ProcessEngineFactoryBean();
     processEngineFactoryBean.setProcessEngineConfiguration(configuration);
     return processEngineFactoryBean;
-  }
-
-  public SpringProcessEngineConfiguration processEngineConfigurationBean(Resource[] processDefinitions,
-                                                                         DataSource dataSource,
-                                                                         PlatformTransactionManager transactionManager,
-                                                                         SpringAsyncExecutor springAsyncExecutor)
-        throws IOException {
-
-    SpringProcessEngineConfiguration engine = new SpringProcessEngineConfiguration();
-    if (processDefinitions != null && processDefinitions.length > 0) {
-      engine.setDeploymentResources(processDefinitions);
-    }
-    engine.setDataSource(dataSource);
-    engine.setTransactionManager(transactionManager);
-
-    if (null != springAsyncExecutor) {
-      engine.setAsyncExecutor(springAsyncExecutor);
-    }
-
-    return engine;
-  }
-
-  public List<Resource> discoverProcessDefinitionResources(ResourcePatternResolver applicationContext, String prefix, List<String> suffixes, boolean checkPDs) throws IOException {
-    if (checkPDs) {
-
-    	List<Resource> result = new ArrayList<Resource>();
-    	for (String suffix : suffixes) {
-    		String path = prefix + suffix;
-    		Resource[] resources = applicationContext.getResources(path);
-    		if (resources != null && resources.length > 0) {
-    			for (Resource resource : resources) {
-    				result.add(resource);
-    			}
-    		}
-    	}
-    	
-    	if (result.isEmpty()) {
-      	logger.info(String.format("No process definitions were found for autodeployment"));
-    	}
-    	
-      return result;
-    }
-    return new ArrayList<Resource>();
   }
 
   public RuntimeService runtimeServiceBean(ProcessEngine processEngine) {

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
@@ -24,7 +24,7 @@ public class ActivitiProperties {
 
   private boolean checkProcessDefinitions = true;
   private boolean asyncExecutorActivate = false;
-  private String deploymentName;
+  private String deploymentName = "SpringAutoDeployment";
   private String mailServerHost = "localhost";
   private int mailServerPort = 1025;
   private String mailServerUserName;

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessDefinitionResourceFinder.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessDefinitionResourceFinder.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.boot;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+
+public class ProcessDefinitionResourceFinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProcessDefinitionResourceFinder.class);
+
+    private ActivitiProperties activitiProperties;
+
+    private ResourcePatternResolver resourceLoader;
+
+    public ProcessDefinitionResourceFinder(ActivitiProperties activitiProperties,
+                                           ResourcePatternResolver resourceLoader) {
+        this.activitiProperties = activitiProperties;
+        this.resourceLoader = resourceLoader;
+    }
+
+    public List<Resource> discoverProcessDefinitionResources() throws IOException {
+        List<Resource> resources = new ArrayList<>();
+        if (activitiProperties.isCheckProcessDefinitions()) {
+
+            Resource processFolder = resourceLoader.getResource(activitiProperties.getProcessDefinitionLocationPrefix());
+            if (processFolder.exists()) {
+                for (String suffix : activitiProperties.getProcessDefinitionLocationSuffixes()) {
+                    String path = activitiProperties.getProcessDefinitionLocationPrefix() + suffix;
+                    resources.addAll(Arrays.asList(resourceLoader.getResources(path)));
+                }
+                if (resources.isEmpty()) {
+                    LOGGER.info("No process definitions were found for auto-deployment in the location `" + activitiProperties.getProcessDefinitionLocationPrefix() + "`");
+                } else {
+                    List<String> resourcesNames = resources.stream().map(Resource::getFilename).collect(Collectors.toList());
+                    LOGGER.info("The following process definition files will be deployed: " + resourcesNames);
+                }
+            } else {
+                LOGGER.warn("Unable to locate folder `" + activitiProperties.getProcessDefinitionLocationPrefix() +
+                                    "`. No process definitions will be auto-deployed");
+            }
+        }
+        return resources;
+    }
+}

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -18,7 +18,6 @@ import java.util.List;
 import javax.sql.DataSource;
 
 import org.activiti.engine.impl.persistence.StrongUuidGenerator;
-import org.activiti.runtime.api.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringProcessEngineConfiguration;

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -13,11 +13,16 @@
 package org.activiti.spring.boot;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
 import javax.sql.DataSource;
 
+import org.activiti.engine.impl.persistence.StrongUuidGenerator;
+import org.activiti.runtime.api.identity.UserGroupManager;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringProcessEngineConfiguration;
+import org.activiti.spring.bpmn.parser.CloudActivityBehaviorFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -25,6 +30,8 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
@@ -32,20 +39,90 @@ import org.springframework.transaction.PlatformTransactionManager;
 @EnableConfigurationProperties(ActivitiProperties.class)
 public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoConfiguration {
 
-    @Autowired
-    protected UserGroupManager userGroupManager;
+    private final UserGroupManager userGroupManager;
+
+    public ProcessEngineAutoConfiguration(UserGroupManager userGroupManager) {
+        this.userGroupManager = userGroupManager;
+    }
 
     @Bean
     @ConditionalOnMissingBean
     public SpringProcessEngineConfiguration springProcessEngineConfiguration(
             DataSource dataSource,
             PlatformTransactionManager transactionManager,
-            SpringAsyncExecutor springAsyncExecutor) throws IOException {
+            SpringAsyncExecutor springAsyncExecutor,
+            ActivitiProperties activitiProperties,
+            ProcessDefinitionResourceFinder processDefinitionResourceFinder,
+            @Autowired(required = false) ProcessEngineConfigurationConfigurer processEngineConfigurationConfigurer) throws IOException {
 
-        return this.baseSpringProcessEngineConfiguration(dataSource,
-                                                         transactionManager,
-                                                         springAsyncExecutor,
-                                                         userGroupManager);
+        SpringProcessEngineConfiguration conf = new SpringProcessEngineConfiguration();
+        configureProcessDefinitionResources(processDefinitionResourceFinder,
+                                            conf);
+        conf.setDataSource(dataSource);
+        conf.setTransactionManager(transactionManager);
+
+        if (springAsyncExecutor != null) {
+            conf.setAsyncExecutor(springAsyncExecutor);
+        }
+        conf.setDeploymentName(activitiProperties.getDeploymentName());
+        conf.setDatabaseSchema(activitiProperties.getDatabaseSchema());
+        conf.setDatabaseSchemaUpdate(activitiProperties.getDatabaseSchemaUpdate());
+        conf.setDbHistoryUsed(activitiProperties.isDbHistoryUsed());
+        conf.setAsyncExecutorActivate(activitiProperties.isAsyncExecutorActivate());
+        conf.setMailServerHost(activitiProperties.getMailServerHost());
+        conf.setMailServerPort(activitiProperties.getMailServerPort());
+        conf.setMailServerUsername(activitiProperties.getMailServerUserName());
+        conf.setMailServerPassword(activitiProperties.getMailServerPassword());
+        conf.setMailServerDefaultFrom(activitiProperties.getMailServerDefaultFrom());
+        conf.setMailServerUseSSL(activitiProperties.isMailServerUseSsl());
+        conf.setMailServerUseTLS(activitiProperties.isMailServerUseTls());
+
+        if (userGroupManager != null) {
+            conf.setUserGroupManager(userGroupManager);
+        }
+
+        conf.setHistoryLevel(activitiProperties.getHistoryLevel());
+
+        if (activitiProperties.getCustomMybatisMappers() != null) {
+            conf.setCustomMybatisMappers(getCustomMybatisMapperClasses(activitiProperties.getCustomMybatisMappers()));
+        }
+
+        if (activitiProperties.getCustomMybatisXMLMappers() != null) {
+            conf.setCustomMybatisXMLMappers(new HashSet<>(activitiProperties.getCustomMybatisXMLMappers()));
+        }
+
+        if (activitiProperties.getCustomMybatisXMLMappers() != null) {
+            conf.setCustomMybatisXMLMappers(new HashSet<>(activitiProperties.getCustomMybatisXMLMappers()));
+        }
+
+        if (activitiProperties.isUseStrongUuids()) {
+            conf.setIdGenerator(new StrongUuidGenerator());
+        }
+
+        conf.setActivityBehaviorFactory(new CloudActivityBehaviorFactory());
+
+        if (processEngineConfigurationConfigurer != null) {
+            processEngineConfigurationConfigurer.configure(conf);
+        }
+
+        return conf;
     }
+
+    private void configureProcessDefinitionResources(ProcessDefinitionResourceFinder processDefinitionResourceFinder,
+                                                     SpringProcessEngineConfiguration conf) throws IOException {
+        List<Resource> procDefResources = processDefinitionResourceFinder.discoverProcessDefinitionResources();
+        if (!procDefResources.isEmpty()) {
+            conf.setDeploymentResources(procDefResources.toArray(new Resource[0]));
+        }
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionResourceFinder processDefinitionResourceFinder(ActivitiProperties activitiProperties,
+                                                                           ResourcePatternResolver resourcePatternResolver) {
+        return new ProcessDefinitionResourceFinder(activitiProperties,
+                                                   resourcePatternResolver);
+    }
+
 }
 

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ProcessDefinitionResourceFinderIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ProcessDefinitionResourceFinderIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.boot;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class ProcessDefinitionResourceFinderIT {
+
+    @Autowired
+    private ProcessDefinitionResourceFinder resourceFinder;
+
+    @SpyBean
+    private ActivitiProperties activitiProperties;
+
+    @Test
+    public void shouldReturnAllTheProcessDefinitionFilesOnSpecifiedFolder() throws Exception {
+        //when
+        List<Resource> resources = resourceFinder.discoverProcessDefinitionResources();
+
+        //then
+        assertThat(resources)
+                .extracting(Resource::getFilename)
+                .contains("categorize-human.bpmn20.xml",
+                          "categorize-image.bpmn20.xml",
+                          "gw.bpmn20.xml",
+                          "waiter.bpmn20.xml");
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenNoProcessDefIsFoundOnSpecifiedFolder() throws Exception {
+        //given
+        given(activitiProperties.getProcessDefinitionLocationPrefix()).willReturn("classpath:/processes-empty/");
+
+        //when
+        List<Resource> resources = resourceFinder.discoverProcessDefinitionResources();
+
+        //then
+        assertThat(resources).isEmpty();
+    }
+
+    @Test
+    public void shouldReturnEmptyListWhenProcessDefinitionsFolderIsNotFound() throws Exception {
+        //given
+        given(activitiProperties.getProcessDefinitionLocationPrefix()).willReturn("classpath:/does-not-exist/");
+
+        //when
+        List<Resource> resources = resourceFinder.discoverProcessDefinitionResources();
+
+        //then
+        assertThat(resources).isEmpty();
+    }
+}

--- a/activiti-spring-boot-starter/src/test/resources/processes-empty/non-process-definition-file.txt
+++ b/activiti-spring-boot-starter/src/test/resources/processes-empty/non-process-definition-file.txt
@@ -1,0 +1,1 @@
+File inside a folder containing no process definitions

--- a/activiti-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
+++ b/activiti-spring/src/main/java/org/activiti/spring/autodeployment/DefaultAutoDeploymentStrategy.java
@@ -13,13 +13,9 @@
 
 package org.activiti.spring.autodeployment;
 
-import org.activiti.engine.ActivitiException;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.repository.DeploymentBuilder;
 import org.springframework.core.io.Resource;
-
-import java.io.IOException;
-import java.util.zip.ZipInputStream;
 
 /**
  * Default implementation of {@link AutoDeploymentStrategy} that groups all {@link Resource}s into a single deployment. This implementation is equivalent to the previously used implementation.
@@ -49,19 +45,11 @@ public class DefaultAutoDeploymentStrategy extends AbstractAutoDeploymentStrateg
     for (final Resource resource : resources) {
       final String resourceName = determineResourceName(resource);
 
-      try {
-        if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
-          deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
-        } else {
-          deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
-        }
-      } catch (IOException e) {
-        throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
-      }
+      deploymentBuilder.addInputStream(resourceName,
+                                       resource);
     }
 
     deploymentBuilder.deploy();
 
   }
-
 }

--- a/activiti-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
+++ b/activiti-spring/src/main/java/org/activiti/spring/autodeployment/ResourceParentFolderAutoDeploymentStrategy.java
@@ -13,18 +13,16 @@
 
 package org.activiti.spring.autodeployment;
 
-import org.activiti.engine.ActivitiException;
-import org.activiti.engine.RepositoryService;
-import org.activiti.engine.repository.DeploymentBuilder;
-import org.springframework.core.io.Resource;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.zip.ZipInputStream;
+
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.DeploymentBuilder;
+import org.springframework.core.io.Resource;
 
 /**
  * Implementation of {@link AutoDeploymentStrategy} that performs a separate deployment for each set of {@link Resource}s that share the same parent folder. The namehint is used to prefix the names of
@@ -63,15 +61,8 @@ public class ResourceParentFolderAutoDeploymentStrategy extends AbstractAutoDepl
       for (final Resource resource : group.getValue()) {
         final String resourceName = determineResourceName(resource);
 
-        try {
-          if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
-            deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
-          } else {
-            deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
-          }
-        } catch (IOException e) {
-          throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
-        }
+        deploymentBuilder.addInputStream(resourceName,
+                                         resource);
       }
       deploymentBuilder.deploy();
     }

--- a/activiti-spring/src/main/java/org/activiti/spring/autodeployment/SingleResourceAutoDeploymentStrategy.java
+++ b/activiti-spring/src/main/java/org/activiti/spring/autodeployment/SingleResourceAutoDeploymentStrategy.java
@@ -13,13 +13,9 @@
 
 package org.activiti.spring.autodeployment;
 
-import org.activiti.engine.ActivitiException;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.repository.DeploymentBuilder;
 import org.springframework.core.io.Resource;
-
-import java.io.IOException;
-import java.util.zip.ZipInputStream;
 
 /**
  * Implementation of {@link AutoDeploymentStrategy} that performs a separate deployment for each resource by name.
@@ -49,15 +45,8 @@ public class SingleResourceAutoDeploymentStrategy extends AbstractAutoDeployment
       final String resourceName = determineResourceName(resource);
       final DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name(resourceName);
 
-      try {
-        if (resourceName.endsWith(".bar") || resourceName.endsWith(".zip") || resourceName.endsWith(".jar")) {
-          deploymentBuilder.addZipInputStream(new ZipInputStream(resource.getInputStream()));
-        } else {
-          deploymentBuilder.addInputStream(resourceName, resource.getInputStream());
-        }
-      } catch (IOException e) {
-        throw new ActivitiException("couldn't auto deploy resource '" + resource + "': " + e.getMessage(), e);
-      }
+      deploymentBuilder.addInputStream(resourceName,
+                                       resource);
 
       deploymentBuilder.deploy();
     }

--- a/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -27,6 +27,7 @@ import org.springframework.core.io.Resource;
 
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
 public class AbstractAutoDeploymentStrategyTest {
 
@@ -82,7 +83,7 @@ public class AbstractAutoDeploymentStrategyTest {
 
     @Before
     public void before() throws Exception {
-
+        initMocks(this);
         when(resourceMock1.getPathWithinContext()).thenReturn(resourceName1);
         when(resourceMock1.getFile()).thenReturn(fileMock1);
 

--- a/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -17,69 +17,66 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 
-import org.activiti.engine.ActivitiException;
 import org.activiti.spring.autodeployment.DefaultAutoDeploymentStrategy;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.core.io.Resource;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.Silent.class)
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
-    private DefaultAutoDeploymentStrategy classUnderTest;
+    private DefaultAutoDeploymentStrategy deploymentStrategy;
 
     @Before
     public void before() throws Exception {
         super.before();
-        classUnderTest = new DefaultAutoDeploymentStrategy();
-        assertNotNull(classUnderTest);
+        deploymentStrategy = new DefaultAutoDeploymentStrategy();
     }
 
     @Test
     public void testHandlesMode() {
-        assertTrue(classUnderTest.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
-        assertFalse(classUnderTest.handlesMode("other-mode"));
-        assertFalse(classUnderTest.handlesMode(null));
+        assertTrue(deploymentStrategy.handlesMode(DefaultAutoDeploymentStrategy.DEPLOYMENT_MODE));
+        assertFalse(deploymentStrategy.handlesMode("other-mode"));
+        assertFalse(deploymentStrategy.handlesMode(null));
     }
 
     @Test
     public void testDeployResources() {
         final Resource[] resources = new Resource[]{resourceMock1, resourceMock2, resourceMock3, resourceMock4, resourceMock5};
-        classUnderTest.deployResources(deploymentNameHint,
-                                       resources,
-                                       repositoryServiceMock);
+        deploymentStrategy.deployResources(deploymentNameHint,
+                                           resources,
+                                           repositoryServiceMock);
 
-        verify(repositoryServiceMock,
-               times(1)).createDeployment();
-        verify(deploymentBuilderMock,
-               times(1)).enableDuplicateFiltering();
-        verify(deploymentBuilderMock,
-               times(1)).name(deploymentNameHint);
-        verify(deploymentBuilderMock,
-               times(1)).addInputStream(eq(resourceName1),
-                                        isA(InputStream.class));
-        verify(deploymentBuilderMock,
-               times(1)).addInputStream(eq(resourceName2),
-                                        isA(InputStream.class));
-        verify(deploymentBuilderMock,
-               times(3)).addZipInputStream(isA(ZipInputStream.class));
-        verify(deploymentBuilderMock,
-               times(1)).deploy();
+        verify(repositoryServiceMock).createDeployment();
+        verify(deploymentBuilderMock).enableDuplicateFiltering();
+        verify(deploymentBuilderMock).name(deploymentNameHint);
+        verify(deploymentBuilderMock).addInputStream(eq(resourceName1),
+                                        isA(Resource.class));
+        verify(deploymentBuilderMock).addInputStream(eq(resourceName2),
+                                        isA(Resource.class));
+        verify(deploymentBuilderMock).addInputStream(eq(resourceName3),
+                                        isA(Resource.class));
+        verify(deploymentBuilderMock).addInputStream(eq(resourceName4),
+                                        isA(Resource.class));
+        verify(deploymentBuilderMock).addInputStream(eq(resourceName5),
+                                        isA(Resource.class));
+        verify(deploymentBuilderMock).deploy();
     }
 
     @Test
     public void testDeployResourcesNoResources() {
         final Resource[] resources = new Resource[]{};
-        classUnderTest.deployResources(deploymentNameHint,
-                                       resources,
-                                       repositoryServiceMock);
+        deploymentStrategy.deployResources(deploymentNameHint,
+                                           resources,
+                                           repositoryServiceMock);
 
         verify(repositoryServiceMock,
                times(1)).createDeployment();
@@ -99,26 +96,14 @@ public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStr
                times(1)).deploy();
     }
 
-    @Test(expected = ActivitiException.class)
-    public void testDeployResourcesIOExceptionYieldsActivitiException() throws Exception {
-        when(resourceMock3.getInputStream()).thenThrow(new IOException());
-
-        final Resource[] resources = new Resource[]{resourceMock3};
-        classUnderTest.deployResources(deploymentNameHint,
-                                       resources,
-                                       repositoryServiceMock);
-
-        fail("Expected exception for IOException");
-    }
-
     @Test
     public void testDetermineResourceNameWithExceptionFailsGracefully() throws Exception {
         when(resourceMock3.getFile()).thenThrow(new IOException());
         when(resourceMock3.getFilename()).thenReturn(resourceName3);
 
         final Resource[] resources = new Resource[]{resourceMock3};
-        classUnderTest.deployResources(deploymentNameHint,
-                                       resources,
-                                       repositoryServiceMock);
+        deploymentStrategy.deployResources(deploymentNameHint,
+                                           resources,
+                                           repositoryServiceMock);
     }
 }


### PR DESCRIPTION
Fixes #1965
Instead of failing when the folder does not exist just log an warning