### PR TITLE
fix: Support BPMN Message Events XML export/import for correlationKey and messageExpression attributes

### DIFF
--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
@@ -477,6 +477,13 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
       }
     }
     writeDefaultAttribute(ATTRIBUTE_MESSAGE_REF, messageRef, xtw);
+
+    if (StringUtils.isNotEmpty(messageDefinition.getCorrelationKey())) {
+      xtw.writeAttribute(ACTIVITI_EXTENSIONS_PREFIX, 
+                         ACTIVITI_EXTENSIONS_NAMESPACE, 
+                         ATTRIBUTE_MESSAGE_CORRELATION_KEY, 
+                         messageDefinition.getCorrelationKey());
+    }
     boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(messageDefinition, false, xtw);
     if (didWriteExtensionStartElement) {
       xtw.writeEndElement();

--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BaseBpmnXMLConverter.java
@@ -484,6 +484,14 @@ public abstract class BaseBpmnXMLConverter implements BpmnXMLConstants {
                          ATTRIBUTE_MESSAGE_CORRELATION_KEY, 
                          messageDefinition.getCorrelationKey());
     }
+    
+    if (StringUtils.isNotEmpty(messageDefinition.getMessageExpression())) {
+        xtw.writeAttribute(ACTIVITI_EXTENSIONS_PREFIX, 
+                           ACTIVITI_EXTENSIONS_NAMESPACE, 
+                           ATTRIBUTE_MESSAGE_EXPRESSION, 
+                           messageDefinition.getMessageExpression());
+      }    
+    
     boolean didWriteExtensionStartElement = BpmnXMLUtil.writeExtensionElements(messageDefinition, false, xtw);
     if (didWriteExtensionStartElement) {
       xtw.writeEndElement();

--- a/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageEventDefinitionConverterTest.java
+++ b/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageEventDefinitionConverterTest.java
@@ -1,0 +1,88 @@
+package org.activiti.editor.language.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.EndEvent;
+import org.activiti.bpmn.model.EventSubProcess;
+import org.activiti.bpmn.model.IntermediateCatchEvent;
+import org.activiti.bpmn.model.Message;
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.bpmn.model.ThrowEvent;
+import org.junit.Test;
+
+public class MessageEventDefinitionConverterTest extends AbstractConverterTest {
+
+    @Test
+    public void convertXMLToModel() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void convertModelToXML() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+        validateModel(parsedModel);
+    }
+
+    private void validateModel(BpmnModel model) {
+        Message message = model.getMessage("Message_1");
+
+        assertThat(message).isNotNull()
+                           .extracting(Message::getId,
+                                       Message::getName)
+                           .contains("Message_1",
+                                     "catchMessage");
+
+        assertThat(model.getProcessById("intermediateCatchProcess")
+                        .getFlowElements()).filteredOn(IntermediateCatchEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("intermediateThrowProcess")
+                        .getFlowElements()).filteredOn(ThrowEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("endThrowProcess")
+                        .getFlowElements()).filteredOn(EndEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("boundaryCatchProcess")
+                        .getFlowElements()).filteredOn(BoundaryEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("startMessageEventSubprocess")
+                        .getFlowElements()).filteredOn(EventSubProcess.class::isInstance)
+                                           .flatExtracting("flowElements")
+                                           .filteredOn(StartEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("startMessageProcess")
+                        .getFlowElements()).filteredOn(StartEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", null));
+
+        assertThat(model.getProcessById("boundaryCatchSubrocess")
+                        .getFlowElements()).filteredOn(BoundaryEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "correlationKey")
+                                           .contains(tuple("Message_1", "${correlationId}"));
+    }
+
+    protected String getResource() {
+        return "MessageEventDefinitionConverterTest.bpmn";
+    }
+}

--- a/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageEventDefinitionConverterTest.java
+++ b/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/MessageEventDefinitionConverterTest.java
@@ -80,6 +80,13 @@ public class MessageEventDefinitionConverterTest extends AbstractConverterTest {
                                            .flatExtracting("eventDefinitions")
                                            .extracting("messageRef", "correlationKey")
                                            .contains(tuple("Message_1", "${correlationId}"));
+
+        assertThat(model.getProcessById("intermediateCatchMessageExpressionProcess")
+                        .getFlowElements()).filteredOn(IntermediateCatchEvent.class::isInstance)
+                                           .flatExtracting("eventDefinitions")
+                                           .extracting("messageRef", "messageExpression", "correlationKey")
+                                           .contains(tuple(null, "catchMessage", "${correlationId}"));
+        
     }
 
     protected String getResource() {

--- a/activiti-bpmn-converter/src/test/resources/MessageEventDefinitionConverterTest.bpmn
+++ b/activiti-bpmn-converter/src/test/resources/MessageEventDefinitionConverterTest.bpmn
@@ -9,12 +9,14 @@
     <bpmn:participant id="Participant_07xhfx6" processRef="startMessageEventSubprocess" />
     <bpmn:participant id="Participant_0sro5q0" processRef="startMessageProcess" />
     <bpmn:participant id="Participant_0nteap9" processRef="boundaryCatchSubrocess" />
+    <bpmn:participant id="Participant_0mtat8r" processRef="intermediateCatchMessageExpressionProcess" />
     <bpmn:messageFlow id="MessageFlow_1jzt5b6" sourceRef="IntermediateThrowEvent" targetRef="intermediateCatchEvent" />
     <bpmn:messageFlow id="MessageFlow_0hqoly2" sourceRef="EndEvent_0jpp84v" targetRef="intermediateCatchEvent" />
     <bpmn:messageFlow id="MessageFlow_04x2yx9" sourceRef="EndEvent_0jpp84v" targetRef="BoundaryEvent_05lvrhj" />
     <bpmn:messageFlow id="MessageFlow_1h69myg" sourceRef="IntermediateThrowEvent" targetRef="StartEvent_0br2ok3" />
     <bpmn:messageFlow id="MessageFlow_0pjiy45" sourceRef="EndEvent_0jpp84v" targetRef="StartEvent_0d5q67m" />
     <bpmn:messageFlow id="MessageFlow_1t82r37" sourceRef="EndEvent_1upe6lc" targetRef="BoundaryEvent_0wrfoqw" />
+    <bpmn:messageFlow id="MessageFlow_04ma9ot" sourceRef="EndEvent_1kptcch" targetRef="IntermediateCatchEvent_095woej" />
   </bpmn:collaboration>
   <bpmn:process id="intermediateCatchProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
@@ -97,14 +99,15 @@
       <bpmn:outgoing>SequenceFlow_0rcahsa</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0rcahsa" sourceRef="StartEvent_00zy25x" targetRef="Task_13v9w3j" />
-    <bpmn:endEvent id="EndEvent_1kptcch">
-      <bpmn:incoming>SequenceFlow_0dfk044</bpmn:incoming>
-    </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0dfk044" sourceRef="Task_13v9w3j" targetRef="EndEvent_1kptcch" />
     <bpmn:userTask id="Task_13v9w3j" name="Task">
       <bpmn:incoming>SequenceFlow_0rcahsa</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0dfk044</bpmn:outgoing>
     </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent_1kptcch">
+      <bpmn:incoming>SequenceFlow_0dfk044</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="Message_1" />
+    </bpmn:endEvent>
   </bpmn:process>
   <bpmn:process id="startMessageProcess" isExecutable="true">
     <bpmn:sequenceFlow id="SequenceFlow_0lf6d4r" sourceRef="StartEvent_0d5q67m" targetRef="EndEvent_0earbi6" />
@@ -147,6 +150,21 @@
       <bpmn:incoming>SequenceFlow_0xjr70t</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0yoie86</bpmn:outgoing>
     </bpmn:exclusiveGateway>
+  </bpmn:process>
+  <bpmn:process id="intermediateCatchMessageExpressionProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_0iyn8y3">
+      <bpmn:outgoing>SequenceFlow_054hom6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1dwfuxf">
+      <bpmn:incoming>SequenceFlow_1jvbd83</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_095woej">
+      <bpmn:incoming>SequenceFlow_054hom6</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1jvbd83</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_01s1004" activiti:correlationKey="${correlationId}" activiti:messageExpression="catchMessage" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1jvbd83" sourceRef="IntermediateCatchEvent_095woej" targetRef="EndEvent_1dwfuxf" />
+    <bpmn:sequenceFlow id="SequenceFlow_054hom6" sourceRef="StartEvent_0iyn8y3" targetRef="IntermediateCatchEvent_095woej" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0nstryt">
@@ -261,9 +279,6 @@
         <di:waypoint x="250" y="940" />
         <di:waypoint x="300" y="940" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_1kptcch_di" bpmnElement="EndEvent_1kptcch">
-        <dc:Bounds x="450" y="922" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0dfk044_di" bpmnElement="SequenceFlow_0dfk044">
         <di:waypoint x="400" y="940" />
         <di:waypoint x="450" y="940" />
@@ -355,6 +370,34 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_139gp3m_di" bpmnElement="EndEvent_1upe6lc">
         <dc:Bounds x="380" y="626" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0mtat8r_di" bpmnElement="Participant_0mtat8r" isHorizontal="true">
+        <dc:Bounds x="585" y="735" width="318" height="131" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0iyn8y3_di" bpmnElement="StartEvent_0iyn8y3">
+        <dc:Bounds x="649" y="786" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1dwfuxf_di" bpmnElement="EndEvent_1dwfuxf">
+        <dc:Bounds x="819" y="786" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_095woej_di" bpmnElement="IntermediateCatchEvent_095woej">
+        <dc:Bounds x="730" y="786" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jvbd83_di" bpmnElement="SequenceFlow_1jvbd83">
+        <di:waypoint x="766" y="804" />
+        <di:waypoint x="819" y="804" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_054hom6_di" bpmnElement="SequenceFlow_054hom6">
+        <di:waypoint x="685" y="804" />
+        <di:waypoint x="730" y="804" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="MessageFlow_04ma9ot_di" bpmnElement="MessageFlow_04ma9ot">
+        <di:waypoint x="486" y="940" />
+        <di:waypoint x="748" y="940" />
+        <di:waypoint x="748" y="822" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0tetzwq_di" bpmnElement="EndEvent_1kptcch">
+        <dc:Bounds x="450" y="922" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/activiti-bpmn-converter/src/test/resources/MessageEventDefinitionConverterTest.bpmn
+++ b/activiti-bpmn-converter/src/test/resources/MessageEventDefinitionConverterTest.bpmn
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:activiti="http://activiti.org/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ie03cr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta">
+  <bpmn:message id="Message_1" name="catchMessage" />
+  <bpmn:collaboration id="Collaboration_0nstryt">
+    <bpmn:participant id="Participant_18as85l" processRef="intermediateCatchProcess" />
+    <bpmn:participant id="Participant_18f5fet" processRef="intermediateThrowProcess" />
+    <bpmn:participant id="Participant_1l058s9" processRef="endThrowProcess" />
+    <bpmn:participant id="Participant_109exce" name="Lane" processRef="boundaryCatchProcess" />
+    <bpmn:participant id="Participant_07xhfx6" processRef="startMessageEventSubprocess" />
+    <bpmn:participant id="Participant_0sro5q0" processRef="startMessageProcess" />
+    <bpmn:participant id="Participant_0nteap9" processRef="boundaryCatchSubrocess" />
+    <bpmn:messageFlow id="MessageFlow_1jzt5b6" sourceRef="IntermediateThrowEvent" targetRef="intermediateCatchEvent" />
+    <bpmn:messageFlow id="MessageFlow_0hqoly2" sourceRef="EndEvent_0jpp84v" targetRef="intermediateCatchEvent" />
+    <bpmn:messageFlow id="MessageFlow_04x2yx9" sourceRef="EndEvent_0jpp84v" targetRef="BoundaryEvent_05lvrhj" />
+    <bpmn:messageFlow id="MessageFlow_1h69myg" sourceRef="IntermediateThrowEvent" targetRef="StartEvent_0br2ok3" />
+    <bpmn:messageFlow id="MessageFlow_0pjiy45" sourceRef="EndEvent_0jpp84v" targetRef="StartEvent_0d5q67m" />
+    <bpmn:messageFlow id="MessageFlow_1t82r37" sourceRef="EndEvent_1upe6lc" targetRef="BoundaryEvent_0wrfoqw" />
+  </bpmn:collaboration>
+  <bpmn:process id="intermediateCatchProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_1lfab5c</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1h4b0y7">
+      <bpmn:incoming>SequenceFlow_1nhhhse</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:intermediateCatchEvent id="intermediateCatchEvent">
+      <bpmn:incoming>SequenceFlow_1lfab5c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1nhhhse</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1lfab5c" sourceRef="StartEvent_1" targetRef="intermediateCatchEvent" />
+    <bpmn:sequenceFlow id="SequenceFlow_1nhhhse" sourceRef="intermediateCatchEvent" targetRef="EndEvent_1h4b0y7" />
+  </bpmn:process>
+  <bpmn:process id="intermediateThrowProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_0exio6x">
+      <bpmn:outgoing>SequenceFlow_0xbgyns</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="IntermediateThrowEvent">
+      <bpmn:incoming>SequenceFlow_0xbgyns</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_07ejtkg</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0xbgyns" sourceRef="StartEvent_0exio6x" targetRef="IntermediateThrowEvent" />
+    <bpmn:sequenceFlow id="SequenceFlow_07ejtkg" sourceRef="IntermediateThrowEvent" targetRef="EndEvent_1upe6lc" />
+    <bpmn:endEvent id="EndEvent_1upe6lc">
+      <bpmn:incoming>SequenceFlow_07ejtkg</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmn:process id="endThrowProcess" isExecutable="true">
+    <bpmn:endEvent id="EndEvent_0jpp84v">
+      <bpmn:incoming>SequenceFlow_0mkuasq</bpmn:incoming>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:endEvent>
+    <bpmn:startEvent id="IntermediateThrowEvent_1024u0z">
+      <bpmn:outgoing>SequenceFlow_0mkuasq</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0mkuasq" sourceRef="IntermediateThrowEvent_1024u0z" targetRef="EndEvent_0jpp84v" />
+  </bpmn:process>
+  <bpmn:process id="boundaryCatchProcess" name="" isExecutable="true">
+    <bpmn:endEvent id="EndEvent_1peoupm">
+      <bpmn:incoming>SequenceFlow_1whh2y7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_1qno7ds">
+      <bpmn:outgoing>SequenceFlow_15idq89</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_0dzyiuk" name="Task">
+      <bpmn:incoming>SequenceFlow_15idq89</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_15ctb1g</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_15st2dq">
+      <bpmn:incoming>SequenceFlow_15ctb1g</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0xcrns1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1whh2y7</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:boundaryEvent id="BoundaryEvent_05lvrhj" attachedToRef="Task_0dzyiuk">
+      <bpmn:outgoing>SequenceFlow_0xcrns1</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_15idq89" sourceRef="StartEvent_1qno7ds" targetRef="Task_0dzyiuk" />
+    <bpmn:sequenceFlow id="SequenceFlow_15ctb1g" sourceRef="Task_0dzyiuk" targetRef="ExclusiveGateway_15st2dq" />
+    <bpmn:sequenceFlow id="SequenceFlow_1whh2y7" sourceRef="ExclusiveGateway_15st2dq" targetRef="EndEvent_1peoupm" />
+    <bpmn:sequenceFlow id="SequenceFlow_0xcrns1" sourceRef="BoundaryEvent_05lvrhj" targetRef="ExclusiveGateway_15st2dq" />
+  </bpmn:process>
+  <bpmn:process id="startMessageEventSubprocess" isExecutable="true">
+    <bpmn:subProcess id="SubProcess_161i59a" triggeredByEvent="true">
+      <bpmn:startEvent id="StartEvent_0br2ok3">
+        <bpmn:outgoing>SequenceFlow_1c4cta9</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1c4cta9" sourceRef="StartEvent_0br2ok3" targetRef="EndEvent_1xg37g3" />
+      <bpmn:endEvent id="EndEvent_1xg37g3">
+        <bpmn:incoming>SequenceFlow_1c4cta9</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:startEvent id="StartEvent_00zy25x">
+      <bpmn:outgoing>SequenceFlow_0rcahsa</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0rcahsa" sourceRef="StartEvent_00zy25x" targetRef="Task_13v9w3j" />
+    <bpmn:endEvent id="EndEvent_1kptcch">
+      <bpmn:incoming>SequenceFlow_0dfk044</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0dfk044" sourceRef="Task_13v9w3j" targetRef="EndEvent_1kptcch" />
+    <bpmn:userTask id="Task_13v9w3j" name="Task">
+      <bpmn:incoming>SequenceFlow_0rcahsa</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0dfk044</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmn:process id="startMessageProcess" isExecutable="true">
+    <bpmn:sequenceFlow id="SequenceFlow_0lf6d4r" sourceRef="StartEvent_0d5q67m" targetRef="EndEvent_0earbi6" />
+    <bpmn:endEvent id="EndEvent_0earbi6">
+      <bpmn:incoming>SequenceFlow_0lf6d4r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_0d5q67m">
+      <bpmn:outgoing>SequenceFlow_0lf6d4r</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1" />
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:process id="boundaryCatchSubrocess" isExecutable="false">
+    <bpmn:endEvent id="EndEvent_0jqkadg">
+      <bpmn:incoming>SequenceFlow_0yoie86</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_0gdk0sw">
+      <bpmn:outgoing>SequenceFlow_1ponrln</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="SubProcess_0naw10c" name="Subprocess">
+      <bpmn:incoming>SequenceFlow_1ponrln</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0wwqn22</bpmn:outgoing>
+      <bpmn:startEvent id="StartEvent_0qg01h4">
+        <bpmn:outgoing>SequenceFlow_16s1e3n</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_16s1e3n" sourceRef="StartEvent_0qg01h4" targetRef="EndEvent_0dbz9ar" />
+      <bpmn:endEvent id="EndEvent_0dbz9ar">
+        <bpmn:incoming>SequenceFlow_16s1e3n</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="BoundaryEvent_0wrfoqw" attachedToRef="SubProcess_0naw10c">
+      <bpmn:outgoing>SequenceFlow_0xjr70t</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1" activiti:correlationKey="${correlationId}" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0wwqn22" sourceRef="SubProcess_0naw10c" targetRef="ExclusiveGateway_030m0gf" />
+    <bpmn:sequenceFlow id="SequenceFlow_1ponrln" sourceRef="StartEvent_0gdk0sw" targetRef="SubProcess_0naw10c" />
+    <bpmn:sequenceFlow id="SequenceFlow_0yoie86" sourceRef="ExclusiveGateway_030m0gf" targetRef="EndEvent_0jqkadg" />
+    <bpmn:sequenceFlow id="SequenceFlow_0xjr70t" sourceRef="BoundaryEvent_0wrfoqw" targetRef="ExclusiveGateway_030m0gf" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_030m0gf">
+      <bpmn:incoming>SequenceFlow_0wwqn22</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0xjr70t</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0yoie86</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_0nstryt">
+      <bpmndi:BPMNShape id="Participant_18as85l_di" bpmnElement="Participant_18as85l" isHorizontal="true">
+        <dc:Bounds x="156" y="446" width="301" height="98" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="204" y="481" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1h4b0y7_di" bpmnElement="EndEvent_1h4b0y7">
+        <dc:Bounds x="376" y="481" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="IntermediateCatchEvent_1al2moj_di" bpmnElement="intermediateCatchEvent">
+        <dc:Bounds x="290" y="481" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1nhhhse_di" bpmnElement="SequenceFlow_1nhhhse">
+        <di:waypoint x="326" y="499" />
+        <di:waypoint x="376" y="499" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lfab5c_di" bpmnElement="SequenceFlow_1lfab5c">
+        <di:waypoint x="240" y="499" />
+        <di:waypoint x="290" y="499" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_18f5fet_di" bpmnElement="Participant_18f5fet" isHorizontal="true">
+        <dc:Bounds x="156" y="595" width="300" height="103" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0exio6x_di" bpmnElement="StartEvent_0exio6x">
+        <dc:Bounds x="210" y="626" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xbgyns_di" bpmnElement="SequenceFlow_0xbgyns">
+        <di:waypoint x="246" y="644" />
+        <di:waypoint x="292" y="644" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_07ejtkg_di" bpmnElement="SequenceFlow_07ejtkg">
+        <di:waypoint x="328" y="644" />
+        <di:waypoint x="380" y="644" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="IntermediateThrowEvent_0uji00w_di" bpmnElement="IntermediateThrowEvent">
+        <dc:Bounds x="292" y="626" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_1jzt5b6_di" bpmnElement="MessageFlow_1jzt5b6">
+        <di:waypoint x="308" y="626" />
+        <di:waypoint x="308" y="517" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_1l058s9_di" bpmnElement="Participant_1l058s9" isHorizontal="true">
+        <dc:Bounds x="156" y="276" width="300" height="104" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0mkuasq_di" bpmnElement="SequenceFlow_0mkuasq">
+        <di:waypoint x="233" y="326" />
+        <di:waypoint x="291" y="326" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_03usopj_di" bpmnElement="EndEvent_0jpp84v">
+        <dc:Bounds x="291" y="308" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_05udxo1_di" bpmnElement="IntermediateThrowEvent_1024u0z">
+        <dc:Bounds x="197" y="308" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_0hqoly2_di" bpmnElement="MessageFlow_0hqoly2">
+        <di:waypoint x="308" y="344" />
+        <di:waypoint x="308" y="481" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_109exce_di" bpmnElement="Participant_109exce" isHorizontal="true">
+        <dc:Bounds x="156" y="81" width="353" height="147" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1qno7ds_di" bpmnElement="StartEvent_1qno7ds">
+        <dc:Bounds x="196" y="133" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0dzyiuk_di" bpmnElement="Task_0dzyiuk">
+        <dc:Bounds x="253" y="111" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_15idq89_di" bpmnElement="SequenceFlow_15idq89">
+        <di:waypoint x="232" y="151" />
+        <di:waypoint x="253" y="151" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1peoupm_di" bpmnElement="EndEvent_1peoupm">
+        <dc:Bounds x="451" y="133" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_19hqmcd_di" bpmnElement="BoundaryEvent_05lvrhj">
+        <dc:Bounds x="293" y="173" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_04x2yx9_di" bpmnElement="MessageFlow_04x2yx9">
+        <di:waypoint x="311" y="308" />
+        <di:waypoint x="311" y="209" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_15ctb1g_di" bpmnElement="SequenceFlow_15ctb1g">
+        <di:waypoint x="353" y="151" />
+        <di:waypoint x="373" y="151" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ExclusiveGateway_15st2dq_di" bpmnElement="ExclusiveGateway_15st2dq" isMarkerVisible="true">
+        <dc:Bounds x="373" y="126" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1whh2y7_di" bpmnElement="SequenceFlow_1whh2y7">
+        <di:waypoint x="423" y="151" />
+        <di:waypoint x="451" y="151" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xcrns1_di" bpmnElement="SequenceFlow_0xcrns1">
+        <di:waypoint x="326" y="200" />
+        <di:waypoint x="345" y="212" />
+        <di:waypoint x="398" y="212" />
+        <di:waypoint x="398" y="176" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_07xhfx6_di" bpmnElement="Participant_07xhfx6" isHorizontal="true">
+        <dc:Bounds x="156" y="735" width="372" height="265" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_0qg3klh_di" bpmnElement="SubProcess_161i59a" isExpanded="true">
+        <dc:Bounds x="258" y="752" width="192" height="120" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_00zy25x_di" bpmnElement="StartEvent_00zy25x">
+        <dc:Bounds x="214" y="922" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rcahsa_di" bpmnElement="SequenceFlow_0rcahsa">
+        <di:waypoint x="250" y="940" />
+        <di:waypoint x="300" y="940" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1kptcch_di" bpmnElement="EndEvent_1kptcch">
+        <dc:Bounds x="450" y="922" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dfk044_di" bpmnElement="SequenceFlow_0dfk044">
+        <di:waypoint x="400" y="940" />
+        <di:waypoint x="450" y="940" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0w3262l_di" bpmnElement="Task_13v9w3j">
+        <dc:Bounds x="300" y="900" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_062lyis_di" bpmnElement="StartEvent_0br2ok3">
+        <dc:Bounds x="289" y="794" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_1h69myg_di" bpmnElement="MessageFlow_1h69myg">
+        <di:waypoint x="307" y="662" />
+        <di:waypoint x="307" y="794" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1c4cta9_di" bpmnElement="SequenceFlow_1c4cta9">
+        <di:waypoint x="325" y="812" />
+        <di:waypoint x="381" y="812" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1xg37g3_di" bpmnElement="EndEvent_1xg37g3">
+        <dc:Bounds x="381" y="794" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0sro5q0_di" bpmnElement="Participant_0sro5q0" isHorizontal="true">
+        <dc:Bounds x="521" y="276" width="300" height="101" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0earbi6_di" bpmnElement="EndEvent_0earbi6">
+        <dc:Bounds x="716" y="307" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lf6d4r_di" bpmnElement="SequenceFlow_0lf6d4r">
+        <di:waypoint x="636" y="325" />
+        <di:waypoint x="716" y="325" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0k17cjs_di" bpmnElement="StartEvent_0d5q67m">
+        <dc:Bounds x="600" y="307" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_0pjiy45_di" bpmnElement="MessageFlow_0pjiy45">
+        <di:waypoint x="327" y="325" />
+        <di:waypoint x="600" y="325" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0nteap9_di" bpmnElement="Participant_0nteap9" isHorizontal="true">
+        <dc:Bounds x="521" y="416" width="471" height="271" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0gdk0sw_di" bpmnElement="StartEvent_0gdk0sw">
+        <dc:Bounds x="566" y="519" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_0naw10c_di" bpmnElement="SubProcess_0naw10c" isExpanded="true">
+        <dc:Bounds x="644" y="462" width="173" height="149" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0jqkadg_di" bpmnElement="EndEvent_0jqkadg">
+        <dc:Bounds x="936" y="519" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wwqn22_di" bpmnElement="SequenceFlow_0wwqn22">
+        <di:waypoint x="817" y="537" />
+        <di:waypoint x="857" y="537" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ponrln_di" bpmnElement="SequenceFlow_1ponrln">
+        <di:waypoint x="602" y="537" />
+        <di:waypoint x="644" y="537" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0qg01h4_di" bpmnElement="StartEvent_0qg01h4">
+        <dc:Bounds x="664" y="521" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_16s1e3n_di" bpmnElement="SequenceFlow_16s1e3n">
+        <di:waypoint x="700" y="539" />
+        <di:waypoint x="749" y="539" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0dbz9ar_di" bpmnElement="EndEvent_0dbz9ar">
+        <dc:Bounds x="749" y="521" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_07mrejs_di" bpmnElement="BoundaryEvent_0wrfoqw">
+        <dc:Bounds x="710" y="593" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_030m0gf_di" bpmnElement="ExclusiveGateway_030m0gf" isMarkerVisible="true">
+        <dc:Bounds x="857" y="512" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yoie86_di" bpmnElement="SequenceFlow_0yoie86">
+        <di:waypoint x="907" y="537" />
+        <di:waypoint x="936" y="537" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xjr70t_di" bpmnElement="SequenceFlow_0xjr70t">
+        <di:waypoint x="728" y="629" />
+        <di:waypoint x="728" y="656" />
+        <di:waypoint x="882" y="656" />
+        <di:waypoint x="882" y="562" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="MessageFlow_1t82r37_di" bpmnElement="MessageFlow_1t82r37">
+        <di:waypoint x="416" y="644" />
+        <di:waypoint x="698" y="644" />
+        <di:waypoint x="716" y="624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_139gp3m_di" bpmnElement="EndEvent_1upe6lc">
+        <dc:Bounds x="380" y="626" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
This PR adds tests to assure correct BPMN Xml export/import for message event definitions with `correlationKey` and `messageExpression` attributes for the the following test coverage:

![image](https://user-images.githubusercontent.com/20428629/64567508-43f9f100-d30d-11e9-804c-14951b09389d.png)


Part of https://github.com/Activiti/Activiti/issues/2637
