### PR TITLE
update org.activiti.core.common:activiti-core-common-dependencies to 7.0.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <url>http://activiti.org</url>
   <properties>
     <activiti-build.version>7.0.41</activiti-build.version>
-    <activiti-core-common.version>7.0.17</activiti-core-common.version>
+    <activiti-core-common.version>7.0.18</activiti-core-common.version>
     <activiti.version>${project.version}</activiti.version>
     <batik.version>1.10</batik.version>
     <commons-email.version>1.5</commons-email.version>


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `org.activiti.core.common:activiti-core-common-dependencies` to: `7.0.18`