### PR TITLE
fix: add support for container of object for integration context variables 

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
@@ -58,19 +58,23 @@ import org.activiti.api.runtime.model.impl.BPMNTimerImpl;
 import org.activiti.api.runtime.model.impl.DateToStringConverter;
 import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.api.runtime.model.impl.JsonNodeToStringConverter;
+import org.activiti.api.runtime.model.impl.ListToStringConverter;
 import org.activiti.api.runtime.model.impl.MapToStringConverter;
 import org.activiti.api.runtime.model.impl.MessageSubscriptionImpl;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
+import org.activiti.api.runtime.model.impl.ProcessVariableTypeConverter;
 import org.activiti.api.runtime.model.impl.ProcessVariablesMap;
 import org.activiti.api.runtime.model.impl.ProcessVariablesMapDeserializer;
 import org.activiti.api.runtime.model.impl.ProcessVariablesMapSerializer;
+import org.activiti.api.runtime.model.impl.SetToStringConverter;
 import org.activiti.api.runtime.model.impl.StartMessageDeploymentDefinitionImpl;
 import org.activiti.api.runtime.model.impl.StartMessageSubscriptionImpl;
 import org.activiti.api.runtime.model.impl.StringToDateConverter;
 import org.activiti.api.runtime.model.impl.StringToJsonNodeConverter;
+import org.activiti.api.runtime.model.impl.StringToListConverter;
 import org.activiti.api.runtime.model.impl.StringToMapConverter;
-import org.activiti.api.runtime.model.impl.ProcessVariableTypeConverter;
+import org.activiti.api.runtime.model.impl.StringToSetConverter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -233,6 +237,23 @@ public class ProcessModelAutoConfiguration {
         return new DateToStringConverter();
     }
 
+    @Bean
+    public StringToListConverter sringToListConverter(@Lazy ObjectMapper objectMapper) {
+        return new StringToListConverter(objectMapper);
+    }
 
+    @Bean
+    public ListToStringConverter listToStringConverter(@Lazy ObjectMapper objectMapper) {
+        return new ListToStringConverter(objectMapper);
+    }
 
+    @Bean
+    public StringToSetConverter stringToSetConverter(@Lazy ObjectMapper objectMapper) {
+        return new StringToSetConverter(objectMapper);
+    }
+
+    @Bean
+    public SetToStringConverter setToStringConverter(@Lazy ObjectMapper objectMapper) {
+        return new SetToStringConverter(objectMapper);
+    }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ListToStringConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ListToStringConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import java.util.List;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class ListToStringConverter implements Converter<List<Object>, String> {
+    private final ObjectMapper objectMapper;
+
+    public ListToStringConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String convert(List<Object> source) {
+
+        try {
+            return objectMapper.writeValueAsString(source);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/SetToStringConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/SetToStringConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import java.util.Set;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class SetToStringConverter implements Converter<Set<Object>, String> {
+    private final ObjectMapper objectMapper;
+
+    public SetToStringConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String convert(Set<Object> source) {
+
+        try {
+            return objectMapper.writeValueAsString(source);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToListConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToListConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import java.util.List;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class StringToListConverter implements Converter<String, List<Object>> {
+    private final ObjectMapper objectMapper;
+
+    public StringToListConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public List<Object> convert(String source) {
+        JavaType javaType = objectMapper.getTypeFactory()
+                                        .constructParametricType(List.class,
+                                                                 Object.class);
+        try {
+            return objectMapper.readValue(source, javaType);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToSetConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToSetConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import java.util.Set;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class StringToSetConverter implements Converter<String, Set<Object>> {
+    private final ObjectMapper objectMapper;
+
+    public StringToSetConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Set<Object> convert(String source) {
+        JavaType javaType = objectMapper.getTypeFactory()
+                                        .constructParametricType(Set.class,
+                                                                 Object.class);
+        try {
+            return objectMapper.readValue(source, javaType);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
@@ -15,12 +15,14 @@
  */
 package org.activiti.api.runtime.test.model.impl;
 
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.stream.Stream;
@@ -69,12 +71,11 @@ class IntegrationContextImplTest {
                                              Arguments.of(123.123f, 123.123f),
                                              Arguments.of(null, null),
                                              Arguments.of(Date.from(instant), Date.from(instant)),
-                                             Arguments.of(Collections.singletonList("item"),
-                                                          Collections.singletonList("item")),
-                                             Arguments.of(Collections.singleton("item"),
-                                                          Collections.singleton("item")),
-                                             Arguments.of(Collections.singletonMap("key", "value"),
-                                                          Collections.singletonMap("key", "value")),
+                                             Arguments.of(singletonList("item"), singletonList("item")),
+                                             Arguments.of(singletonList(singletonMap("key", "value")), singletonList(singletonMap("key", "value"))),
+                                             Arguments.of(singleton(singletonMap("key", "value")), singleton(singletonMap("key", "value"))),
+                                             Arguments.of(singleton("item"), singleton("item")),
+                                             Arguments.of(singletonMap("key", "value"), singletonMap("key", "value")),
                                              Arguments.of(JsonNodeFactory.instance.objectNode().set("key", TextNode.valueOf("value")),
                                                           JsonNodeFactory.instance.objectNode().set("key", TextNode.valueOf("value"))),
                                              Arguments.of(new CustomPojo("field1", "field2"),


### PR DESCRIPTION
This PR add support for passing integration context variables  using list/set of objects, i.e.

- [x] List of Maps
- [x] Set of Maps