### PR TITLE
Fix: dispatch task and process updated events from CommandContext

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -38,8 +38,6 @@ import org.activiti.api.process.model.payloads.SuspendProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
 import org.activiti.api.process.runtime.ProcessRuntime;
 import org.activiti.api.process.runtime.conf.ProcessRuntimeConfiguration;
-import org.activiti.api.process.runtime.events.ProcessUpdatedEvent;
-import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionMetaImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceMetaImpl;
@@ -53,7 +51,6 @@ import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.RuntimeService;
 import org.activiti.engine.repository.ProcessDefinitionQuery;
-import org.activiti.runtime.api.event.impl.ProcessUpdatedEventImpl;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
 import org.activiti.runtime.api.model.impl.APIVariableInstanceConverter;
@@ -77,16 +74,14 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
 
     private final ProcessSecurityPoliciesManager securityPoliciesManager;
     
-    private final List<ProcessRuntimeEventListener<ProcessUpdatedEvent>> processUpdatedListeners;
-
     public ProcessRuntimeImpl(RepositoryService repositoryService,
                               APIProcessDefinitionConverter processDefinitionConverter,
                               RuntimeService runtimeService,
                               ProcessSecurityPoliciesManager securityPoliciesManager,
                               APIProcessInstanceConverter processInstanceConverter,
                               APIVariableInstanceConverter variableInstanceConverter,
-                              ProcessRuntimeConfiguration configuration,
-                              List<ProcessRuntimeEventListener<ProcessUpdatedEvent>> processUpdatedListeners) {
+                              ProcessRuntimeConfiguration configuration
+                              ) {
         this.repositoryService = repositoryService;
         this.processDefinitionConverter = processDefinitionConverter;
         this.runtimeService = runtimeService;
@@ -94,7 +89,6 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         this.processInstanceConverter = processInstanceConverter;
         this.variableInstanceConverter = variableInstanceConverter;
         this.configuration = configuration;
-        this.processUpdatedListeners=processUpdatedListeners;
     }
 
     @Override
@@ -337,14 +331,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
                                                                              .processInstanceId(updateProcessPayload.getProcessInstanceId())
                                                                              .singleResult());
         
-        fireProcessUpdatedEvent(updatedProcessInstance);
         return updatedProcessInstance;
  
-    }
-    
-    private void fireProcessUpdatedEvent(ProcessInstance updatedProcessInstance) {
-        for (ProcessRuntimeEventListener<ProcessUpdatedEvent> listener : processUpdatedListeners) {
-            listener.onEvent(new ProcessUpdatedEventImpl(updatedProcessInstance));
-        }
     }
 }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/conf/activiti/runtime/api/ProcessRuntimeAutoConfiguration.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/conf/activiti/runtime/api/ProcessRuntimeAutoConfiguration.java
@@ -86,16 +86,16 @@ public class ProcessRuntimeAutoConfiguration {
                                          ProcessSecurityPoliciesManager securityPoliciesManager,
                                          APIProcessInstanceConverter processInstanceConverter,
                                          APIVariableInstanceConverter variableInstanceConverter,
-                                         ProcessRuntimeConfiguration processRuntimeConfiguration,
-                                         @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessUpdatedEvent>> listeners) {
+                                         ProcessRuntimeConfiguration processRuntimeConfiguration
+                                         ) {
         return new ProcessRuntimeImpl(repositoryService,
                 processDefinitionConverter,
                 runtimeService,
                 securityPoliciesManager,
                 processInstanceConverter,
                 variableInstanceConverter,
-                processRuntimeConfiguration,
-                getInitializedProcessRuntimeEventListeners(listeners));
+                processRuntimeConfiguration
+                );
     }
 
     @Bean

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -16,8 +16,6 @@
 
 package org.activiti.runtime.api.impl;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -102,21 +100,4 @@ public class ProcessRuntimeImplTest {
         verifyNoMoreInteractions(internalProcess);
     }
     
