### PR TITLE
AAE-764: Extensions files are  not loaded in examples

### DIFF
--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -179,7 +179,7 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     @Bean
     @ConditionalOnMissingBean
     public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(ActivitiProperties activitiProperties,
-                                                                                             @Value("${spring.activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
+                                                                                             @Value("${spring.activiti.process.extensions.dir:classpath*:**/processes/}") String locationPrefix,
                                                                                              @Value("${spring.activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
         return new ProcessExtensionResourceFinderDescriptor(activitiProperties.isCheckProcessDefinitions(),
                 locationPrefix,

--- a/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -179,8 +179,8 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     @Bean
     @ConditionalOnMissingBean
     public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(ActivitiProperties activitiProperties,
-                                                                                             @Value("${activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
-                                                                                             @Value("${activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
+                                                                                             @Value("${spring.activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
+                                                                                             @Value("${spring.activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
         return new ProcessExtensionResourceFinderDescriptor(activitiProperties.isCheckProcessDefinitions(),
                 locationPrefix,
                 locationSuffix);

--- a/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/conf/ProcessExtensionsAutoConfiguration.java
+++ b/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/conf/ProcessExtensionsAutoConfiguration.java
@@ -74,16 +74,6 @@ public class ProcessExtensionsAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnMissingBean
-    public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(
-            @Value("${activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
-            @Value("${activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
-        return new ProcessExtensionResourceFinderDescriptor(true,
-                locationPrefix,
-                locationSuffix);
-    }
-
-    @Bean
     InitializingBean initRepositoryServiceForProcessExtensionService(RepositoryService repositoryService,
                                                                      ProcessExtensionService processExtensionService) {
         return () -> processExtensionService.setRepositoryService(repositoryService);

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
@@ -1,0 +1,54 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.process.conf;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.common.util.DateFormatterProvider;
+import org.activiti.engine.RepositoryService;
+import org.activiti.spring.process.ProcessExtensionResourceFinderDescriptor;
+import org.activiti.spring.process.ProcessExtensionResourceReader;
+import org.activiti.spring.process.ProcessExtensionService;
+import org.activiti.spring.process.ProcessVariablesInitiator;
+import org.activiti.spring.process.model.ProcessExtensionModel;
+import org.activiti.spring.process.variable.VariableParsingService;
+import org.activiti.spring.process.variable.VariableValidationService;
+import org.activiti.spring.process.variable.types.DateVariableType;
+import org.activiti.spring.process.variable.types.JavaObjectVariableType;
+import org.activiti.spring.process.variable.types.JsonObjectVariableType;
+import org.activiti.spring.process.variable.types.VariableType;
+import org.activiti.spring.resources.DeploymentResourceLoader;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class ProcessExtensionResourceFinderDescriptorAutoConfiguration {
+
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(
+            @Value("${spring.activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
+            @Value("${spring.activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
+        return new ProcessExtensionResourceFinderDescriptor(true,
+                locationPrefix,
+                locationSuffix);
+    }
+}

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class ProcessExtensionResourceFinderDescriptorAutoConfiguration {
 
-
     @Bean
     @ConditionalOnMissingBean
     public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(

--- a/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
+++ b/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/conf/ProcessExtensionResourceFinderDescriptorAutoConfiguration.java
@@ -13,30 +13,11 @@
 
 package org.activiti.spring.process.conf;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.activiti.common.util.DateFormatterProvider;
-import org.activiti.engine.RepositoryService;
 import org.activiti.spring.process.ProcessExtensionResourceFinderDescriptor;
-import org.activiti.spring.process.ProcessExtensionResourceReader;
-import org.activiti.spring.process.ProcessExtensionService;
-import org.activiti.spring.process.ProcessVariablesInitiator;
-import org.activiti.spring.process.model.ProcessExtensionModel;
-import org.activiti.spring.process.variable.VariableParsingService;
-import org.activiti.spring.process.variable.VariableValidationService;
-import org.activiti.spring.process.variable.types.DateVariableType;
-import org.activiti.spring.process.variable.types.JavaObjectVariableType;
-import org.activiti.spring.process.variable.types.JsonObjectVariableType;
-import org.activiti.spring.process.variable.types.VariableType;
-import org.activiti.spring.resources.DeploymentResourceLoader;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
 
 @Configuration
 public class ProcessExtensionResourceFinderDescriptorAutoConfiguration {
@@ -45,7 +26,7 @@ public class ProcessExtensionResourceFinderDescriptorAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ProcessExtensionResourceFinderDescriptor processExtensionResourceFinderDescriptor(
-            @Value("${spring.activiti.process.extensions.dir:classpath:**/processes/}") String locationPrefix,
+            @Value("${spring.activiti.process.extensions.dir:classpath*:**/processes/}") String locationPrefix,
             @Value("${spring.activiti.process.extensions.suffix:**-extensions.json}") String locationSuffix) {
         return new ProcessExtensionResourceFinderDescriptor(true,
                 locationPrefix,


### PR DESCRIPTION
Due to a misconfiguration of resource loader pattern, examples are not able to load extensions files

Fix it by changing `classpath:` to `classpath*:` 