### PR TITLE
fix(Jenkinsfile): Removed "updatebot update --merge" step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,6 +56,7 @@ pipeline {
             sh "jx step git credentials"
 
             sh "make updatebot/push-version"
+          }
         }
       }
       stage('Build Release from Tag') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,12 +54,8 @@ pipeline {
             sh "git config --global credential.helper store"
 
             sh "jx step git credentials"
-            //sh "updatebot push-version --kind maven org.activiti.dependencies:activiti-dependencies \$(cat VERSION) --merge false"
+
             sh "make updatebot/push-version"
-
-            sh "updatebot update --merge false"
-
-          }
         }
       }
       stage('Build Release from Tag') {


### PR DESCRIPTION
This PR removes redundant `updatebot update --merge` step from Jenkinsfile.