### PR TITLE
Revert "Read OutputDataItem as elementText"

### DIFF
--- a/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/multi/instance/MultiInstanceOutputDataItemParser.java
+++ b/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/child/multi/instance/MultiInstanceOutputDataItemParser.java
@@ -19,7 +19,6 @@ package org.activiti.bpmn.converter.child.multi.instance;
 import static org.activiti.bpmn.constants.BpmnXMLConstants.ATTRIBUTE_NAME;
 import static org.activiti.bpmn.constants.BpmnXMLConstants.ELEMENT_MULTI_INSTANCE_OUTPUT_DATA_ITEM;
 
-import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import org.activiti.bpmn.converter.child.ElementParser;
 import org.activiti.bpmn.model.MultiInstanceLoopCharacteristics;
@@ -34,15 +33,11 @@ public class MultiInstanceOutputDataItemParser implements
 
     @Override
     public void setInformation(XMLStreamReader reader,
-        MultiInstanceLoopCharacteristics loopCharacteristics) throws XMLStreamException {
+        MultiInstanceLoopCharacteristics loopCharacteristics) {
         String attributeValue = reader.getAttributeValue(null,
             ATTRIBUTE_NAME);
         if (attributeValue != null) {
             loopCharacteristics.setOutputDataItem(attributeValue);
-        }
-        String elementText = reader.getElementText();
-        if (elementText != null && !elementText.trim().isEmpty()) {
-            loopCharacteristics.setOutputDataItem(elementText);
         }
     }
 }

--- a/activiti-core/activiti-bpmn-converter/src/test/resources/multi-instance-loop-characteristics-output-data-item-as-value.xml
+++ b/activiti-core/activiti-bpmn-converter/src/test/resources/multi-instance-loop-characteristics-output-data-item-as-value.xml
@@ -1,7 +1,0 @@
-<multiInstanceLoopCharacteristics isSequential="false">
-  <loopDataInputRef>assigneeList</loopDataInputRef>
-  <inputDataItem name="assignee" />
-  <completionCondition>${nrOfCompletedInstances/nrOfInstances >= 0.6 }</completionCondition>
-  <loopDataOutputRef>meals</loopDataOutputRef>
-  <outputDataItem>meal</outputDataItem>
-</multiInstanceLoopCharacteristics>


### PR DESCRIPTION
Keep as defined in the specification, the name should be provided inside `name` attribute only.,
This reverts commit ffd15829c3a46156eeebbb32cacb17e75ee7c29c.