### PR TITLE
Use connectorName.actionName to match connector implementation

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
@@ -1,6 +1,7 @@
 package org.activiti.runtime.api.connector;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -20,28 +21,51 @@ public class ConnectorActionDefinitionFinder {
 
         Optional<ActionDefinition> actionDefinitionOptional = Optional.empty();
 
-        String connectorId = StringUtils.substringBefore(implementation,
+        String connectorName = StringUtils.substringBefore(implementation,
                                                          ".");
-        String actionId = StringUtils.substringAfter(implementation,
+        String actionName = StringUtils.substringAfter(implementation,
                                                      ".");
 
-        List<ConnectorDefinition> resultingConnectors = connectorDefinitions.stream().filter(c -> c.getId().equals(connectorId)).collect(Collectors.toList());
+        List<ConnectorDefinition> resultingConnectors = connectorDefinitions.stream()
+        										        .filter(c -> connectorName.equals(c.getName()))
+        										        .collect(Collectors.toList());
+        
         if (resultingConnectors != null && resultingConnectors.size() != 0) {
             if (resultingConnectors.size() != 1) {
-                throw new RuntimeException("Expecting exactly 1 connector definition with id mapping `" + connectorId +
-                                                   "`, but were found " + resultingConnectors.size());
+                throw new RuntimeException("Expecting exactly 1 connector definition with name mapping `" + connectorName +
+                                           "`, but were found " + resultingConnectors.size());
             }
-            ConnectorDefinition connectorDefinition = resultingConnectors.get(0);
-
-            ActionDefinition actionDefinition = connectorDefinition.getActions().get(actionId);
+        
+            ActionDefinition actionDefinition = null;
+            List<ActionDefinition> actionDefinitions = filterByName(resultingConnectors.get(0).getActions(), actionName);
+            
+            if (actionDefinitions != null) {
+            	 if (actionDefinitions.size() != 1) {
+                     throw new RuntimeException("Expecting exactly 1 action definition with name mapping `" + actionName +
+                                                "`, but were found " + actionDefinitions.size());
+                 }
+            	    
+            	 actionDefinition = actionDefinitions.get(0);
+            }
+            
             if (actionDefinition == null) {
-                throw new RuntimeException("No action with id mapping `" + actionId + "` was found in connector `" +
-                                                   connectorId + "`");
+                throw new RuntimeException("No action with name mapping `" + actionName + "` was found in connector `" +
+                		                   connectorName + "`");
             }
 
             actionDefinitionOptional = Optional.of(actionDefinition);
         }
 
         return actionDefinitionOptional;
+    }
+    
+    public static List<ActionDefinition> filterByName(Map<String, ActionDefinition> actionDefinitions, 
+    		                                                 String actionName) {
+    	if (actionDefinitions == null || actionName == null) return null;
+        return actionDefinitions.entrySet()
+        		.stream()
+                .filter(a -> actionName.equals(a.getValue().getName()))
+                .map(a -> a.getValue())
+                .collect(Collectors.toList());
     }
 }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
@@ -60,15 +60,15 @@ public class ConnectorActionDefinitionFinder {
         return actionDefinitionOptional;
     }
 
-    public static List<ActionDefinition> filterByName(Map<String, ActionDefinition> actionDefinitions,
+    private List<ActionDefinition> filterByName(Map<String, ActionDefinition> actionDefinitions,
                                                       String actionName) {
         if (actionDefinitions == null || actionName == null) {
             return null;
         }
         return actionDefinitions.entrySet()
                 .stream()
-                .filter(a -> actionName.equals(a.getValue().getName()))
-                .map(a -> a.getValue())
+                .filter(entry -> actionName.equals(entry.getValue().getName()))
+                .map(Map.Entry::getValue)
                 .collect(Collectors.toList());
     }
 }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinder.java
@@ -17,40 +17,41 @@ public class ConnectorActionDefinitionFinder {
         this.connectorDefinitions = connectorDefinitions;
     }
 
-    public Optional<ActionDefinition> find(String implementation){
+    public Optional<ActionDefinition> find(String implementation) {
 
         Optional<ActionDefinition> actionDefinitionOptional = Optional.empty();
 
         String connectorName = StringUtils.substringBefore(implementation,
-                                                         ".");
+                                                           ".");
         String actionName = StringUtils.substringAfter(implementation,
-                                                     ".");
+                                                       ".");
 
         List<ConnectorDefinition> resultingConnectors = connectorDefinitions.stream()
-        										        .filter(c -> connectorName.equals(c.getName()))
-        										        .collect(Collectors.toList());
-        
+                .filter(c -> connectorName.equals(c.getName()))
+                .collect(Collectors.toList());
+
         if (resultingConnectors != null && resultingConnectors.size() != 0) {
             if (resultingConnectors.size() != 1) {
                 throw new RuntimeException("Expecting exactly 1 connector definition with name mapping `" + connectorName +
-                                           "`, but were found " + resultingConnectors.size());
+                                                   "`, but were found " + resultingConnectors.size());
             }
-        
+
             ActionDefinition actionDefinition = null;
-            List<ActionDefinition> actionDefinitions = filterByName(resultingConnectors.get(0).getActions(), actionName);
-            
+            List<ActionDefinition> actionDefinitions = filterByName(resultingConnectors.get(0).getActions(),
+                                                                    actionName);
+
             if (actionDefinitions != null) {
-            	 if (actionDefinitions.size() != 1) {
-                     throw new RuntimeException("Expecting exactly 1 action definition with name mapping `" + actionName +
-                                                "`, but were found " + actionDefinitions.size());
-                 }
-            	    
-            	 actionDefinition = actionDefinitions.get(0);
+                if (actionDefinitions.size() != 1) {
+                    throw new RuntimeException("Expecting exactly 1 action definition with name mapping `" + actionName +
+                                                       "`, but were found " + actionDefinitions.size());
+                }
+
+                actionDefinition = actionDefinitions.get(0);
             }
-            
+
             if (actionDefinition == null) {
                 throw new RuntimeException("No action with name mapping `" + actionName + "` was found in connector `" +
-                		                   connectorName + "`");
+                                                   connectorName + "`");
             }
 
             actionDefinitionOptional = Optional.of(actionDefinition);
