### PR TITLE
fixing timer job lock issue if fetch more than 1 record

### DIFF
--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cfg/ProcessEngineConfigurationImpl.java
@@ -1728,6 +1728,10 @@ public abstract class ProcessEngineConfigurationImpl extends ProcessEngineConfig
       defaultAsyncExecutor.setDefaultTimerJobAcquireWaitTimeInMillis(asyncExecutorDefaultTimerJobAcquireWaitTime);
       defaultAsyncExecutor.setDefaultAsyncJobAcquireWaitTimeInMillis(asyncExecutorDefaultAsyncJobAcquireWaitTime);
 
+      // Acquisition size
+      defaultAsyncExecutor.setMaxTimerJobsPerAcquisition(asyncExecutorMaxTimerJobsPerAcquisition);
+      defaultAsyncExecutor.setMaxAsyncJobsDuePerAcquisition(asyncExecutorMaxAsyncJobsDuePerAcquisition);
+
       // Queue full wait time
       defaultAsyncExecutor.setDefaultQueueSizeFullWaitTimeInMillis(asyncExecutorDefaultQueueSizeFullWaitTime);
 

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AcquireTimerJobsCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/AcquireTimerJobsCmd.java
@@ -40,22 +40,9 @@ public class AcquireTimerJobsCmd implements Command<AcquiredTimerJobEntities> {
         .findTimerJobsToExecute(new Page(0, asyncExecutor.getMaxAsyncJobsDuePerAcquisition()));
 
     for (TimerJobEntity job : timerJobs) {
-      lockJob(commandContext, job, asyncExecutor.getAsyncJobLockTimeInMillis());
       acquiredJobs.addJob(job);
     }
 
     return acquiredJobs;
-  }
-
-  protected void lockJob(CommandContext commandContext, TimerJobEntity job, int lockTimeInMillis) {
-    
-    // This will trigger an optimistic locking exception when two concurrent executors 
-    // try to lock, as the revision will not match.
-    
-    GregorianCalendar gregorianCalendar = new GregorianCalendar();
-    gregorianCalendar.setTime(commandContext.getProcessEngineConfiguration().getClock().getCurrentTime());
-    gregorianCalendar.add(Calendar.MILLISECOND, lockTimeInMillis);
-    job.setLockOwner(asyncExecutor.getLockOwner());
-    job.setLockExpirationTime(gregorianCalendar.getTime());
   }
 }

--- a/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteTimerJobsCmd.java
+++ b/modules/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ExecuteTimerJobsCmd.java
@@ -1,0 +1,39 @@
+package org.activiti.engine.impl.cmd;
+
+import org.activiti.engine.impl.asyncexecutor.AsyncExecutor;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.TimerJobEntity;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class ExecuteTimerJobsCmd implements Command<Void> {
+
+    private final AsyncExecutor asyncExecutor;
+
+    private final TimerJobEntity job;
+
+    public ExecuteTimerJobsCmd(AsyncExecutor asyncExecutor, TimerJobEntity job) {
+        this.asyncExecutor = asyncExecutor;
+        this.job = job;
+    }
+
+    public Void execute(CommandContext commandContext) {
+        lockJob(commandContext, job, asyncExecutor.getAsyncJobLockTimeInMillis());
+        asyncExecutor.getProcessEngineConfiguration().getJobManager().moveTimerJobToExecutableJob(job);
+        return null;
+    }
+
+    protected void lockJob(CommandContext commandContext, TimerJobEntity job, int lockTimeInMillis) {
+
+        // This will trigger an optimistic locking exception when two concurrent executors
+        // try to lock, as the revision will not match.
+
+        GregorianCalendar gregorianCalendar = new GregorianCalendar();
+        gregorianCalendar.setTime(commandContext.getProcessEngineConfiguration().getClock().getCurrentTime());
+        gregorianCalendar.add(Calendar.MILLISECOND, lockTimeInMillis);
+        job.setLockOwner(asyncExecutor.getLockOwner());
+        job.setLockExpirationTime(gregorianCalendar.getTime());
+    }
+}


### PR DESCRIPTION
The original AcquireTimerJobsCmd as below
`
final AcquiredTimerJobEntities acquiredJobs = commandExecutor.execute(new AcquireTimerJobsCmd(asyncExecutor));
`
will fetch timer jobs and lock one by one;
Then begin a new transaction to `moveTimerJobToExecutableJob`, if error occurred the loop will break. But the AcquiredTimerJobs have been locked like this
|  ID_  | REV_ | TYPE_ | LOCK_EXP_TIME_ | LOCK_OWNER_
|  ----  | ----  | ----  | ----  | ----  |
| 811f2eb2-4f00-11ea-bef1-0a580a81015e  | 1 | timer | 2020-02-14 14:54:41 | 34e166b8-4f01-11ea-b993-0a580a820166 |

If the `maxAsyncJobsDuePerAcquisition` is more than 1, it will cause lots of timer jobs sleep in `act_ru_timer_job` and can not be woke up any more.  
There is no methods to query expired jobs in `TimerJobEntityManager`.