### PR TITLE
update org.activiti.api:activiti-api-dependencies to 7.0.47

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>http://activiti.org</url>
   <properties>
     <activiti-build.version>7.0.40</activiti-build.version>
-    <activiti-api.version>7.0.46</activiti-api.version>
+    <activiti-api.version>7.0.47</activiti-api.version>
     <activiti-core-common.version>7.0.13</activiti-core-common.version>
     <activiti.version>${project.version}</activiti.version>
     <batik.version>1.10</batik.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.api:activiti-api-dependencies` to: `7.0.47`