### PR TITLE
[AAE-916] Remove boolean parameter from ExecutionEntityManager.deleteExecutionAndRelatedData

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
@@ -116,9 +116,7 @@ public class ContinueProcessOperation extends AbstractOperation {
         subProcessExecution.setCurrentFlowElement(subProcess);
         subProcessExecution.setScope(true);
 
-        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution,
-                                                                                 null,
-                                                                                 false);
+        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution, null);
         execution = subProcessExecution;
     }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/DestroyScopeOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/DestroyScopeOperation.java
@@ -123,9 +123,7 @@ public class DestroyScopeOperation extends AbstractOperation {
         // Delete all child executions
         Collection<ExecutionEntity> childExecutions = executionEntityManager.findChildExecutionsByParentExecutionId(scopeExecution.getId());
         for (ExecutionEntity childExecution : childExecutions) {
-            executionEntityManager.deleteExecutionAndRelatedData(childExecution,
-                                                                 execution.getDeleteReason(),
-                                                                 false);
+            executionEntityManager.deleteExecutionAndRelatedData(childExecution, execution.getDeleteReason());
         }
         return executionEntityManager;
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
@@ -142,17 +142,13 @@ public class EndExecutionOperation extends AbstractOperation {
 
         // If the execution is a scope, all the child executions must be deleted first.
         if (execution.isScope()) {
-            executionEntityManager.deleteChildExecutions(execution,
-                                                         null,
-                                                         false);
+            executionEntityManager.deleteChildExecutions(execution, null);
         }
 
         // Delete current execution
         logger.debug("Ending execution {}",
                      execution.getId());
-        executionEntityManager.deleteExecutionAndRelatedData(execution,
-                                                             null,
-                                                             false);
+        executionEntityManager.deleteExecutionAndRelatedData(execution, null);
 
         logger.debug("Parent execution found. Continuing process using execution {}",
                      parentExecution.getId());
@@ -245,12 +241,8 @@ public class EndExecutionOperation extends AbstractOperation {
             ScopeUtil.createCopyOfSubProcessExecutionForCompensation(parentExecution);
         }
 
-        executionEntityManager.deleteChildExecutions(parentExecution,
-                                                     null,
-                                                     false);
-        executionEntityManager.deleteExecutionAndRelatedData(parentExecution,
-                                                             null,
-                                                             false);
+        executionEntityManager.deleteChildExecutions(parentExecution, null);
+        executionEntityManager.deleteExecutionAndRelatedData(parentExecution, null);
 
         Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                 ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPLETED,
@@ -284,12 +276,8 @@ public class EndExecutionOperation extends AbstractOperation {
                     executionToContinue = executionEntityManager.createChildExecution(parentExecution.getParent());
                     executionToContinue.setCurrentFlowElement(parentExecution.getCurrentFlowElement());
 
-                    executionEntityManager.deleteChildExecutions(parentExecution,
-                                                                 null,
-                                                                 false);
-                    executionEntityManager.deleteExecutionAndRelatedData(parentExecution,
-                                                                         null,
-                                                                         false);
+                    executionEntityManager.deleteChildExecutions(parentExecution, null);
+                    executionEntityManager.deleteExecutionAndRelatedData(parentExecution,                         null);
                 } else {
                     executionToContinue = parentExecution;
                 }
@@ -383,9 +371,7 @@ public class EndExecutionOperation extends AbstractOperation {
         List<ExecutionEntity> executions = executionEntityManager.findChildExecutionsByParentExecutionId(parentExecution.getId());
         for (ExecutionEntity childExecution : executions) {
             if (childExecution.isEventScope() && childExecution.getExecutions().size() == 0) {
-                executionEntityManager.deleteExecutionAndRelatedData(childExecution,
-                                                                     null,
-                                                                     false);
+                executionEntityManager.deleteExecutionAndRelatedData(childExecution, null);
             } else {
                 allEventScopeExecutions = false;
                 break;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
@@ -224,9 +224,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
         if (flowNode.getOutgoingFlows().size() > 0) {
             leaveFlowNode(flowNode);
         } else {
-            commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution,
-                                                                                     null,
-                                                                                     false);
+            commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution, null);
         }
 
         if (completeAdhocSubProcess) {
@@ -259,9 +257,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
 
         commandContext.getHistoryManager().recordActivityEnd(execution,
                                                              null);
-        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution,
-                                                                                 null,
-                                                                                 false);
+        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution, null);
 
         ExecutionEntity parentExecutionEntity = execution.getParent();
         if (parentExecutionEntity.isScope() && !parentExecutionEntity.isProcessInstanceType()) {
@@ -318,9 +314,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
                 Collection<ExecutionEntity> childExecutions = commandContext.getExecutionEntityManager().findChildExecutionsByParentExecutionId(execution.getId());
                 for (ExecutionEntity childExecution : childExecutions) {
                     if (childExecution.getCurrentFlowElement() == null || !notToDeleteEvents.contains(childExecution.getCurrentFlowElement().getId())) {
-                        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(childExecution,
-                                                                                                 null,
-                                                                                                 false);
+                        commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(childExecution, null);
                     }
                 }
             }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryCancelEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryCancelEventActivityBehavior.java
@@ -68,7 +68,7 @@ public class BoundaryCancelEventActivityBehavior extends BoundaryEventActivityBe
       
       // cancel boundary is always sync
       ScopeUtil.throwCompensationEvent(eventSubscriptions, execution, false);
-      executionEntityManager.deleteExecutionAndRelatedData(subProcessExecution, deleteReason, false);
+      executionEntityManager.deleteExecutionAndRelatedData(subProcessExecution, deleteReason);
       if (subProcessExecution.getCurrentFlowElement() instanceof Activity) {
         Activity activity = (Activity) subProcessExecution.getCurrentFlowElement();
         if (activity.getLoopCharacteristics() != null) {
@@ -76,7 +76,7 @@ public class BoundaryCancelEventActivityBehavior extends BoundaryEventActivityBe
           List<ExecutionEntity> miChildExecutions = executionEntityManager.findChildExecutionsByParentExecutionId(miExecution.getId());
           for (ExecutionEntity miChildExecution : miChildExecutions) {
             if (subProcessExecution.getId().equals(miChildExecution.getId()) == false && activity.getId().equals(miChildExecution.getCurrentActivityId())) {
-              executionEntityManager.deleteExecutionAndRelatedData(miChildExecution, deleteReason, false);
+              executionEntityManager.deleteExecutionAndRelatedData(miChildExecution, deleteReason);
             }
           }
         }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/BoundaryEventActivityBehavior.java
@@ -154,7 +154,7 @@ public class BoundaryEventActivityBehavior extends FlowNodeActivityBehavior {
       }
     }
 
-    executionEntityManager.deleteExecutionAndRelatedData(parentExecution, deleteReason, true);
+    executionEntityManager.cancelExecutionAndRelatedData(parentExecution, deleteReason);
   }
 
   public boolean isInterrupting() {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CancelEndEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CancelEndEventActivityBehavior.java
@@ -148,7 +148,7 @@ public class CancelEndEventActivityBehavior extends FlowNodeActivityBehavior {
       }
     }
 
-    executionEntityManager.deleteExecutionAndRelatedData(parentExecution, deleteReason, false);
+    executionEntityManager.deleteExecutionAndRelatedData(parentExecution, deleteReason);
   }
 
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventSubProcessMessageStartEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/EventSubProcessMessageStartEventActivityBehavior.java
@@ -77,8 +77,8 @@ public class EventSubProcessMessageStartEventActivityBehavior extends AbstractBp
       List<ExecutionEntity> childExecutions = executionEntityManager.findChildExecutionsByParentExecutionId(executionEntity.getParentId());
       for (ExecutionEntity childExecution : childExecutions) {
         if (!childExecution.getId().equals(executionEntity.getId())) {
-          executionEntityManager.deleteExecutionAndRelatedData(childExecution,
-              DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(" + startEvent.getId() + ")", true);
+          executionEntityManager.cancelExecutionAndRelatedData(childExecution,
+              DeleteReason.EVENT_SUBPROCESS_INTERRUPTING + "(" + startEvent.getId() + ")");
         }
       }
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/InclusiveGatewayActivityBehavior.java
@@ -90,7 +90,7 @@ public class InclusiveGatewayActivityBehavior extends GatewayActivityBehavior im
       for (ExecutionEntity executionEntityInGateway : executionsInGateway) {
         if (!executionEntityInGateway.getId().equals(execution.getId())) {
           commandContext.getHistoryManager().recordActivityEnd(executionEntityInGateway, null);
-          executionEntityManager.deleteExecutionAndRelatedData(executionEntityInGateway, null, false);
+          executionEntityManager.deleteExecutionAndRelatedData(executionEntityInGateway, null);
         }
       }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchEventActivityBehavior.java
@@ -61,7 +61,7 @@ public class IntermediateCatchEventActivityBehavior extends AbstractBpmnActivity
    */
   public void eventCancelledByEventGateway(DelegateExecution execution) {
     Context.getCommandContext().getExecutionEntityManager().deleteExecutionAndRelatedData((ExecutionEntity) execution, 
-        DeleteReason.EVENT_BASED_GATEWAY_CANCEL, false);
+        DeleteReason.EVENT_BASED_GATEWAY_CANCEL);
   }
   
   protected EventGateway getPrecedingEventBasedGateway(DelegateExecution execution) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchMessageEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchMessageEventActivityBehavior.java
