### PR TITLE
fix(Updatebot): Revert removed propagation to cloud repositories

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -2,9 +2,18 @@ github:
   organisations:
   - name: activiti
     repositories:
+    - name: activiti-cloud-runtime-bundle-service
+      branch: develop
+      useSinglePullRequest: true
+    - name: activiti-cloud-query-service
+      branch: develop
+      useSinglePullRequest: true
     - name: activiti-cloud-service-common
       branch: develop
       useSinglePullRequest: true
     - name: activiti-cloud-api
+      branch: develop
+      useSinglePullRequest: true
+    - name: activiti-cloud-modeling-service
       branch: develop
       useSinglePullRequest: true

--- a/pom.xml
+++ b/pom.xml
@@ -58,16 +58,6 @@
     <system>Travis</system>
     <url>https://travis-ci.org/Activiti/${project.artifactId}</url>
   </ciManagement>
-  <repositories>
-    <repository>
-      <id>activiti-releases</id>
-      <name>Activiti Releases</name>
-      <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases/</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-    </repository>
-  </repositories>
   <properties>
     <!-- plugins -->
     <asm.version>6.2</asm.version>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,16 @@
     <system>Travis</system>
     <url>https://travis-ci.org/Activiti/${project.artifactId}</url>
   </ciManagement>
+  <repositories>
+    <repository>
+      <id>activiti-releases</id>
+      <name>Activiti Releases</name>
+      <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases/</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
   <properties>
     <!-- plugins -->
     <asm.version>6.2</asm.version>


### PR DESCRIPTION
This PR fixes broken Updatebot propagation dependencies to `activiti-cloud-runtime-bundle-service`, `ctiviti-cloud-query-service`, and `activiti-cloud-modeling-service` repositories. 
