### PR TITLE
feat(AAE-1291): Added support for Integration error event type in Activiti Core Api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
           branch 'PR-*'
         }
         environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+          PREVIEW_VERSION = "7.1.0-$BRANCH_NAME-$BUILD_NUMBER"
           PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }
@@ -21,6 +21,7 @@ pipeline {
           container('maven') {
             sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
+            sh "mvn deploy -DskipTests -DskipITs"
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
           container('maven') {
             sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install -DskipITs"
-            sh "mvn deploy -DskipTests -DskipITs"
+            // sh "mvn deploy -DskipTests -DskipITs"
           }
         }
       }

--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/BPMNActivity.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/BPMNActivity.java
@@ -5,4 +5,7 @@ public interface BPMNActivity extends BPMNElement {
     String getActivityName();
 
     String getActivityType();
+
+    String getExecutionId();
+
 }

--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/IntegrationContext.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/IntegrationContext.java
@@ -25,15 +25,17 @@ public interface IntegrationContext {
     String getProcessInstanceId();
 
     String getParentProcessInstanceId();
-    
+
+    String getExecutionId();
+
     String getProcessDefinitionId();
 
     String getProcessDefinitionKey();
 
     Integer getProcessDefinitionVersion();
-    
+
     String getBusinessKey();
-    
+
     String getConnectorType();
 
     String getAppVersion();

--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/events/IntegrationEvent.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/events/IntegrationEvent.java
@@ -16,8 +16,8 @@
 
 package org.activiti.api.process.model.events;
 
-import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.model.shared.event.RuntimeEvent;
+import org.activiti.api.process.model.IntegrationContext;
 
 public interface IntegrationEvent extends RuntimeEvent<IntegrationContext, IntegrationEvent.IntegrationEvents> {
 
@@ -25,7 +25,9 @@ public interface IntegrationEvent extends RuntimeEvent<IntegrationContext, Integ
 
         INTEGRATION_REQUESTED,
 
-        INTEGRATION_RESULT_RECEIVED
+        INTEGRATION_RESULT_RECEIVED,
+
+        INTEGRATION_ERROR_RECEIVED
     }
 
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/BPMNActivityImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/BPMNActivityImpl.java
@@ -8,7 +8,7 @@ public class BPMNActivityImpl extends BPMNElementImpl implements BPMNActivity {
 
     private String activityName;
     private String activityType;
-
+    private String executionId;
 
     public BPMNActivityImpl() {
     }
@@ -21,6 +21,7 @@ public class BPMNActivityImpl extends BPMNElementImpl implements BPMNActivity {
         this.activityType = activityType;
     }
 
+    @Override
     public String getActivityName() {
         return activityName;
     }
@@ -29,6 +30,7 @@ public class BPMNActivityImpl extends BPMNElementImpl implements BPMNActivity {
         this.activityName = activityName;
     }
 
+    @Override
     public String getActivityType() {
         return activityType;
     }
@@ -37,39 +39,52 @@ public class BPMNActivityImpl extends BPMNElementImpl implements BPMNActivity {
         this.activityType = activityType;
     }
 
+    @Override
+    public String getExecutionId() {
+        return this.executionId;
+    }
+
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object obj) {
+        if (this == obj) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!super.equals(obj)) {
             return false;
         }
-        BPMNActivityImpl that = (BPMNActivityImpl) o;
-
-        return Objects.equals(getElementId(),
-                that.getElementId()) &&
-                Objects.equals(activityName,
-                        that.activityName) &&
-                Objects.equals(activityType,
-                        that.activityType);
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        BPMNActivityImpl other = (BPMNActivityImpl) obj;
+        return Objects.equals(activityName, other.activityName) &&
+               Objects.equals(activityType, other.activityType) &&
+               Objects.equals(executionId, other.executionId);
     }
 
     @Override
     public int hashCode() {
-
-        return Objects.hash(getElementId(),
-                activityName,
-                activityType);
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + Objects.hash(activityName, activityType, executionId);
+        return result;
     }
 
     @Override
     public String toString() {
-        return "BPMNActivityImpl{" +
-                "activityName='" + activityName + '\'' +
-                ", activityType='" + activityType + '\'' +
-                ", elementId='" + getElementId() + '\'' +
-                '}';
+        StringBuilder builder = new StringBuilder();
+        builder.append("BPMNActivityImpl [activityName=")
+               .append(activityName)
+               .append(", activityType=")
+               .append(activityType)
+               .append(", executionId=")
+               .append(executionId)
+               .append(", toString()=")
+               .append(super.toString())
+               .append("]");
+        return builder.toString();
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/IntegrationContextImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/IntegrationContextImpl.java
@@ -16,8 +16,11 @@
 
 package org.activiti.api.runtime.model.impl;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.activiti.api.process.model.IntegrationContext;
@@ -30,6 +33,7 @@ public class IntegrationContextImpl implements IntegrationContext {
     private String processInstanceId;
     private String parentProcessInstanceId;
     private String processDefinitionId;
+    private String executionId;
     private String processDefinitionKey;
     private Integer processDefinitionVersion;
     private String businessKey;
@@ -111,16 +115,16 @@ public class IntegrationContextImpl implements IntegrationContext {
     public void addOutBoundVariables(Map<String, Object> variables) {
         outBoundVariables.putAll(variables);
     }
-    
+
     @Override
     public String getProcessDefinitionKey() {
         return processDefinitionKey;
     }
-    
+
     public void setProcessDefinitionKey(String processDefinitionKey) {
         this.processDefinitionKey = processDefinitionKey;
     }
-    
+
     @Override
     public Integer getProcessDefinitionVersion() {
         return processDefinitionVersion;
@@ -129,13 +133,13 @@ public class IntegrationContextImpl implements IntegrationContext {
     public void setProcessDefinitionVersion(Integer processDefinitionVersion) {
         this.processDefinitionVersion = processDefinitionVersion;
     }
-    
+
     @Override
     public String getClientName() {
         return clientName;
     }
 
-    
+
     public void setClientName(String clientName) {
         this.clientName = clientName;
     }
@@ -145,17 +149,17 @@ public class IntegrationContextImpl implements IntegrationContext {
         return clientType;
     }
 
-    
+
     public void setClientType(String clientType) {
         this.clientType = clientType;
     }
 
-    
+
     @Override
-    public String getBusinessKey() { 
+    public String getBusinessKey() {
         return businessKey;
     }
-    
+
     public void setBusinessKey(String businessKey) {
         this.businessKey = businessKey;
     }
@@ -164,7 +168,7 @@ public class IntegrationContextImpl implements IntegrationContext {
     public String getParentProcessInstanceId() {
         return parentProcessInstanceId;
     }
-    
+
     public void setParentProcessInstanceId(String parentProcessInstanceId) {
         this.parentProcessInstanceId = parentProcessInstanceId;
     }
@@ -176,5 +180,116 @@ public class IntegrationContextImpl implements IntegrationContext {
 
     public void setAppVersion(String appVersion) {
         this.appVersion = appVersion;
+    }
+
+
+    @Override
+    public String getExecutionId() {
+        return executionId;
+    }
+
+
+    public void setExecutionId(String executionId) {
+        this.executionId = executionId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appVersion,
+                            businessKey,
+                            clientId,
+                            clientName,
+                            clientType,
+                            connectorType,
+                            executionId,
+                            id,
+                            inboundVariables,
+                            outBoundVariables,
+                            parentProcessInstanceId,
+                            processDefinitionId,
+                            processDefinitionKey,
+                            processDefinitionVersion,
+                            processInstanceId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        IntegrationContextImpl other = (IntegrationContextImpl) obj;
+        return Objects.equals(appVersion, other.appVersion) &&
+               Objects.equals(businessKey, other.businessKey) &&
+               Objects.equals(clientId, other.clientId) &&
+               Objects.equals(clientName, other.clientName) &&
+               Objects.equals(clientType, other.clientType) &&
+               Objects.equals(connectorType, other.connectorType) &&
+               Objects.equals(executionId, other.executionId) &&
+               Objects.equals(id, other.id) &&
+               Objects.equals(inboundVariables, other.inboundVariables) &&
+               Objects.equals(outBoundVariables, other.outBoundVariables) &&
+               Objects.equals(parentProcessInstanceId, other.parentProcessInstanceId) &&
+               Objects.equals(processDefinitionId, other.processDefinitionId) &&
+               Objects.equals(processDefinitionKey, other.processDefinitionKey) &&
+               Objects.equals(processDefinitionVersion, other.processDefinitionVersion) &&
+               Objects.equals(processInstanceId, other.processInstanceId);
+    }
+
+    @Override
+    public String toString() {
+        final int maxLen = 10;
+        StringBuilder builder = new StringBuilder();
+        builder.append("IntegrationContextImpl [id=")
+               .append(id)
+               .append(", inboundVariables=")
+               .append(inboundVariables != null ? toString(inboundVariables.entrySet(), maxLen) : null)
+               .append(", outBoundVariables=")
+               .append(outBoundVariables != null ? toString(outBoundVariables.entrySet(), maxLen) : null)
+               .append(", processInstanceId=")
+               .append(processInstanceId)
+               .append(", parentProcessInstanceId=")
+               .append(parentProcessInstanceId)
+               .append(", processDefinitionId=")
+               .append(processDefinitionId)
+               .append(", executionId=")
+               .append(executionId)
+               .append(", processDefinitionKey=")
+               .append(processDefinitionKey)
+               .append(", processDefinitionVersion=")
+               .append(processDefinitionVersion)
+               .append(", businessKey=")
+               .append(businessKey)
+               .append(", clientId=")
+               .append(clientId)
+               .append(", clientName=")
+               .append(clientName)
+               .append(", clientType=")
+               .append(clientType)
+               .append(", appVersion=")
+               .append(appVersion)
+               .append(", connectorType=")
+               .append(connectorType)
+               .append("]");
+        return builder.toString();
+    }
+
+    private String toString(Collection<?> collection, int maxLen) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("[");
+        int i = 0;
+        for (Iterator<?> iterator = collection.iterator(); iterator.hasNext() && i < maxLen; i++) {
+            if (i > 0) {
+                builder.append(", ");
+            }
+            builder.append(iterator.next());
+        }
+        builder.append("]");
+        return builder.toString();
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -53,6 +53,7 @@ public class IntegrationContextBuilder {
         integrationContext.setProcessDefinitionId(execution.getProcessDefinitionId());
         integrationContext.setBusinessKey(execution.getProcessInstanceBusinessKey());
         integrationContext.setClientId(execution.getCurrentActivityId());
+        integrationContext.setExecutionId(execution.getId());
 
         if (ExecutionEntity.class.isInstance(execution)) {
             ExecutionContext executionContext = new ExecutionContext(ExecutionEntity.class.cast(execution));

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/BPMNErrorConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/event/impl/BPMNErrorConverter.java
@@ -26,12 +26,13 @@ public class BPMNErrorConverter {
         BPMNErrorImpl bpmnError = new BPMNErrorImpl(internalEvent.getActivityId(),
                                                     internalEvent.getActivityName(),
                                                     internalEvent.getActivityType());
-        
+
         bpmnError.setProcessDefinitionId(internalEvent.getProcessDefinitionId());
         bpmnError.setProcessInstanceId(internalEvent.getProcessInstanceId());
-   
+        bpmnError.setExecutionId(internalEvent.getExecutionId());
+
         bpmnError.setErrorId(internalEvent.getErrorId());
-        bpmnError.setErrorCode(internalEvent.getErrorCode());       
+        bpmnError.setErrorCode(internalEvent.getErrorCode());
 
         return bpmnError;
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/ToActivityConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/impl/ToActivityConverter.java
@@ -28,6 +28,8 @@ public class ToActivityConverter {
                                                              internalEvent.getActivityType());
         activity.setProcessDefinitionId(internalEvent.getProcessDefinitionId());
         activity.setProcessInstanceId(internalEvent.getProcessInstanceId());
+        activity.setExecutionId(internalEvent.getExecutionId());
+
         return activity;
     }
 


### PR DESCRIPTION
This PR adds support for INTEGRATION_ERROR_RECEIVED event type for IntegrationEvent interface and implementation.

It also adds support for exposing executionId attribute for BPMNActivity and ExecutionContext process runtime entity models apis. 

Fixes AAE-1291

Part of https://github.com/Activiti/Activiti/issues/2712