### PR TITLE
fix: Revert changes for activiti-build parent and activiti-core-dependencies propagation

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -17,7 +17,4 @@ github:
     - name: activiti-cloud-modeling-service
       branch: develop
       useSinglePullRequest: true
-    - name: activiti-cloud-build
-      branch: develop
-      useSinglePullRequest: true
     

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,7 @@ updatebot/push-version:
 	updatebot push-version --kind maven \
 		org.activiti.dependencies:activiti-dependencies $(RELEASE_VERSION) \
 		org.activiti.api:activiti-api-dependencies $(RELEASE_VERSION) \
-		org.activiti.core.common:activiti-core-common-dependencies $(RELEASE_VERSION) \
-		org.activiti:activiti-core-dependencies $(RELEASE_VERSION) \
-		org.activiti.build:activiti-parent $(RELEASE_VERSION)
+		org.activiti.core.common:activiti-core-common-dependencies $(RELEASE_VERSION)
 
 updatebot/update:
 	@echo doing updatebot update $(RELEASE_VERSION)

--- a/activiti-api/pom.xml
+++ b/activiti-api/pom.xml
@@ -11,6 +11,30 @@
   <artifactId>activiti-api</artifactId>
   <name>Activiti :: API :: Parent</name>
   <packaging>pom</packaging>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.activiti</groupId>
+        <artifactId>activiti-api-task-runtime-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti</groupId>
+        <artifactId>activiti-api-model-shared-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti</groupId>
+        <artifactId>activiti-api-process-model-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti</groupId>
+        <artifactId>activiti-api-task-model-impl</artifactId>
+        <version>${project.version}</version>
+      </dependency>      
+    </dependencies>
+  </dependencyManagement>
   <modules>
     <module>activiti-api-dependencies</module>
     <module>activiti-api-model-shared</module>

--- a/activiti-core-common/activiti-core-common-dependencies/pom.xml
+++ b/activiti-core-common/activiti-core-common-dependencies/pom.xml
@@ -13,13 +13,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.activiti.core.common</groupId>
         <artifactId>activiti-connector-model</artifactId>
         <version>${project.version}</version>

--- a/activiti-core-common/pom.xml
+++ b/activiti-core-common/pom.xml
@@ -11,6 +11,17 @@
   <artifactId>activiti-core-common</artifactId>
   <packaging>pom</packaging>
   <name>Activiti :: Core :: Common :: Parent</name>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.activiti.api</groupId>
+        <artifactId>activiti-api-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.activiti.api</groupId>

--- a/activiti-core/activiti-core-dependencies/pom.xml
+++ b/activiti-core/activiti-core-dependencies/pom.xml
@@ -12,20 +12,6 @@
   <name>Activiti :: Dependencies BOM (Bill Of Materials)</name>
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.activiti.api</groupId>
-        <artifactId>activiti-api-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.activiti.core.common</groupId>
-        <artifactId>activiti-core-common-dependencies</artifactId>
-        <version>${project.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <!-- Activiti Modules for managed dependencies -->
       <dependency>
         <groupId>org.activiti</groupId>

--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -36,6 +36,20 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.activiti.api</groupId>
+        <artifactId>activiti-api-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.activiti.core.common</groupId>
+        <artifactId>activiti-core-common-dependencies</artifactId>
+        <version>${project.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>javax.el</groupId>
         <artifactId>el-api</artifactId>
         <version>${el-api.version}</version>


### PR DESCRIPTION
This PR reverts changes for activiti-build parent and activiti-core-dependencies propagation

Part of https://github.com/Activiti/Activiti/issues/3099