-    @Test
-    public void shouldFailInRuntimeBundleService() {
-        assumeTrue(isClassnameAvailable("org.activiti.cloud.services.events.listeners.CloudProcessUpdatedProducer"));
-        
-        fail("Should implement and update tests in activiti-cloud-runtime-bundle-service ");
-    }
-    
-    private boolean isClassnameAvailable(String clazzName) {
-        try {
-            Class.forName(clazzName, false, this.getClass().getClassLoader());
-        } catch (LinkageError | ClassNotFoundException e) {
-            return false;
-        }
-        return true;
-    }    
- 
-
 }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -16,7 +16,8 @@
 
 package org.activiti.runtime.api.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -24,13 +25,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-import java.util.Collections;
-
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
-import org.activiti.api.process.runtime.events.ProcessUpdatedEvent;
-import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManager;
 import org.activiti.engine.RepositoryService;
@@ -39,7 +36,6 @@ import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
 public class ProcessRuntimeImplTest {
@@ -58,10 +54,6 @@ public class ProcessRuntimeImplTest {
     @Mock
     private  APIProcessInstanceConverter processInstanceConverter;
     
-    @Mock
-    private ProcessRuntimeEventListener<ProcessUpdatedEvent> listener;
-    
-    
     @Before
     public void setUp() {
         initMocks(this);
@@ -71,8 +63,9 @@ public class ProcessRuntimeImplTest {
                                                     securityPoliciesManager,
                                                     processInstanceConverter,
                                                     null,
-                                                    null,
-                                                    Collections.singletonList(listener)));
+                                                    null)
+                             );
+        
        doReturn(true).when(securityPoliciesManager).canWrite("processDefinitionKey");
   
     }
@@ -107,13 +100,23 @@ public class ProcessRuntimeImplTest {
         //then
         verify(runtimeService).updateBusinessKey("processId", "businessKey");
         verifyNoMoreInteractions(internalProcess);
-        
-        ArgumentCaptor<ProcessUpdatedEvent> captor = ArgumentCaptor.forClass(ProcessUpdatedEvent.class);
-        verify(listener).onEvent(captor.capture());
-        assertThat(captor.getValue().getEntity()).isEqualTo(updatedProcess);
     }
     
- 
+    @Test
+    public void shouldFailInRuntimeBundleService() {
+        assumeTrue(isClassnameAvailable("org.activiti.cloud.services.events.listeners.CloudProcessUpdatedProducer"));
+        
+        fail("Should implement and update tests in activiti-cloud-runtime-bundle-service ");
+    }
+    
+    private boolean isClassnameAvailable(String clazzName) {
+        try {
+            Class.forName(clazzName, false, this.getClass().getClassLoader());
+        } catch (LinkageError | ClassNotFoundException e) {
+            return false;
+        }
+        return true;
+    }    
  
 
 }

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/conf/TaskRuntimeAutoConfiguration.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/conf/TaskRuntimeAutoConfiguration.java
@@ -62,6 +62,7 @@ import org.activiti.runtime.api.event.internal.TaskCandidateUserRemovedListenerD
 import org.activiti.runtime.api.event.internal.TaskCompletedListenerDelegate;
 import org.activiti.runtime.api.event.internal.TaskCreatedListenerDelegate;
 import org.activiti.runtime.api.event.internal.TaskSuspendedListenerDelegate;
+import org.activiti.runtime.api.event.internal.TaskUpdatedListenerDelegate;
 import org.activiti.runtime.api.impl.TaskAdminRuntimeImpl;
 import org.activiti.runtime.api.impl.TaskRuntimeImpl;
 import org.activiti.runtime.api.model.impl.APITaskCandidateGroupConverter;
