### PR TITLE
Rename TaskExecutor to match with applicationTaskExecutor

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
@@ -42,8 +42,8 @@ public abstract class AbstractProcessEngineAutoConfiguration
         extends AbstractProcessEngineConfiguration {
 
   @Bean
-  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor taskExecutor) {
-    return new SpringAsyncExecutor(taskExecutor, springRejectedJobsHandler());
+  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor applicationTaskExecutor) {
+    return new SpringAsyncExecutor(applicationTaskExecutor, springRejectedJobsHandler());
   }
   
   @Bean 


### PR DESCRIPTION
So that Spring can choose between to two available beans
Refs https://github.com/Activiti/Activiti/issues/2206