### PR TITLE
Remove MVCC flag from test db

### DIFF
--- a/activiti-engine/src/test/resources/META-INF/persistence.xml
+++ b/activiti-engine/src/test/resources/META-INF/persistence.xml
@@ -35,7 +35,7 @@
     <exclude-unlisted-classes>true</exclude-unlisted-classes>
     <properties>
         <property name="javax.persistence.jdbc.driver" value="org.h2.Driver" />
-        <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:activiti-jpa;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+        <property name="javax.persistence.jdbc.url" value="jdbc:h2:mem:activiti-jpa;DB_CLOSE_DELAY=1000" />
         <property name="javax.persistence.jdbc.user" value="sa" />
         <property name="javax.persistence.jdbc.password" value="" />
         <property name="hibernate.show_sql" value="true" />

--- a/activiti-engine/src/test/resources/activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/activiti.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1;MVCC=TRUE" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageThrowCatchEventTest.activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageThrowCatchEventTest.activiti.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageThrowEventTest.activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/message/MessageThrowEventTest.activiti.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/activiti-engine/src/test/resources/org/activiti/standalone/cfg/identity/customIdentitySession-activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/org/activiti/standalone/cfg/identity/customIdentitySession-activiti.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
   
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/activiti-engine/src/test/resources/org/activiti/standalone/cfg/variable/custom-serialize-variables-activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/org/activiti/standalone/cfg/variable/custom-serialize-variables-activiti.cfg.xml
@@ -6,7 +6,7 @@
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
 
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=1000" />
     <property name="jdbcDriver" value="org.h2.Driver" />
     <property name="jdbcUsername" value="sa" />
     <property name="jdbcPassword" value="" />

--- a/activiti-engine/src/test/resources/org/activiti/standalone/idgenerator/uuidgenerator.test.activiti.cfg.xml
+++ b/activiti-engine/src/test/resources/org/activiti/standalone/idgenerator/uuidgenerator.test.activiti.cfg.xml
@@ -7,7 +7,7 @@
 	<bean id="processEngineConfiguration"
 		class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
 		
-		<property name="jdbcUrl" value="jdbc:h2:mem:activiti-uuid-generator-test;DB_CLOSE_DELAY=1000;MVCC=TRUE" />
+		<property name="jdbcUrl" value="jdbc:h2:mem:activiti-uuid-generator-test;DB_CLOSE_DELAY=1000" />
 
 		<property name="databaseSchemaUpdate" value="true" />
 		

--- a/activiti-spring/src/test/resources/org/activiti/spring/test/components/SpringjobExecutorTest-context.xml
+++ b/activiti-spring/src/test/resources/org/activiti/spring/test/components/SpringjobExecutorTest-context.xml
@@ -9,7 +9,7 @@
         <property name="targetDataSource">
             <bean class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
                 <property name="driverClass" value="org.h2.Driver"/>
-                <property name="url" value="jdbc:h2:mem:activiti-spring-async-executor-test;DB_CLOSE_DELAY=1000;mvcc=true;"/>
+                <property name="url" value="jdbc:h2:mem:activiti-spring-async-executor-test;DB_CLOSE_DELAY=1000;"/>
                 <property name="username" value="sa"/>
                 <property name="password" value=""/>
             </bean>


### PR DESCRIPTION
This flag is no longer supported in the latest version of h2:
- https://github.com/h2database/h2database/releases/tag/version-1.4.198
- https://github.com/h2database/h2database/releases/tag/version-1.4.200
This should fix https://github.com/Activiti/Activiti/pull/2990

Ref https://github.com/Activiti/Activiti/issues/2991