### PR TITLE
[AAE-1614] fix warning for message flow reference

### DIFF
--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DefaultProcessValidatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DefaultProcessValidatorTest.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -236,37 +236,51 @@ public class DefaultProcessValidatorTest {
 
   @Test
   public void testWarningError() throws UnsupportedEncodingException, XMLStreamException {
-    String flowWithoutConditionNoDefaultFlow = "<?xml version='1.0' encoding='UTF-8'?>"
-        + "<definitions id='definitions' xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:activiti='http://activiti.org/bpmn' targetNamespace='Examples'>"
-        + "  <process id='exclusiveGwDefaultSequenceFlow'> " + "    <startEvent id='theStart' /> " + "    <sequenceFlow id='flow1' sourceRef='theStart' targetRef='exclusiveGw' /> " +
-
-        "    <exclusiveGateway id='exclusiveGw' name='Exclusive Gateway' /> "
-        + // no default = "flow3" !!
-        "    <sequenceFlow id='flow2' sourceRef='exclusiveGw' targetRef='theTask1'> " + "      <conditionExpression xsi:type='tFormalExpression'>${input == 1}</conditionExpression> "
-        + "    </sequenceFlow> " + "    <sequenceFlow id='flow3' sourceRef='exclusiveGw' targetRef='theTask2'/> " + // one
-                                                                                                                    // would
-                                                                                                                    // be
-                                                                                                                    // OK
-        "    <sequenceFlow id='flow4' sourceRef='exclusiveGw' targetRef='theTask2'/> " + // but
-                                                                                         // two
-                                                                                         // unconditional
-                                                                                         // not!
-
-        "    <userTask id='theTask1' name='Input is one' /> " + "    <userTask id='theTask2' name='Default input' /> " + "  </process>" + "</definitions>";
-
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream("org/activiti/engine/test/validation/flowWithoutConditionNoDefaultFlow.bpmn20.xml");
     XMLInputFactory xif = XMLInputFactory.newInstance();
-    InputStreamReader in = new InputStreamReader(new ByteArrayInputStream(flowWithoutConditionNoDefaultFlow.getBytes()), "UTF-8");
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
     XMLStreamReader xtr = xif.createXMLStreamReader(in);
     BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
+    Assert.assertNotNull(bpmnModel);
+
     Assert.assertNotNull(bpmnModel);
     List<ValidationError> allErrors = processValidator.validate(bpmnModel);
     Assert.assertEquals(1, allErrors.size());
     Assert.assertTrue(allErrors.get(0).isWarning());
+   }
+
+   @Test
+   public void testValidMessageFlow() throws UnsupportedEncodingException, XMLStreamException {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream("org/activiti/engine/test/validation/validMessageProcess.bpmn20.xml");
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
+    Assert.assertNotNull(bpmnModel);
+
+    Assert.assertNotNull(bpmnModel);
+    List<ValidationError> allErrors = processValidator.validate(bpmnModel);
+    Assert.assertEquals(0, allErrors.size());
   }
+
+   @Test
+   public void testInvalidMessageFlow() throws UnsupportedEncodingException, XMLStreamException {
+    InputStream xmlStream = this.getClass().getClassLoader().getResourceAsStream("org/activiti/engine/test/validation/invalidMessageProcess.bpmn20.xml");
+    XMLInputFactory xif = XMLInputFactory.newInstance();
+    InputStreamReader in = new InputStreamReader(xmlStream, "UTF-8");
+    XMLStreamReader xtr = xif.createXMLStreamReader(in);
+    BpmnModel bpmnModel = new BpmnXMLConverter().convertToBpmnModel(xtr);
+    Assert.assertNotNull(bpmnModel);
+
+    Assert.assertNotNull(bpmnModel);
+    List<ValidationError> allErrors = processValidator.validate(bpmnModel);
+    Assert.assertEquals(1, allErrors.size());
+    Assert.assertTrue(allErrors.get(0).isWarning());
+   }
 
   /*
    * Test for https://jira.codehaus.org/browse/ACT-2071:
-   * 
+   *
    * If all processes in a deployment are not executable, throw an exception as this doesn't make sense to do.
    */
   @Test
@@ -284,7 +298,7 @@ public class DefaultProcessValidatorTest {
 
   /*
    * Test for https://jira.codehaus.org/browse/ACT-2071:
-   * 
+   *
    * If there is at least one process definition which is executable, and the deployment contains other process definitions which are not executable, then add a warning for those non executable
    * process definitions
    */

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/MessageFlowValidationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/MessageFlowValidationTest.java
@@ -1,0 +1,4 @@
+package org.activiti.standalone.validation;
+
+public class MessageFlowValidationTest {
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/MessageFlowValidationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/MessageFlowValidationTest.java
@@ -1,4 +1,0 @@
-package org.activiti.standalone.validation;
-
-public class MessageFlowValidationTest {
-}

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/flowWithoutConditionNoDefaultFlow.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/flowWithoutConditionNoDefaultFlow.bpmn20.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions id='definitions' xmlns='http://www.omg.org/spec/BPMN/20100524/MODEL'
+             xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:activiti='http://activiti.org/bpmn'
+             targetNamespace='Examples'>
+  <process id='exclusiveGwDefaultSequenceFlow'>
+    <startEvent id='theStart'/>
+    <sequenceFlow id='flow1' sourceRef='theStart' targetRef='exclusiveGw'/>
+    <exclusiveGateway id='exclusiveGw' name='Exclusive Gateway'/>
+    <sequenceFlow id='flow2' sourceRef='exclusiveGw' targetRef='theTask1'>
+      <conditionExpression xsi:type='tFormalExpression'>${input == 1}</conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id='flow3' sourceRef='exclusiveGw' targetRef='theTask2'/>
+    <sequenceFlow id='flow4' sourceRef='exclusiveGw' targetRef='theTask2'/>
+    <userTask id='theTask1' name='Input is one'/>
+    <userTask id='theTask2' name='Default input'/>
+  </process>
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/invalidMessageProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/invalidMessageProcess.bpmn20.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="model-7c6c3736-52c1-47de-bbfc-4b83e4531418" name="prova" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:collaboration id="Collaboration_1fwdbcl">
+    <bpmn2:participant id="Participant_0dyd1kz" processRef="Process_Lboy8ATE" />
+    <bpmn2:participant id="Participant_1al248d" name="poool1" processRef="Process_011iab4" />
+    <bpmn2:messageFlow id="WrongId" sourceRef="Event_18zdv8c" targetRef="Event_1" />
+  </bpmn2:collaboration>
+  <bpmn2:process id="Process_Lboy8ATE" name="prova">
+    <bpmn2:documentation />
+    <bpmn2:sequenceFlow id="SequenceFlow_0hvshgh" sourceRef="Event_1" targetRef="Task_068p9sr" />
+    <bpmn2:endEvent id="Event_1vpe601">
+      <bpmn2:incoming>SequenceFlow_09q7ecx</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_09q7ecx" sourceRef="Task_068p9sr" targetRef="Event_1vpe601" />
+    <bpmn2:userTask id="Task_068p9sr" activiti:formKey="form-6f2fc66f-d44e-4044-a18b-fc6045b07bcc" activiti:assignee="hr">
+      <bpmn2:incoming>SequenceFlow_0hvshgh</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_09q7ecx</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_0hvshgh</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1kdkt8l" messageRef="Message_04nl3hs" />
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmn2:process id="Process_011iab4">
+    <bpmn2:startEvent id="Event_0v9l67f">
+      <bpmn2:outgoing>SequenceFlow_0uf1mqk</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="Task_0kl2oy5">
+      <bpmn2:incoming>SequenceFlow_0uf1mqk</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0ufpzl5</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="SequenceFlow_0uf1mqk" sourceRef="Event_0v9l67f" targetRef="Task_0kl2oy5" />
+    <bpmn2:sequenceFlow id="SequenceFlow_0ufpzl5" sourceRef="Task_0kl2oy5" targetRef="Event_18zdv8c" />
+    <bpmn2:endEvent id="Event_18zdv8c">
+      <bpmn2:incoming>SequenceFlow_0ufpzl5</bpmn2:incoming>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_04aysb0" messageRef="Message_04nl3hs" />
+    </bpmn2:endEvent>
+
+
+
+  </bpmn2:process>
+  <bpmn2:message id="Message_04nl3hs" name="Message_one" />
+  <bpmn2:message id="Message_1dp0gig" name="Message_two" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1fwdbcl">
+      <bpmndi:BPMNShape id="Participant_0dyd1kz_di" bpmnElement="Participant_0dyd1kz" isHorizontal="true">
+        <dc:Bounds x="362" y="158" width="400" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hvshgh_di" bpmnElement="SequenceFlow_0hvshgh">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="500" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1vpe601_di" bpmnElement="Event_1vpe601">
+        <dc:Bounds x="652" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_09q7ecx_di" bpmnElement="SequenceFlow_09q7ecx">
+        <di:waypoint x="600" y="258" />
+        <di:waypoint x="652" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_057hs4l_di" bpmnElement="Participant_1al248d" isHorizontal="true">
+        <dc:Bounds x="180" y="480" width="400" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0v9l67f_di" bpmnElement="Event_0v9l67f">
+        <dc:Bounds x="282" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0kl2oy5_di" bpmnElement="Task_0kl2oy5">
+        <dc:Bounds x="370" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uf1mqk_di" bpmnElement="SequenceFlow_0uf1mqk">
+        <di:waypoint x="318" y="590" />
+        <di:waypoint x="370" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ufpzl5_di" bpmnElement="SequenceFlow_0ufpzl5">
+        <di:waypoint x="470" y="590" />
+        <di:waypoint x="522" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1vfks65_di" bpmnElement="Task_068p9sr">
+        <dc:Bounds x="500" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1famo4o_di" bpmnElement="Event_18zdv8c">
+        <dc:Bounds x="522" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_0w8igbb_di" bpmnElement="MessageFlow_0w8igbb">
+        <di:waypoint x="540" y="572" />
+        <di:waypoint x="540" y="424" />
+        <di:waypoint x="430" y="424" />
+        <di:waypoint x="430" y="276" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0qbqhwf_di" bpmnElement="Event_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/validMessageProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/validation/validMessageProcess.bpmn20.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="model-7c6c3736-52c1-47de-bbfc-4b83e4531418" name="prova" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:collaboration id="Collaboration_1fwdbcl">
+    <bpmn2:participant id="Participant_0dyd1kz" processRef="Process_Lboy8ATE" />
+    <bpmn2:participant id="Participant_1al248d" name="poool1" processRef="Process_011iab4" />
+    <bpmn2:messageFlow id="MessageFlow_0w8igbb" sourceRef="Event_18zdv8c" targetRef="Event_1" />
+  </bpmn2:collaboration>
+  <bpmn2:process id="Process_Lboy8ATE" name="prova">
+    <bpmn2:documentation />
+    <bpmn2:sequenceFlow id="SequenceFlow_0hvshgh" sourceRef="Event_1" targetRef="Task_068p9sr" />
+    <bpmn2:endEvent id="Event_1vpe601">
+      <bpmn2:incoming>SequenceFlow_09q7ecx</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_09q7ecx" sourceRef="Task_068p9sr" targetRef="Event_1vpe601" />
+    <bpmn2:userTask id="Task_068p9sr" activiti:formKey="form-6f2fc66f-d44e-4044-a18b-fc6045b07bcc" activiti:assignee="hr">
+      <bpmn2:incoming>SequenceFlow_0hvshgh</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_09q7ecx</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_0hvshgh</bpmn2:outgoing>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_1kdkt8l" messageRef="Message_04nl3hs" />
+    </bpmn2:startEvent>
+  </bpmn2:process>
+  <bpmn2:process id="Process_011iab4">
+    <bpmn2:startEvent id="Event_0v9l67f">
+      <bpmn2:outgoing>SequenceFlow_0uf1mqk</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="Task_0kl2oy5">
+      <bpmn2:incoming>SequenceFlow_0uf1mqk</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_0ufpzl5</bpmn2:outgoing>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="SequenceFlow_0uf1mqk" sourceRef="Event_0v9l67f" targetRef="Task_0kl2oy5" />
+    <bpmn2:sequenceFlow id="SequenceFlow_0ufpzl5" sourceRef="Task_0kl2oy5" targetRef="Event_18zdv8c" />
+    <bpmn2:endEvent id="Event_18zdv8c">
+      <bpmn2:incoming>SequenceFlow_0ufpzl5</bpmn2:incoming>
+      <bpmn2:messageEventDefinition id="MessageEventDefinition_04aysb0" messageRef="Message_04nl3hs" />
+    </bpmn2:endEvent>
+
+
+
+  </bpmn2:process>
+  <bpmn2:message id="Message_04nl3hs" name="Message_one" />
+  <bpmn2:message id="Message_1dp0gig" name="Message_two" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1fwdbcl">
+      <bpmndi:BPMNShape id="Participant_0dyd1kz_di" bpmnElement="Participant_0dyd1kz" isHorizontal="true">
+        <dc:Bounds x="362" y="158" width="400" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hvshgh_di" bpmnElement="SequenceFlow_0hvshgh">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="500" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1vpe601_di" bpmnElement="Event_1vpe601">
+        <dc:Bounds x="652" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_09q7ecx_di" bpmnElement="SequenceFlow_09q7ecx">
+        <di:waypoint x="600" y="258" />
+        <di:waypoint x="652" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_057hs4l_di" bpmnElement="Participant_1al248d" isHorizontal="true">
+        <dc:Bounds x="180" y="480" width="400" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_0v9l67f_di" bpmnElement="Event_0v9l67f">
+        <dc:Bounds x="282" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0kl2oy5_di" bpmnElement="Task_0kl2oy5">
+        <dc:Bounds x="370" y="550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uf1mqk_di" bpmnElement="SequenceFlow_0uf1mqk">
+        <di:waypoint x="318" y="590" />
+        <di:waypoint x="370" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ufpzl5_di" bpmnElement="SequenceFlow_0ufpzl5">
+        <di:waypoint x="470" y="590" />
+        <di:waypoint x="522" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1vfks65_di" bpmnElement="Task_068p9sr">
+        <dc:Bounds x="500" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1famo4o_di" bpmnElement="Event_18zdv8c">
+        <dc:Bounds x="522" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="MessageFlow_0w8igbb_di" bpmnElement="MessageFlow_0w8igbb">
+        <di:waypoint x="540" y="572" />
+        <di:waypoint x="540" y="424" />
+        <di:waypoint x="430" y="424" />
+        <di:waypoint x="430" y="276" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="StartEvent_0qbqhwf_di" bpmnElement="Event_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-core/activiti-process-validation/src/main/java/org/activiti/validation/validator/impl/DiagramInterchangeInfoValidator.java
+++ b/activiti-core/activiti-process-validation/src/main/java/org/activiti/validation/validator/impl/DiagramInterchangeInfoValidator.java
@@ -1,9 +1,9 @@
 /* Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.activiti.bpmn.model.BpmnModel;
 import org.activiti.bpmn.model.FlowNode;
+import org.activiti.bpmn.model.MessageFlow;
 import org.activiti.bpmn.model.SequenceFlow;
 import org.activiti.validation.ValidationError;
 import org.activiti.validation.validator.Problems;
@@ -52,16 +53,19 @@ public class DiagramInterchangeInfoValidator extends ValidatorImpl {
     if (!bpmnModel.getFlowLocationMap().isEmpty()) {
       // flowlocation map
       for (String bpmnReference : bpmnModel.getFlowLocationMap().keySet()) {
-        if (bpmnModel.getFlowElement(bpmnReference) == null) {
+        if (bpmnModel.getFlowElement(bpmnReference) == null && bpmnModel.getMessageFlow(bpmnReference) == null) {
           // ACT-1625: don't warn when artifacts are referenced from
           // DI
           if (bpmnModel.getArtifact(bpmnReference) == null) {
             addWarning(errors, Problems.DI_INVALID_REFERENCE, null, bpmnModel.getFlowElement(bpmnReference), "Invalid reference in diagram interchange definition: could not find " + bpmnReference);
           }
-        } else if (!(bpmnModel.getFlowElement(bpmnReference) instanceof SequenceFlow)) {
+        }
+
+        if (bpmnModel.getFlowElement(bpmnReference) != null  && !(bpmnModel.getFlowElement(bpmnReference) instanceof SequenceFlow)) {
           addWarning(errors, Problems.DI_DOES_NOT_REFERENCE_SEQ_FLOW, null, bpmnModel.getFlowElement(bpmnReference), "Invalid reference in diagram interchange definition: " + bpmnReference
               + " does not reference a sequence flow");
         }
+
       }
     }
   }


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/3119

All the time we validate a process that contains a Collaboration that shows the Message Flows. We receive a warning message from the Validator:

[main|org.activiti.engine.impl.bpmn.parser.BpmnParse] WARN  Invalid reference in diagram interchange definition: could not find messageflow2
In Collaboration Diagrams, a Message Flow can be extended to show the message that is passed from one Participant to another.
Message Flow is defined it is contained either within a Collaboration. We need to let the validator search for a bpmnReference of the bpmnElement also inside the MessageFlow elements