@@ -62,7 +62,7 @@ public class IntermediateCatchMessageEventActivityBehavior extends IntermediateC
   public void eventCancelledByEventGateway(DelegateExecution execution) {
     deleteMessageEventSubScription(execution);
     Context.getCommandContext().getExecutionEntityManager().deleteExecutionAndRelatedData((ExecutionEntity) execution, 
-        DeleteReason.EVENT_BASED_GATEWAY_CANCEL, false);
+        DeleteReason.EVENT_BASED_GATEWAY_CANCEL);
   }
 
   protected ExecutionEntity deleteMessageEventSubScription(DelegateExecution execution) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchSignalEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchSignalEventActivityBehavior.java
@@ -65,7 +65,7 @@ public class IntermediateCatchSignalEventActivityBehavior extends IntermediateCa
   public void eventCancelledByEventGateway(DelegateExecution execution) {
     deleteSignalEventSubscription(execution);
     Context.getCommandContext().getExecutionEntityManager().deleteExecutionAndRelatedData((ExecutionEntity) execution, 
-        DeleteReason.EVENT_BASED_GATEWAY_CANCEL, false);
+        DeleteReason.EVENT_BASED_GATEWAY_CANCEL);
   }
 
   protected ExecutionEntity deleteSignalEventSubscription(DelegateExecution execution) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchTimerEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/IntermediateCatchTimerEventActivityBehavior.java
