### PR TITLE
fix(config): added conditional on missing `@EnableGlobalMethodSecurity` bean

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiMethodSecurityAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiMethodSecurityAutoConfiguration.java
@@ -1,6 +1,7 @@
 package org.activiti.spring.boot;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -12,6 +13,7 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 public class ActivitiMethodSecurityAutoConfiguration {
 
     @Configuration
+    @ConditionalOnMissingBean(annotation = EnableGlobalMethodSecurity.class)
     @EnableGlobalMethodSecurity(prePostEnabled = true,
                                 securedEnabled = true,
                                 jsr250Enabled = true)

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiMethodSecurityAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ActivitiMethodSecurityAutoConfiguration.java
@@ -10,10 +10,10 @@ import org.springframework.security.config.annotation.method.configuration.Globa
 @Configuration
 @ConditionalOnProperty(name = "spring.activiti.security.enabled", matchIfMissing = true)
 @ConditionalOnClass(GlobalMethodSecurityConfiguration.class)
+@ConditionalOnMissingBean(annotation = EnableGlobalMethodSecurity.class)
 public class ActivitiMethodSecurityAutoConfiguration {
 
     @Configuration
-    @ConditionalOnMissingBean(annotation = EnableGlobalMethodSecurity.class)
     @EnableGlobalMethodSecurity(prePostEnabled = true,
                                 securedEnabled = true,
                                 jsr250Enabled = true)


### PR DESCRIPTION
This PR fixes https://github.com/Activiti/Activiti/issues/2845 to apply `@ConditionalOnMissingBean` with `@EnableGlobalMethodSecurity` annotation to avoid triggering `ActivitiMethodSecurityAutoConfiguration` if there is already application specific `GlobalMethodSecurityConfiguration`present in the context.