### PR TITLE
fix: (IntegrationContext) add process instance execution context attributes

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -16,16 +16,16 @@
 
 package org.activiti.runtime.api.connector;
 
-import org.activiti.api.process.model.IntegrationContext;
-import org.activiti.bpmn.model.ServiceTask;
-import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
-import org.activiti.core.common.model.connector.ActionDefinition;
-import org.activiti.core.common.model.connector.VariableDefinition;
-import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
-
 import java.util.List;
 import java.util.Map;
+
+import org.activiti.api.process.model.IntegrationContext;
+import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
+import org.activiti.bpmn.model.ServiceTask;
+import org.activiti.core.common.model.connector.ActionDefinition;
+import org.activiti.core.common.model.connector.VariableDefinition;
+import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 
 public class IntegrationContextBuilder {
 
@@ -53,6 +53,12 @@ public class IntegrationContextBuilder {
         IntegrationContextImpl integrationContext = new IntegrationContextImpl();
         integrationContext.setProcessInstanceId(execution.getProcessInstanceId());
         integrationContext.setProcessDefinitionId(execution.getProcessDefinitionId());
+        integrationContext.setActivityElementId(execution.getCurrentActivityId());
+        integrationContext.setBusinessKey(execution.getProcessInstanceBusinessKey());
+        // TODO How to get these attributes?
+        //integrationContext.setParentProcessInstanceId(?);
+        //integrationContext.setProcessDefinitionKey(?);
+        //integrationContext.setProcessDefinitionVersion(?);        
         integrationContext.setActivityElementId(execution.getCurrentActivityId());
 
         String implementation = ((ServiceTask) execution.getCurrentFlowElement()).getImplementation();

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -25,11 +25,8 @@ import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.core.common.model.connector.ActionDefinition;
 import org.activiti.core.common.model.connector.VariableDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.engine.impl.context.ExecutionContext;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
-import org.activiti.engine.repository.ProcessDefinition;
-import org.activiti.engine.runtime.ProcessInstance;
 
 public class IntegrationContextBuilder {
 
@@ -61,14 +58,13 @@ public class IntegrationContextBuilder {
         integrationContext.setBusinessKey(execution.getProcessInstanceBusinessKey());
 
         if(ExecutionEntity.class.isInstance(execution)) {
-            ExecutionContext executionContext = new ExecutionContext(ExecutionEntity.class.cast(execution));
-            
-            ProcessInstance processInstance = executionContext.getProcessInstance();
-            ProcessDefinition processDefinition = executionContext.getProcessDefinition();
-            
-            integrationContext.setProcessDefinitionKey(processDefinition.getKey());
-            integrationContext.setProcessDefinitionVersion(processDefinition.getVersion());
-            integrationContext.setParentProcessInstanceId(processInstance.getSuperExecutionId());
+            ExecutionEntity processInstance = ExecutionEntity.class.cast(execution)
+                                                                   .getProcessInstance();
+            if(processInstance != null) {
+                integrationContext.setProcessDefinitionKey(processInstance.getProcessDefinitionKey());
+                integrationContext.setProcessDefinitionVersion(processInstance.getProcessDefinitionVersion());
+                integrationContext.setParentProcessInstanceId(processInstance.getSuperExecutionId());
+            }
         }
         
         String implementation = ((ServiceTask) execution.getCurrentFlowElement()).getImplementation();
@@ -81,7 +77,7 @@ public class IntegrationContextBuilder {
 
         return integrationContext;
     }
-
+    
     private Map<String, Object> buildInBoundVariables(ActionDefinition actionDefinition,
                                                       DelegateExecution execution) {
 

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -25,7 +25,11 @@ import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.core.common.model.connector.ActionDefinition;
 import org.activiti.core.common.model.connector.VariableDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.impl.context.ExecutionContext;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.runtime.ProcessInstance;
 
 public class IntegrationContextBuilder {
 
@@ -55,12 +59,18 @@ public class IntegrationContextBuilder {
         integrationContext.setProcessDefinitionId(execution.getProcessDefinitionId());
         integrationContext.setActivityElementId(execution.getCurrentActivityId());
         integrationContext.setBusinessKey(execution.getProcessInstanceBusinessKey());
-        // TODO How to get these attributes?
-        //integrationContext.setParentProcessInstanceId(?);
-        //integrationContext.setProcessDefinitionKey(?);
-        //integrationContext.setProcessDefinitionVersion(?);        
-        integrationContext.setActivityElementId(execution.getCurrentActivityId());
 
+        if(ExecutionEntity.class.isInstance(execution)) {
+            ExecutionContext executionContext = new ExecutionContext(ExecutionEntity.class.cast(execution));
+            
+            ProcessInstance processInstance = executionContext.getProcessInstance();
+            ProcessDefinition processDefinition = executionContext.getProcessDefinition();
+            
+            integrationContext.setProcessDefinitionKey(processDefinition.getKey());
+            integrationContext.setProcessDefinitionVersion(processDefinition.getVersion());
+            integrationContext.setParentProcessInstanceId(processInstance.getSuperExecutionId());
+        }
+        
         String implementation = ((ServiceTask) execution.getCurrentFlowElement()).getImplementation();
 
         integrationContext.setConnectorType(implementation);

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -67,9 +67,14 @@ public class IntegrationContextBuilder {
                 
                 // Let's try extract parent process instance from super execution  
                 if(processInstance.getSuperExecutionId() != null) {
-                    Optional.ofNullable(processInstance.getSuperExecution())
-                            .ifPresent(superExecution -> integrationContext
-                                           .setParentProcessInstanceId(superExecution.getProcessInstanceId()));
+                    try {
+                        Optional.ofNullable(processInstance.getSuperExecution())
+                                .ifPresent(superExecution -> integrationContext
+                                .setParentProcessInstanceId(superExecution.getProcessInstanceId()));
+                    } catch (NullPointerException e) {
+                        // Ignore the exception in case getSuperExecution method call
+                        // cannot resolve entity because CommandContext is not available
+                    }
                 }
             }
         }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -18,6 +18,7 @@ package org.activiti.runtime.api.connector;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
@@ -63,7 +64,13 @@ public class IntegrationContextBuilder {
             if(processInstance != null) {
                 integrationContext.setProcessDefinitionKey(processInstance.getProcessDefinitionKey());
                 integrationContext.setProcessDefinitionVersion(processInstance.getProcessDefinitionVersion());
-                integrationContext.setParentProcessInstanceId(processInstance.getSuperExecutionId());
+                
+                // Let's try extract parent process instance from super execution  
+                if(processInstance.getSuperExecutionId() != null) {
+                    Optional.ofNullable(processInstance.getSuperExecution())
+                            .ifPresent(superExecution -> integrationContext
+                                           .setParentProcessInstanceId(superExecution.getProcessInstanceId()));
+                }
             }
         }
         

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/ConformanceServiceTaskModifyVariableTest.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/ConformanceServiceTaskModifyVariableTest.java
@@ -1,5 +1,9 @@
 package org.activiti.spring.conformance.set1;
 
+import static org.activiti.spring.conformance.set1.Set1RuntimeTestConfiguration.collectedEvents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.model.shared.event.VariableEvent;
 import org.activiti.api.model.shared.event.VariableUpdatedEvent;
@@ -18,10 +22,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.activiti.spring.conformance.set1.Set1RuntimeTestConfiguration.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
-
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public class ConformanceServiceTaskModifyVariableTest {
@@ -35,8 +35,7 @@ public class ConformanceServiceTaskModifyVariableTest {
 
     @After
     public void cleanUp() {
-        collectedEvents.clear();
-        connector2Executed = false;
+        Set1RuntimeTestConfiguration.reset();
     }
 
     /*
@@ -92,7 +91,7 @@ public class ConformanceServiceTaskModifyVariableTest {
         assertThat(throwable)
                 .isInstanceOf(NotFoundException.class);
 
-        assertThat(connector2Executed).isTrue();
+        assertThat(Set1RuntimeTestConfiguration.isConnector2Executed()).isTrue();
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/Set1RuntimeTestConfiguration.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/Set1RuntimeTestConfiguration.java
@@ -1,28 +1,38 @@
 package org.activiti.spring.conformance.set1;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.model.shared.event.VariableCreatedEvent;
 import org.activiti.api.model.shared.event.VariableDeletedEvent;
 import org.activiti.api.model.shared.event.VariableUpdatedEvent;
+import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.model.events.BPMNActivityCancelledEvent;
 import org.activiti.api.process.model.events.BPMNActivityCompletedEvent;
 import org.activiti.api.process.model.events.BPMNActivityStartedEvent;
 import org.activiti.api.process.model.events.BPMNSequenceFlowTakenEvent;
 import org.activiti.api.process.runtime.connector.Connector;
-import org.activiti.api.process.runtime.events.*;
+import org.activiti.api.process.runtime.events.ProcessCancelledEvent;
+import org.activiti.api.process.runtime.events.ProcessCompletedEvent;
+import org.activiti.api.process.runtime.events.ProcessCreatedEvent;
+import org.activiti.api.process.runtime.events.ProcessResumedEvent;
+import org.activiti.api.process.runtime.events.ProcessStartedEvent;
+import org.activiti.api.process.runtime.events.ProcessSuspendedEvent;
 import org.activiti.api.process.runtime.events.listener.BPMNElementEventListener;
 import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
 import org.activiti.api.runtime.shared.events.VariableEventListener;
-import org.activiti.api.task.runtime.events.*;
+import org.activiti.api.task.runtime.events.TaskAssignedEvent;
+import org.activiti.api.task.runtime.events.TaskCompletedEvent;
+import org.activiti.api.task.runtime.events.TaskCreatedEvent;
+import org.activiti.api.task.runtime.events.TaskSuspendedEvent;
+import org.activiti.api.task.runtime.events.TaskUpdatedEvent;
 import org.activiti.api.task.runtime.events.listener.TaskEventListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Configuration
 public class Set1RuntimeTestConfiguration {
@@ -31,10 +41,12 @@ public class Set1RuntimeTestConfiguration {
 
     public static List<RuntimeEvent> collectedEvents = new ArrayList<>();
 
-    public static boolean connector1Executed = false;
+    private static boolean connector1Executed = false;
 
-    public static boolean connector2Executed = false;
+    private static boolean connector2Executed = false;
 
+    private static IntegrationContext resultIntegrationContext = null;
+    
 
     @Bean
     public BPMNElementEventListener<BPMNActivityStartedEvent> bpmnActivityStartedListener() {
@@ -133,6 +145,9 @@ public class Set1RuntimeTestConfiguration {
     public Connector serviceImplementation() {
         return integrationContext -> {
             connector1Executed = true;
+            
+            resultIntegrationContext = integrationContext;
+            
             return integrationContext;
         };
     }
@@ -144,6 +159,29 @@ public class Set1RuntimeTestConfiguration {
             integrationContext.getOutBoundVariables().put("var1", integrationContext.getInBoundVariables().get("var1") + "-modified");
             return integrationContext;
         };
+    }
+
+    
+    public static IntegrationContext getResultIntegrationContext() {
+        return resultIntegrationContext;
+    }
+
+    
+    public static void reset() {
+        collectedEvents.clear();
+        resultIntegrationContext = null;
+        connector1Executed = false;
+        connector2Executed = false;
+    }
+
+    
+    public static boolean isConnector1Executed() {
+        return connector1Executed;
+    }
+
+    
+    public static boolean isConnector2Executed() {
+        return connector2Executed;
     }
 
 }


### PR DESCRIPTION
This PR injects process instance execution context attributes into IntegrationContext holder class at runtime.
