### PR TITLE
fix updatebot configuration to propagate to new activiti cloud monorepo

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -2,19 +2,7 @@ github:
   organisations:
   - name: activiti
     repositories:
-    - name: activiti-cloud-runtime-bundle-service
+    - name: activiti-cloud
       branch: develop
       useSinglePullRequest: true
-    - name: activiti-cloud-query-service
-      branch: develop
-      useSinglePullRequest: true
-    - name: activiti-cloud-service-common
-      branch: develop
-      useSinglePullRequest: true
-    - name: activiti-cloud-api
-      branch: develop
-      useSinglePullRequest: true
-    - name: activiti-cloud-modeling-service
-      branch: develop
-      useSinglePullRequest: true
-    
+


### PR DESCRIPTION
fix updatebot configuration to propagate to new activiti cloud monorepo