@@ -83,15 +84,13 @@ public class TaskRuntimeAutoConfiguration {
                                    SecurityManager securityManager,
                                    APITaskConverter taskConverter,
                                    APIVariableInstanceConverter variableInstanceConverter,
-                                   TaskRuntimeConfiguration configuration,
-                                   @Autowired(required = false) List<TaskRuntimeEventListener<TaskUpdatedEvent>> listeners) {
+                                   TaskRuntimeConfiguration configuration) {
         return new TaskRuntimeImpl(taskService,
                                    userGroupManager,
                                    securityManager,
                                    taskConverter,
                                    variableInstanceConverter,
-                                   configuration,
-                                   getInitializedTaskRuntimeEventListeners(listeners));
+                                   configuration);
     }
 
     @Bean
@@ -129,6 +128,16 @@ public class TaskRuntimeAutoConfiguration {
                                                                                      taskCreatedEventConverter),
                                                      ActivitiEventType.TASK_CREATED);
     }
+    
+    @Bean
+    public InitializingBean registerTaskUpdatedEventListener(RuntimeService runtimeService,
+                                                             @Autowired(required = false) List<TaskRuntimeEventListener<TaskUpdatedEvent>> listeners,
+                                                             ToAPITaskUpdatedEventConverter taskCreatedEventConverter) {
+        return () -> runtimeService.addEventListener(new TaskUpdatedListenerDelegate(getInitializedTaskRuntimeEventListeners(listeners),
+                                                                                     taskCreatedEventConverter),
+                                                     ActivitiEventType.ENTITY_UPDATED);
+    }
+    
 
     private <T> List<T> getInitializedTaskRuntimeEventListeners(List<T> taskRuntimeEventListeners) {
         return taskRuntimeEventListeners != null ? taskRuntimeEventListeners : Collections.emptyList();

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/internal/TaskUpdatedListenerDelegate.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/internal/TaskUpdatedListenerDelegate.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.event.internal;
+
+import java.util.List;
+
+import org.activiti.api.task.runtime.events.TaskUpdatedEvent;
+import org.activiti.api.task.runtime.events.listener.TaskRuntimeEventListener;
+import org.activiti.engine.delegate.event.ActivitiEntityEvent;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventListener;
+import org.activiti.runtime.api.event.impl.ToAPITaskUpdatedEventConverter;
+
+public class TaskUpdatedListenerDelegate implements ActivitiEventListener {
+
+    private List<TaskRuntimeEventListener<TaskUpdatedEvent>> taskUpdatedListeners;
+
+    private ToAPITaskUpdatedEventConverter taskUpdatedEventConverter;
+
+    public TaskUpdatedListenerDelegate(List<TaskRuntimeEventListener<TaskUpdatedEvent>> taskCreatedListeners,
+                                       ToAPITaskUpdatedEventConverter taskCreatedEventConverter) {
+        this.taskUpdatedListeners = taskCreatedListeners;
+        this.taskUpdatedEventConverter = taskCreatedEventConverter;
+    }
+
+    @Override
+    public void onEvent(ActivitiEvent event) {
+        if (event instanceof ActivitiEntityEvent) {
+            taskUpdatedEventConverter.from((ActivitiEntityEvent) event)
+                    .ifPresent(convertedEvent -> {
+                        for (TaskRuntimeEventListener<TaskUpdatedEvent> listener : taskUpdatedListeners) {
+                            listener.onEvent(convertedEvent);
+                        }
+                    });
+        }
+    }
+
+    @Override
+    public boolean isFailOnException() {
+        return false;
+    }
+}

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
@@ -39,11 +39,8 @@ import org.activiti.api.task.model.payloads.SetTaskVariablesPayload;
 import org.activiti.api.task.model.payloads.UpdateTaskPayload;
 import org.activiti.api.task.runtime.TaskRuntime;
 import org.activiti.api.task.runtime.conf.TaskRuntimeConfiguration;
-import org.activiti.api.task.runtime.events.TaskUpdatedEvent;
-import org.activiti.api.task.runtime.events.listener.TaskRuntimeEventListener;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.task.TaskQuery;
-import org.activiti.runtime.api.event.impl.TaskUpdatedEventImpl;
 import org.activiti.runtime.api.model.impl.APITaskConverter;
 import org.activiti.runtime.api.model.impl.APIVariableInstanceConverter;
 import org.activiti.runtime.api.query.impl.PageImpl;
@@ -64,22 +61,18 @@ public class TaskRuntimeImpl implements TaskRuntime {
 
     private final SecurityManager securityManager;
 
-    private final List<TaskRuntimeEventListener<TaskUpdatedEvent>> taskUpdatedListeners;
-
     public TaskRuntimeImpl(TaskService taskService,
                            UserGroupManager userGroupManager,
                            SecurityManager securityManager,
                            APITaskConverter taskConverter,
                            APIVariableInstanceConverter variableInstanceConverter,
-                           TaskRuntimeConfiguration configuration,
-                           List<TaskRuntimeEventListener<TaskUpdatedEvent>> taskUpdatedListeners) {
+                           TaskRuntimeConfiguration configuration) {
         this.taskService = taskService;
         this.userGroupManager = userGroupManager;
         this.securityManager = securityManager;
         this.taskConverter = taskConverter;
         this.variableInstanceConverter = variableInstanceConverter;
         this.configuration = configuration;
-        this.taskUpdatedListeners = taskUpdatedListeners;
     }
 
     @Override
@@ -261,16 +254,9 @@ public class TaskRuntimeImpl implements TaskRuntime {
             internalTask.setFormKey(updateTaskPayload.getFormKey());
         }
         //@TODO: add check to see if something was changed before saving + add all other updateable values
-        taskService.saveTask(internalTask);
-        Task convertedTask = task(updateTaskPayload.getTaskId());
-        fireTaskUpdatedEvent(convertedTask);
-        return convertedTask;
-    }
-
-    private void fireTaskUpdatedEvent(Task convertedTask) {
-        for (TaskRuntimeEventListener<TaskUpdatedEvent> listener : taskUpdatedListeners) {
-            listener.onEvent(new TaskUpdatedEventImpl(convertedTask));
-        }
+        org.activiti.engine.task.Task updatedTask = taskService.saveTask(internalTask);
+        
+        return taskConverter.from(updatedTask);
     }
 
     @Override

--- a/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/TaskService.java
@@ -57,7 +57,7 @@ public interface TaskService {
    * @param task
    *          the task, cannot be null.
    */
-  void saveTask(Task task);
+  Task saveTask(Task task);
 
   /**
    * Deletes the given task, not deleting historic information that is related to this task.

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/TaskServiceImpl.java
@@ -96,8 +96,8 @@ public class TaskServiceImpl extends ServiceImpl implements TaskService {
     return commandExecutor.execute(new NewTaskCmd(taskId));
   }
 
-  public void saveTask(Task task) {
-    commandExecutor.execute(new SaveTaskCmd(task));
+  public Task saveTask(Task task) {
+    return commandExecutor.execute(new SaveTaskCmd(task));
   }
 
   public void deleteTask(String taskId) {

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SaveTaskCmd.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SaveTaskCmd.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
 
  */
-public class SaveTaskCmd implements Command<Void>, Serializable {
+public class SaveTaskCmd implements Command<Task>, Serializable {
 
   private static final long serialVersionUID = 1L;
 
@@ -41,7 +41,7 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
     this.task = (TaskEntity) task;
   }
 
-  public Void execute(CommandContext commandContext) {
+  public Task execute(CommandContext commandContext) {
     if (task == null) {
       throw new ActivitiIllegalArgumentException("task is null");
     }
@@ -131,8 +131,8 @@ public class SaveTaskCmd implements Command<Void>, Serializable {
 
       }
       
-      commandContext.getTaskEntityManager().update(task);
-
+      return commandContext.getTaskEntityManager().update(task);
+      
     }
 
 

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SetProcessInstanceNameCmd.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SetProcessInstanceNameCmd.java
@@ -17,6 +17,8 @@ import java.io.Serializable;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
@@ -56,6 +58,10 @@ public class SetProcessInstanceNameCmd implements Command<Void>, Serializable {
 
     // Actually set the name
     execution.setName(name);
+    
+    if (commandContext.getEventDispatcher().isEnabled()) {
+        commandContext.getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_UPDATED, execution));
+      }
 
     // Record the change in history
     commandContext.getHistoryManager().recordProcessInstanceNameChange(processInstanceId, name);

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManagerImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManagerImpl.java
@@ -122,7 +122,7 @@ public class TaskEntityManagerImpl extends AbstractEntityManager<TaskEntity> imp
       if (taskEntity.getId() != null) {
         getHistoryManager().recordTaskAssigneeChange(taskEntity.getId(), taskEntity.getAssignee());
         addAssigneeIdentityLinks(taskEntity);
-        update(taskEntity);
+        update(taskEntity, fireEvents);
       }
     }
   }

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-set2/src/test/java/org/activiti/spring/conformance/set2/UserTaskCandidateGroupRuntimeTest.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-set2/src/test/java/org/activiti/spring/conformance/set2/UserTaskCandidateGroupRuntimeTest.java
@@ -1,5 +1,9 @@
 package org.activiti.spring.conformance.set2;
 
+import static org.activiti.spring.conformance.set2.Set2RuntimeTestConfiguration.collectedEvents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -15,6 +19,7 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.api.task.runtime.TaskRuntime;
+import org.activiti.spring.conformance.util.security.SecurityUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,11 +27,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.activiti.spring.conformance.util.security.SecurityUtil;
-
-import static org.activiti.spring.conformance.set2.Set2RuntimeTestConfiguration.collectedEvents;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -143,7 +143,8 @@ public class UserTaskCandidateGroupRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
 
         collectedEvents.clear();
 
@@ -223,8 +224,8 @@ public class UserTaskCandidateGroupRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
-
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
         collectedEvents.clear();
 
         // Check with user3, he/she shouldn't see any task now that the task was assigned
@@ -245,7 +246,8 @@ public class UserTaskCandidateGroupRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
 
         collectedEvents.clear();
 

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-set2/src/test/java/org/activiti/spring/conformance/set2/UserTaskCandidateUserRuntimeTest.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-set2/src/test/java/org/activiti/spring/conformance/set2/UserTaskCandidateUserRuntimeTest.java
@@ -1,5 +1,9 @@
 package org.activiti.spring.conformance.set2;
 
+import static org.activiti.spring.conformance.set2.Set2RuntimeTestConfiguration.collectedEvents;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -15,6 +19,7 @@ import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.api.task.runtime.TaskRuntime;
+import org.activiti.spring.conformance.util.security.SecurityUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -22,11 +27,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.activiti.spring.conformance.util.security.SecurityUtil;
-
-import static org.activiti.spring.conformance.set2.Set2RuntimeTestConfiguration.collectedEvents;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -135,8 +135,9 @@ public class UserTaskCandidateUserRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
-
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
+        
         collectedEvents.clear();
 
         //complete task now should work
@@ -204,8 +205,9 @@ public class UserTaskCandidateUserRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
-
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
+        
         collectedEvents.clear();
 
         Task releasedTask = taskRuntime.release(TaskPayloadBuilder.release().withTaskId(task.getId()).build());
@@ -215,7 +217,8 @@ public class UserTaskCandidateUserRuntimeTest {
 
         assertThat(collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
-                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED);
+                .containsExactly(TaskRuntimeEvent.TaskEvents.TASK_ASSIGNED,
+                                 TaskRuntimeEvent.TaskEvents.TASK_UPDATED);
 
         collectedEvents.clear();
 


### PR DESCRIPTION
This PR fixes #2252 event dispatching for task and process name update  commands to ensure that events are always generated and dispatched from existing CommandContext inside Activiti transaction, so that they can be aggregated and sent as event messages when Activiti transaction successfully completes.

