### PR TITLE
update org.activiti.build:activiti-parent to 7.0.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.build</groupId>
     <artifactId>activiti-parent</artifactId>
-    <version>7.0.28</version>
+    <version>7.0.31</version>
     <relativePath/>
   </parent>
   <groupId>org.activiti</groupId>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.build:activiti-parent` to: `7.0.29`