### PR TITLE
Add ConditionalOnMissingBean annotation when defining SpringAsyncExec…

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
@@ -42,8 +42,9 @@ public abstract class AbstractProcessEngineAutoConfiguration
         extends AbstractProcessEngineConfiguration {
 
   @Bean
-  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor taskExecutor) {
-    return new SpringAsyncExecutor(taskExecutor, springRejectedJobsHandler());
+  @ConditionalOnMissingBean
+  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor taskExecutor, SpringRejectedJobsHandler springRejectedJobsHandler) {
+    return new SpringAsyncExecutor(taskExecutor, springRejectedJobsHandler);
   }
   
   @Bean 


### PR DESCRIPTION
…utor.

This will allow users to define their own implementation of SpringAsyncExecutor.

Close #1985