### PR TITLE
Activiti[3288] - Fix mapping for null variables

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/VariablesMappingProvider.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/VariablesMappingProvider.java
@@ -16,14 +16,19 @@
 
 package org.activiti.runtime.api.impl;
 
-import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.spring.process.ProcessExtensionService;
-import org.activiti.spring.process.model.*;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.spring.process.ProcessExtensionService;
+import org.activiti.spring.process.model.ConstantDefinition;
+import org.activiti.spring.process.model.Mapping;
+import org.activiti.spring.process.model.ProcessConstantsMapping;
+import org.activiti.spring.process.model.ProcessExtensionModel;
+import org.activiti.spring.process.model.ProcessVariablesMapping;
+import org.activiti.spring.process.model.VariableDefinition;
 
 public class VariablesMappingProvider {
 
@@ -46,7 +51,7 @@ public class VariablesMappingProvider {
 
                 VariableDefinition processVariableDefinition = extensions.getExtensions().getPropertyByName(name);
                 if (processVariableDefinition != null) {
-                    return Optional.of(execution.getVariable(processVariableDefinition.getName()));
+                    return Optional.ofNullable(execution.getVariable(processVariableDefinition.getName()));
                 }
             }
         }
@@ -102,7 +107,7 @@ public class VariablesMappingProvider {
                     String name = mapping.getValue().toString();
 
                     return currentContextVariables != null ?
-                            Optional.of(currentContextVariables.get(name)) :
+                            Optional.ofNullable(currentContextVariables.get(name)) :
                             Optional.empty();
                 }
             }

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/VariablesMappingProviderTest.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/VariablesMappingProviderTest.java
@@ -1,5 +1,9 @@
 package org.activiti.runtime.api.impl;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.spring.process.ProcessExtensionService;
@@ -9,14 +13,10 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.activiti.runtime.api.impl.MappingExecutionContext.buildMappingExecutionContext;
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 public class VariablesMappingProviderTest {
@@ -41,12 +41,16 @@ public class VariablesMappingProviderTest {
 
         DelegateExecution execution = buildExecution(extensions);
         given(execution.getVariable("process_variable_inputmap_1")).willReturn("new-input-value");
+        given(execution.getVariable("property-with-no-default-value")).willReturn(null);
 
         //when
         Map<String,Object> inputVariables = variablesMappingProvider.calculateInputVariables(execution);
 
         //then
         assertThat(inputVariables.get("task_input_variable_name_1")).isEqualTo("new-input-value");
+
+        //mapped with process variable that is null, so it should not be present
+        assertThat(inputVariables).doesNotContainKeys("task_input_variable_mapped_with_null_process_variable");
     }
 
     private DelegateExecution buildExecution(ProcessExtensionModel extensions) {
@@ -110,6 +114,9 @@ public class VariablesMappingProviderTest {
 
         //then
         assertThat(outPutVariables.get("process_variable_outputmap_1")).isEqualTo("var-one");
+
+        //mapped with a task variable that is not present, so it should not be present
+        assertThat(outPutVariables).doesNotContainKey("property-with-no-default-value");
     }
 
     @Test

--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/task-variable-mapping-extensions.json
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/task-variable-mapping-extensions.json
@@ -29,6 +29,12 @@
         "type": "string",
         "required": true,
         "value": "outputmap1Value"
+      },
+      "property-with-no-default-value-id": {
+        "id": "property-with-no-default-value-id",
+        "name": "property-with-no-default-value",
+        "type": "string",
+        "required": false
       }
     },
     "mappings": {
@@ -41,12 +47,20 @@
           "task_input_variable_name_2": {
             "type": "VALUE",
             "value": "the value"
+          },
+          "task_input_variable_mapped_with_null_process_variable": {
+            "type": "VARIABLE",
+            "value": "property-with-no-default-value"
           }
         },
         "outputs": {
           "process_variable_outputmap_1": {
             "type": "VARIABLE",
             "value": "task_output_variable_name_1"
+          },
+          "property-with-no-default-value": {
+            "type": "VARIABLE",
+            "value": "not-set-variable"
           }
         }
       }

--- a/activiti-spring-boot-starter/src/test/resources/processes/variable-mapping-extensions.json
+++ b/activiti-spring-boot-starter/src/test/resources/processes/variable-mapping-extensions.json
@@ -50,6 +50,12 @@
         "type": "string",
         "required": false,
         "value": "default"
+      },
+      "property-with-no-default-value-id": {
+        "id": "property-with-no-default-value-id",
+        "name": "property-with-no-default-value-name",
+        "type": "string",
+        "required": false
       }
     },
     "mappings": {
@@ -66,6 +72,10 @@
           "input-variable-name-3": {
             "type": "value",
             "value": 5
+          },
+          "input-variable-name-4": {
+            "type": "variable",
+            "value": "property-with-no-default-value-name"
           }
         },
         "outputs": {


### PR DESCRIPTION
In some cases a mapping can reference variables that are not set. In this case the entry of the mapping should be ignored instead of throwing NPE