@@ -58,7 +58,7 @@ public class IntermediateCatchTimerEventActivityBehavior extends IntermediateCat
     }
     
     Context.getCommandContext().getExecutionEntityManager().deleteExecutionAndRelatedData((ExecutionEntity) execution, 
-        DeleteReason.EVENT_BASED_GATEWAY_CANCEL, false);
+        DeleteReason.EVENT_BASED_GATEWAY_CANCEL);
   }
 
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelGatewayActivityBehavior.java
@@ -101,7 +101,7 @@ public class ParallelGatewayActivityBehavior extends GatewayActivityBehavior {
 
           // The current execution will be reused and not deleted
           if (!joinedExecution.getId().equals(execution.getId())) {
-            executionEntityManager.deleteExecutionAndRelatedData(joinedExecution, null, false);
+            executionEntityManager.deleteExecutionAndRelatedData(joinedExecution, null);
           }
 
         }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehavior.java
@@ -252,7 +252,7 @@ public class ParallelMultiInstanceBehavior extends MultiInstanceActivityBehavior
     }
 
     if (deleteExecution) {
-        executionEntityManager.deleteExecutionAndRelatedData(parentExecution, "Multi-instance complete condition expression passed", true);
+        executionEntityManager.cancelExecutionAndRelatedData(parentExecution, "Multi-instance complete condition expression passed");
     }
   }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SequentialMultiInstanceBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/SequentialMultiInstanceBehavior.java
