### PR TITLE
Pulling new versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>http://activiti.org</url>
   <properties>
     <activiti.version>${project.version}</activiti.version>
-    <activiti-api.version>7.0.20</activiti-api.version>
+    <activiti-api.version>7.0.21</activiti-api.version>
     <batik.version>1.10</batik.version>
     <commons-email.version>1.5</commons-email.version>
     <commons-fileupload.version>1.3.3</commons-fileupload.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.api:activiti-api-dependencies` to: `7.0.21`