### PR TITLE
Load ProcessEngineAutoConfiguration after TaskExecutionAutoConfiguration

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/AbstractProcessEngineAutoConfiguration.java
@@ -29,10 +29,8 @@ import org.activiti.spring.SpringAsyncExecutor;
 import org.activiti.spring.SpringCallerRunsRejectedJobsHandler;
 import org.activiti.spring.SpringProcessEngineConfiguration;
 import org.activiti.spring.SpringRejectedJobsHandler;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskExecutor;
 
@@ -44,7 +42,7 @@ public abstract class AbstractProcessEngineAutoConfiguration
         extends AbstractProcessEngineConfiguration {
 
   @Bean
-  public SpringAsyncExecutor springAsyncExecutor(@Qualifier("taskExecutor") TaskExecutor applicationTaskExecutor) {
+  public SpringAsyncExecutor springAsyncExecutor(TaskExecutor applicationTaskExecutor) {
     return new SpringAsyncExecutor(applicationTaskExecutor, springRejectedJobsHandler());
   }
   

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,7 +42,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @Configuration
-@AutoConfigureAfter(DataSourceAutoConfiguration.class)
+@AutoConfigureAfter({DataSourceAutoConfiguration.class, TaskExecutionAutoConfiguration.class})
 @EnableConfigurationProperties(ActivitiProperties.class)
 public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoConfiguration {
 
@@ -56,7 +57,7 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     public SpringProcessEngineConfiguration springProcessEngineConfiguration(
             DataSource dataSource,
             PlatformTransactionManager transactionManager,
-            @Autowired(required = false) SpringAsyncExecutor springAsyncExecutor,
+            SpringAsyncExecutor springAsyncExecutor,
             ActivitiProperties activitiProperties,
             ProcessDefinitionResourceFinder processDefinitionResourceFinder,
             @Autowired(required = false) ProcessEngineConfigurationConfigurer processEngineConfigurationConfigurer) throws IOException {

--- a/activiti-spring-boot-starter/src/main/resources/META-INF/spring.factories
+++ b/activiti-spring-boot-starter/src/main/resources/META-INF/spring.factories
@@ -1,4 +1,5 @@
 # Activiti auto-configurations
 
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-    org.activiti.spring.boot.EndpointAutoConfiguration
+    org.activiti.spring.boot.EndpointAutoConfiguration,\
+    org.activiti.spring.boot.ProcessEngineAutoConfiguration


### PR DESCRIPTION
as TaskExecutionAutoConfiguration is the one providing a bean of type `TaskExecutor`
Refs https://github.com/Activiti/Activiti/issues/2206