### PR TITLE
Pulling new versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <properties>
     <activiti-build.version>7.0.39</activiti-build.version>
     <activiti.version>${project.version}</activiti.version>
-    <activiti-api.version>${project.version}</activiti-api.version>
+    <activiti-api.version>7.0.33</activiti-api.version>
     <activiti-core-common.version>${project.version}</activiti-core-common.version>
     <batik.version>1.10</batik.version>
     <commons-email.version>1.5</commons-email.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.api:activiti-api-dependencies` to: `7.0.33`