### PR TITLE
fix(ACTIVITI-3875): added support for interrupting and non-interrupting start message event for event subprocess 

### DIFF
--- a/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/StartEventXMLConverter.java
+++ b/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/StartEventXMLConverter.java
@@ -12,13 +12,16 @@
  */
 package org.activiti.bpmn.converter;
 
-import javax.xml.stream.XMLStreamReader;
-import javax.xml.stream.XMLStreamWriter;
-
 import org.activiti.bpmn.converter.util.BpmnXMLUtil;
-import org.activiti.bpmn.model.*;
+import org.activiti.bpmn.model.BaseElement;
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.FlowNode;
+import org.activiti.bpmn.model.StartEvent;
 import org.activiti.bpmn.model.alfresco.AlfrescoStartEvent;
 import org.apache.commons.lang3.StringUtils;
+
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
 
 public class StartEventXMLConverter extends BaseBpmnXMLConverter {
 
@@ -49,7 +52,7 @@ public class StartEventXMLConverter extends BaseBpmnXMLConverter {
         startEvent.setInitiator(xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE,
                                                       ATTRIBUTE_EVENT_START_INITIATOR));
         boolean interrupting = true;
-        String interruptingAttribute = xtr.getAttributeValue(ACTIVITI_EXTENSIONS_NAMESPACE,
+        String interruptingAttribute = xtr.getAttributeValue(null,
                                                              ATTRIBUTE_EVENT_START_INTERRUPTING);
         if (ATTRIBUTE_VALUE_FALSE.equalsIgnoreCase(interruptingAttribute)) {
             interrupting = false;

--- a/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/StartEventNonInterruptingEventSubprocessConverterTest.java
+++ b/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/StartEventNonInterruptingEventSubprocessConverterTest.java
@@ -1,0 +1,48 @@
+package org.activiti.editor.language.xml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.EventSubProcess;
+import org.activiti.bpmn.model.Message;
+import org.activiti.bpmn.model.StartEvent;
+import org.junit.Test;
+
+public class StartEventNonInterruptingEventSubprocessConverterTest extends AbstractConverterTest {
+
+    @Test
+    public void convertXMLToModel() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        validateModel(bpmnModel);
+    }
+
+    @Test
+    public void convertModelToXML() throws Exception {
+        BpmnModel bpmnModel = readXMLFile();
+        BpmnModel parsedModel = exportAndReadXMLFile(bpmnModel);
+        validateModel(parsedModel);
+    }
+
+    private void validateModel(BpmnModel model) {
+        Message message = model.getMessage("Message_1");
+
+        assertThat(message).isNotNull()
+                           .extracting(Message::getId,
+                                       Message::getName)
+                           .contains("Message_1",
+                                     "eventSubprocessMessage");
+
+        assertThat(model.getProcessById("process")
+                        .getFlowElements()).filteredOn(EventSubProcess.class::isInstance)
+                                           .flatExtracting("flowElements")
+                                           .filteredOn(StartEvent.class::isInstance)
+                                           .extracting("id", "isInterrupting")
+                                           .contains(tuple("eventProcessStart", false));
+
+    }
+
+    protected String getResource() {
+        return "StartEventNonInterruptingEventSubprocessConverterTest.bpmn";
+    }
+}

--- a/activiti-bpmn-converter/src/test/resources/StartEventNonInterruptingEventSubprocessConverterTest.bpmn
+++ b/activiti-bpmn-converter/src/test/resources/StartEventNonInterruptingEventSubprocessConverterTest.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0f0q57q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Activiti Modeler" exporterVersion="3.0.0-beta">
+  <bpmn:process id="process" isExecutable="true">
+    <bpmn:startEvent id="theStart">
+      <bpmn:outgoing>SequenceFlow_106n723</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_106n723" sourceRef="theStart" targetRef="task" />
+    <bpmn:endEvent id="theEnd">
+      <bpmn:incoming>SequenceFlow_1b9zary</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1b9zary" sourceRef="task" targetRef="theEnd" />
+    <bpmn:userTask id="task" name="Task">
+      <bpmn:incoming>SequenceFlow_106n723</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1b9zary</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:subProcess id="startMessageEventSubprocess" triggeredByEvent="true">
+      <bpmn:startEvent id="eventProcessStart" isInterrupting="false">
+        <bpmn:outgoing>SequenceFlow_00r0rza</bpmn:outgoing>
+        <bpmn:messageEventDefinition messageRef="Message_1" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_00r0rza" sourceRef="eventProcessStart" targetRef="eventSubProcessTask" />
+      <bpmn:endEvent id="eventSubProcessEnd">
+        <bpmn:incoming>SequenceFlow_06mz811</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_06mz811" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+      <bpmn:userTask id="eventSubProcessTask" name="Task">
+        <bpmn:incoming>SequenceFlow_00r0rza</bpmn:incoming>
+        <bpmn:outgoing>SequenceFlow_06mz811</bpmn:outgoing>
+      </bpmn:userTask>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:message id="Message_1" name="eventSubprocessMessage" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="theStart">
+        <dc:Bounds x="195" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_106n723_di" bpmnElement="SequenceFlow_106n723">
+        <di:waypoint x="231" y="121" />
+        <di:waypoint x="281" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0ew27ki_di" bpmnElement="theEnd">
+        <dc:Bounds x="431" y="103" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1b9zary_di" bpmnElement="SequenceFlow_1b9zary">
+        <di:waypoint x="381" y="121" />
+        <di:waypoint x="431" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1q7z4k0_di" bpmnElement="task">
+        <dc:Bounds x="281" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1jo1dcp_di" bpmnElement="startMessageEventSubprocess" isExpanded="true">
+        <dc:Bounds x="156" y="230" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_15n8e39_di" bpmnElement="eventProcessStart">
+        <dc:Bounds x="194" y="311" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_00r0rza_di" bpmnElement="SequenceFlow_00r0rza">
+        <di:waypoint x="230" y="329" />
+        <di:waypoint x="280" y="329" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_08ds64l_di" bpmnElement="eventSubProcessEnd">
+        <dc:Bounds x="430" y="311" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_06mz811_di" bpmnElement="SequenceFlow_06mz811">
+        <di:waypoint x="380" y="329" />
+        <di:waypoint x="430" y="329" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_0y9xfny_di" bpmnElement="eventSubProcessTask">
+        <dc:Bounds x="280" y="289" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
@@ -1,9 +1,5 @@
 package org.activiti.engine.impl.agenda;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.activiti.bpmn.model.Activity;
 import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.CompensateEventDefinition;
@@ -29,6 +25,10 @@ import org.activiti.engine.impl.util.CollectionUtil;
 import org.activiti.engine.impl.util.ProcessDefinitionUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * This operations ends an execution and follows the typical BPMN rules to continue the process (if possible).
@@ -382,7 +382,7 @@ public class EndExecutionOperation extends AbstractOperation {
         boolean allEventScopeExecutions = true;
         List<ExecutionEntity> executions = executionEntityManager.findChildExecutionsByParentExecutionId(parentExecution.getId());
         for (ExecutionEntity childExecution : executions) {
-            if (childExecution.isEventScope()) {
+            if (childExecution.isEventScope() && childExecution.getExecutions().size() == 0) {
                 executionEntityManager.deleteExecutionAndRelatedData(childExecution,
                                                                      null,
                                                                      false);

--- a/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageEventSubprocessTest.testNonInterruptingUnderProcessDefinition.bpmn20.xml
+++ b/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageEventSubprocessTest.testNonInterruptingUnderProcessDefinition.bpmn20.xml
@@ -14,7 +14,7 @@
 		<endEvent id="theEnd" />
 
 		<subProcess triggeredByEvent="true">
-			<startEvent id="eventProcessStart" activiti:isInterrupting="false">
+			<startEvent id="eventProcessStart" isInterrupting="false">
 				<messageEventDefinition messageRef="messageId" />
 			</startEvent>
 			<sequenceFlow sourceRef="eventProcessStart" targetRef="eventSubProcessTask" />

--- a/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageEventSubprocessTest.testNonInterruptingUnderProcessDefinition.bpmn20.xml
+++ b/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageEventSubprocessTest.testNonInterruptingUnderProcessDefinition.bpmn20.xml
@@ -14,7 +14,7 @@
 		<endEvent id="theEnd" />
 
 		<subProcess triggeredByEvent="true">
-			<startEvent id="eventProcessStart" isInterrupting="false">
+			<startEvent id="eventProcessStart" activiti:isInterrupting="false">
 				<messageEventDefinition messageRef="messageId" />
 			</startEvent>
 			<sequenceFlow sourceRef="eventProcessStart" targetRef="eventSubProcessTask" />


### PR DESCRIPTION
This PR fixes runtime error when running tasks in the process with interrupting and non-interrupting Start Message Event is triggered inside an Event Subprocess. The existing `StartEventXMLConverter` is using non-standard `activiti:isInterrupting` attribute to specify start message event behavior in event subprocess:

https://github.com/Activiti/Activiti/blob/d5282ebbddff656e7448012570f4904746000275/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/StartEventXMLConverter.java#L52

The updated `StartEventXMLConverter` implementation removes parsing non-standard `activiti:isInterrupting` attribute and uses the standard `isInterrupting` attribute in order to adhere to BPMN specification  (page 244, table 10.87): 

```
isInterrupting: boolean = true | This attribute only applies to Start Events of Event Sub-Processes; 
it is ignored for other Start Events. This attribute denotes whether the Sub-Process encompassing the 
Event Sub-Process should be canceled or not, If the encompassing Sub- Process is not canceled, 
multiple instances of the Event Sub-Process can run concurrently. This attribute cannot be applied to 
Error Events (where it’s always true), or Compensation Events (where it doesn’t apply).
```

![image](https://user-images.githubusercontent.com/20428629/65629729-bbc05080-df88-11e9-8596-80b048b9a449.png)


Fixes https://github.com/Activiti/Activiti/issues/2922

Part of https://github.com/Activiti/Activiti/issues/2637