### PR TITLE
feat: add activiti-core-dependencies-tests module 

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,5 +9,17 @@ pull_request_rules:
     actions:
       delete_head_branch: {}
       merge:
+        method: merge
+        strict: true
+  - name: automatic merge when CI passes and 1 approving reviews
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success=continuous-integration/jenkins/pr-head
+      - status-success=continuous-integration/travis-ci/pr
+      - status-success=continuous-integration/travis-ci/push
+      - status-success=license/cla
+    actions:
+      delete_head_branch: {}
+      merge:
         method: squash
         strict: true

--- a/activiti-api-impl/pom.xml
+++ b/activiti-api-impl/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
   <artifactId>activiti-api-impl</artifactId>
   <name>Activiti :: Runtime API Parent</name>

--- a/activiti-bpmn-converter/pom.xml
+++ b/activiti-bpmn-converter/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-bpmn-converter</artifactId>

--- a/activiti-bpmn-layout/pom.xml
+++ b/activiti-bpmn-layout/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-bpmn-layout</artifactId>

--- a/activiti-bpmn-model/pom.xml
+++ b/activiti-bpmn-model/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-bpmn-model</artifactId>

--- a/activiti-core-dependencies-tests/pom.xml
+++ b/activiti-core-dependencies-tests/pom.xml
@@ -1,0 +1,162 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.activiti</groupId>
+    <artifactId>activiti-root</artifactId>
+    <version>7.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>activiti-core-dependencies-tests</artifactId>
+  <packaging>pom</packaging>
+
+  <name>Activiti Core :: BOM (Bill of Materials) Tests</name>
+
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Exclude Actviti Build Managed Dependencies -->
+     <dependency>
+        <groupId>org.activiti.build</groupId>
+        <artifactId>activiti-dependencies-parent</artifactId>
+        <version>${activiti-build.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- Activiti Api Dependencies -->
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-model-shared</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-runtime-shared</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-model</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-runtime</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-model</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-runtime</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-model-shared-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-process-model-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.api</groupId>
+      <artifactId>activiti-api-task-model-impl</artifactId>
+      <version>${activiti-api.version}</version>
+      <type>pom</type>
+    </dependency>
+    <!-- Activiti Common Dependencies -->
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-connector-model</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-spring-application</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-spring-connector</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-spring-identity</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-spring-security</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.activiti.core.common</groupId>
+      <artifactId>activiti-spring-security-policies</artifactId>
+      <version>${activiti-core-common.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M2</version>
+        <executions>
+          <execution>
+            <id>enforce-dependency-convergence</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <fail>true</fail>
+              <rules>
+                <reactorModuleConvergence>
+                  <message>The reactor is not valid</message>
+                  <ignoreModuleDependencies>false</ignoreModuleDependencies>
+                </reactorModuleConvergence>
+                <dependencyConvergence />
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- disable parent execution which fails here -->
+            <id>enforce-plugin-versions</id>
+            <configuration>
+              <fail>false</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/activiti-core-dependencies-tests/pom.xml
+++ b/activiti-core-dependencies-tests/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <enforceFail>true</enforceFail>    
   </properties>
 
   <dependencyManagement>
@@ -137,7 +138,7 @@
               <goal>enforce</goal>
             </goals>
             <configuration>
-              <fail>true</fail>
+              <fail>${enforceFail}</fail>
               <rules>
                 <reactorModuleConvergence>
                   <message>The reactor is not valid</message>

--- a/activiti-core-dependencies/pom.xml
+++ b/activiti-core-dependencies/pom.xml
@@ -12,6 +12,29 @@
   <name>Activiti :: Dependencies BOM (Bill Of Materials)</name>
   <dependencyManagement>
     <dependencies>
+      <!-- External dependencies -->
+      <dependency>
+        <groupId>org.activiti.build</groupId>
+        <artifactId>activiti-dependencies-parent</artifactId>
+        <version>${activiti-build.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.api</groupId>
+        <artifactId>activiti-api-dependencies</artifactId>
+        <version>${activiti-api.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.core.common</groupId>
+        <artifactId>activiti-core-common-dependencies</artifactId>
+        <version>${activiti-core-common.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    
       <!-- Activiti Modules for managed dependencies -->
       <dependency>
         <groupId>org.activiti</groupId>

--- a/activiti-engine/pom.xml
+++ b/activiti-engine/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-engine</artifactId>

--- a/activiti-image-generator/pom.xml
+++ b/activiti-image-generator/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-image-generator</artifactId>

--- a/activiti-json-converter/pom.xml
+++ b/activiti-json-converter/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-json-converter</artifactId>

--- a/activiti-process-validation/pom.xml
+++ b/activiti-process-validation/pom.xml
@@ -5,8 +5,9 @@
 
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
 
   <artifactId>activiti-process-validation</artifactId>

--- a/activiti-spring-app-process/pom.xml
+++ b/activiti-spring-app-process/pom.xml
@@ -20,8 +20,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
   <artifactId>activiti-spring-app-process</artifactId>
   <name>Activiti :: Application</name>

--- a/activiti-spring-boot-starter/pom.xml
+++ b/activiti-spring-boot-starter/pom.xml
@@ -3,9 +3,10 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-root</artifactId>
-        <version>7.0.0-SNAPSHOT</version>
+      <groupId>org.activiti</groupId>
+      <artifactId>activiti-core-dependencies</artifactId>
+      <version>7.0.0-SNAPSHOT</version>
+      <relativePath>../activiti-core-dependencies</relativePath>
     </parent>
     <artifactId>activiti-spring-boot-starter</artifactId>
     <name>Activiti :: Spring Boot Starter</name>

--- a/activiti-spring/pom.xml
+++ b/activiti-spring/pom.xml
@@ -4,8 +4,9 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.activiti</groupId>
-    <artifactId>activiti-root</artifactId>
+    <artifactId>activiti-core-dependencies</artifactId>
     <version>7.0.0-SNAPSHOT</version>
+    <relativePath>../activiti-core-dependencies</relativePath>
   </parent>
   <artifactId>activiti-spring</artifactId>
   <name>Activiti :: Spring</name>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,17 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  
+  <!-- Activiti Build Parent Marker Dependency for Dependency Convergence Tests -->
+  <dependencies>
+    <dependency>
+      <groupId>org.activiti.build</groupId>
+      <artifactId>activiti-parent</artifactId>
+      <version>${activiti-build.version}</version>
+      <type>pom</type>
+    </dependency>
+  </dependencies>
+  
   <modules>
     <module>activiti-core-dependencies-tests</module>
     <module>activiti-core-dependencies</module>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <description>Activiti Core :: Parent</description>
   <url>http://activiti.org</url>
   <properties>
-    <activiti-build.version>7.0.40</activiti-build.version>
+    <activiti-build.version>7.0.41</activiti-build.version>
     <activiti-api.version>7.0.52</activiti-api.version>
     <activiti-core-common.version>7.0.21</activiti-core-common.version>
     <activiti.version>${project.version}</activiti.version>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,8 @@
   <description>Activiti Core :: Parent</description>
   <url>http://activiti.org</url>
   <properties>
-    <activiti-build.version>7.0.41</activiti-build.version>
+    <activiti-build.version>7.0.40</activiti-build.version>
+    <activiti-api.version>7.0.52</activiti-api.version>
     <activiti-core-common.version>7.0.21</activiti-core-common.version>
     <activiti.version>${project.version}</activiti.version>
     <batik.version>1.10</batik.version>
@@ -43,92 +44,6 @@
   </properties>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.activiti.build</groupId>
-        <artifactId>activiti-dependencies-parent</artifactId>
-        <version>${activiti-build.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Activiti Modules for managed dependencies -->
-      <!-- This duplicates activiti-dependencies module but we can't import that module here as this is its parent-->
-      <dependency>
-        <groupId>org.activiti.core.common</groupId>
-        <artifactId>activiti-core-common-dependencies</artifactId>
-        <version>${activiti-core-common.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-api-impl</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-api-runtime-shared-impl</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-api-process-runtime-impl</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-api-task-runtime-impl</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-engine</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-spring</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-spring-app-process</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-spring-boot-starter</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-bpmn-model</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-image-generator</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-bpmn-converter</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-json-converter</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-bpmn-layout</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti</groupId>
-        <artifactId>activiti-process-validation</artifactId>
-        <version>${activiti.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
@@ -285,6 +200,7 @@
     </dependencies>
   </dependencyManagement>
   <modules>
+    <module>activiti-core-dependencies-tests</module>
     <module>activiti-core-dependencies</module>
     <module>activiti-api-impl</module>
     <module>activiti-bpmn-model</module>
@@ -326,7 +242,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version></plugin>
+        <version>2.8.2</version>
+        <configuration>
+          <deployAtEnd>true</deployAtEnd>
+        </configuration>
+      </plugin>
     
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This PR proposes to add dependency convergence tests for external activiti-api and activiti-core-common dependencies as part of #2198.

Also, added same parent version convergence test as part of #2200 

It also fixes Maven-deploy-plugin configuration to follow best practice for deploying multi-module project at the end. (See #2172)
