### PR TITLE
update org.activiti.build:activiti-parent to 7.0.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.build</groupId>
     <artifactId>activiti-parent</artifactId>
-    <version>7.0.26</version>
+    <version>7.0.27</version>
     <relativePath/>
   </parent>
   <groupId>org.activiti</groupId>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.build:activiti-parent` to: `7.0.27`