### PR TITLE
Pulling new versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <description>Activiti Core :: Parent</description>
   <url>http://activiti.org</url>
   <properties>
-    <activiti-build.version>7.0.33</activiti-build.version>
+    <activiti-build.version>7.0.32</activiti-build.version>
     <activiti.version>${project.version}</activiti.version>
     <activiti-api.version>7.0.27</activiti-api.version>
     <batik.version>1.10</batik.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.build:activiti-dependencies-parent` to: `7.0.32`