### PR TITLE
update org.activiti.build:activiti-parent to 7.0.39

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.build</groupId>
     <artifactId>activiti-parent</artifactId>
-    <version>7.0.38</version>
+    <version>7.0.39</version>
     <relativePath/>
   </parent>
   <groupId>org.activiti</groupId>
@@ -16,7 +16,7 @@
   <description>Activiti Core :: Parent</description>
   <url>http://activiti.org</url>
   <properties>
-    <activiti-build.version>7.0.38</activiti-build.version>
+    <activiti-build.version>7.0.39</activiti-build.version>
     <activiti.version>${project.version}</activiti.version>
     <activiti-api.version>7.0.31</activiti-api.version>
     <batik.version>1.10</batik.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.build:activiti-parent` to: `7.0.39`