### PR TITLE
update org.activiti.build:activiti-parent to 7.0.40

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.activiti.build</groupId>
     <artifactId>activiti-parent</artifactId>
-    <version>7.0.39</version>
+    <version>7.0.40</version>
     <relativePath/>
   </parent>
   <groupId>org.activiti</groupId>
@@ -16,7 +16,7 @@
   <description>Activiti Core :: Parent</description>
   <url>http://activiti.org</url>
   <properties>
-    <activiti-build.version>7.0.39</activiti-build.version>
+    <activiti-build.version>7.0.40</activiti-build.version>
     <activiti-api.version>7.0.39</activiti-api.version>
     <activiti-core-common.version>7.0.9</activiti-core-common.version>
     <activiti.version>${project.version}</activiti.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.build:activiti-parent` to: `7.0.40`