### PR TITLE
fix(ACTIVITI-3874): handle duplicate event subscriptions for boundary and intermediate message events

### DIFF
--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/AbstractThrowMessageEventActivityBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/AbstractThrowMessageEventActivityBehavior.java
@@ -12,9 +12,6 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.activiti.bpmn.model.MessageEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
@@ -24,6 +21,8 @@ import org.activiti.engine.impl.delegate.ThrowMessage;
 import org.activiti.engine.impl.delegate.ThrowMessageDelegate;
 import org.activiti.engine.impl.delegate.invocation.DelegateInvocation;
 import org.activiti.engine.impl.delegate.invocation.ThrowMessageDelegateInvocation;
+
+import java.util.Optional;
 
 public abstract class AbstractThrowMessageEventActivityBehavior extends FlowNodeActivityBehavior {
 
@@ -69,17 +68,7 @@ public abstract class AbstractThrowMessageEventActivityBehavior extends FlowNode
     }
     
     protected ThrowMessage getThrowMessage(DelegateExecution execution) {
-        String name = messageExecutionContext.getMessageName(execution);
-        Optional<String> correlationKey = messageExecutionContext.getCorrelationKey(execution);
-        Optional<String> businessKey = Optional.ofNullable(execution.getProcessInstanceBusinessKey());
-        Optional<Map<String, Object>> payload = messageExecutionContext.getMessagePayload(execution);
-        
-        return ThrowMessage.builder()
-                           .name(name)
-                           .correlationKey(correlationKey)
-                           .businessKey(businessKey)
-                           .payload(payload)
-                           .build();
+        return messageExecutionContext.createThrowMessage(execution);
     }
 
     protected void dispatchEvent(DelegateExecution execution, ThrowMessage throwMessage) {

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryMessageEventActivityBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryMessageEventActivityBehavior.java
@@ -12,9 +12,6 @@
  */
 package org.activiti.engine.impl.bpmn.behavior;
 
-import java.util.List;
-import java.util.Optional;
-
 import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.MessageEventDefinition;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -26,6 +23,8 @@ import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
 import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntityManager;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
+
+import java.util.List;
 
 /**
 
@@ -49,21 +48,14 @@ public class BoundaryMessageEventActivityBehavior extends BoundaryEventActivityB
     CommandContext commandContext = Context.getCommandContext();
     ExecutionEntity executionEntity = (ExecutionEntity) execution;
     
-    String messageName = messageExecutionContext.getMessageName(execution);
-    
-    MessageEventSubscriptionEntity messageEvent = commandContext.getEventSubscriptionEntityManager()
-                                                                .insertMessageEvent(messageName, 
-                                                                                    executionEntity);
-    Optional<String> correlationKey = messageExecutionContext.getCorrelationKey(execution);
-    
-    correlationKey.ifPresent(messageEvent::setConfiguration);
-    
+    MessageEventSubscriptionEntity messageEvent = messageExecutionContext.createMessageEventSubscription(commandContext, 
+                                                                                                         executionEntity);
     if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
         
         commandContext.getProcessEngineConfiguration().getEventDispatcher()
                 .dispatchEvent(ActivitiEventBuilder.createMessageWaitingEvent(executionEntity, 
-                                                                              messageName,
-                                                                              correlationKey.orElse(null)));
+                                                                              messageEvent.getEventName(),
+                                                                              messageEvent.getConfiguration()));
     }
   }
 

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultMessageExecutionContext.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/DefaultMessageExecutionContext.java
@@ -12,13 +12,21 @@
  */
 package org.activiti.engine.impl.bpmn.parser.factory;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.activiti.bpmn.model.MessageEventDefinition;
+import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.impl.delegate.MessagePayloadMappingProvider;
+import org.activiti.engine.impl.delegate.ThrowMessage;
 import org.activiti.engine.impl.el.ExpressionManager;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.EventSubscriptionEntity;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 
 public class DefaultMessageExecutionContext implements MessageExecutionContext {
     private final ExpressionManager expressionManager;
@@ -40,7 +48,6 @@ public class DefaultMessageExecutionContext implements MessageExecutionContext {
                                   execution);
     }
 
-    @Override
     public Optional<String> getCorrelationKey(DelegateExecution execution) {
         return Optional.ofNullable(messageEventDefinition.getCorrelationKey())
                        .map(correlationKey -> {
@@ -49,9 +56,44 @@ public class DefaultMessageExecutionContext implements MessageExecutionContext {
                        });
     }
     
-    @Override
+    
+    
     public Optional<Map<String, Object>> getMessagePayload(DelegateExecution execution) {
         return messagePayloadMappingProvider.getMessagePayload(execution);
+    }
+    
+    @Override
+    public ThrowMessage createThrowMessage(DelegateExecution execution) {
+        String name = getMessageName(execution);
+        Optional<String> correlationKey = getCorrelationKey(execution);
+        Optional<String> businessKey = Optional.ofNullable(execution.getProcessInstanceBusinessKey());
+        Optional<Map<String, Object>> payload = getMessagePayload(execution);
+        
+        return ThrowMessage.builder()
+                           .name(name)
+                           .correlationKey(correlationKey)
+                           .businessKey(businessKey)
+                           .payload(payload)
+                           .build();
+    }    
+    
+    @Override
+    public MessageEventSubscriptionEntity createMessageEventSubscription(CommandContext commandContext,
+                                                                         DelegateExecution execution) {
+        
+        String messageName = getMessageName(execution);
+        Optional<String> correlationKey = getCorrelationKey(execution); 
+
+        correlationKey.ifPresent(key -> assertNoExistingDuplicateEventSubscriptions(messageName,
+                                                                                    key,
+                                                                                    commandContext));
+        
+        MessageEventSubscriptionEntity messageEvent = commandContext.getEventSubscriptionEntityManager()
+                                                                    .insertMessageEvent(messageName,
+                                                                                        ExecutionEntity.class.cast(execution));
+        correlationKey.ifPresent(messageEvent::setConfiguration);
+        
+        return messageEvent;
     }
 
     public ExpressionManager getExpressionManager() {
@@ -69,5 +111,23 @@ public class DefaultMessageExecutionContext implements MessageExecutionContext {
                                 .toString();
     }
     
+    protected void assertNoExistingDuplicateEventSubscriptions(String messageName,
+                                                               String correlationKey,
+                                                               CommandContext commandContext) {
+
+        List<EventSubscriptionEntity> existing = commandContext.getEventSubscriptionEntityManager()
+                                                               .findEventSubscriptionsByName("message",
+                                                                                             messageName,
+                                                                                             null);
+        existing.stream()
+                .filter(subscription -> Objects.equals(subscription.getConfiguration(),
+                                                       correlationKey))
+                .findFirst()
+                .ifPresent(subscription -> {
+                    throw new ActivitiIllegalArgumentException("Duplicate message subscription '" + subscription.getEventName() + 
+                                                               "' with correlation key '" + subscription.getConfiguration() + "'");
+                });
+
+    }
 
 }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/MessageExecutionContext.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/parser/factory/MessageExecutionContext.java
@@ -12,17 +12,17 @@
  */
 package org.activiti.engine.impl.bpmn.parser.factory;
 
-import java.util.Map;
-import java.util.Optional;
-
 import org.activiti.engine.delegate.DelegateExecution;
+import org.activiti.engine.impl.delegate.ThrowMessage;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.MessageEventSubscriptionEntity;
 
 public interface MessageExecutionContext {
     
     String getMessageName(DelegateExecution execution);
     
-    Optional<String> getCorrelationKey(DelegateExecution execution);
+    ThrowMessage createThrowMessage(DelegateExecution execution);
     
-    Optional<Map<String, Object>> getMessagePayload(DelegateExecution execution);
-    
+    MessageEventSubscriptionEntity createMessageEventSubscription(CommandContext commandContext,
+                                                                  DelegateExecution execution);
 }


### PR DESCRIPTION
The existing engine intermediate and boundary catch message event behaviors allow to create duplicate message event subscriptions with the same correlation key for different process instances. 

This PR fixes handling of catch message subscription to ensure that duplicate event message subscription with the same correlation key cannot be created by raising `ActivitiIllegalArgumentException` runtime exception during execution.