### PR TITLE
fix(ACTIVITI-3864): handle catch message expression and variable mappings

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/RuntimeReceiveMessagePayloadEventListener.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/RuntimeReceiveMessagePayloadEventListener.java
@@ -16,8 +16,6 @@
 
 package org.activiti.runtime.api.impl;
 
-import java.util.Map;
-
 import org.activiti.api.process.model.payloads.ReceiveMessagePayload;
 import org.activiti.engine.ActivitiObjectNotFoundException;
 import org.activiti.engine.ManagementService;
@@ -27,6 +25,9 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.activiti.runtime.api.message.ReceiveMessagePayloadEventListener;
+
+import java.util.Map;
+import java.util.Objects;
 
 /**
  * Default implementation of SignalPayloadEventListener that delegates 
@@ -52,7 +53,7 @@ public class RuntimeReceiveMessagePayloadEventListener implements ReceiveMessage
                 
         EventSubscriptionEntity subscription = managementService.executeCommand(new FindMessageEventSubscription(messageName,
                                                                                                                  correlationKey));
-        if (subscription != null) {
+        if (subscription != null && Objects.equals(correlationKey, subscription.getConfiguration())) {
             Map<String, Object> variables = messagePayload.getVariables();
             String executionId = subscription.getExecutionId();
             

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultMessageExecutionContext.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultMessageExecutionContext.java
@@ -12,13 +12,14 @@
  */
 package org.activiti.engine.impl.bpmn.parser.factory;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.activiti.bpmn.model.MessageEventDefinition;
