### PR TITLE
Move DateFormatterProvider to activiti core

### DIFF
--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessExtensionsTest.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessExtensionsTest.java
@@ -8,7 +8,6 @@ import org.activiti.api.process.runtime.conf.ProcessRuntimeConfiguration;
 import org.activiti.engine.ActivitiException;
 import org.activiti.spring.boot.security.util.SecurityUtil;
 import org.activiti.spring.boot.test.util.ProcessCleanUpUtil;
-import org.activiti.spring.process.variable.types.DateVariableType;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,7 +98,7 @@ public class ProcessExtensionsTest {
                         "bob")
                 .withVariable("subscribe",
                         true)
-                .withVariable("birth", new SimpleDateFormat(DateVariableType.defaultFormat).parse("2009-11-30"))
+                .withVariable("birth", new SimpleDateFormat("yyyy-MM-dd").parse("2009-11-30"))
                 .withBusinessKey("my business key")
                 .build());
 

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
@@ -16,14 +16,6 @@
 
 package org.activiti.spring.boot.tasks;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessInstance;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
@@ -49,6 +41,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -88,8 +88,8 @@ public class TaskRuntimeVariableMappingIT {
                                                                .withProcessDefinitionKey(TASK_VAR_MAPPING)
                                                                .build());
 
-        Date date = dateFormatterProvider.convert2Date("2019-09-01");
-        Date datetime = dateFormatterProvider.convert2Date("2019-09-01T10:20:30.000Z");
+        Date date = dateFormatterProvider.parse("2019-09-01");
+        Date datetime = dateFormatterProvider.parse("2019-09-01T10:20:30.000Z");
         
         Task task = checkTasks(process.getId());
 

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
@@ -19,6 +19,7 @@ package org.activiti.spring.boot.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -38,6 +39,7 @@ import org.activiti.api.task.runtime.TaskRuntime;
 import org.activiti.spring.boot.security.util.SecurityUtil;
 import org.activiti.spring.boot.test.util.ProcessCleanUpUtil;
 import org.activiti.spring.boot.test.util.TaskCleanUpUtil;
+import org.activiti.spring.process.variable.DateFormatterProvider;
 import org.junit.After;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
