### PR TITLE
Converter: SubProcess IO specification is wrongly set on active process instead of active *sub*process

### DIFF
--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -354,10 +354,10 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
           interfaceParser.parse(xtr, model);
 
         } else if (ELEMENT_IOSPECIFICATION.equals(xtr.getLocalName())) {
-                  BaseElement parentElement;
+                  BaseElement parentElement = null;
                   if (!activeSubProcessList.isEmpty()) {
                     parentElement = activeSubProcessList.get(activeSubProcessList.size() - 1);
-                  } else {
+                  } else if (activeProcess != null) {
                     parentElement = activeProcess;
                   }
           ioSpecificationParser.parseChildElement(xtr, parentElement, model);

--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -354,7 +354,13 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
           interfaceParser.parse(xtr, model);
 
         } else if (ELEMENT_IOSPECIFICATION.equals(xtr.getLocalName())) {
-          ioSpecificationParser.parseChildElement(xtr, activeProcess, model);
+                  BaseElement parentElement;
+                  if (!activeSubProcessList.isEmpty()) {
+                    parentElement = activeSubProcessList.get(activeSubProcessList.size() - 1);
+                  } else {
+                    parentElement = activeProcess;
+                  }
+          ioSpecificationParser.parseChildElement(xtr, parentElement, model);
 
         } else if (ELEMENT_PARTICIPANT.equals(xtr.getLocalName())) {
           participantParser.parse(xtr, model);


### PR DESCRIPTION
Use the same approche as for the `documentation` tag.