### PR TITLE
Restore default phases for attach sources and sign jars (#3184)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -262,7 +262,6 @@
           <executions>
             <execution>
               <id>attach-sources</id>
-              <phase>deploy</phase>
               <goals>
                 <goal>jar-no-fork</goal>
               </goals>
@@ -731,7 +730,6 @@
             <executions>
               <execution>
                 <id>sign-artifacts</id>
-                <phase>deploy</phase>
                 <goals>
                   <goal>sign</goal>
                 </goals>


### PR DESCRIPTION
Changing the default phases is causing issues while signing artifacts (sources jars and some pom files are not signed)
Ref https://github.com/Activiti/Activiti/issues/3184