### PR TITLE
Move jar signature to deploy phase

### DIFF
--- a/activiti-core/activiti-spring-conformance-tests/pom.xml
+++ b/activiti-core/activiti-spring-conformance-tests/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>activiti-spring-conformance-tests</artifactId>
   <packaging>pom</packaging>
   <name>Activiti :: Spring :: Conformance Tests Parent</name>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
   <modules>
     <module>activiti-spring-conformance-util</module>
     <module>activiti-spring-conformance-set0</module>

--- a/activiti-examples/pom.xml
+++ b/activiti-examples/pom.xml
@@ -11,6 +11,9 @@
   <artifactId>activiti-examples</artifactId>
   <packaging>pom</packaging>
   <name>Activiti :: Examples :: Parent</name>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+  </properties>
   <modules>
     <module>activiti-api-basic-full-example-bean</module>
     <module>activiti-api-basic-full-example-nobean</module>

--- a/pom.xml
+++ b/pom.xml
@@ -733,6 +733,7 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
+                <phase>deploy</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
Sources artifacts are configured to be generated at deploy phase, so jar should be signed only after that.
This is also skipping the deployment for examples and conformance tests that are not required to be deployed

Ref https://github.com/Activiti/Activiti/issues/3184