### PR TITLE
Trigger process deployed events

### DIFF
--- a/activiti-spring-boot-starter/pom.xml
+++ b/activiti-spring-boot-starter/pom.xml
@@ -24,6 +24,22 @@
         </dependency>
         <dependency>
             <groupId>org.activiti.api</groupId>
+            <artifactId>activiti-api-process-model</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.activiti.api</groupId>
+            <artifactId>activiti-api-process-runtime</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.activiti.api</groupId>
+            <artifactId>activiti-api-process-model-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.activiti.api</groupId>
+            <artifactId>activiti-api-model-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.activiti.api</groupId>
             <artifactId>activiti-api-runtime-shared</artifactId>
         </dependency>
         <dependency>

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/ProcessDeployedEventProducer.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/ProcessDeployedEventProducer.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring;
+
+import java.util.List;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
+import org.activiti.api.runtime.event.impl.ProcessDeployedEventImpl;
+import org.activiti.engine.RepositoryService;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+
+public class ProcessDeployedEventProducer implements ApplicationListener<ApplicationReadyEvent> {
+
+    private RepositoryService repositoryService;
+    private APIProcessDefinitionConverter converter;
+    private List<ProcessRuntimeEventListener<ProcessDeployedEvent>> listeners;
+
+    public ProcessDeployedEventProducer(RepositoryService repositoryService,
+                                        APIProcessDefinitionConverter converter,
+                                        List<ProcessRuntimeEventListener<ProcessDeployedEvent>> listeners) {
+        this.repositoryService = repositoryService;
+        this.converter = converter;
+        this.listeners = listeners;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        if (!WebApplicationType.NONE.equals(event.getSpringApplication().getWebApplicationType())) {
+            List<ProcessDefinition> processDefinitions = converter.from(repositoryService.createProcessDefinitionQuery().list());
+            for (ProcessDefinition processDefinition : processDefinitions) {
+                ProcessDeployedEventImpl processDeployedEvent = new ProcessDeployedEventImpl(processDefinition);
+                for (ProcessRuntimeEventListener<ProcessDeployedEvent> listener : listeners) {
+                    listener.onEvent(processDeployedEvent);
+                }
+            }
+        }
+    }
+
+}

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -13,12 +13,19 @@
 package org.activiti.spring.boot;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import javax.sql.DataSource;
 
-import org.activiti.engine.impl.persistence.StrongUuidGenerator;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.impl.persistence.StrongUuidGenerator;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.activiti.spring.ProcessDeployedEventProducer;
 import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.activiti.spring.bpmn.parser.CloudActivityBehaviorFactory;
