### PR TITLE
Resolve Execution entity parentProcessInstanceId attribute via Mybatis query mapping

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -65,13 +65,7 @@ public class IntegrationContextBuilder {
             if(processInstance != null) {
                 integrationContext.setProcessDefinitionKey(processInstance.getProcessDefinitionKey());
                 integrationContext.setProcessDefinitionVersion(processInstance.getProcessDefinitionVersion());
-                
-                // Let's try extract parent process instance from super execution  
-                if(processInstance.getSuperExecutionId() != null) {
-                    ExecutionEntity superExecution = extractSuperExecutionFromCommandContext(processInstance);
-                    
-                    integrationContext.setParentProcessInstanceId(superExecution.getProcessInstanceId());
-                }
+                integrationContext.setParentProcessInstanceId(processInstance.getParentProcessInstanceId());
             }
         }
         
@@ -84,15 +78,6 @@ public class IntegrationContextBuilder {
                 execution));
 
         return integrationContext;
-    }
-    
-    protected ExecutionEntity extractSuperExecutionFromCommandContext(ExecutionEntity processInstance) {
-        try {
-            return Optional.of(processInstance.getSuperExecution()).get();
-        } catch(NullPointerException cause) {
-            throw new ActivitiException("Activiti CommandContext is required.");
-        }
-        
     }
     
     private Map<String, Object> buildInBoundVariables(ActionDefinition actionDefinition,

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
@@ -31,8 +31,7 @@ public class APIProcessInstanceConverter extends ListConverter<org.activiti.engi
         processInstance.setDescription(internalProcessInstance.getDescription());
         processInstance.setProcessDefinitionId(internalProcessInstance.getProcessDefinitionId());
         processInstance.setProcessDefinitionKey(internalProcessInstance.getProcessDefinitionKey());
-        // @TODO Depends on PR in activiti-api: https://github.com/Activiti/activiti-api/pull/62
-        //processInstance.setProcessDefinitionVersion(internalProcessInstance.getProcessDefinitionVersion());
+        processInstance.setProcessDefinitionVersion(internalProcessInstance.getProcessDefinitionVersion());
         processInstance.setInitiator(internalProcessInstance.getStartUserId());
         processInstance.setStartDate(internalProcessInstance.getStartTime());
         processInstance.setProcessDefinitionKey(internalProcessInstance.getProcessDefinitionKey());

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverter.java
@@ -26,9 +26,13 @@ public class APIProcessInstanceConverter extends ListConverter<org.activiti.engi
     public ProcessInstance from(org.activiti.engine.runtime.ProcessInstance internalProcessInstance) {
         ProcessInstanceImpl processInstance = new ProcessInstanceImpl();
         processInstance.setId(internalProcessInstance.getId());
+        processInstance.setParentId(internalProcessInstance.getParentProcessInstanceId());
         processInstance.setName(internalProcessInstance.getName());
         processInstance.setDescription(internalProcessInstance.getDescription());
         processInstance.setProcessDefinitionId(internalProcessInstance.getProcessDefinitionId());
+        processInstance.setProcessDefinitionKey(internalProcessInstance.getProcessDefinitionKey());
+        // @TODO Depends on PR in activiti-api: https://github.com/Activiti/activiti-api/pull/62
+        //processInstance.setProcessDefinitionVersion(internalProcessInstance.getProcessDefinitionVersion());
         processInstance.setInitiator(internalProcessInstance.getStartUserId());
         processInstance.setStartDate(internalProcessInstance.getStartTime());
         processInstance.setProcessDefinitionKey(internalProcessInstance.getProcessDefinitionKey());

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
@@ -1,7 +1,6 @@
 package org.activiti.runtime.api.connector;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -10,8 +9,6 @@ import java.util.Map;
 
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.bpmn.model.ServiceTask;
-import org.activiti.core.common.model.connector.ActionDefinition;
-import org.activiti.engine.ActivitiException;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.junit.Test;
 
@@ -35,7 +32,6 @@ public class IntegrationContextBuilderTest {
         //given
         ExecutionEntity execution = mock(ExecutionEntity.class);
         ExecutionEntity processInstance = mock(ExecutionEntity.class);
-        ExecutionEntity superExecution = mock(ExecutionEntity.class);
         ServiceTask serviceTask = mock(ServiceTask.class);
         Map<String, Object> variables = Collections.singletonMap("key", "value");
 
@@ -50,9 +46,7 @@ public class IntegrationContextBuilderTest {
         given(execution.getProcessInstance()).willReturn(processInstance);
         given(processInstance.getProcessDefinitionKey()).willReturn(PROCESS_DEFINITION_KEY);
         given(processInstance.getProcessDefinitionVersion()).willReturn(PROCESS_DEFINITION_VERSION);
-        given(processInstance.getSuperExecutionId()).willReturn(SUPER_EXECUTION_ID);
-        given(processInstance.getSuperExecution()).willReturn(superExecution);
-        given(superExecution.getProcessInstanceId()).willReturn(PARENT_PROCESS_INSTANCE_ID);
+        given(processInstance.getParentProcessInstanceId()).willReturn(PARENT_PROCESS_INSTANCE_ID);
         
         //when
         IntegrationContext integrationContext = subject.from(execution, null);
@@ -69,22 +63,4 @@ public class IntegrationContextBuilderTest {
         assertThat(integrationContext.getParentProcessInstanceId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
         assertThat(integrationContext.getInBoundVariables()).containsAllEntriesOf(variables);
     }    
-    
-    @Test(expected=ActivitiException.class)
-    public void shouldThrowActivitiExceptionIfUsedOutsideCommandContext() {
-        //given
-        ExecutionEntity execution = mock(ExecutionEntity.class);
-        ExecutionEntity processInstance = mock(ExecutionEntity.class);
-        
-        given(execution.getProcessInstance()).willReturn(processInstance);
-        given(processInstance.getSuperExecutionId()).willReturn(SUPER_EXECUTION_ID);
-        given(processInstance.getSuperExecution()).willThrow(NullPointerException.class);
-        
-        //when
-        subject.from(execution, new ActionDefinition());
-
-        //then
-        fail("Expected ActivitiException!");
-    }
-    
 }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.runtime.api.connector;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,7 +33,6 @@ public class IntegrationContextBuilderTest {
     
     private static final int PROCESS_DEFINITION_VERSION = 1;
     private static final String PARENT_PROCESS_INSTANCE_ID = "parentProcessInstanceId";
-    private static final String SUPER_EXECUTION_ID = "superExecutionId";
     private static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
     private static final String PROCESS_INSTANCE_BUSINESS_KEY = "processInstanceBusinessKey";
     private static final String CURRENT_ACTIVITY_ID = "currentActivityId";

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.model.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.ProcessInstance.ProcessInstanceStatus;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl;
+import org.activiti.engine.impl.persistence.entity.SuspensionState;
+import org.junit.Test;
+
+
+public class APIProcessInstanceConverterTest {
+
+    private static final String BUSINESS_KEY = "businessKey";
+    private static final String START_USER_ID = "startUserId";
+    private static final String DESCRIPTION = "description";
+    private static final String NAME = "name";
+    private static final int PROCESS_DEFINITION_VERSION = 1;
+    private static final String PARENT_PROCESS_INSTANCE_ID = "parentProcessInstanceId";
+    private static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+    private static final String PROCESS_DEFINITION_ID = "processDefinitionId";
+    private static final String PROCESS_INSTANCE_ID = "processInstanceId";
+    
+    private APIProcessInstanceConverter subject = new APIProcessInstanceConverter();
+    private Date startTime = new Date();
+    
+    @Test
+    public void shouldConvertFromInternalProcessInstanceWithRunningStatus() {
+        //given
+        ExecutionEntity internalProcessInstance = anInternalProcessInstance(startTime);
+
+        internalProcessInstance.setActive(true);
+        
+        //when
+        ProcessInstance result = subject.from(internalProcessInstance);
+
+        //then
+        assertThat(result.getStatus()).isEqualTo(ProcessInstanceStatus.RUNNING);
+    }
+
+    @Test
+    public void shouldConvertFromInternalProcessInstanceWithSuspendedStatus() {
+        //given
+        ExecutionEntity internalProcessInstance = anInternalProcessInstance(startTime);
+
+        internalProcessInstance.setSuspensionState(SuspensionState.SUSPENDED.getStateCode());
+        
+        //when
+        ProcessInstance result = subject.from(internalProcessInstance);
+
+        //then
+        assertValidProcessInstanceResult(result);
+        assertThat(result.getStatus()).isEqualTo(ProcessInstanceStatus.SUSPENDED);
+    }
+
+    @Test
+    public void shouldConvertFromInternalProcessInstanceWithCompletedStatus() {
+        //given
+        ExecutionEntity internalProcessInstance = anInternalProcessInstance(startTime);
+
+        internalProcessInstance.setEnded(true);
+        
+        //when
+        ProcessInstance result = subject.from(internalProcessInstance);
+
+        //then
+        assertThat(result).isNotNull();
+        assertThat(result.getStatus()).isEqualTo(ProcessInstanceStatus.COMPLETED);
+    }
+
+    private void assertValidProcessInstanceResult(ProcessInstance result) {
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(PROCESS_INSTANCE_ID);
+        assertThat(result.getBusinessKey()).isEqualTo(BUSINESS_KEY);
+        assertThat(result.getProcessDefinitionId()).isEqualTo(PROCESS_DEFINITION_ID);
+        assertThat(result.getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
+        // @TODO Depends on PR in activiti-api: https://github.com/Activiti/activiti-api/pull/62
+        //assertThat(result.getProcessDefinitionVersion()).isEqualTo(PROCESS_DEFINITION_VERSION);
+        assertThat(result.getParentId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
+        assertThat(result.getName()).isEqualTo(NAME);
+        assertThat(result.getParentId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
+        assertThat(result.getInitiator()).isEqualTo(START_USER_ID);
+        assertThat(result.getStartDate()).isEqualTo(startTime);
+    }
+    
+    private ExecutionEntity anInternalProcessInstance(Date startTime) {
+        ExecutionEntity internalProcessInstance = new ExecutionEntityImpl();        
+        
+        internalProcessInstance.setId(PROCESS_INSTANCE_ID);
+        internalProcessInstance.setParentProcessInstanceId(PARENT_PROCESS_INSTANCE_ID);
+        internalProcessInstance.setProcessDefinitionId(PROCESS_DEFINITION_ID);
+        internalProcessInstance.setProcessDefinitionKey(PROCESS_DEFINITION_KEY);
+        internalProcessInstance.setProcessDefinitionVersion(PROCESS_DEFINITION_VERSION);
+        internalProcessInstance.setBusinessKey(BUSINESS_KEY);
+        internalProcessInstance.setName(NAME);
+        internalProcessInstance.setDescription(DESCRIPTION);
+        internalProcessInstance.setStartUserId(START_USER_ID);
+        internalProcessInstance.setStartTime(startTime);
+        internalProcessInstance.setActive(true);
+        
+        return internalProcessInstance;
+    }
+    
+}

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
@@ -16,8 +16,6 @@
 
 package org.activiti.runtime.api.model.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Date;
 
 import org.activiti.api.process.model.ProcessInstance;
@@ -26,6 +24,8 @@ import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl;
 import org.activiti.engine.impl.persistence.entity.SuspensionState;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class APIProcessInstanceConverterTest {
@@ -94,8 +94,7 @@ public class APIProcessInstanceConverterTest {
         assertThat(result.getBusinessKey()).isEqualTo(BUSINESS_KEY);
         assertThat(result.getProcessDefinitionId()).isEqualTo(PROCESS_DEFINITION_ID);
         assertThat(result.getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
-        // @TODO Depends on PR in activiti-api: https://github.com/Activiti/activiti-api/pull/62
-        //assertThat(result.getProcessDefinitionVersion()).isEqualTo(PROCESS_DEFINITION_VERSION);
+        assertThat(result.getProcessDefinitionVersion()).isEqualTo(PROCESS_DEFINITION_VERSION);
         assertThat(result.getParentId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
         assertThat(result.getName()).isEqualTo(NAME);
         assertThat(result.getDescription()).isEqualTo(DESCRIPTION);

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
@@ -54,6 +54,7 @@ public class APIProcessInstanceConverterTest {
         ProcessInstance result = subject.from(internalProcessInstance);
 
         //then
+        assertValidProcessInstanceResult(result);
         assertThat(result.getStatus()).isEqualTo(ProcessInstanceStatus.RUNNING);
     }
 
@@ -83,7 +84,7 @@ public class APIProcessInstanceConverterTest {
         ProcessInstance result = subject.from(internalProcessInstance);
 
         //then
-        assertThat(result).isNotNull();
+        assertValidProcessInstanceResult(result);
         assertThat(result.getStatus()).isEqualTo(ProcessInstanceStatus.COMPLETED);
     }
 

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/impl/APIProcessInstanceConverterTest.java
@@ -98,6 +98,7 @@ public class APIProcessInstanceConverterTest {
         //assertThat(result.getProcessDefinitionVersion()).isEqualTo(PROCESS_DEFINITION_VERSION);
         assertThat(result.getParentId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
         assertThat(result.getName()).isEqualTo(NAME);
+        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
         assertThat(result.getParentId()).isEqualTo(PARENT_PROCESS_INSTANCE_ID);
         assertThat(result.getInitiator()).isEqualTo(START_USER_ID);
         assertThat(result.getStartDate()).isEqualTo(startTime);

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntity.java
@@ -61,6 +61,8 @@ public interface ExecutionEntity extends DelegateExecution, Execution, ProcessIn
 
   void setRootProcessInstanceId(String rootProcessInstanceId);
   
+  public void setParentProcessInstanceId(String parentProcessInstanceId);
+  
   ExecutionEntity getRootProcessInstance();
   
   void setRootProcessInstance(ExecutionEntity rootProcessInstance);

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -198,6 +198,8 @@ public class ExecutionEntityImpl extends VariableScopeImpl implements ExecutionE
   
   protected boolean isDeleted; // TODO: should be in entity superclass probably
 
+  protected String parentProcessInstanceId;
+
   public ExecutionEntityImpl() {
     
   }
@@ -410,6 +412,16 @@ public class ExecutionEntityImpl extends VariableScopeImpl implements ExecutionE
     }
   }
 
+  // parent process instance id      /////////////////////////////////////////
+
+  public String getParentProcessInstanceId() {
+    return parentProcessInstanceId;
+  }
+
+  public void setParentProcessInstanceId(String parentProcessInstanceId) {
+      this.parentProcessInstanceId = parentProcessInstanceId;
+    }
+  
   // super- and subprocess executions /////////////////////////////////////////
 
   public String getSuperExecutionId() {
@@ -429,8 +441,10 @@ public class ExecutionEntityImpl extends VariableScopeImpl implements ExecutionE
 
     if (superExecution != null) {
       this.superExecutionId = ((ExecutionEntityImpl) superExecution).getId();
+      this.parentProcessInstanceId = superExecution.getProcessInstanceId(); 
     } else {
       this.superExecutionId = null;
+      this.parentProcessInstanceId = null;
     }
   }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -264,6 +264,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     childExecution.setProcessDefinitionKey(parentExecutionEntity.getProcessDefinitionKey());
     childExecution.setProcessInstanceId(parentExecutionEntity.getProcessInstanceId() != null 
         ? parentExecutionEntity.getProcessInstanceId() : parentExecutionEntity.getId());
+    childExecution.setParentProcessInstanceId(parentExecutionEntity.getParentProcessInstanceId());
     childExecution.setScope(false);
 
     // manage the bidirectional parent-child relation

--- a/activiti-engine/src/main/java/org/activiti/engine/runtime/Execution.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/runtime/Execution.java
@@ -60,6 +60,12 @@ public interface Execution {
    * Id of the root of the execution tree representing the process instance that has no super execution.
    */
   public String getRootProcessInstanceId();
+  
+  /**
+   * Id of the root of the execution tree representing the process instance that has no super execution.
+   */
+  public String getParentProcessInstanceId();
+  
 
   /**
    * The tenant identifier of this process instance

--- a/activiti-engine/src/main/java/org/activiti/engine/runtime/Execution.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/runtime/Execution.java
@@ -62,7 +62,7 @@ public interface Execution {
   public String getRootProcessInstanceId();
   
   /**
-   * Id of the root of the execution tree representing the process instance that has no super execution.
+   * Returns Id of the process instance related to the super execution of this execution.
    */
   public String getParentProcessInstanceId();
   

--- a/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -495,7 +495,8 @@
   <sql id="selectProcessInstanceWithVariablesByQueryCriteriaColumns">
    ${limitBefore}
    <if test="_databaseId != 'db2' and _databaseId != 'mssql'">  
-    select distinct RES.*, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId, S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_, 
+    select distinct RES.*, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId,
+    S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_, 
     VAR.ID_ as VAR_ID_, VAR.NAME_ as VAR_NAME_, VAR.TYPE_ as VAR_TYPE_, VAR.REV_ as VAR_REV_,
     VAR.PROC_INST_ID_ as VAR_PROC_INST_ID_, VAR.EXECUTION_ID_ as VAR_EXECUTION_ID_, VAR.TASK_ID_ as VAR_TASK_ID_,
     VAR.BYTEARRAY_ID_ as VAR_BYTEARRAY_ID_, VAR.DOUBLE_ as VAR_DOUBLE_, 
@@ -503,7 +504,8 @@
     ${limitBetween}
    </if>
    <if test="_databaseId == 'db2' || _databaseId == 'mssql'">
-    select distinct TEMPRES_ID_ as ID_, TEMPP_KEY_ as ProcessDefinitionKey, TEMPP_ID_ as ProcessDefinitionId, TEMPP_NAME_ as ProcessDefinitionName, TEMPP_VERSION_ as ProcessDefinitionVersion, TEMPP_DEPLOYMENT_ID_ as DeploymentId, 
+    select distinct TEMPRES_ID_ as ID_, TEMPP_KEY_ as ProcessDefinitionKey, TEMPP_ID_ as ProcessDefinitionId, TEMPP_NAME_ as ProcessDefinitionName, TEMPP_VERSION_ as ProcessDefinitionVersion, TEMPP_DEPLOYMENT_ID_ as DeploymentId,
+    TEMPS_PARENT_PROC_INST_ID_ AS PARENT_PROC_INST_ID_, 
     TEMPRES_REV_ as REV_, TEMPRES_ACT_ID_ as ACT_ID_,
     TEMPRES_BUSINESS_KEY_ as BUSINESS_KEY_, TEMPRES_IS_ACTIVE_ as IS_ACTIVE_,
     TEMPRES_IS_CONCURRENT_ as IS_CONCURRENT_, TEMPRES_IS_SCOPE_ as IS_SCOPE_,
@@ -528,6 +530,7 @@
     TEMPVAR_TEXT_ as VAR_TEXT_, TEMPVAR_TEXT2_ as VAR_TEXT2_, TEMPVAR_LONG_ as VAR_LONG_
      ${limitOuterJoinBetween}
     RES.ID_ as TEMPRES_ID_, RES.REV_ as TEMPRES_REV_, P.KEY_ as TEMPP_KEY_, P.ID_ as TEMPP_ID_, P.NAME_ as TEMPP_NAME_, P.VERSION_ as TEMPP_VERSION_, P.DEPLOYMENT_ID_ as TEMPP_DEPLOYMENT_ID_,
+    S.PROC_INST_ID_ AS TEMPS_PARENT_PROC_INST_ID_, 
     
     RES.ACT_ID_ as TEMPRES_ACT_ID_, 
     RES.PROC_INST_ID_ as TEMPRES_PROC_INST_ID_, 

--- a/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -240,6 +240,7 @@
     <result property="deadLetterJobCount" column="DEADLETTER_JOB_COUNT_" jdbcType="INTEGER" />
     <result property="variableCount" column="VAR_COUNT_" jdbcType="INTEGER" />
     <result property="identityLinkCount" column="ID_LINK_COUNT_" jdbcType="INTEGER" />
+    <result property="parentProcessInstanceId" column="PARENT_PROC_INST_ID_" jdbcType="VARCHAR"/>
   </resultMap>
   
   <resultMap id="processInstanceResultMap" type="org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl">
@@ -279,8 +280,10 @@
     <result property="deadLetterJobCount" column="DEADLETTER_JOB_COUNT_" jdbcType="INTEGER" />
     <result property="variableCount" column="VAR_COUNT_" jdbcType="INTEGER" />
     <result property="identityLinkCount" column="ID_LINK_COUNT_" jdbcType="INTEGER" />
+    <result property="parentProcessInstanceId" column="PARENT_PROC_INST_ID_" jdbcType="VARCHAR"/>
   </resultMap>
   
+  <!-- TODO Review because not used anywhere -->
   <resultMap id="executionAndVariablesResultMap" type="org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl">
     <id property="id" column="ID_" jdbcType="VARCHAR" />
     <result property="revision" column="REV_" jdbcType="INTEGER" />
@@ -310,6 +313,7 @@
     <result property="deadLetterJobCount" column="DEADLETTER_JOB_COUNT_" jdbcType="INTEGER" />
     <result property="variableCount" column="VAR_COUNT_" jdbcType="INTEGER" />
     <result property="identityLinkCount" column="ID_LINK_COUNT_" jdbcType="INTEGER" />
+    <result property="parentProcessInstanceId" column="PARENT_PROC_INST_ID_" jdbcType="VARCHAR"/>
     <collection property="queryVariables" column="EXECUTION_ID_" javaType="ArrayList" ofType="org.activiti.engine.impl.persistence.entity.VariableInstanceEntityImpl">
       <id property="id" column="VAR_ID_"/>
       <result property="name" column="VAR_NAME_" javaType="String" jdbcType="VARCHAR" />
@@ -360,6 +364,7 @@
     <result property="deadLetterJobCount" column="DEADLETTER_JOB_COUNT_" jdbcType="INTEGER" />
     <result property="variableCount" column="VAR_COUNT_" jdbcType="INTEGER" />
     <result property="identityLinkCount" column="ID_LINK_COUNT_" jdbcType="INTEGER" />
+    <result property="parentProcessInstanceId" column="PARENT_PROC_INST_ID_" jdbcType="VARCHAR"/>
     <collection property="queryVariables" column="EXECUTION_ID_" javaType="ArrayList" ofType="org.activiti.engine.impl.persistence.entity.VariableInstanceEntityImpl">
       <id property="id" column="VAR_ID_"/>
       <result property="name" column="VAR_NAME_" javaType="String" jdbcType="VARCHAR" />
@@ -378,33 +383,44 @@
   
   <!-- EXECUTION SELECT -->
   
+  <sql id="selectExecutionsFromSql">  
+    select E.*, S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_ 
+    from ${prefix}ACT_RU_EXECUTION E LEFT OUTER JOIN ${prefix}ACT_RU_EXECUTION S ON E.SUPER_EXEC_ = S.ID_  
+  </sql>
+  
   <select id="selectExecutionsWithSameRootProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION
-    where ROOT_PROC_INST_ID_ = (select ROOT_PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = #{parameter})
+    <include refid="selectExecutionsFromSql"/>
+    where E.ROOT_PROC_INST_ID_ = (select ROOT_PROC_INST_ID_ from ${prefix}ACT_RU_EXECUTION where ID_ = #{parameter})
   </select>
   
   <select id="selectExecution" parameterType="string" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION where ID_ = #{id, jdbcType=VARCHAR}
+    <include refid="selectExecutionsFromSql"/>
+    where E.ID_ = #{id, jdbcType=VARCHAR}
+  </select>
+
+  <select id="selectSuperExecution" parameterType="string" resultMap="executionResultMap">
+    <include refid="selectExecutionsFromSql"/>
+    where E.ID_ = #{id, jdbcType=VARCHAR}
   </select>
   
   <select id="selectExecutionsByParentExecutionId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION
-    where PARENT_ID_ = #{parameter}
+    <include refid="selectExecutionsFromSql"/>
+    where E.PARENT_ID_ = #{parameter}
   </select>
   
   <select id="selectExecutionsByRootProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION
-    where ROOT_PROC_INST_ID_ = #{parameter}
+    <include refid="selectExecutionsFromSql"/>
+    where E.ROOT_PROC_INST_ID_ = #{parameter}
   </select>
   
   <select id="selectChildExecutionsByProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION
-    where PROC_INST_ID_ = #{parameter} and PARENT_ID_ is not null
+    <include refid="selectExecutionsFromSql"/>
+    where E.PROC_INST_ID_ = #{parameter} and E.PARENT_ID_ is not null
   </select>
   
   <select id="selectExecutionsByProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select * from ${prefix}ACT_RU_EXECUTION
-    where PROC_INST_ID_ = #{parameter}
+    <include refid="selectExecutionsFromSql"/>
+    where E.PROC_INST_ID_ = #{parameter}
   </select>
   
   <select id="selectProcessInstanceIdsByProcessDefinitionId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultType="string">
@@ -414,25 +430,22 @@
   </select>
   
   <select id="selectInactiveExecutionsForProcessInstance" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-  	select *
-  	from ${prefix}ACT_RU_EXECUTION
-  	where PROC_INST_ID_ = #{parameter.processInstanceId}	
-  	and IS_ACTIVE_ = #{parameter.isActive}
+    <include refid="selectExecutionsFromSql"/>
+  	where E.PROC_INST_ID_ = #{parameter.processInstanceId}	
+  	and E.IS_ACTIVE_ = #{parameter.isActive}
   </select>
   
   <select id="selectInactiveExecutionsInActivityAndProcessInstance" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-  	select *
-  	from ${prefix}ACT_RU_EXECUTION
-  	where ACT_ID_ = #{parameter.activityId}
-  	and PROC_INST_ID_ = #{parameter.processInstanceId}
-  	and IS_ACTIVE_ = #{parameter.isActive}
+    <include refid="selectExecutionsFromSql"/>
+  	where E.ACT_ID_ = #{parameter.activityId}
+  	and E.PROC_INST_ID_ = #{parameter.processInstanceId}
+  	and E.IS_ACTIVE_ = #{parameter.isActive}
   </select>
   
   <select id="selectExecutionsByParentExecutionAndActivityIds" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="executionResultMap">
-    select *
-    from ${prefix}ACT_RU_EXECUTION
-    where PARENT_ID_ = #{parameter.parentExecutionId}
-    and ACT_ID_ in 
+    <include refid="selectExecutionsFromSql"/>
+    where E.PARENT_ID_ = #{parameter.parentExecutionId}
+    and E.ACT_ID_ in 
     <foreach item="activityId" collection="parameter.activityIds" open="(" separator="," close=")">
           #{activityId}
     </foreach>
@@ -440,7 +453,7 @@
   
   <select id="selectExecutionsByQueryCriteria" parameterType="org.activiti.engine.impl.ExecutionQueryImpl" resultMap="executionResultMap">
   	${limitBefore}
-    select distinct RES.* ${limitBetween}, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId
+    select distinct RES.* ${limitBetween}, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_ 
     <include refid="selectExecutionsByQueryCriteriaSql"/>
     ${orderBy}
     ${limitAfter}
@@ -454,7 +467,7 @@
   <!--  same as selectExecutionsByQueryCriteria, but with different parameterType -->
   <select id="selectProcessInstanceByQueryCriteria" parameterType="org.activiti.engine.impl.ProcessInstanceQueryImpl" resultMap="processInstanceResultMap">
   	${limitBefore}
-    select distinct RES.* ${limitBetween}, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId
+    select distinct RES.* ${limitBetween}, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId, S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_
     <include refid="selectExecutionsByQueryCriteriaSql"/>
     ${orderBy}
     ${limitAfter}
@@ -468,6 +481,7 @@
   <sql id="selectExecutionsByQueryCriteriaSql">  
     from ${prefix}ACT_RU_EXECUTION RES
     inner join ${prefix}ACT_RE_PROCDEF P on RES.PROC_DEF_ID_ = P.ID_
+    left outer join ${prefix}ACT_RU_EXECUTION S on RES.SUPER_EXEC_ = S.ID_
     <include refid="commonSelectExecutionsByQueryCriteriaSql"/>
   </sql>
   
@@ -481,7 +495,7 @@
   <sql id="selectProcessInstanceWithVariablesByQueryCriteriaColumns">
    ${limitBefore}
    <if test="_databaseId != 'db2' and _databaseId != 'mssql'">  
-    select distinct RES.*, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId, 
+    select distinct RES.*, P.KEY_ as ProcessDefinitionKey, P.ID_ as ProcessDefinitionId, P.NAME_ as ProcessDefinitionName, P.VERSION_ as ProcessDefinitionVersion, P.DEPLOYMENT_ID_ as DeploymentId, S.PROC_INST_ID_ AS PARENT_PROC_INST_ID_, 
     VAR.ID_ as VAR_ID_, VAR.NAME_ as VAR_NAME_, VAR.TYPE_ as VAR_TYPE_, VAR.REV_ as VAR_REV_,
     VAR.PROC_INST_ID_ as VAR_PROC_INST_ID_, VAR.EXECUTION_ID_ as VAR_EXECUTION_ID_, VAR.TASK_ID_ as VAR_TASK_ID_,
     VAR.BYTEARRAY_ID_ as VAR_BYTEARRAY_ID_, VAR.DOUBLE_ as VAR_DOUBLE_, 
@@ -552,6 +566,7 @@
   <sql id="selectProcessInstanceWithVariablesByQueryCriteriaSql">  
     from ${prefix}ACT_RU_EXECUTION RES
     inner join ${prefix}ACT_RE_PROCDEF P on RES.PROC_DEF_ID_ = P.ID_
+    left outer join ${prefix}ACT_RU_EXECUTION S on RES.SUPER_EXEC_ = S.ID_
     <if test="includeProcessVariables">
       left outer join ${prefix}ACT_RU_VARIABLE VAR ON RES.PROC_INST_ID_ = VAR.EXECUTION_ID_ and VAR.TASK_ID_ is null
     </if>

--- a/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.identity.Authentication;
@@ -47,8 +48,6 @@ import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ExecutionQuery;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.test.Deployment;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
 
@@ -1647,4 +1646,17 @@ public class ExecutionQueryTest extends PluggableActivitiTestCase {
       }
     }
   }
+  
+    @Deployment(resources = {"org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", 
+                             "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml"})
+    public void testOnlyExecutionsWithParentProcessInstanceId() throws Exception {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().onlySubProcessExecutions().list();
+        assertEquals(1, executions.size());
+        for (Execution execution : executions) {
+            assertTrue(null != execution.getParentProcessInstanceId());
+            assertEquals(processInstance.getId(), execution.getParentProcessInstanceId());
+        }
+    }
 }

--- a/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ExecutionQueryTest.java
@@ -1649,7 +1649,7 @@ public class ExecutionQueryTest extends PluggableActivitiTestCase {
   
     @Deployment(resources = {"org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", 
                              "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml"})
-    public void testOnlyExecutionsWithParentProcessInstanceId() throws Exception {
+    public void testExecutionQueryParentProcessInstanceIdResultMapping() throws Exception {
         ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
 
         List<Execution> executions = runtimeService.createExecutionQuery().onlySubProcessExecutions().list();

--- a/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -469,10 +469,25 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
   }
 
   @Deployment(resources = { "org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml" })
-  public void testQueryParentProcessInstanceId() {
+  public void testQueryParentProcessInstanceIdResultMapping() {
     ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
 
     ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().superProcessInstanceId(superProcessInstance.getId());
+    ProcessInstance subProcessInstance = query.singleResult();
+    assertNotNull(subProcessInstance);
+    assertEquals(1, query.list().size());
+    assertEquals(1, query.count());
+    assertEquals(superProcessInstance.getId(), subProcessInstance.getParentProcessInstanceId());
+  }
+
+  @Deployment(resources = { "org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml" })
+  public void testQueryWithVariablesParentProcessInstanceIdResultMapping() {
+    ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
+
+    ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery()
+                                               .superProcessInstanceId(superProcessInstance.getId())
+                                               .includeProcessVariables();
+    
     ProcessInstance subProcessInstance = query.singleResult();
     assertNotNull(subProcessInstance);
     assertEquals(1, query.list().size());

--- a/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.history.HistoryLevel;
@@ -35,8 +36,6 @@ import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.runtime.ProcessInstanceQuery;
 import org.activiti.engine.test.Deployment;
-
-import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
 
@@ -469,6 +468,18 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
     assertEquals(1, query.count());
   }
 
+  @Deployment(resources = { "org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml" })
+  public void testQueryParentProcessInstanceId() {
+    ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");
+
+    ProcessInstanceQuery query = runtimeService.createProcessInstanceQuery().superProcessInstanceId(superProcessInstance.getId());
+    ProcessInstance subProcessInstance = query.singleResult();
+    assertNotNull(subProcessInstance);
+    assertEquals(1, query.list().size());
+    assertEquals(1, query.count());
+    assertEquals(superProcessInstance.getId(), subProcessInstance.getParentProcessInstanceId());
+  }
+  
   @Deployment(resources = { "org/activiti/engine/test/api/runtime/superProcess.bpmn20.xml", "org/activiti/engine/test/api/runtime/subProcess.bpmn20.xml" })
   public void testOrQueryBySuperProcessInstanceId() {
     ProcessInstance superProcessInstance = runtimeService.startProcessInstanceByKey("subProcessQueryTest");


### PR DESCRIPTION
This PR adds support to expose `parentProcessInstanceId` attribute for Execution entity in the Activiti engine core . The rationale to do so is that internal entity model converters always need to run inside Activiti transaction in order to be able to resolve lazily associated `superExecution` entity to get parent process instance id. Resolving lazy associations this way for each execution record will create additional queries to the engine database from many places, i.e. when resolving execution context for aggregated events, model converters and runtime bundle query api that use model converters that need to run inside Activiti transaction in order to be able resolve `superExecution` entity via additional query.

The parent process instance id attribute seems to be a common property shared and used by model entities and event classes, so this particular use case is best solved by making changes in Mybatis Execution entity mapping to perform a left join query in order to retrieve super execution's process instance id in a single query. This should have better performance overall especially for queries via Rest api.

This approach enables minimal changes in the Activiti core expose parentProcessInstanceId for simple extraction and conversion into events and model for activiti api using simple getter:

```
 processInstance.setParentId(execution.getParentProcessInstanceId());
```

This will greatly simplify the efforts to provide parentProcessInstanceId for query and audit service without ugly hacks in many places to extract and inject it into events and models, i.e. https://github.com/Activiti/Activiti/pull/2260, 

The change is mostly contained in Mybatis execution entity query result mappings for Execution and ProcessInstance entities. The unit tests are implemented to verify correct mapping outcome.  

It also removes superExecution boilerplate code from `IntegrationContextBuilder`.

It also adds support for parentId  attribute conversion in APIProcessInstanceConverter class with test coverage.