### PR TITLE
fix: add support for simple process variable types in IntegrationContext

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
@@ -48,14 +48,10 @@ public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVar
                 String type = entryValue.get("type").textValue();
                 String value = entryValue.get("value").asText();
 
-                try {
-                    Class<?> clazz = Class.forName(type);
-                    Object result = conversionService.convert(value, clazz);
+                Class<?> clazz = ProcessVariablesMapTypeRegistry.forType(type);
+                Object result = conversionService.convert(value, clazz);
 
-                    map.put(name, result);
-                } catch (ClassNotFoundException e) {
-                    map.put(name, null);
-                }
+                map.put(name, result);
             } else {
                 map.put(name, null);
             }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.api.runtime.model.impl;
 
 import java.math.BigDecimal;

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
@@ -1,0 +1,99 @@
+package org.activiti.api.runtime.model.impl;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ProcessVariablesMapTypeRegistry {
+
+    private static Map<String, Class<?>> typeRegistry = new HashMap<>();
+    private static Map<Class<?>, String> classRegistry = new HashMap<>();
+    private static List<Class<?>> scalarTypes = Arrays.asList(int.class,
+                                                              byte.class,
+                                                              short.class,
+                                                              boolean.class,
+                                                              long.class,
+                                                              double.class,
+                                                              float.class,
+                                                              char.class,
+                                                              Character.class,
+                                                              Integer.class,
+                                                              Byte.class,
+                                                              Short.class,
+                                                              Boolean.class,
+                                                              Long.class,
+                                                              Double.class,
+                                                              Float.class,
+                                                              BigDecimal.class,
+                                                              Date.class,
+                                                              String.class);
+
+    private static Class<?>[] containerTypes = {Map.class,
+                                                JsonNode.class,
+                                                List.class,
+                                                Set.class};
+    static {
+        typeRegistry.put("byte", Byte.class);
+        typeRegistry.put("character", Character.class);
+        typeRegistry.put("short", Short.class);
+        typeRegistry.put("string", String.class);
+        typeRegistry.put("long", Long.class);
+        typeRegistry.put("integer", Integer.class);
+        typeRegistry.put("boolean", Boolean.class);
+        typeRegistry.put("double", Double.class);
+        typeRegistry.put("float", Float.class);
+        typeRegistry.put("date", Date.class);
+        typeRegistry.put("localdate", LocalDate.class);
+        typeRegistry.put("bigdecimal", BigDecimal.class);
+        typeRegistry.put("json", JsonNode.class);
+        typeRegistry.put("map", Map.class);
+        typeRegistry.put("set", Set.class);
+        typeRegistry.put("list", List.class);
+
+        classRegistry.put(Byte.class, "byte");
+        classRegistry.put(Character.class, "character");
+        classRegistry.put(Short.class, "short");
+        classRegistry.put(String.class, "string");
+        classRegistry.put(Long.class, "long");
+        classRegistry.put(Integer.class, "integer");
+        classRegistry.put(Boolean.class, "boolean");
+        classRegistry.put(Double.class, "double");
+        classRegistry.put(Float.class, "float");
+        classRegistry.put(Date.class, "date");
+        classRegistry.put(LocalDate.class, "localdate");
+        classRegistry.put(BigDecimal.class, "bigdecimal");
+        classRegistry.put(JsonNode.class, "json");
+        classRegistry.put(Map.class, "map");
+        classRegistry.put(List.class, "list");
+        classRegistry.put(Set.class, "set");
+    }
+
+    public static Class<?> forType(String type) {
+        return typeRegistry.getOrDefault(type, Map.class);
+    }
+
+    public static String forClass(Class<?> clazz) {
+        return classRegistry.getOrDefault(clazz, "map");
+    }
+
+    public static boolean isScalarType(Class<?> clazz) {
+        return scalarTypes.contains(clazz);
+    }
+
+    public static Optional<Class<?>> getContainerType(Class<?> clazz,
+                                                      Object value) {
+        return Stream.of(containerTypes)
+                     .filter(type -> type.isInstance(value))
+                     .findFirst();
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
@@ -17,10 +17,6 @@ package org.activiti.api.runtime.test.model.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.Module;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -28,6 +24,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.stream.Stream;
+
 import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,6 +35,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
+
+import com.fasterxml.jackson.databind.Module;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.TextNode;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
 class IntegrationContextImplTest {
@@ -51,7 +53,6 @@ class IntegrationContextImplTest {
                                              Arguments.of(Long.valueOf(100000000000L), Long.valueOf(100000000000L)),
                                              Arguments.of(Integer.valueOf(123), Integer.valueOf(123)),
                                              Arguments.of(String.valueOf("string"), String.valueOf("string")),
-                                             Arguments.of(String.valueOf("item1,item2"), String.valueOf("item1,item2")),
                                              Arguments.of(String.valueOf("item1,item2"), String.valueOf("item1,item2")),
                                              Arguments.of(Boolean.valueOf(true), Boolean.valueOf(true)),
                                              Arguments.of('A', 'A'),


### PR DESCRIPTION
This PR fixes variable type names for IntegrationContext variables passed between Rb and Connectors to use simple names instead of full Java class name for data types in the raw json to match types in the ProcessVariables entity stored inside Query and Audit databases, i.e.

The current format contains full Java class name:
```
          "outBoundVariables": {
            "processDefinitionId": {
              "type": "java.lang.String",
              "value": "HeadersConnectorProcess:1:dc32c0bc-9a56-11ea-afc3-92581787ab92"
            },
            "processDefinitionVersion": {
              "type": "java.lang.Integer",
              "value": "1"
            },
            "processDefinitionKey": {
              "type": "java.lang.String",
              "value": "HeadersConnectorProcess"
            }
            "amount": {
              "type": "java.lang.BigDecimal",
              "value": "10.00"
            }
          }
```
The updated format, will contain simple type names:

```
          "outBoundVariables": {
            "processDefinitionId": {
              "type": "string",
              "value": "HeadersConnectorProcess:1:dc32c0bc-9a56-11ea-afc3-92581787ab92"
            },
            "processDefinitionVersion": {
              "type": "integer",
              "value": "1"
            },
            "processDefinitionKey": {
              "type": "string",
              "value": "HeadersConnectorProcess"
            }
            "amount": {
              "type": "bigdecimal",
              "value": "10.00"
            }
         }

```