### PR TITLE
Issue 2188

### DIFF
--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/MessageParser.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/MessageParser.java
@@ -46,7 +46,8 @@ public class MessageParser implements BpmnXMLConstants {
         String resolvedNamespace = model.getNamespace(prefix);
         result = resolvedNamespace + ":" + itemRef.substring(indexOfP + 1);
       } else {
-        result = itemRef;
+        String resolvedNamespace = model.getTargetNamespace();
+        result = resolvedNamespace + ":" + itemRef;
       }
     }
     return result;

--- a/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageConverterTest.java
+++ b/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageConverterTest.java
@@ -34,6 +34,13 @@ public class MessageConverterTest extends AbstractConverterTest {
     assertEquals("http://foo.bar.com/Examples:writeReportItem2", message2.getItemRef());
     assertEquals("newWriteReport2", message2.getName());
     assertEquals("writeReport2", message2.getId());
+    
+    Message message3 = model.getMessage("writeReport3");
+    assertNotNull(message3);
+    assertEquals("Examples:writeReportItem3", message3.getItemRef());
+    assertEquals("newWriteReport3", message3.getName());
+    assertEquals("writeReport3", message3.getId());
+
   }
   
   protected String getResource() {

--- a/activiti-bpmn-converter/src/test/resources/message.bpmn
+++ b/activiti-bpmn-converter/src/test/resources/message.bpmn
@@ -9,6 +9,7 @@
  
   <message id="writeReport" name="newWriteReport" itemRef="tns:writeReportItem"/>
   <message id="writeReport2" name="newWriteReport2" itemRef="tns2:writeReportItem2"/>
+  <message id="writeReport3" name="newWriteReport3" itemRef="writeReportItem3"/>
 
   <process id="process01" isExecutable="true">
  


### PR DESCRIPTION
Proposed fix for Issue #2188.

The change is very simple - treat un-prefixed `itemRef`-s as being in the `targetNamespace` but it would be good if somebody could confirm if the behavior is actually correct.

 Added a corresponding test.