### PR TITLE
[AAE-683] [Activiti] Tasks are not destroyed once completion condition expression passed

### DIFF
--- a/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ProcessCompletedImpl.java
+++ b/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ProcessCompletedImpl.java
@@ -26,6 +26,7 @@ public class ProcessCompletedImpl extends RuntimeEventImpl<ProcessInstance, Proc
 
     public ProcessCompletedImpl(ProcessInstance entity) {
         super(entity);
+        setProcessInstanceId(entity.getId());
     }
 
     @Override

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
@@ -48,7 +48,9 @@ public class ToTaskCancelledConverter implements EventConverter<TaskCancelledEve
                 taskQuery.taskDefinitionKey(internalEvent.getActivityId());
             }
 
-            if (internalEvent.getExecutionId() != null) {
+            if (internalEvent.getActivityType() != null &&
+                internalEvent.getActivityType().contains("multi-instance") &&
+                internalEvent.getExecutionId() != null) {
                 taskQuery.executionId(internalEvent.getExecutionId());
             }
         } else {

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
@@ -47,6 +47,10 @@ public class ToTaskCancelledConverter implements EventConverter<TaskCancelledEve
             if (internalEvent.getActivityId() != null) {
                 taskQuery.taskDefinitionKey(internalEvent.getActivityId());
             }
+
+            if (internalEvent.getExecutionId() != null) {
+                taskQuery.executionId(internalEvent.getExecutionId());
+            }
         } else {
             if (internalEvent.getExecutionId() != null) {
                 //temporary workaround for stand alone tasks, task id is mapped as execution id

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverter.java
@@ -16,6 +16,9 @@
 
 package org.activiti.runtime.api.event.impl;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.impl.TaskImpl;
 import org.activiti.api.task.runtime.events.TaskCancelledEvent;
@@ -23,9 +26,6 @@ import org.activiti.engine.TaskService;
 import org.activiti.engine.delegate.event.ActivitiActivityCancelledEvent;
 import org.activiti.engine.task.TaskQuery;
 import org.activiti.runtime.api.model.impl.APITaskConverter;
-
-import java.util.List;
-import java.util.Optional;
 
 public class ToTaskCancelledConverter implements EventConverter<TaskCancelledEvent, ActivitiActivityCancelledEvent> {
 
@@ -47,10 +47,7 @@ public class ToTaskCancelledConverter implements EventConverter<TaskCancelledEve
             if (internalEvent.getActivityId() != null) {
                 taskQuery.taskDefinitionKey(internalEvent.getActivityId());
             }
-
-            if (internalEvent.getActivityType() != null &&
-                internalEvent.getActivityType().contains("multi-instance") &&
-                internalEvent.getExecutionId() != null) {
+            if (internalEvent.getExecutionId() != null) {
                 taskQuery.executionId(internalEvent.getExecutionId());
             }
         } else {

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/test/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverterTest.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/test/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverterTest.java
@@ -16,6 +16,14 @@
 
 package org.activiti.runtime.api.event.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Collections;
+
 import org.activiti.api.task.model.events.TaskRuntimeEvent;
 import org.activiti.api.task.model.impl.TaskImpl;
 import org.activiti.api.task.runtime.events.TaskCancelledEvent;
@@ -29,14 +37,6 @@ import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ToTaskCancelledConverterTest {
 
@@ -55,13 +55,15 @@ public class ToTaskCancelledConverterTest {
     }
 
     @Test
-    public void fromShouldFilterOnProcessInstanceAndTaskDefinitionKeyWhenTheyAreSet() {
+    public void from_shouldFilterOnProcessInstanceTaskDefinitionKeyAndExecution_when_TheyAreSet() {
         //given
         String procInstId = "procInstId";
         String activityId = "activityId";
+        String executionId = "executionId";
         ActivitiActivityCancelledEventImpl internalEvent = new ActivitiActivityCancelledEventImpl();
         internalEvent.setProcessInstanceId(procInstId);
         internalEvent.setActivityId(activityId);
+        internalEvent.setExecutionId(executionId);
 
         TaskQuery taskQuery = mock(TaskQuery.class,
                               Answers.RETURNS_SELF);
@@ -85,10 +87,11 @@ public class ToTaskCancelledConverterTest {
 
         verify(taskQuery).processInstanceId(procInstId);
         verify(taskQuery).taskDefinitionKey(activityId);
+        verify(taskQuery).executionId(executionId);
     }
 
     @Test
-    public void fromShouldFilterOnTaskIdWhenProcessInstanceIsNotSet() {
+    public void from_should_filterOnTaskId_when_processInstanceIsNotSet() {
         //given
         String taskId = "taskId";
         ActivitiActivityCancelledEventImpl internalEvent = new ActivitiActivityCancelledEventImpl();

--- a/activiti-api-impl/activiti-api-task-runtime-impl/src/test/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverterTest.java
+++ b/activiti-api-impl/activiti-api-task-runtime-impl/src/test/java/org/activiti/runtime/api/event/impl/ToTaskCancelledConverterTest.java
@@ -29,6 +29,7 @@ import org.activiti.api.task.model.impl.TaskImpl;
 import org.activiti.api.task.runtime.events.TaskCancelledEvent;
 import org.activiti.engine.TaskService;
 import org.activiti.engine.delegate.event.impl.ActivitiActivityCancelledEventImpl;
+import org.activiti.engine.impl.bpmn.behavior.ParallelMultiInstanceBehavior;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
 import org.activiti.runtime.api.model.impl.APITaskConverter;
@@ -64,6 +65,7 @@ public class ToTaskCancelledConverterTest {
         internalEvent.setProcessInstanceId(procInstId);
         internalEvent.setActivityId(activityId);
         internalEvent.setExecutionId(executionId);
+        internalEvent.setBehaviorClass(ParallelMultiInstanceBehavior.class.getName());
 
         TaskQuery taskQuery = mock(TaskQuery.class,
                               Answers.RETURNS_SELF);

--- a/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventBuilder.java
@@ -12,6 +12,8 @@
  */
 package org.activiti.engine.delegate.event.impl;
 
+import java.util.Map;
+
 import org.activiti.bpmn.model.FlowElement;
 import org.activiti.bpmn.model.FlowNode;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -37,8 +39,6 @@ import org.activiti.engine.impl.variable.VariableType;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.Job;
 import org.activiti.engine.task.Task;
-
-import java.util.Map;
 
 /**
  * Builder class used to create {@link ActivitiEvent} implementations.
@@ -245,6 +245,22 @@ public class ActivitiEventBuilder {
     newEvent.setCause(cause);
     return newEvent;
   }
+
+    public static ActivitiActivityCancelledEvent createActivityCancelledEvent(ExecutionEntity execution,
+                                                                              Object cause) {
+        FlowNode currentFlowNode = (FlowNode) execution.getCurrentFlowElement();
+
+        ActivitiActivityCancelledEventImpl newEvent = new ActivitiActivityCancelledEventImpl();
+        newEvent.setActivityId(execution.getActivityId());
+        newEvent.setActivityName(currentFlowNode.getName());
+        newEvent.setExecutionId(execution.getId());
+        newEvent.setProcessDefinitionId(execution.getProcessDefinitionId());
+        newEvent.setProcessInstanceId(execution.getProcessInstanceId());
+        newEvent.setActivityType(parseActivityType(currentFlowNode));
+        newEvent.setBehaviorClass(parseActivityBehavior(currentFlowNode));
+        newEvent.setCause(cause);
+        return newEvent;
+    }
 
   public static ActivitiCancelledEvent createCancelledEvent(String executionId, String processInstanceId, String processDefinitionId, Object cause) {
     ActivitiProcessCancelledEventImpl newEvent = new ActivitiProcessCancelledEventImpl();

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -254,7 +254,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
                     parentExecution.getId(),
                     parentExecution.getProcessInstanceId(),
                     parentExecution.getProcessDefinitionId(),
-                    parseActivityType((FlowNode) parentExecution.getCurrentFlowElement()),
+                    "multi-instance " + parseActivityType((FlowNode) parentExecution.getCurrentFlowElement()),
                     "Complete Condition Expression Passed"
             ));
         }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -21,7 +21,6 @@ import org.activiti.bpmn.model.BoundaryEvent;
 import org.activiti.bpmn.model.CallActivity;
 import org.activiti.bpmn.model.CompensateEventDefinition;
 import org.activiti.bpmn.model.FlowElement;
-import org.activiti.bpmn.model.FlowNode;
 import org.activiti.bpmn.model.SubProcess;
 import org.activiti.bpmn.model.Transaction;
 import org.activiti.engine.ActivitiIllegalArgumentException;
@@ -256,12 +255,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
         executionEntityManager.deleteExecutionAndRelatedData(parentExecution, null, false);
         if (isActiveElement) {
             commandContext.getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createActivityCancelledEvent(
-                    parentExecution.getActivityId(),
-                    parentExecution.getName(),
-                    parentExecution.getId(),
-                    parentExecution.getProcessInstanceId(),
-                    parentExecution.getProcessDefinitionId(),
-                    parseActivityType((FlowNode) parentExecution.getCurrentFlowElement()),
+                    parentExecution,
                     "Multi-instance complete condition expression passed"
             ));
         }

--- a/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -16,7 +16,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.activiti.bpmn.model.*;
+import org.activiti.bpmn.model.Activity;
+import org.activiti.bpmn.model.BoundaryEvent;
+import org.activiti.bpmn.model.CallActivity;
+import org.activiti.bpmn.model.CompensateEventDefinition;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.FlowNode;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.bpmn.model.Transaction;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
@@ -245,17 +252,17 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
     }
 
     if (deleteExecution) {
-        Boolean isActiveElement = parentExecution.isActive();
+        boolean isActiveElement = parentExecution.isActive();
         executionEntityManager.deleteExecutionAndRelatedData(parentExecution, null, false);
-        if(isActiveElement) {
+        if (isActiveElement) {
             commandContext.getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createActivityCancelledEvent(
                     parentExecution.getActivityId(),
                     parentExecution.getName(),
                     parentExecution.getId(),
                     parentExecution.getProcessInstanceId(),
                     parentExecution.getProcessDefinitionId(),
-                    "multi-instance " + parseActivityType((FlowNode) parentExecution.getCurrentFlowElement()),
-                    "Complete Condition Expression Passed"
+                    parseActivityType((FlowNode) parentExecution.getCurrentFlowElement()),
+                    "Multi-instance complete condition expression passed"
             ));
         }
     }

--- a/activiti-spring-boot-starter/pom.xml
+++ b/activiti-spring-boot-starter/pom.xml
@@ -180,5 +180,10 @@
             <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.activiti.core.common</groupId>
+            <artifactId>activiti-core-test-local-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskBaseRuntime.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskBaseRuntime.java
@@ -18,17 +18,18 @@ package org.activiti.spring.boot.tasks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Collections;
 
+import org.activiti.api.model.shared.model.VariableInstance;
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.runtime.shared.query.Pageable;
 import org.activiti.api.task.model.Task;
 import org.activiti.api.task.model.Task.TaskStatus;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.activiti.api.runtime.shared.query.Pageable;
 import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.runtime.TaskRuntime;
-import org.activiti.api.model.shared.model.VariableInstance;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestComponent;
 
 @TestComponent
@@ -49,12 +50,20 @@ public class TaskBaseRuntime {
         return taskList;
     }
 
+    public List<Task> getTasks(ProcessInstance processInstance) {
+        return getTasksByProcessInstanceId(processInstance.getId());
+    }
+
     public List<VariableInstance> getTasksVariablesByTaskId(String taskId) {
         return taskRuntime.variables(TaskPayloadBuilder.variables().withTaskId(taskId).build());
     }
 
     public void completeTask(String taskId) {
-        this.completeTask(taskId, Collections.<String, Object>emptyMap());
+        completeTask(taskId, Collections.emptyMap());
+    }
+
+    public void completeTask(Task task) {
+        this.completeTask(task.getId(), Collections.emptyMap());
     }
 
     public void completeTask(String taskId, Map<String, Object> variables) {

--- a/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeMultiInstanceIT.java
+++ b/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeMultiInstanceIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2019 Alfresco, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.spring.boot.tasks;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.activiti.api.model.shared.event.RuntimeEvent;
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.events.ProcessRuntimeEvent;
+import org.activiti.api.task.model.Task;
+import org.activiti.api.task.model.events.TaskRuntimeEvent;
+import org.activiti.api.task.runtime.events.TaskCreatedEvent;
+import org.activiti.spring.boot.process.ProcessBaseRuntime;
+import org.activiti.spring.boot.test.util.ProcessCleanUpUtil;
+import org.activiti.test.LocalEventSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class TaskRuntimeMultiInstanceIT {
+
+    @Autowired
+    private ProcessBaseRuntime processBaseRuntime;
+
+    @Autowired
+    private TaskBaseRuntime taskBaseRuntime;
+
+    @Autowired
+    private LocalEventSource localEventSource;
+
+    @Autowired
+    private ProcessCleanUpUtil processCleanUpUtil;
+
+    @Before
+    public void setUp() {
+        localEventSource.clearEvents();
+    }
+
+    @After
+    public void tearDown() {
+        processCleanUpUtil.cleanUpWithAdmin();
+    }
+
+    @Test
+    public void processWithMultiInstances_should_emmitEventsAndContinueOnceCompletionConditionIsReached() {
+        //when
+        ProcessInstance processInstance = processBaseRuntime.startProcessWithProcessDefinitionKey("miParallelUserTasksCompletionCondition");
+
+        //then
+        List<Task> tasks = taskBaseRuntime.getTasks(processInstance);
+        assertThat(tasks)
+                .extracting(Task::getName)
+                .containsExactlyInAnyOrder("My Task 0",
+                          "My Task 1",
+                          "My Task 2",
+                          "My Task 3");
+
+        List<TaskCreatedEvent> taskCreatedEvents = localEventSource.getEvents().stream()
+                .filter(event -> event.getEventType().equals(TaskRuntimeEvent.TaskEvents.TASK_CREATED))
+                .map(TaskCreatedEvent.class::cast)
+                .collect(Collectors.toList());
+        assertThat(taskCreatedEvents)
+                .extracting(event -> event.getEntity().getName())
+                .containsExactlyInAnyOrder("My Task 0",
+                                           "My Task 1",
+                                           "My Task 2",
+                                           "My Task 3");
+
+        //given
+        Task taskToComplete = tasks.get(0);
+        localEventSource.clearEvents();
+
+        //when first multi instance is completed: 3 remaining / completion condition not reached
+        taskBaseRuntime.completeTask(taskToComplete);
+
+        //then
+        assertThat(localEventSource.getEvents())
+                .filteredOn(event -> event.getEventType().equals(TaskRuntimeEvent.TaskEvents.TASK_COMPLETED)
+                        || event.getEventType().equals(TaskRuntimeEvent.TaskEvents.TASK_CANCELLED))
+                .extracting(RuntimeEvent::getEventType,
+                            event -> ((Task) event.getEntity()).getName())
+                .containsExactly(tuple(TaskRuntimeEvent.TaskEvents.TASK_COMPLETED,
+                                       taskToComplete.getName()));
+
+        //given
+        localEventSource.clearEvents();
+        taskToComplete = tasks.get(1);
+
+        //when second multi instance is completed: 2 remaining / completion condition reached
+        taskBaseRuntime.completeTask(taskToComplete);
+
+        //then
+        assertThat(localEventSource.getEvents())
+                .filteredOn(event -> event.getEventType().equals(TaskRuntimeEvent.TaskEvents.TASK_COMPLETED)
+                        || event.getEventType().equals(TaskRuntimeEvent.TaskEvents.TASK_CANCELLED))
+                .extracting(RuntimeEvent::getEventType,
+                            event -> ((Task) event.getEntity()).getName())
+                .containsExactlyInAnyOrder(tuple(TaskRuntimeEvent.TaskEvents.TASK_COMPLETED,
+                                                 taskToComplete.getName()),
+                                           tuple(TaskRuntimeEvent.TaskEvents.TASK_CANCELLED,
+                                                 tasks.get(2).getName()),
+                                           tuple(TaskRuntimeEvent.TaskEvents.TASK_CANCELLED,
+                                                 tasks.get(3).getName())
+                );
+
+        assertThat(taskBaseRuntime.getTasks(processInstance)).isEmpty();
+        assertThat(localEventSource.getEvents())
+                .extracting(RuntimeEvent::getEventType,
+                            RuntimeEvent::getProcessInstanceId)
+                .contains(tuple(ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED,
+                                processInstance.getId()));
+    }
+}

--- a/activiti-spring-boot-starter/src/test/resources/processes/MultiInstanceParallelUserTasksCompletionCondition.bpmn20.xml
+++ b/activiti-spring-boot-starter/src/test/resources/processes/MultiInstanceParallelUserTasksCompletionCondition.bpmn20.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2019 Alfresco, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="definition"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+  
+  <process id="miParallelUserTasksCompletionCondition">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="miTasks" />
+    
+    <userTask id="miTasks" name="My Task ${loopCounter}" activiti:assignee="user">
+      <multiInstanceLoopCharacteristics isSequential="false">
+        <loopCardinality>${4}</loopCardinality>
+        <completionCondition>${nrOfCompletedInstances/nrOfInstances >= 0.5}</completionCondition>
+      </multiInstanceLoopCharacteristics>
+    </userTask>
+    
+    <sequenceFlow id="flow3" sourceRef="miTasks" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>


### PR DESCRIPTION
**Component:-** 
Multi-Instance

Runtime Bundle is not sending the event once completion condition expression passed

 
**Current Behaviour:-**
When this expression evaluates to true, Still tasks are available in the pending list.

**Expected Behaviour:-**
When this expression evaluates to true, all remaining instances are destroyed and the multi-instance activity ends, continuing the process. 


fixes https://github.com/Activiti/Activiti/issues/2969