### PR TITLE
fixing auto configs to use names instead of .class references

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -12,19 +12,12 @@
  */
 package org.activiti.spring.boot;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import javax.sql.DataSource;
-
 import org.activiti.api.process.model.events.ProcessDeployedEvent;
 import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
-import org.activiti.engine.cfg.ProcessEngineConfigurator;
-import org.activiti.engine.impl.persistence.StrongUuidGenerator;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.engine.RepositoryService;
+import org.activiti.engine.cfg.ProcessEngineConfigurator;
+import org.activiti.engine.impl.persistence.StrongUuidGenerator;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.spring.ProcessDeployedEventProducer;
 import org.activiti.spring.SpringAsyncExecutor;
@@ -36,8 +29,6 @@ import org.activiti.validation.validator.ValidatorSet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
-import org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -45,8 +36,16 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.transaction.PlatformTransactionManager;
 
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+
 @Configuration
-@AutoConfigureAfter({DataSourceAutoConfiguration.class, TaskExecutionAutoConfiguration.class})
+@AutoConfigureAfter(name = {"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration",
+        "org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration"})
 @EnableConfigurationProperties(ActivitiProperties.class)
 public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoConfiguration {
 
@@ -70,7 +69,7 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
         SpringProcessEngineConfiguration conf = new SpringProcessEngineConfiguration();
         conf.setConfigurators(processEngineConfigurators);
         configureProcessDefinitionResources(processDefinitionResourceFinder,
-                                            conf);
+                conf);
         conf.setDataSource(dataSource);
         conf.setTransactionManager(transactionManager);
 
@@ -152,7 +151,7 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     public ProcessDefinitionResourceFinder processDefinitionResourceFinder(ActivitiProperties activitiProperties,
                                                                            ResourcePatternResolver resourcePatternResolver) {
         return new ProcessDefinitionResourceFinder(activitiProperties,
-                                                   resourcePatternResolver);
+                resourcePatternResolver);
     }
 
     @Bean
@@ -161,9 +160,9 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
                                                                      APIProcessDefinitionConverter converter,
                                                                      @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessDeployedEvent>> listeners) {
         return new ProcessDeployedEventProducer(repositoryService,
-                                                converter,
-                                                Optional.ofNullable(listeners)
-                                                        .orElse(Collections.emptyList()));
+                converter,
+                Optional.ofNullable(listeners)
+                        .orElse(Collections.emptyList()));
     }
 }
 


### PR DESCRIPTION
This PR just update the AutoConfiguration to use names instead of .class references which blows up when the classes referenced in the @AutoConfigureAfter are not present in the class path. 