### PR TITLE
fix(signal): dispatch ACTIVITY_SIGNALED start event within execution context

### DIFF
--- a/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
@@ -258,10 +258,10 @@ public class ActivitiEventBuilder {
   public static ActivitiSignalEvent createActivitiySignalledEvent(DelegateExecution execution,
                                                                   String signalName, 
                                                                   Object payload) {
-    return  createSingalEvent(ActivitiEventType.ACTIVITY_SIGNALED, 
-                               execution, 
-                               signalName, 
-                               payload); 
+    return  createSignalEvent(ActivitiEventType.ACTIVITY_SIGNALED,
+                              execution,
+                              signalName,
+                              payload);
   }    
 
   public static ActivitiMessageEvent createMessageReceivedEvent(DelegateExecution execution,
@@ -378,9 +378,9 @@ public class ActivitiEventBuilder {
     }
   }
   
-  private static ActivitiSignalEvent createSingalEvent(ActivitiEventType type, 
+  private static ActivitiSignalEvent createSignalEvent(ActivitiEventType type,
                                                        DelegateExecution execution,
-                                                       String signalName, 
+                                                       String signalName,
                                                        Object payload) {
      ActivitiSignalEventImpl newEvent = new ActivitiSignalEventImpl(type);
      newEvent.setSignalName(signalName);

--- a/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
@@ -12,8 +12,6 @@
  */
 package org.activiti.engine.delegate.event.impl;
 
-import java.util.Map;
-
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -39,6 +37,8 @@ import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.Job;
 import org.activiti.engine.task.Task;
+
+import java.util.Map;
 
 /**
  * Builder class used to create {@link ActivitiEvent} implementations.
@@ -254,19 +254,16 @@ public class ActivitiEventBuilder {
     newEvent.setCause(cause);
     return newEvent;
   }
-
-  public static ActivitiSignalEvent createSignalEvent(ActivitiEventType type, String activityId, String signalName, Object signalData, String executionId, String processInstanceId,
-      String processDefinitionId) {
-    ActivitiSignalEventImpl newEvent = new ActivitiSignalEventImpl(type);
-    newEvent.setActivityId(activityId);
-    newEvent.setExecutionId(executionId);
-    newEvent.setProcessDefinitionId(processDefinitionId);
-    newEvent.setProcessInstanceId(processInstanceId);
-    newEvent.setSignalName(signalName);
-    newEvent.setSignalData(signalData);
-    return newEvent;
-  }
   
+  public static ActivitiSignalEvent createActivitiySignalledEvent(DelegateExecution execution,
+                                                                  String signalName, 
+                                                                  Object payload) {
+    return  createSingalEvent(ActivitiEventType.ACTIVITY_SIGNALED, 
+                               execution, 
+                               signalName, 
+                               payload); 
+  }    
+
   public static ActivitiMessageEvent createMessageReceivedEvent(DelegateExecution execution,
                                                                 String messageName, 
                                                                 String correlationKey, 
@@ -297,7 +294,7 @@ public class ActivitiEventBuilder {
                               messageName,
                               correlationKey,
                               payload);
-  }  
+  }
   
   private static ActivitiMessageEvent createMessageEvent(ActivitiEventType type, 
                                                          DelegateExecution execution,
@@ -308,21 +305,9 @@ public class ActivitiEventBuilder {
     newEvent.setMessageName(messageName);
     newEvent.setMessageCorrelationKey(correlationKey);
     newEvent.setMessageData(payload);  
+
+    applyExecution(newEvent, execution);
     
-    if (execution != null) {
-        newEvent.setActivityId(execution.getCurrentActivityId());
-        newEvent.setExecutionId(execution.getId());
-        newEvent.setProcessDefinitionId(execution.getProcessDefinitionId());
-        newEvent.setProcessInstanceId(execution.getProcessInstanceId());
-        newEvent.setMessageBusinessKey(execution.getProcessInstanceBusinessKey());
-        
-        if (execution.getCurrentFlowElement() instanceof FlowNode) {
-            FlowNode flowNode = (FlowNode) execution.getCurrentFlowElement();
-            newEvent.setActivityType(parseActivityType(flowNode));
-            newEvent.setBehaviorClass(parseActivityBehavior(flowNode));
-            newEvent.setActivityName(flowNode.getName());
-        }
-    }  
     return newEvent;
   } 
 
@@ -391,4 +376,35 @@ public class ActivitiEventBuilder {
       }
     }
   }
+  
+  private static ActivitiSignalEvent createSingalEvent(ActivitiEventType type, 
+                                                       DelegateExecution execution,
+                                                       String signalName, 
+                                                       Object payload) {
+     ActivitiSignalEventImpl newEvent = new ActivitiSignalEventImpl(type);
+     newEvent.setSignalName(signalName);
+     newEvent.setSignalData(payload);  
+     
+     applyExecution(newEvent, execution);
+     
+     return newEvent;
+  }  
+  
+  private static void applyExecution(ActivitiActivityEventImpl newEvent, 
+                                     DelegateExecution execution) {
+    if (execution != null) {
+      newEvent.setActivityId(execution.getCurrentActivityId());
+      newEvent.setExecutionId(execution.getId());
+      newEvent.setProcessDefinitionId(execution.getProcessDefinitionId());
+      newEvent.setProcessInstanceId(execution.getProcessInstanceId());
+      
+      if (execution.getCurrentFlowElement() instanceof FlowNode) {
+          FlowNode flowNode = (FlowNode) execution.getCurrentFlowElement();
+          newEvent.setActivityType(parseActivityType(flowNode));
+          newEvent.setBehaviorClass(parseActivityBehavior(flowNode));
+          newEvent.setActivityName(flowNode.getName());
+      }
+    }  
+  }
+  
 }

--- a/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
@@ -305,6 +305,7 @@ public class ActivitiEventBuilder {
     newEvent.setMessageName(messageName);
     newEvent.setMessageCorrelationKey(correlationKey);
     newEvent.setMessageData(payload);  
+    newEvent.setMessageBusinessKey(execution.getProcessInstanceBusinessKey());
 
     applyExecution(newEvent, execution);
     

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
@@ -17,7 +17,6 @@ import org.activiti.bpmn.model.Signal;
 import org.activiti.bpmn.model.SignalEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
-import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManager;
@@ -26,6 +25,8 @@ import org.activiti.engine.impl.persistence.entity.SignalEventSubscriptionEntity
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
@@ -77,13 +78,12 @@ public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnAc
         }
 
         for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : subscriptionEntities) {
-            Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-                    ActivitiEventBuilder.createActivitiySignalledEvent(signalEventSubscriptionEntity.getExecution(),
-                                                                       eventSubscriptionName,
-                                                                       null));
-
+            Map<String, Object> signalVariables = Optional.ofNullable(execution.getVariables())
+                                                          .filter(it -> !it.isEmpty())
+                                                          .orElse(null);
+            
             eventSubscriptionEntityManager.eventReceived(signalEventSubscriptionEntity,
-                                                         execution.getVariables(),
+                                                         signalVariables,
                                                          signalEventDefinition.isAsync());
         }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateThrowSignalEventActivityBehavior.java
@@ -13,13 +13,10 @@
 
 package org.activiti.engine.impl.bpmn.behavior;
 
-import java.util.List;
-
 import org.activiti.bpmn.model.Signal;
 import org.activiti.bpmn.model.SignalEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
-import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -27,6 +24,8 @@ import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManage
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.SignalEventSubscriptionEntity;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.List;
 
 public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnActivityBehavior {
 
@@ -79,13 +78,9 @@ public class IntermediateThrowSignalEventActivityBehavior extends AbstractBpmnAc
 
         for (SignalEventSubscriptionEntity signalEventSubscriptionEntity : subscriptionEntities) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-                    ActivitiEventBuilder.createSignalEvent(ActivitiEventType.ACTIVITY_SIGNALED,
-                                                           signalEventSubscriptionEntity.getActivityId(),
-                                                           eventSubscriptionName,
-                                                           null,
-                                                           signalEventSubscriptionEntity.getExecutionId(),
-                                                           signalEventSubscriptionEntity.getProcessInstanceId(),
-                                                           signalEventSubscriptionEntity.getProcessDefinitionId()));
+                    ActivitiEventBuilder.createActivitiySignalledEvent(signalEventSubscriptionEntity.getExecution(),
+                                                                       eventSubscriptionName,
+                                                                       null));
 
             eventSubscriptionEntityManager.eventReceived(signalEventSubscriptionEntity,
                                                          execution.getVariables(),

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SignalEventReceivedCmd.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/SignalEventReceivedCmd.java
@@ -13,21 +13,18 @@
 
 package org.activiti.engine.impl.cmd;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
-import org.activiti.engine.delegate.event.ActivitiEventType;
-import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
-import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManager;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.SignalEventSubscriptionEntity;
 import org.activiti.engine.runtime.Execution;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
 
@@ -92,14 +89,7 @@ public class SignalEventReceivedCmd implements Command<Void> {
       // We only throw the event to globally scoped signals.
       // Process instance scoped signals must be thrown within the process itself
       if (signalEventSubscriptionEntity.isGlobalScoped()) {
-
-        Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-                ActivitiEventBuilder.createSignalEvent(ActivitiEventType.ACTIVITY_SIGNALED, signalEventSubscriptionEntity.getActivityId(), eventName,
-                        payload, signalEventSubscriptionEntity.getExecutionId(), signalEventSubscriptionEntity.getProcessInstanceId(),
-                        signalEventSubscriptionEntity.getProcessDefinitionId()));
-
         eventSubscriptionEntityManager.eventReceived(signalEventSubscriptionEntity, payload, async);
-        
       }
     }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/TriggerCmd.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/TriggerCmd.java
@@ -13,7 +13,6 @@
 
 package org.activiti.engine.impl.cmd;
 
-import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -52,8 +51,9 @@ public class TriggerCmd extends NeedsActiveExecutionCmd<Object> {
     }
 
     Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-        ActivitiEventBuilder.createSignalEvent(ActivitiEventType.ACTIVITY_SIGNALED, execution.getCurrentActivityId(), null,
-            null, execution.getId(), execution.getProcessInstanceId(), execution.getProcessDefinitionId()));
+        ActivitiEventBuilder.createActivitiySignalledEvent(execution,
+                                                           null,
+                                                           null));
 
     Context.getAgenda().planTriggerExecutionOperation(execution);
     return null;

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
@@ -46,11 +46,10 @@ public class SignalEventHandler extends AbstractEventHandler {
   public void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext) {
     if (eventSubscription.getExecutionId() != null) {
       
-      ActivitiSignalEvent signalEvent = ActivitiEventBuilder.createActivitiySignalledEvent(eventSubscription.getExecution(),
-                                                                                         eventSubscription.getEventName(),
-                                                                                         payload);
-    
-      dispatchSignalEvent(signalEvent, commandContext);
+      dispatchActivitySignalledEvent(eventSubscription.getExecution(),
+                                     eventSubscription.getEventName(),
+                                     payload,
+                                     commandContext);
         
       super.handleEvent(eventSubscription, payload, commandContext);
 
@@ -90,13 +89,12 @@ public class SignalEventHandler extends AbstractEventHandler {
                                                                                                           process,
                                                                                                           variables,
                                                                                                           null);
-
       DelegateExecution execution = executionEntity.getExecutions()
                                                    .get(0);
-      ActivitiSignalEvent signalEvent = ActivitiEventBuilder.createActivitiySignalledEvent(execution,
-                                                                                           eventSubscription.getEventName(),
-                                                                                           payload);
-      dispatchSignalEvent(signalEvent, commandContext);
+      dispatchActivitySignalledEvent(execution, 
+                                     eventSubscription.getEventName(),
+                                     payload,
+                                     commandContext);
       
       processInstanceHelper.startProcessInstance(executionEntity, 
                                                  commandContext, 
@@ -106,10 +104,18 @@ public class SignalEventHandler extends AbstractEventHandler {
     }
   }
   
-  protected void dispatchSignalEvent(ActivitiSignalEvent signalEvent, CommandContext commandContext) {
+  protected void dispatchActivitySignalledEvent(DelegateExecution execution, 
+                                     String signalName, 
+                                     Object payload,
+                                     CommandContext commandContext) {
     if (commandContext.getProcessEngineConfiguration()
                       .getEventDispatcher()
                       .isEnabled()) {
+        
+      ActivitiSignalEvent signalEvent = ActivitiEventBuilder.createActivitiySignalledEvent(execution,
+                                                                                           signalName,
+                                                                                           payload);
+        
       Context.getProcessEngineConfiguration().getEventDispatcher()
                                              .dispatchEvent(signalEvent);
     }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/event/SignalEventHandler.java
@@ -13,16 +13,20 @@
 
 package org.activiti.engine.impl.event;
 
-import java.util.Map;
-
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.engine.delegate.event.ActivitiSignalEvent;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
+import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.util.ProcessDefinitionUtil;
 import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.repository.ProcessDefinition;
+
+import java.util.Map;
 
 /**
 
@@ -41,6 +45,8 @@ public class SignalEventHandler extends AbstractEventHandler {
   public void handleEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext) {
     if (eventSubscription.getExecutionId() != null) {
       
+      dispatchSignalEvent(eventSubscription, payload, commandContext);
+        
       super.handleEvent(eventSubscription, payload, commandContext);
 
     } else if (eventSubscription.getProcessDefinitionId() != null) {
@@ -68,12 +74,37 @@ public class SignalEventHandler extends AbstractEventHandler {
       if (payload instanceof Map) {
         variables = (Map<String, Object>) payload;
       }
-      ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration().getProcessInstanceHelper();
-      processInstanceHelper.createAndStartProcessInstanceWithInitialFlowElement(processDefinition, null, null, flowElement, process, variables, null, true);
       
+      ProcessInstanceHelper processInstanceHelper = commandContext.getProcessEngineConfiguration()
+                                                                  .getProcessInstanceHelper();
+      
+      ExecutionEntity executionEntity = processInstanceHelper.createProcessInstanceWithInitialFlowElement(processDefinition,
+                                                                                                          null,
+                                                                                                          null,
+                                                                                                          flowElement,
+                                                                                                          process,
+                                                                                                          variables,
+                                                                                                          null);
+      dispatchSignalEvent(eventSubscription, payload, commandContext);
+      
+      processInstanceHelper.startProcessInstance(executionEntity, 
+                                                 commandContext, 
+                                                 variables);
     } else {
       throw new ActivitiException("Invalid signal handling: no execution nor process definition set");
     }
   }
-
+  
+  protected void dispatchSignalEvent(EventSubscriptionEntity eventSubscription, Object payload, CommandContext commandContext) {
+    if (commandContext.getProcessEngineConfiguration()
+                      .getEventDispatcher()
+                      .isEnabled()) {
+      ActivitiSignalEvent signalEvent = ActivitiEventBuilder.createActivitiySignalledEvent(eventSubscription.getExecution(),
+                                                                                           eventSubscription.getEventName(),
+                                                                                           payload);
+      Context.getProcessEngineConfiguration().getEventDispatcher()
+                                             .dispatchEvent(signalEvent);
+    }
+  }
+  
 }

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-signals/src/test/java/org/activiti/spring/conformance/signals/SignalThrowCatchTest.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-signals/src/test/java/org/activiti/spring/conformance/signals/SignalThrowCatchTest.java
@@ -271,8 +271,8 @@ public class SignalThrowCatchTest {
                 .extracting(RuntimeEvent::getEventType)
                 .containsExactly(
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_CREATED,
-                        BPMNSignalEvent.SignalEvents.SIGNAL_RECEIVED,
                         VariableEvent.VariableEvents.VARIABLE_CREATED,
+                        BPMNSignalEvent.SignalEvents.SIGNAL_RECEIVED,
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED,
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                         BPMNSequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
@@ -281,7 +281,7 @@ public class SignalThrowCatchTest {
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED
                 );
 
-        BPMNSignalReceivedEvent event = (BPMNSignalReceivedEvent) RuntimeTestConfiguration.collectedEvents.get(0);
+        BPMNSignalReceivedEvent event = (BPMNSignalReceivedEvent) RuntimeTestConfiguration.collectedEvents.get(2);
 
         assertThat(event.getEntity()).isNotNull();
         assertThat(event.getEntity().getSignalPayload()).isNotNull();

--- a/activiti-spring-conformance-tests/activiti-spring-conformance-signals/src/test/java/org/activiti/spring/conformance/signals/SignalThrowCatchTest.java
+++ b/activiti-spring-conformance-tests/activiti-spring-conformance-signals/src/test/java/org/activiti/spring/conformance/signals/SignalThrowCatchTest.java
@@ -1,5 +1,8 @@
 package org.activiti.spring.conformance.signals;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
 import org.activiti.api.model.shared.event.RuntimeEvent;
 import org.activiti.api.model.shared.event.VariableEvent;
 import org.activiti.api.process.model.BPMNActivity;
@@ -26,9 +29,6 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
@@ -270,8 +270,8 @@ public class SignalThrowCatchTest {
         assertThat(RuntimeTestConfiguration.collectedEvents)
                 .extracting(RuntimeEvent::getEventType)
                 .containsExactly(
-                        BPMNSignalEvent.SignalEvents.SIGNAL_RECEIVED,
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_CREATED,
+                        BPMNSignalEvent.SignalEvents.SIGNAL_RECEIVED,
                         VariableEvent.VariableEvents.VARIABLE_CREATED,
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_STARTED,
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/ProcessVariablesInitiator.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/ProcessVariablesInitiator.java
@@ -13,13 +13,6 @@
 
 package org.activiti.spring.process;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.Process;
 import org.activiti.engine.ActivitiException;
@@ -30,6 +23,13 @@ import org.activiti.spring.process.model.ProcessExtensionModel;
 import org.activiti.spring.process.model.VariableDefinition;
 import org.activiti.spring.process.variable.VariableParsingService;
 import org.activiti.spring.process.variable.VariableValidationService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 public class ProcessVariablesInitiator extends ProcessInstanceHelper {
 
@@ -76,7 +76,7 @@ public class ProcessVariablesInitiator extends ProcessInstanceHelper {
     }
 
     @Override
-    protected ExecutionEntity createProcessInstanceWithInitialFlowElement(ProcessDefinition processDefinition,
+    public ExecutionEntity createProcessInstanceWithInitialFlowElement(ProcessDefinition processDefinition,
                                                                           String businessKey,
                                                                           String processInstanceName,
                                                                           FlowElement initialFlowElement,


### PR DESCRIPTION
This PR fixes the problem with ACTIVITY_SIGNALED start event dispatching before PROCESS_CREATED event without execution context. 