+import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.impl.delegate.MessagePayloadMappingProvider;
 import org.activiti.engine.impl.el.ExpressionManager;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class DefaultMessageExecutionContext implements MessageExecutionContext {
     private final ExpressionManager expressionManager;
@@ -64,10 +65,10 @@ public class DefaultMessageExecutionContext implements MessageExecutionContext {
     
     protected String evaluateExpression(String expression, 
                                         DelegateExecution execution) {
-        return expressionManager.createExpression(expression)
-                                .getValue(execution)
-                                .toString();
+        return Optional.ofNullable(expressionManager.createExpression(expression))
+                       .map(it -> it.getValue(execution))
+                       .map(Object::toString)
+                       .orElseThrow(() -> new ActivitiIllegalArgumentException("Expression '" + expression + "' is null"));
     }
-    
 
 }

--- a/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -13,6 +13,10 @@
 
 package org.activiti.engine.test.bpmn.event.message;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.EventSubscriptionQueryImpl;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
@@ -21,9 +25,8 @@ import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
 
@@ -78,13 +81,12 @@ public class MessageIntermediateEventTest extends PluggableActivitiTestCase {
   public void testSingleIntermediateMessageExpressionEventWithNullExpressionShouldFail() {
     Map<String, Object> variableMap = new HashMap<String, Object>();
     variableMap.put("myMessageName", null);
-    
-    try {
-      ProcessInstance pi = runtimeService.startProcessInstanceByKey("process", variableMap);
-      fail("Excpected ActivitiIllegalArgumentException");  
-    } catch(ActivitiIllegalArgumentException error) {
-      // success 
-    }
+
+      Throwable throwable = catchThrowable(() -> runtimeService.startProcessInstanceByKey("process",
+                                                                                        variableMap));
+      assertThat(throwable)
+              .isInstanceOf(ActivitiIllegalArgumentException.class)
+              .hasMessage("Expression '${myMessageName}' is null");
   }
   
   @Deployment

--- a/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
+++ b/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/message/MessageIntermediateEventTest.java
@@ -13,16 +13,17 @@
 
 package org.activiti.engine.test.bpmn.event.message;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.EventSubscriptionQueryImpl;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.Execution;
 import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
 
@@ -73,6 +74,19 @@ public class MessageIntermediateEventTest extends PluggableActivitiTestCase {
     taskService.complete(task.getId());
   }
 
+  @Deployment(resources = "org/activiti/engine/test/bpmn/event/message/MessageIntermediateEventTest.testSingleIntermediateMessageExpressionEvent.bpmn20.xml")
+  public void testSingleIntermediateMessageExpressionEventWithNullExpressionShouldFail() {
+    Map<String, Object> variableMap = new HashMap<String, Object>();
+    variableMap.put("myMessageName", null);
+    
+    try {
+      ProcessInstance pi = runtimeService.startProcessInstanceByKey("process", variableMap);
+      fail("Excpected ActivitiIllegalArgumentException");  
+    } catch(ActivitiIllegalArgumentException error) {
+      // success 
+    }
+  }
+  
   @Deployment
   public void testConcurrentIntermediateMessageEvent() {
 

--- a/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testBoundaryMessageExpression.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testBoundaryMessageExpression.bpmn20.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <message id="Message_0b88veq" name="int-boundary-message" />
+  <process id="testBoundaryMessageExpression" name="testBoundaryMessageExpression" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <outgoing>SequenceFlow_1bbm2b0</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_1bbm2b0" sourceRef="StartEvent_1" targetRef="Task_1is7525" />
+    <userTask id="Task_1is7525" name="int-boundary-task" activiti:assignee="hruser">
+      <incoming>SequenceFlow_1bbm2b0</incoming>
+    </userTask>
+    <boundaryEvent id="BoundaryEvent_1pnwbke" attachedToRef="Task_1is7525">
+      <messageEventDefinition activiti:messageExpression="int-boundary-message" activiti:correlationKey="${correlationKey}"/>
+    </boundaryEvent>
+    <sequenceFlow id="SequenceFlow_0m55u7d" sourceRef="BoundaryEvent_1pnwbke" targetRef="EndEvent_1i4w9nk" />
+    <endEvent id="EndEvent_1i4w9nk">
+      <incoming>SequenceFlow_0m55u7d</incoming>
+    </endEvent>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process-b55fe468-63ba-4675-9a37-328a4571eb44">
+    <bpmndi:BPMNPlane id="BPMNPlane_process-b55fe468-63ba-4675-9a37-328a4571eb44" bpmnElement="testBoundaryMessageExpression">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="164" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_1is7525" bpmnElement="Task_1is7525">
+        <omgdc:Bounds x="289" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_BoundaryEvent_1pnwbke" bpmnElement="BoundaryEvent_1pnwbke">
+        <omgdc:Bounds x="327" y="143" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1i4w9nk" bpmnElement="EndEvent_1i4w9nk">
+        <omgdc:Bounds x="437" y="223" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1bbm2b0" bpmnElement="SequenceFlow_1bbm2b0">
+        <omgdi:waypoint x="200" y="121" />
+        <omgdi:waypoint x="289" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_0m55u7d" bpmnElement="SequenceFlow_0m55u7d">
+        <omgdi:waypoint x="345" y="179" />
+        <omgdi:waypoint x="345" y="241" />
+        <omgdi:waypoint x="437" y="241" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression-extensions.json
+++ b/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression-extensions.json
@@ -1,0 +1,39 @@
+{
+  "id":"testCatchMessageExpression",
+  "name":"ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml",
+  "extensions": {
+    "properties": {
+        "e3384837-c071-4027-b02d-850839136f42": {
+            "id": "e3384837-c071-4027-b02d-850839136f42",
+            "name": "intermediate_var",
+            "type": "string",
+            "required": false,
+            "value": ""
+        },
+        "cc9cb897-dc96-4f1e-ae2f-efec6b9ca076": {
+            "id": "cc9cb897-dc96-4f1e-ae2f-efec6b9ca076",
+            "name": "inter_message_var",
+            "type": "string",
+            "required": true,
+            "value": "check2"
+        }
+    },
+    "mappings": {
+        "Task_0jmo194": {
+            "inputs": {
+                "Text0739ze": {
+                    "type": "variable",
+                    "value": "intermediate_var"
+                }
+            },
+            "outputs": {
+                "intermediate_var": {
+                    "type": "variable",
+                    "value": "Text0739ze"
+                }
+            }
+        }
+    },
+    "constants": {}
+  }
+}

--- a/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <process id="testCatchMessageExpression" name="intermediate-message-event" isExecutable="true">
+    <startEvent id="StartEvent_1">
+      <outgoing>SequenceFlow_1mbim8e</outgoing>
+    </startEvent>
+    <sequenceFlow id="SequenceFlow_1mbim8e" sourceRef="StartEvent_1" targetRef="Task_0jmo194" />
+    <sequenceFlow id="SequenceFlow_01qb2vz" sourceRef="IntermediateThrowEvent_0jatjzg" targetRef="Task_0rcgll6" />
+    <endEvent id="EndEvent_1jnezm5">
+      <incoming>SequenceFlow_0shjy0t</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_0shjy0t" sourceRef="Task_0rcgll6" targetRef="EndEvent_1jnezm5" />
+    <intermediateCatchEvent id="IntermediateThrowEvent_0jatjzg">
+      <incoming>SequenceFlow_131qt29</incoming>
+      <messageEventDefinition activiti:correlationKey="${intermediate_var}" activiti:messageExpression="intermediate-catch-message-${inter_message_var}" />
+    </intermediateCatchEvent>
+    <userTask id="Task_0rcgll6" name="intermediate-user-task" activiti:assignee="user" />
+    <userTask id="Task_0jmo194" name="usertaskform" activiti:formKey="form-4c0e1cc9-f0ef-4f1f-8f86-2135bb224e1e" activiti:assignee="user">
+      <incoming>SequenceFlow_1mbim8e</incoming>
+      <outgoing>SequenceFlow_131qt29</outgoing>
+    </userTask>
+    <sequenceFlow id="SequenceFlow_131qt29" sourceRef="Task_0jmo194" targetRef="IntermediateThrowEvent_0jatjzg" />
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_process-009a0f73-8b81-4bfe-b506-074fbcafd856">
+    <bpmndi:BPMNPlane id="BPMNPlane_process-009a0f73-8b81-4bfe-b506-074fbcafd856" bpmnElement="process-009a0f73-8b81-4bfe-b506-074fbcafd856">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <omgdc:Bounds x="174" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1jnezm5" bpmnElement="EndEvent_1jnezm5">
+        <omgdc:Bounds x="866" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_IntermediateThrowEvent_0jatjzg" bpmnElement="IntermediateThrowEvent_0jatjzg">
+        <omgdc:Bounds x="500" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_0rcgll6" bpmnElement="Task_0rcgll6">
+        <omgdc:Bounds x="642" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_Task_0jmo194" bpmnElement="Task_0jmo194">
+        <omgdc:Bounds x="300" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1mbim8e" bpmnElement="SequenceFlow_1mbim8e">
+        <omgdi:waypoint x="210" y="121" />
+        <omgdi:waypoint x="300" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_01qb2vz" bpmnElement="SequenceFlow_01qb2vz">
+        <omgdi:waypoint x="536" y="121" />
+        <omgdi:waypoint x="642" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_0shjy0t" bpmnElement="SequenceFlow_0shjy0t">
+        <omgdi:waypoint x="742" y="121" />
+        <omgdi:waypoint x="866" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_131qt29_di" bpmnElement="SequenceFlow_131qt29">
+        <omgdi:waypoint x="400" y="121" />
+        <omgdi:waypoint x="500" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml
@@ -22,7 +22,7 @@
     <sequenceFlow id="SequenceFlow_131qt29" sourceRef="Task_0jmo194" targetRef="IntermediateThrowEvent_0jatjzg" />
   </process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_process-009a0f73-8b81-4bfe-b506-074fbcafd856">
-    <bpmndi:BPMNPlane id="BPMNPlane_process-009a0f73-8b81-4bfe-b506-074fbcafd856" bpmnElement="process-009a0f73-8b81-4bfe-b506-074fbcafd856">
+    <bpmndi:BPMNPlane id="BPMNPlane_process-009a0f73-8b81-4bfe-b506-074fbcafd856" bpmnElement="testCatchMessageExpression">
       <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
         <omgdc:Bounds x="174" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>


### PR DESCRIPTION
- [x] This PR adds test coverage for message expressions with variable mappings that uses the following BPMN process model:

![image](https://user-images.githubusercontent.com/20428629/65479552-b78a1b00-de42-11e9-8aa1-f9644436dd70.png)

```xml
<?xml version="1.0" encoding="UTF-8"?>
<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
  <process id="testCatchMessageExpression" name="intermediate-message-event" isExecutable="true">
    <startEvent id="StartEvent_1">
      <outgoing>SequenceFlow_1mbim8e</outgoing>
    </startEvent>
    <sequenceFlow id="SequenceFlow_1mbim8e" sourceRef="StartEvent_1" targetRef="Task_0jmo194" />
    <sequenceFlow id="SequenceFlow_01qb2vz" sourceRef="IntermediateThrowEvent_0jatjzg" targetRef="Task_0rcgll6" />
    <endEvent id="EndEvent_1jnezm5">
      <incoming>SequenceFlow_0shjy0t</incoming>
    </endEvent>
    <sequenceFlow id="SequenceFlow_0shjy0t" sourceRef="Task_0rcgll6" targetRef="EndEvent_1jnezm5" />
    <intermediateCatchEvent id="IntermediateThrowEvent_0jatjzg">
      <incoming>SequenceFlow_131qt29</incoming>
      <messageEventDefinition activiti:correlationKey="${intermediate_var}" activiti:messageExpression="intermediate-catch-message-${inter_message_var}" />
    </intermediateCatchEvent>
    <userTask id="Task_0rcgll6" name="intermediate-user-task" activiti:assignee="user" />
    <userTask id="Task_0jmo194" name="usertaskform" activiti:formKey="form-4c0e1cc9-f0ef-4f1f-8f86-2135bb224e1e" activiti:assignee="user">
      <incoming>SequenceFlow_1mbim8e</incoming>
      <outgoing>SequenceFlow_131qt29</outgoing>
    </userTask>
    <sequenceFlow id="SequenceFlow_131qt29" sourceRef="Task_0jmo194" targetRef="IntermediateThrowEvent_0jatjzg" />
  </process>
</definitions>
```

and json mapping extensions:

```json
{
  "id":"testCatchMessageExpression",
  "name":"ProcessRuntimeBPMNMessageIT.testCatchMessageExpression.bpmn20.xml",
  "extensions": {
    "properties": {
        "e3384837-c071-4027-b02d-850839136f42": {
            "id": "e3384837-c071-4027-b02d-850839136f42",
            "name": "intermediate_var",
            "type": "string",
            "required": false,
            "value": ""
        },
        "cc9cb897-dc96-4f1e-ae2f-efec6b9ca076": {
            "id": "cc9cb897-dc96-4f1e-ae2f-efec6b9ca076",
            "name": "inter_message_var",
            "type": "string",
            "required": true,
            "value": "check2"
        }
    },
    "mappings": {
        "Task_0jmo194": {
            "inputs": {
                "Text0739ze": {
                    "type": "variable",
                    "value": "intermediate_var"
                }
            },
            "outputs": {
                "intermediate_var": {
                    "type": "variable",
                    "value": "Text0739ze"
                }
            }
        }
    },
    "constants": {}
  }
}
```

- [x] Added test case to cover message expression on boundary message events:

![image](https://user-images.githubusercontent.com/20428629/65479941-58c5a100-de44-11e9-9871-6d361af39529.png)


- [x] Also, when message expressions evaluate to null, the run-time exception is raised with description that contains expression string causing null value.

- [x] Added test coverage for message runtime api that properly handles not existing message name with  correlation key. 