@@ -124,5 +131,15 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
                                                    resourcePatternResolver);
     }
 
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDeployedEventProducer processDeployedEventProducer(RepositoryService repositoryService,
+                                                                     APIProcessDefinitionConverter converter,
+                                                                     @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessDeployedEvent>> listeners) {
+        return new ProcessDeployedEventProducer(repositoryService,
+                                                converter,
+                                                Optional.ofNullable(listeners)
+                                                        .orElse(Collections.emptyList()));
+    }
 }
 

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.repository.ProcessDefinitionQuery;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ProcessDeployedEventProducerTest {
+
+    private ProcessDeployedEventProducer producer;
+
+    @Mock
+    private RepositoryService repositoryService;
+
+    @Mock
+    private APIProcessDefinitionConverter converter;
+
+    @Mock
+    private ProcessRuntimeEventListener<ProcessDeployedEvent> firstListener;
+
+    @Mock
+    private ProcessRuntimeEventListener<ProcessDeployedEvent> secondListener;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        producer = new ProcessDeployedEventProducer(repositoryService,
+                                                    converter,
+                                                    Arrays.asList(firstListener,
+                                                                  secondListener));
+    }
+
+    @Test
+    public void shouldCallRegisteredListenersWhenWebApplicationTypeIsServlet() {
+        //given
+        ProcessDefinitionQuery definitionQuery = mock(ProcessDefinitionQuery.class);
+        given(repositoryService.createProcessDefinitionQuery()).willReturn(definitionQuery);
+
+        List<ProcessDefinition> internalProcessDefinitions = Arrays.asList(mock(ProcessDefinition.class),
+                                                                           mock(ProcessDefinition.class));
+
+        given(definitionQuery.list()).willReturn(internalProcessDefinitions);
+
+        List<org.activiti.api.process.model.ProcessDefinition> apiProcessDefinitions = Arrays.asList(mock(org.activiti.api.process.model.ProcessDefinition.class),
+                                                                                                     mock(org.activiti.api.process.model.ProcessDefinition.class));
+        given(converter.from(internalProcessDefinitions)).willReturn(apiProcessDefinitions);
+
+        //when
+        producer.onApplicationEvent(buildApplicationReadyEvent(WebApplicationType.SERVLET));
+
+        //then
+        ArgumentCaptor<ProcessDeployedEvent> captor = ArgumentCaptor.forClass(ProcessDeployedEvent.class);
+        verify(firstListener,
+               times(2)).onEvent(captor.capture());
+        verify(secondListener,
+               times(2)).onEvent(captor.capture());
+
+        List<ProcessDeployedEvent> allValues = captor.getAllValues();
+        assertThat(allValues)
+                .extracting(ProcessDeployedEvent::getEntity)
+                .containsExactly(apiProcessDefinitions.get(0),//firstListener
+                                 apiProcessDefinitions.get(1),//firstListener
+                                 apiProcessDefinitions.get(0),//secondListener
+                                 apiProcessDefinitions.get(1));//secondListener
+    }
+
+    private ApplicationReadyEvent buildApplicationReadyEvent(WebApplicationType applicationType) {
+        SpringApplication springApplication = mock(SpringApplication.class);
+        given(springApplication.getWebApplicationType()).willReturn(applicationType);
+
+        ApplicationReadyEvent applicationReadyEvent = mock(ApplicationReadyEvent.class);
+        given(applicationReadyEvent.getSpringApplication()).willReturn(springApplication);
+        return applicationReadyEvent;
+    }
+
+    @Test
+    public void shouldNotCallRegisteredListenerWhenApplicationTypeIsNone() {
+        //when
+        producer.onApplicationEvent(buildApplicationReadyEvent(WebApplicationType.NONE));
+
+        //then
+        verifyZeroInteractions(firstListener, secondListener);
+    }
+}

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/DeployedProcessesListener.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/DeployedProcessesListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.boot.process;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.events.ProcessDeployedEvent;
+import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class DeployedProcessesListener implements ProcessRuntimeEventListener<ProcessDeployedEvent> {
+
+    private List<ProcessDefinition> deployedProcesses = new ArrayList<>();
+
+    @Override
+    public void onEvent(ProcessDeployedEvent event) {
+        deployedProcesses.add(event.getEntity());
+    }
+
+    public List<ProcessDefinition> getDeployedProcesses() {
+        return deployedProcesses;
+    }
+
+}

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessDeployedEventIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessDeployedEventIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.boot.process;
+
+import java.util.List;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class ProcessDeployedEventIT {
+
+    private static final String CATEGORIZE_PROCESS = "categorizeProcess";
+    private static final String CATEGORIZE_HUMAN_PROCESS = "categorizeHumanProcess";
+    private static final String ONE_STEP_PROCESS = "OneStepProcess";
+
+    @Autowired
+    private DeployedProcessesListener listener;
+
+    @Test
+    public void shouldTriggerProcessDeployedEvents() {
+        //when
+        List<ProcessDefinition> deployedProcesses = listener.getDeployedProcesses();
+
+        //then
+        assertThat(deployedProcesses)
+                .extracting(ProcessDefinition::getKey)
+                .contains(CATEGORIZE_PROCESS,
+                          CATEGORIZE_HUMAN_PROCESS,
+                          ONE_STEP_PROCESS);
+    }
+
+}

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessDeployedEventIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessDeployedEventIT.java
@@ -28,7 +28,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 public class ProcessDeployedEventIT {
 
     private static final String CATEGORIZE_PROCESS = "categorizeProcess";


### PR DESCRIPTION
The events will be sent when the Spring Boot application is ready (ApplicationReadyEvent). A ProcessDeployedEvent will be triggered for every process deployed every time the application starts. Listeners to these events should be able do deal with duplicates.

Refs https://github.com/Activiti/Activiti/issues/2149