@@ -58,12 +59,14 @@ public class ConnectorActionDefinitionFinder {
 
         return actionDefinitionOptional;
     }
-    
-    public static List<ActionDefinition> filterByName(Map<String, ActionDefinition> actionDefinitions, 
-    		                                                 String actionName) {
-    	if (actionDefinitions == null || actionName == null) return null;
+
+    public static List<ActionDefinition> filterByName(Map<String, ActionDefinition> actionDefinitions,
+                                                      String actionName) {
+        if (actionDefinitions == null || actionName == null) {
+            return null;
+        }
         return actionDefinitions.entrySet()
-        		.stream()
+                .stream()
                 .filter(a -> actionName.equals(a.getValue().getName()))
                 .map(a -> a.getValue())
                 .collect(Collectors.toList());

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinderTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/ConnectorActionDefinitionFinderTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.connector;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.activiti.core.common.model.connector.ActionDefinition;
+import org.activiti.core.common.model.connector.ConnectorDefinition;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConnectorActionDefinitionFinderTest {
+
+    @Test
+    public void findShouldReturnActionMatchingWithImplementation() {
+        //given
+        ConnectorDefinition firstConnector = buildConnector("firstConnector");
+        ConnectorDefinition secondConnector = buildConnector("secondConnector");
+        ConnectorDefinition thirdConnector = buildConnector("thirdConnector");
+
+        ActionDefinition firstAction = buildActionDefinition("firstAction");
+        ActionDefinition secondAction = buildActionDefinition("secondAction");
+        ActionDefinition thirdAction = buildActionDefinition("thirdAction");
+
+        HashMap<String, ActionDefinition> actions = new HashMap<>();
+        actions.put(firstAction.getId(), firstAction);
+        actions.put(secondAction.getId(), secondAction);
+        actions.put(thirdAction.getId(), thirdAction);
+
+        secondConnector.setActions(actions);
+
+        ConnectorActionDefinitionFinder finder = new ConnectorActionDefinitionFinder(Arrays.asList(firstConnector,
+                                                                                                                            secondConnector,
+                                                                                                                            thirdConnector));
+
+        //when
+        ActionDefinition actionDefinition = finder.find("secondConnector.secondAction").orElse(null);
+
+        //then
+        assertThat(actionDefinition).isNotNull();
+        assertThat(actionDefinition.getName()).isEqualTo("secondAction");
+    }
+
+    private ActionDefinition buildActionDefinition(String name) {
+        ActionDefinition actionDefinition = new ActionDefinition();
+        actionDefinition.setName(name);
+        actionDefinition.setId(UUID.randomUUID().toString());
+        return actionDefinition;
+    }
+
+    private ConnectorDefinition buildConnector(String name) {
+        ConnectorDefinition connectorDefinition = new ConnectorDefinition();
+        connectorDefinition.setName(name);
+        return connectorDefinition;
+    }
+
+    @Test
+    public void findShouldReturnEmptyOptionalWhenImplementationDoesNotContainDotChar() {
+        //given
+        ConnectorDefinition connectorDefinition = new ConnectorDefinition();
+        connectorDefinition.setName("my connector");
+        ConnectorActionDefinitionFinder finder = new ConnectorActionDefinitionFinder(Collections.singletonList(connectorDefinition));
+
+        //when
+        Optional<ActionDefinition> actionDefinitionOptional = finder.find("does not contain dot");
+
+        //then
+        assertThat(actionDefinitionOptional).isNotPresent();
+    }
+}

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
@@ -108,7 +108,7 @@ public class RuntimeTestConfiguration {
         };
     }
 
-    @Bean(name = "processImageConnectorId.processImageActionId")
+    @Bean(name = "Process Image Connector.processImageActionName")
     public Connector processImageActionName() {
         return integrationContext -> {
             Map<String, Object> inBoundVariables = integrationContext.getInBoundVariables();
@@ -123,7 +123,7 @@ public class RuntimeTestConfiguration {
         };
     }
 
-    @Bean(name = "tagImageConnectorId.tagImageActionId")
+    @Bean(name = "Tag Image Connector.tagImageActionName")
     public Connector tagImageActionName() {
         return integrationContext -> {
             Map<String, Object> inBoundVariables = integrationContext.getInBoundVariables();

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
@@ -194,7 +194,7 @@ public class RuntimeTestConfiguration {
         return candidateUserRemovedEvent -> taskCandidateUserRemovedEvents.add(candidateUserRemovedEvent);
     }
 
-    @Bean(name = "variableMappingConnectorId.variableMappingActionId")
+    @Bean(name = "Variable Mapping Connector.variableMappingActionName")
     public Connector variableMappingActionName() {
         return integrationContext -> {
             Map<String, Object> inBoundVariables = integrationContext.getInBoundVariables();

--- a/activiti-spring-boot-starter/src/test/resources/connectors/connector-with-variable-mapping.json
+++ b/activiti-spring-boot-starter/src/test/resources/connectors/connector-with-variable-mapping.json
@@ -1,7 +1,7 @@
 {
   "id": "variableMappingConnectorId",
-  "name": "Name of the connector",
-  "description": "Description of the connector",
+  "name": "Variable Mapping Connector",
+  "description": "Description of the Variable Mapping Connector",
   "actions": {
     "variableMappingActionId": {
       "id": "variableMappingActionId",

--- a/activiti-spring-boot-starter/src/test/resources/connectors/process-image.json
+++ b/activiti-spring-boot-starter/src/test/resources/connectors/process-image.json
@@ -1,7 +1,7 @@
 {
   "id": "processImageConnectorId",
-  "name": "Name of the connector",
-  "description": "Description of the connector",
+  "name": "Process Image Connector",
+  "description": "Description of the Process Image Connector",
   "actions": {
     "processImageActionId": {
       "id": "processImageActionId",

--- a/activiti-spring-boot-starter/src/test/resources/connectors/tag-image.json
+++ b/activiti-spring-boot-starter/src/test/resources/connectors/tag-image.json
@@ -1,7 +1,7 @@
 {
   "id": "tagImageConnectorId",
-  "name": "Name of the connector",
-  "description": "Description of the connector",
+  "name": "Tag Image Connector",
+  "description": "Description of the Tag Image Connector",
   "actions": {
     "tagImageActionId": {
       "id": "tagImageActionId",

--- a/activiti-spring-boot-starter/src/test/resources/processes/categorize-image-connectors.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/categorize-image-connectors.bpmn20.xml
@@ -25,15 +25,15 @@
       <bpmn:incoming>SequenceFlow_1nn2llw</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1nn2llw" sourceRef="Task_0snvh02" targetRef="EndEvent_1ogwwp9" />
-    <bpmn:serviceTask id="Task_1ylvdew" name="Process Image" implementation="processImageConnectorId.processImageActionId">
+    <bpmn:serviceTask id="Task_1ylvdew" name="Process Image" implementation="Process Image Connector.processImageActionName">
       <bpmn:incoming>SequenceFlow_09xowo4</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1jzbgkj</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="Task_0snvh02" name="Tag categorized Image" implementation="tagImageConnectorId.tagImageActionId">
+    <bpmn:serviceTask id="Task_0snvh02" name="Tag categorized Image" implementation="Tag Image Connector.tagImageActionName">
       <bpmn:incoming>SequenceFlow_0tsc63v</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1nn2llw</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="Task_1asxw87" name="Discard and Notify user" implementation="discardImageConnectorId.discardImageActionId">
+    <bpmn:serviceTask id="Task_1asxw87" name="Discard and Notify user" implementation="Discard Image Connector Name.discardImageActionName">
       <bpmn:incoming>SequenceFlow_049fuit</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0upfncf</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/activiti-spring-boot-starter/src/test/resources/processes/connector-var-mapping.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/connector-var-mapping.bpmn20.xml
@@ -10,7 +10,7 @@
 
         <sequenceFlow id="flow1" sourceRef="start" targetRef="serviceTask"/>
 
-        <serviceTask id="serviceTask" implementation="variableMappingConnectorId.variableMappingActionId"/>
+        <serviceTask id="serviceTask" implementation="Variable Mapping Connector.variableMappingActionName"/>
 
         <sequenceFlow id="flow2" sourceRef="serviceTask" targetRef="userTask"/>
 


### PR DESCRIPTION
It was previously using `connectorId.ActionId`.
This will have impact on variables mapping coming from process extensions file. Someone that was using `connectorId.ActionId` before should update the following:
1. BPMN xml file: update `implementation=` field inside service task to use `connectorName.actionName`
2. Rename connector bean name to `connectorName.actionName` (if it's a non-cloud connector)
3. Rename connector consumer destination to use `connectorName.actionName` (it it's a cloud connector)

Related to https://github.com/Activiti/Activiti/issues/2589