@@ -92,7 +92,7 @@ public class SequentialMultiInstanceBehavior extends MultiInstanceActivityBehavi
       multiInstanceRootExecution.setMultiInstanceRoot(false);
       multiInstanceRootExecution.setScope(false);
       multiInstanceRootExecution.setCurrentFlowElement(childExecution.getCurrentFlowElement());
-      Context.getCommandContext().getExecutionEntityManager().deleteChildExecutions((ExecutionEntity) multiInstanceRootExecution, "MI_END", false);
+      Context.getCommandContext().getExecutionEntityManager().deleteChildExecutions((ExecutionEntity) multiInstanceRootExecution, "MI_END");
       dispatchActivityCompletedEvent(childExecution);
       super.leave(multiInstanceRootExecution);
       

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/TerminateEndEventActivityBehavior.java
@@ -174,9 +174,9 @@ public class TerminateEndEventActivityBehavior extends FlowNodeActivityBehavior 
 
     List<ExecutionEntity> childExecutions = executionEntityManager.collectChildren(rootExecutionEntity);
     for (int i=childExecutions.size()-1; i>=0; i--) {
-      executionEntityManager.deleteExecutionAndRelatedData(childExecutions.get(i), deleteReason, false);
+      executionEntityManager.deleteExecutionAndRelatedData(childExecutions.get(i), deleteReason);
     }
-    executionEntityManager.deleteExecutionAndRelatedData(rootExecutionEntity, deleteReason, false);
+    executionEntityManager.deleteExecutionAndRelatedData(rootExecutionEntity, deleteReason);
   }
 
   protected void sendProcessInstanceCancelledEvent(DelegateExecution execution, FlowElement terminateEndEvent) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -184,7 +184,7 @@ public class ErrorPropagation {
       if (!currentExecution.getParentId().equals(parentExecution.getId())) {
         Context.getAgenda().planDestroyScopeOperation(currentExecution);
       } else {
-        executionEntityManager.deleteExecutionAndRelatedData(currentExecution, null, false);
+        executionEntityManager.deleteExecutionAndRelatedData(currentExecution, null);
       }
 
       ExecutionEntity eventSubProcessExecution = executionEntityManager.createChildExecution(parentExecution);

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CompleteAdhocSubProcessCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/CompleteAdhocSubProcessCmd.java
@@ -57,7 +57,7 @@ public class CompleteAdhocSubProcessCmd implements Command<Void>, Serializable {
     ExecutionEntity outgoingFlowExecution = executionEntityManager.createChildExecution(execution.getParent());
     outgoingFlowExecution.setCurrentFlowElement(execution.getCurrentFlowElement());
 
-    executionEntityManager.deleteExecutionAndRelatedData(execution, null, false);
+    executionEntityManager.deleteExecutionAndRelatedData(execution, null);
 
     Context.getAgenda().planTakeOutgoingSequenceFlowsOperation(outgoingFlowExecution, true);
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManager.java
@@ -94,10 +94,13 @@ public interface ExecutionEntityManager extends EntityManager<ExecutionEntity> {
   void deleteProcessInstanceExecutionEntity(String processInstanceId, String currentFlowElementId, 
       String deleteReason, boolean cascade, boolean cancel);
   
-  void deleteChildExecutions(ExecutionEntity executionEntity, String deleteReason, boolean cancel);
-  
-  void deleteExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason, boolean cancel);
+  void deleteChildExecutions(ExecutionEntity executionEntity, String deleteReason);
 
+  void cancelChildExecutions(ExecutionEntity executionEntity, String deleteReason);
+
+  void deleteExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason);
+
+  void cancelExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason);
 
   void updateProcessInstanceLockTime(String processInstanceId);
 


### PR DESCRIPTION
Refactor the method ExecutionEntityManager.deleteExecutionAndRelatedData in order to remove the boolean parameter in favor of two separated methods (deleteExecutionAndRelatedData, cancelExecution).

This kind of parameters is considered as a bad practice (https://martinfowler.com/bliki/FlagArgument.html).
```
void deleteExecutionAndRelatedData(ExecutionEntity executionEntity, String deleteReason, boolean cancel);
```

fixes -> https://issues.alfresco.com/jira/browse/AAE-916