### PR TITLE
Fix #2228(History tables missing)

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiProperties.java
@@ -35,7 +35,7 @@ public class ActivitiProperties {
   private boolean mailServerUseTls;
   private String databaseSchemaUpdate = "true";
   private String databaseSchema;
-  private boolean isDbHistoryUsed = false;
+  private boolean dbHistoryUsed = false;
   private HistoryLevel historyLevel = HistoryLevel.NONE;
   private String processDefinitionLocationPrefix = ResourcePatternResolver.CLASSPATH_ALL_URL_PREFIX + "**/processes/";
   private List<String> processDefinitionLocationSuffixes = Arrays.asList("**.bpmn20.xml", "**.bpmn");
@@ -88,11 +88,11 @@ public class ActivitiProperties {
   }
 
   public boolean isDbHistoryUsed() {
-    return isDbHistoryUsed;
+    return dbHistoryUsed;
   }
 
   public void setDbHistoryUsed(boolean isDbHistoryUsed) {
-    this.isDbHistoryUsed = isDbHistoryUsed;
+    this.dbHistoryUsed = isDbHistoryUsed;
   }
 
   public HistoryLevel getHistoryLevel() {

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
@@ -68,8 +68,6 @@ public class HistoryConfigurationTest {
     @Autowired
     private ApplicationEventPublisher applicationEventPublisher;
 
-    private ApplicationEventPublisher eventPublisher;
-    
     @Autowired
     private ProcessCleanUpUtil processCleanUpUtil;
 
@@ -80,7 +78,7 @@ public class HistoryConfigurationTest {
 
     @Before
     public void init() {
-        eventPublisher = spy(applicationEventPublisher);
+        ApplicationEventPublisher eventPublisher = spy(applicationEventPublisher);
         
         spy(new ProcessRuntimeImpl(repositoryService,
                                                      processDefinitionConverter,

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
@@ -1,0 +1,121 @@
+package org.activiti.spring.boot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.runtime.ProcessRuntime;
+import org.activiti.api.process.runtime.conf.ProcessRuntimeConfiguration;
+import org.activiti.core.common.spring.security.policies.ProcessSecurityPoliciesManager;
+import org.activiti.engine.HistoryService;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.RuntimeService;
+import org.activiti.runtime.api.impl.ProcessAdminRuntimeImpl;
+import org.activiti.runtime.api.impl.ProcessRuntimeImpl;
+import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
+import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
+import org.activiti.runtime.api.model.impl.APIVariableInstanceConverter;
+import org.activiti.spring.boot.security.util.SecurityUtil;
+import org.activiti.spring.boot.test.util.ProcessCleanUpUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestPropertySource("classpath:application-history.properties")
+public class HistoryConfigurationTest {
+
+    private static final String CATEGORIZE_PROCESS = "categorizeProcess";
+
+    @Autowired
+    private ProcessRuntime processRuntime;
+
+    @Autowired
+    private SecurityUtil securityUtil;
+
+    @Autowired
+    private RepositoryService repositoryService;
+
+    @Autowired
+    private HistoryService historyService;
+    
+    @Autowired
+    private APIProcessDefinitionConverter processDefinitionConverter;
+
+    @Autowired
+    private RuntimeService runtimeService;
+
+    @Autowired
+    private ProcessSecurityPoliciesManager securityPoliciesManager;
+
+    @Autowired
+    private APIProcessInstanceConverter processInstanceConverter;
+
+    @Autowired
+    private APIVariableInstanceConverter variableInstanceConverter;
+
+    @Autowired
+    private ProcessRuntimeConfiguration configuration;
+    
+    @Autowired
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    private ApplicationEventPublisher eventPublisher;
+    
+    @Autowired
+    private ProcessCleanUpUtil processCleanUpUtil;
+
+    @After
+    public void cleanUp(){
+        processCleanUpUtil.cleanUpWithAdmin();
+    }
+
+    @Before
+    public void init() {
+        eventPublisher = spy(applicationEventPublisher);
+        
+        spy(new ProcessRuntimeImpl(repositoryService,
+                                                     processDefinitionConverter,
+                                                     runtimeService,
+                                                     securityPoliciesManager,
+                                                     processInstanceConverter,
+                                                     variableInstanceConverter,
+                                                     configuration,
+                                                     eventPublisher));
+
+        spy(new ProcessAdminRuntimeImpl(repositoryService,
+                                                              processDefinitionConverter,
+                                                              runtimeService,
+                                                              processInstanceConverter,
+                                                              eventPublisher));
+
+        //Reset test variables
+        RuntimeTestConfiguration.processImageConnectorExecuted = false;
+        RuntimeTestConfiguration.tagImageConnectorExecuted = false;
+        RuntimeTestConfiguration.discardImageConnectorExecuted = false;
+
+    }
+
+    @Test
+    public void shouldRecordHistory() {
+        securityUtil.logInAs("salaboy");
+
+        //when
+        ProcessInstance categorizeProcess = processRuntime.start(ProcessPayloadBuilder.start()
+                .withProcessDefinitionKey(CATEGORIZE_PROCESS)
+                .withVariable("expectedKey",
+                        true)
+                .build());
+
+        assertThat(RuntimeTestConfiguration.completedProcesses).contains(categorizeProcess.getId());
+        assertThat(historyService.createHistoricProcessInstanceQuery().processInstanceId(categorizeProcess.getId()).count()).isEqualTo(1);
+    }
+}

--- a/activiti-spring-boot-starter/src/test/resources/application-history.properties
+++ b/activiti-spring-boot-starter/src/test/resources/application-history.properties
@@ -1,0 +1,2 @@
+spring.activiti.dbHistoryUsed=true
+spring.activiti.historyLevel=audit


### PR DESCRIPTION
### Spec

* To create history table, set the following property.
`spring.activiti.dbHistoryUsed=true
`
### In addition

* To enable history data, it is necessary to set the following properties.
`spring.activiti.historyLevel=audit`