### PR TITLE
The value of 'path' have to end with a value other than '/'.

### DIFF
--- a/modules/activiti-ui/activiti-app/src/main/webapp/META-INF/context.xml
+++ b/modules/activiti-ui/activiti-app/src/main/webapp/META-INF/context.xml
@@ -18,5 +18,5 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 -->
-<Context path="/" debug="100" privileged="true" reloadable="true" crossContext="true">
+<Context path="" debug="100" privileged="true" reloadable="true" crossContext="true">
 </Context>


### PR DESCRIPTION
If the setting value of context path ends with '/', a warning log will be output.
You can respond by changing the setting value.