@@ -69,6 +71,9 @@ public class TaskRuntimeVariableMappingIT {
 
     @Autowired
     private ProcessCleanUpUtil processCleanUpUtil;
+    
+    @Autowired
+    private DateFormatterProvider dateFormatterProvider;
 
     @After
     public void cleanUp() {
@@ -83,6 +88,9 @@ public class TaskRuntimeVariableMappingIT {
                                                                .withProcessDefinitionKey(TASK_VAR_MAPPING)
                                                                .build());
 
+        Date date = dateFormatterProvider.convert2Date("2019-09-01");
+        Date datetime = dateFormatterProvider.convert2Date("2019-09-01T10:20:30.000Z");
+        
         Task task = checkTasks(process.getId());
 
         assertThat(task.getName()).isEqualTo("testSimpleTask");
@@ -94,13 +102,24 @@ public class TaskRuntimeVariableMappingIT {
         assertThat(procVariables)
                 .isNotNull()
                 .extracting(VariableInstance::getName,
+                            VariableInstance::getType,
                             VariableInstance::getValue)
                 .containsOnly(tuple("process_variable_unmapped_1",
+                                    "string",
                                     "unmapped1Value"),
                               tuple("process_variable_inputmap_1",
+                                    "string",
                                     "inputmap1Value"),
                               tuple("process_variable_outputmap_1",
-                                    "outputmap1Value"));
+                                    "string",
+                                    "outputmap1Value"),
+                              tuple("process-variable-date",
+                                    "date",
+                                    date),
+                              tuple("process-variable-datetime",
+                                    "date",
+                                    datetime)
+                              );
 
         List<VariableInstance> taskVariables = taskRuntime.variables(TaskPayloadBuilder
                                                                              .variables()
@@ -109,9 +128,18 @@ public class TaskRuntimeVariableMappingIT {
         assertThat(taskVariables)
                 .isNotNull()
                 .extracting(VariableInstance::getName,
+                            VariableInstance::getType,
                             VariableInstance::getValue)
                 .containsOnly(tuple("task_input_variable_name_1",
-                                    "inputmap1Value"));
+                                    "string",
+                                    "inputmap1Value"),
+                              tuple("task-variable-date",
+                                    "date",
+                                    date),
+                              tuple("task-variable-datetime",
+                                    "date",
+                                    datetime)
+                              );
 
         Map<String, Object> variables = new HashMap<>();
         variables.put("task_input_variable_name_1",
@@ -136,7 +164,11 @@ public class TaskRuntimeVariableMappingIT {
                         tuple("process_variable_inputmap_1",
                               "inputmap1Value"),
                         tuple("process_variable_outputmap_1",
-                              "outputTaskValue")
+                              "outputTaskValue"),
+                        tuple("process-variable-date",
+                              date),
+                        tuple("process-variable-datetime",
+                              datetime)
 
                 );
 

--- a/activiti-spring-boot-starter/src/test/resources/processes/task-variable-mapping-extensions.json
+++ b/activiti-spring-boot-starter/src/test/resources/processes/task-variable-mapping-extensions.json
@@ -24,6 +24,20 @@
         "type": "string",
         "required": true,
         "value": "outputmap1Value"
+      },
+      "process-variable-date-id": {
+        "id": "process-variable-date-id",
+        "name": "process-variable-date",
+        "type": "date",
+        "required": true,
+        "value": "2019-09-01"
+      },
+      "process-variable-datetime-id": {
+        "id": "process-variable-datetime-id",
+        "name": "process-variable-datetime",
+        "type": "date",
+        "required": true,
+        "value": "2019-09-01T10:20:30.000Z"
       }
     },
   "mappings": {
@@ -32,12 +46,28 @@
         "task_input_variable_name_1": {
           "type": "variable",
           "value": "process_variable_inputmap_1"
+        },
+        "task-variable-date": {
+          "type": "variable",
+          "value": "process-variable-date"
+        },
+        "task-variable-datetime": {
+          "type": "variable",
+          "value": "process-variable-datetime"
         }
       },
       "outputs": {
         "process_variable_outputmap_1": {
           "type": "variable",
           "value": "task_output_variable_name_1"
+        },
+        "process-variable-date": {
+          "type": "variable",
+          "value": "task-variable-date"
+        },
+        "process-variable-datetime": {
+          "type": "variable",
+          "value": "task-variable-datetime"
         }
       }
     }

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/conf/ProcessExtensionsAutoConfiguration.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/conf/ProcessExtensionsAutoConfiguration.java
@@ -37,7 +37,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
-
 @Configuration
 public class ProcessExtensionsAutoConfiguration {
 
@@ -78,14 +77,14 @@ public class ProcessExtensionsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public DateFormatterProvider dateFormatterProvider() {
-        return new DateFormatterProvider();
+    public DateFormatterProvider dateFormatterProvider(@Value("${spring.activiti.date-format-pattern:yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS'Z']]}")
+                                                                       String dateFormatPattern) {
+        return new DateFormatterProvider(dateFormatPattern);
     }
 
     @Bean
-    public Map<String, VariableType> variableTypeMap(ObjectMapper objectMapper,
-                                                     DateFormatterProvider dateFormatterProvider){
-
+    public Map<String, VariableType> variableTypeMap(ObjectMapper objectMapper, 
+                                                     DateFormatterProvider dateFormatterProvider) {
         Map<String, VariableType> variableTypeMap = new HashMap<>();
         variableTypeMap.put("boolean", new JavaObjectVariableType(Boolean.class));
         variableTypeMap.put("string", new JavaObjectVariableType(String.class));
@@ -97,12 +96,12 @@ public class ProcessExtensionsAutoConfiguration {
     }
 
     @Bean
-    public VariableValidationService variableValidationService(Map<String, VariableType> variableTypeMap){
+    public VariableValidationService variableValidationService(Map<String, VariableType> variableTypeMap) {
         return new VariableValidationService(variableTypeMap);
     }
 
     @Bean
-    public VariableParsingService variableParsingService(Map<String, VariableType> variableTypeMap){
+    public VariableParsingService variableParsingService(Map<String, VariableType> variableTypeMap) {
         return new VariableParsingService(variableTypeMap);
     }
 }

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/DateFormatterProvider.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/DateFormatterProvider.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.activiti.spring.process.variable;
+
+import java.text.MessageFormat;
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+
+public class DateFormatterProvider  {
+   
+    @Value("${spring.activiti.date-format-pattern.date-format-pattern:yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS'Z']]}")
+    private String dateFormatPattern;
+    
+    private ZoneId zoneId = ZoneOffset.UTC;
+ 
+    public DateFormatterProvider() {
+    }
+    
+    public ZoneId getZoneId() {
+        return zoneId;
+    }
+    
+    public String getDateFormatPattern() {
+        return dateFormatPattern;
+    }
+    
+    public void setDateFormatPattern(String dateFormatPattern) {
+        this.dateFormatPattern = dateFormatPattern;
+    }
+ 
+    public Date convert2Date(String value) throws DateTimeException { 
+        DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
+                                                      .appendPattern(getDateFormatPattern())
+                                                      .toFormatter()
+                                                      .withZone(getZoneId());
+        
+        try {
+            LocalDateTime localDateTime = dateTimeFormatter.parse(value,
+                                                                  LocalDateTime::from);
+            return Date.from(localDateTime.atZone(getZoneId()).toInstant());                
+        } catch (DateTimeException e) {
+            LocalDate localDate = dateTimeFormatter.parse(String.valueOf(value),
+                                                          LocalDate::from);
+            return Date.from(localDate.atStartOfDay().atZone(getZoneId()).toInstant());
+        }
+    }    
+    
+    public Date convert2Date(Object value) throws DateTimeException {
+        if (value instanceof String) {
+            return convert2Date(String.valueOf(value));
+        }
+
+        if (value instanceof Date) {
+            return (Date)value;
+        }
+        
+        if (value instanceof Long) {
+            return new Date((long)value);                       
+        }
+ 
+        throw new DateTimeException(MessageFormat.format("Error parsing date/time variable: {0}",value));
+    }    
+}

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/DateFormatterProvider.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/DateFormatterProvider.java
@@ -16,27 +16,21 @@
 package org.activiti.spring.process.variable;
 
 import java.text.MessageFormat;
-import java.time.DateTimeException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.Date;
 
-import org.springframework.beans.factory.annotation.Value;
-
 public class DateFormatterProvider  {
    
-    @Value("${spring.activiti.date-format-pattern.date-format-pattern:yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS'Z']]}")
     private String dateFormatPattern;
     
     private ZoneId zoneId = ZoneOffset.UTC;
  
-    public DateFormatterProvider() {
+    public DateFormatterProvider(String dateFormatPattern) {
+        this.dateFormatPattern = dateFormatPattern;
     }
-    
+
     public ZoneId getZoneId() {
         return zoneId;
     }
@@ -49,7 +43,7 @@ public class DateFormatterProvider  {
         this.dateFormatPattern = dateFormatPattern;
     }
  
-    public Date convert2Date(String value) throws DateTimeException { 
+    public Date parse(String value) throws DateTimeException {
         DateTimeFormatter dateTimeFormatter = new DateTimeFormatterBuilder()
                                                       .appendPattern(getDateFormatPattern())
                                                       .toFormatter()
@@ -66,9 +60,9 @@ public class DateFormatterProvider  {
         }
     }    
     
-    public Date convert2Date(Object value) throws DateTimeException {
+    public Date toDate(Object value) {
         if (value instanceof String) {
-            return convert2Date(String.valueOf(value));
+            return parse((String) value);
         }
 
         if (value instanceof Date) {
@@ -79,6 +73,6 @@ public class DateFormatterProvider  {
             return new Date((long)value);                       
         }
  
-        throw new DateTimeException(MessageFormat.format("Error parsing date/time variable: {0}",value));
+        throw new DateTimeException(MessageFormat.format("Error while parsing date. Type: {0}, value: {1}", value.getClass().getName(), value));
     }    
 }

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/DateVariableType.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/DateVariableType.java
@@ -1,20 +1,15 @@
 package org.activiti.spring.process.variable.types;
 
-import java.time.DateTimeException;
-import java.util.List;
-
 import org.activiti.engine.ActivitiException;
 import org.activiti.spring.process.variable.DateFormatterProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /**
  * Basic date type for setting default date values for vars in extension json
  */
 public class DateVariableType extends JavaObjectVariableType {
 
-    public static String defaultFormat = "yyyy-MM-dd";
-    private static final Logger logger = LoggerFactory.getLogger(DateVariableType.class);
     private final DateFormatterProvider dateFormatterProvider;
     
     public DateVariableType(Class clazz, DateFormatterProvider dateFormatterProvider) {
@@ -24,15 +19,15 @@ public class DateVariableType extends JavaObjectVariableType {
 
     @Override
     public void validate(Object var, List<ActivitiException> errors) {
-        super.validate(var,errors);
-    };
+        super.validate(var, errors);
+    }
 
     @Override
     public Object parseFromValue(Object value) throws ActivitiException {
 
         try {
-            return dateFormatterProvider.convert2Date(value);
-        } catch (DateTimeException e) {
+            return dateFormatterProvider.toDate(value);
+        } catch (Exception e) {
             throw new ActivitiException("Error parsing date value " + value, e);
         }
     }

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/DateVariableType.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/DateVariableType.java
@@ -1,10 +1,10 @@
 package org.activiti.spring.process.variable.types;
 
-import java.text.DateFormat;
-import java.text.ParseException;
+import java.time.DateTimeException;
 import java.util.List;
 
 import org.activiti.engine.ActivitiException;
+import org.activiti.spring.process.variable.DateFormatterProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,34 +14,25 @@ import org.slf4j.LoggerFactory;
 public class DateVariableType extends JavaObjectVariableType {
 
     public static String defaultFormat = "yyyy-MM-dd";
-    public DateFormat format;
     private static final Logger logger = LoggerFactory.getLogger(DateVariableType.class);
-
-
-    public DateVariableType(Class clazz, DateFormat format) {
+    private final DateFormatterProvider dateFormatterProvider;
+    
+    public DateVariableType(Class clazz, DateFormatterProvider dateFormatterProvider) {
         super(clazz);
-        this.format = format;
-    }
-
-    public DateFormat getFormat() {
-        return format;
-    }
-
-    public void setFormat(DateFormat format) {
-        this.format = format;
+        this.dateFormatterProvider = dateFormatterProvider;
     }
 
     @Override
     public void validate(Object var, List<ActivitiException> errors) {
         super.validate(var,errors);
-    }
+    };
 
     @Override
     public Object parseFromValue(Object value) throws ActivitiException {
 
         try {
-            return format.parse(String.valueOf(value));
-        } catch (ParseException e) {
+            return dateFormatterProvider.convert2Date(value);
+        } catch (DateTimeException e) {
             throw new ActivitiException("Error parsing date value " + value, e);
         }
     }

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
@@ -37,9 +37,6 @@ public class DateFormatterProviderTest {
 
         Date date = provider.toDate(dateStr);
 
-        assertThat(date).hasYear(1970);
-        assertThat(date).hasMonth(1);
-        assertThat(date).hasDayOfMonth(1);
         assertThat(date).hasTime(0);
     }
 

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
@@ -32,61 +32,55 @@ public class DateFormatterProviderTest {
 
     @Test
     public void should_returnDate_when_stringRepresentsADate() {
-        //given
+
         String dateStr = "1970-01-01";
 
-        //when
         Date date = provider.toDate(dateStr);
 
-        //then
+        assertThat(date).hasYear(1970);
+        assertThat(date).hasMonth(1);
+        assertThat(date).hasDayOfMonth(1);
         assertThat(date).hasTime(0);
     }
 
     @Test
     public void should_returnDate_when_stringRepresentsADateWithTimeInformation() {
-        //given
+
         String dateStr = "1970-01-01T01:01:01.001Z";
         //calculate number of milliseconds after 1970-01-01T00:00:00.000Z
         long time = Duration.ofHours(1).toMillis() + Duration.ofMinutes(1).toMillis() + Duration.ofSeconds(1).toMillis() + 1;
 
-        //when
         Date date = provider.toDate(dateStr);
 
-        //then
         assertThat(date).hasTime(time);
     }
 
     @Test
     public void should_throwException_when_stringIsNotADate() {
-        //given
+        
         String dateStr = "this is not a date";
 
-        //when
         assertThatExceptionOfType(DateTimeParseException.class)
                 .isThrownBy(() -> provider.parse(dateStr));
     }
 
     @Test
     public void should_returnDate_when_longIsProvided() {
-        //given
+
         long time = 1000;
 
-        //when
         Date date = provider.toDate(time);
 
-        //then
         assertThat(date).hasTime(time);
     }
 
     @Test
     public void should_returnDate_when_dateIsProvided() {
-        //given
+        
         Date initialDate = new Date(1000);
 
-        //when
         Date date = provider.toDate(initialDate);
 
-        //then
         assertThat(date).isEqualTo(initialDate);
     }
 

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/DateFormatterProviderTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.process.variable;
+
+import org.junit.Test;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+public class DateFormatterProviderTest {
+
+    private DateFormatterProvider provider = new DateFormatterProvider("yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS'Z']]");
+
+    @Test
+    public void should_returnDate_when_stringRepresentsADate() {
+        //given
+        String dateStr = "1970-01-01";
+
+        //when
+        Date date = provider.toDate(dateStr);
+
+        //then
+        assertThat(date).hasTime(0);
+    }
+
+    @Test
+    public void should_returnDate_when_stringRepresentsADateWithTimeInformation() {
+        //given
+        String dateStr = "1970-01-01T01:01:01.001Z";
+        //calculate number of milliseconds after 1970-01-01T00:00:00.000Z
+        long time = Duration.ofHours(1).toMillis() + Duration.ofMinutes(1).toMillis() + Duration.ofSeconds(1).toMillis() + 1;
+
+        //when
+        Date date = provider.toDate(dateStr);
+
+        //then
+        assertThat(date).hasTime(time);
+    }
+
+    @Test
+    public void should_throwException_when_stringIsNotADate() {
+        //given
+        String dateStr = "this is not a date";
+
+        //when
+        assertThatExceptionOfType(DateTimeParseException.class)
+                .isThrownBy(() -> provider.parse(dateStr));
+    }
+
+    @Test
+    public void should_returnDate_when_longIsProvided() {
+        //given
+        long time = 1000;
+
+        //when
+        Date date = provider.toDate(time);
+
+        //then
+        assertThat(date).hasTime(time);
+    }
+
+    @Test
+    public void should_returnDate_when_dateIsProvided() {
+        //given
+        Date initialDate = new Date(1000);
+
+        //when
+        Date date = provider.toDate(initialDate);
+
+        //then
+        assertThat(date).isEqualTo(initialDate);
+    }
+
+    @Test
+    public void should_throwException_when_isNotAStringADateOrALong() {
+        double value = 1.2;
+
+        assertThatExceptionOfType(DateTimeException.class)
+                .isThrownBy(
+                        () -> provider.toDate(value))
+                .withMessageContaining("Error while parsing date");
+    }
+}


### PR DESCRIPTION
Related to https://github.com/Activiti/Activiti/issues/2886
DateFormatterProvider is moved to activiti core
Default process variables having date type are supported