### PR TITLE
fix(AAE-2825): New serializer for IntegrationRequests produces wrong results #3316

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/pom.xml
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-logging</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
@@ -63,6 +63,7 @@ import org.activiti.api.runtime.model.impl.LocalDateTimeToStringConverter;
 import org.activiti.api.runtime.model.impl.LocalDateToStringConverter;
 import org.activiti.api.runtime.model.impl.MapToStringConverter;
 import org.activiti.api.runtime.model.impl.MessageSubscriptionImpl;
+import org.activiti.api.runtime.model.impl.ObjectValueToStringConverter;
 import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
 import org.activiti.api.runtime.model.impl.ProcessInstanceImpl;
 import org.activiti.api.runtime.model.impl.ProcessVariableTypeConverter;
@@ -78,6 +79,7 @@ import org.activiti.api.runtime.model.impl.StringToListConverter;
 import org.activiti.api.runtime.model.impl.StringToLocalDateConverter;
 import org.activiti.api.runtime.model.impl.StringToLocalDateTimeConverter;
 import org.activiti.api.runtime.model.impl.StringToMapConverter;
+import org.activiti.api.runtime.model.impl.StringToObjectValueConverter;
 import org.activiti.api.runtime.model.impl.StringToSetConverter;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -280,4 +282,15 @@ public class ProcessModelAutoConfiguration {
     public SetToStringConverter setToStringConverter(@Lazy ObjectMapper objectMapper) {
         return new SetToStringConverter(objectMapper);
     }
+
+    @Bean
+    public StringToObjectValueConverter stringToObjectConverter(@Lazy ObjectMapper objectMapper) {
+        return new StringToObjectValueConverter(objectMapper);
+    }
+
+    @Bean
+    public ObjectValueToStringConverter objectToStringConverter(@Lazy ObjectMapper objectMapper) {
+        return new ObjectValueToStringConverter(objectMapper);
+    }
+
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
@@ -284,12 +284,12 @@ public class ProcessModelAutoConfiguration {
     }
 
     @Bean
-    public StringToObjectValueConverter stringToObjectConverter(@Lazy ObjectMapper objectMapper) {
+    public StringToObjectValueConverter stringToObjectValueConverter(@Lazy ObjectMapper objectMapper) {
         return new StringToObjectValueConverter(objectMapper);
     }
 
     @Bean
-    public ObjectValueToStringConverter objectToStringConverter(@Lazy ObjectMapper objectMapper) {
+    public ObjectValueToStringConverter objectValueToStringConverter(@Lazy ObjectMapper objectMapper) {
         return new ObjectValueToStringConverter(objectMapper);
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValue.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValue.java
@@ -15,6 +15,9 @@
  */
 package org.activiti.api.runtime.model.impl;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ObjectValue {
     private Object object;
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValue.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValue.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+public class ObjectValue {
+    private Object object;
+
+    ObjectValue() {
+    }
+
+    public ObjectValue(Object object) {
+        this.object = object;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import java.util.Map;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class ObjectValueToStringConverter implements Converter<ObjectValue, String> {
+    private final ObjectMapper objectMapper;
+
+    public ObjectValueToStringConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public String convert(ObjectValue source) {
+
+        try {
+            Map<String, Object> value = objectMapper.convertValue(source, Map.class);
+
+            if (Map.class.isInstance(value.get("object"))) {
+                Map<String, Object> object = objectMapper.convertValue(source.getObject(), Map.class);
+
+                if (object.containsKey("@class")) {
+                    Map.class.cast(value.get("object")).put("@class", object.get("@class"));
+                }
+            }
+
+            return objectMapper.writeValueAsString(value);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
@@ -23,23 +23,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ProcessVariableTypeConverter
 public class ObjectValueToStringConverter implements Converter<ObjectValue, String> {
+    private static final String CLASS = "@class";
+    private static final String OBJECT = "object";
     private final ObjectMapper objectMapper;
 
     public ObjectValueToStringConverter(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public String convert(ObjectValue source) {
 
         try {
             Map<String, Object> value = objectMapper.convertValue(source, Map.class);
 
-            if (Map.class.isInstance(value.get("object"))) {
+            if (Map.class.isInstance(value.get(OBJECT))) {
                 Map<String, Object> object = objectMapper.convertValue(source.getObject(), Map.class);
 
-                if (object.containsKey("@class")) {
-                    Map.class.cast(value.get("object")).put("@class", object.get("@class"));
+                if (object.containsKey(CLASS)) {
+                    Map.class.cast(value.get(OBJECT)).put(CLASS, object.get(CLASS));
                 }
             }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ObjectValueToStringConverter.java
@@ -15,6 +15,8 @@
  */
 package org.activiti.api.runtime.model.impl;
 
+import static org.activiti.api.runtime.model.impl.ProcessVariablesMapTypeRegistry.OBJECT_TYPE_KEY;
+
 import java.util.Map;
 
 import org.springframework.core.convert.converter.Converter;
@@ -24,7 +26,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @ProcessVariableTypeConverter
 public class ObjectValueToStringConverter implements Converter<ObjectValue, String> {
     private static final String CLASS = "@class";
-    private static final String OBJECT = "object";
     private final ObjectMapper objectMapper;
 
     public ObjectValueToStringConverter(ObjectMapper objectMapper) {
@@ -38,11 +39,11 @@ public class ObjectValueToStringConverter implements Converter<ObjectValue, Stri
         try {
             Map<String, Object> value = objectMapper.convertValue(source, Map.class);
 
-            if (Map.class.isInstance(value.get(OBJECT))) {
+            if (Map.class.isInstance(value.get(OBJECT_TYPE_KEY))) {
                 Map<String, Object> object = objectMapper.convertValue(source.getObject(), Map.class);
 
                 if (object.containsKey(CLASS)) {
-                    Map.class.cast(value.get(OBJECT)).put(CLASS, object.get(CLASS));
+                    Map.class.cast(value.get(OBJECT_TYPE_KEY)).put(CLASS, object.get(CLASS));
                 }
             }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
@@ -61,13 +61,11 @@ public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVar
                     map.put(name, result);
                 }
                 else {
-                    // TODO implement fallback
                     Object value = null;
                     try {
                         value = new ObjectMapper().treeToValue(entryValue,
                                                                Object.class);
                     } catch (JsonProcessingException e) {
-                        // TODO Auto-generated catch block
                         e.printStackTrace();
                     }
                     map.put(name, value);

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
@@ -51,7 +51,13 @@ public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVar
                 Class<?> clazz = ProcessVariablesMapTypeRegistry.forType(type);
                 Object result = conversionService.convert(value, clazz);
 
+                if(ObjectValue.class.isInstance(result)) {
+                    result = ObjectValue.class.cast(result)
+                                              .getObject();
+                }
+
                 map.put(name, result);
+
             } else {
                 map.put(name, null);
             }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapDeserializer.java
@@ -17,6 +17,8 @@ package org.activiti.api.runtime.model.impl;
 
 import java.io.IOException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.convert.ConversionService;
 
 import com.fasterxml.jackson.core.JsonParser;
@@ -27,7 +29,11 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVariablesMap<String, Object>> {
+    private static final Logger logger = LoggerFactory.getLogger(ProcessVariablesMapDeserializer.class);
 
+    private static final String VALUE = "value";
+    private static final String TYPE = "type";
+    private final static ObjectMapper objectMapper = new ObjectMapper();
     private final ConversionService conversionService;
 
     public ProcessVariablesMapDeserializer(ConversionService conversionService) {
@@ -46,9 +52,9 @@ public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVar
             JsonNode entryValue = entry.getValue();
 
             if(!entryValue.isNull()) {
-                if (entryValue.get("type") != null && entryValue.get("value") != null) {
-                    String type = entryValue.get("type").textValue();
-                    String value = entryValue.get("value").asText();
+                if (entryValue.get(TYPE) != null && entryValue.get(VALUE) != null) {
+                    String type = entryValue.get(TYPE).textValue();
+                    String value = entryValue.get(VALUE).asText();
 
                     Class<?> clazz = ProcessVariablesMapTypeRegistry.forType(type);
                     Object result = conversionService.convert(value, clazz);
@@ -63,10 +69,10 @@ public class ProcessVariablesMapDeserializer extends JsonDeserializer<ProcessVar
                 else {
                     Object value = null;
                     try {
-                        value = new ObjectMapper().treeToValue(entryValue,
-                                                               Object.class);
+                        value = objectMapper.treeToValue(entryValue,
+                                                         Object.class);
                     } catch (JsonProcessingException e) {
-                        e.printStackTrace();
+                        logger.error("Unexpected Json Processing Exception: ", e);
                     }
                     map.put(name, value);
                 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapSerializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapSerializer.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.api.runtime.model.impl;
 
+import static org.activiti.api.runtime.model.impl.ProcessVariablesMapTypeRegistry.OBJECT_TYPE_KEY;
 import static org.activiti.api.runtime.model.impl.ProcessVariablesMapTypeRegistry.forClass;
 import static org.activiti.api.runtime.model.impl.ProcessVariablesMapTypeRegistry.getContainerType;
 import static org.activiti.api.runtime.model.impl.ProcessVariablesMapTypeRegistry.isScalarType;
@@ -26,13 +27,11 @@ import java.util.Map;
 import org.springframework.core.convert.ConversionService;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 public class ProcessVariablesMapSerializer extends StdSerializer<ProcessVariablesMap<String, Object>> {
 
-    private static final String OBJECT = "object";
     private static final long serialVersionUID = 1L;
     private final ConversionService conversionService;
 
@@ -57,15 +56,14 @@ public class ProcessVariablesMapSerializer extends StdSerializer<ProcessVariable
         gen.writeObject(map);
     }
 
-    private ProcessVariableValue buildProcessVariableValue(Object value)
-        throws JsonProcessingException {
+    private ProcessVariableValue buildProcessVariableValue(Object value) {
         ProcessVariableValue variableValue = null;
 
         if (value != null) {
             Class<?> entryValueClass = value.getClass();
             String entryType = resolveEntryType(entryValueClass, value);
 
-            if(OBJECT.equals(entryType)) {
+            if (OBJECT_TYPE_KEY.equals(entryType)) {
                 value = new ObjectValue(value);
             }
 
@@ -82,8 +80,7 @@ public class ProcessVariablesMapSerializer extends StdSerializer<ProcessVariable
 
         if (isScalarType(clazz)) {
             entryType = clazz;
-        }
-        else {
+        } else {
             entryType = getContainerType(clazz, value)
                             .orElse(ObjectValue.class);
         }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapSerializer.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapSerializer.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 public class ProcessVariablesMapSerializer extends StdSerializer<ProcessVariablesMap<String, Object>> {
 
+    private static final String OBJECT = "object";
     private static final long serialVersionUID = 1L;
     private final ConversionService conversionService;
 
@@ -64,7 +65,7 @@ public class ProcessVariablesMapSerializer extends StdSerializer<ProcessVariable
             Class<?> entryValueClass = value.getClass();
             String entryType = resolveEntryType(entryValueClass, value);
 
-            if("object".equals(entryType)) {
+            if(OBJECT.equals(entryType)) {
                 value = new ObjectValue(value);
             }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
@@ -79,6 +79,7 @@ public class ProcessVariablesMapTypeRegistry {
         typeRegistry.put("map", Map.class);
         typeRegistry.put("set", Set.class);
         typeRegistry.put("list", List.class);
+        typeRegistry.put("object", ObjectValue.class);
 
         classRegistry.put(Byte.class, "byte");
         classRegistry.put(Character.class, "character");
@@ -97,10 +98,11 @@ public class ProcessVariablesMapTypeRegistry {
         classRegistry.put(List.class, "list");
         classRegistry.put(Set.class, "set");
         classRegistry.put(LocalDateTime.class, "localdatetime");
+        classRegistry.put(ObjectValue.class, "object");
     }
 
     public static Class<?> forType(String type) {
-        return forType(type, Map.class);
+        return forType(type, ObjectValue.class);
     }
 
     public static Class<?> forType(String type, Class<?> defaultType) {
@@ -108,7 +110,7 @@ public class ProcessVariablesMapTypeRegistry {
     }
 
     public static String forClass(Class<?> clazz) {
-        return classRegistry.getOrDefault(clazz, "map");
+        return classRegistry.getOrDefault(clazz, "object");
     }
 
     public static boolean isScalarType(Class<?> clazz) {
@@ -120,6 +122,16 @@ public class ProcessVariablesMapTypeRegistry {
         return Stream.of(containerTypes)
                      .filter(type -> type.isInstance(value))
                      .findFirst();
+    }
+
+    public static boolean canConvert(Object value) {
+        Class<?> clazz = value.getClass();
+
+        return scalarTypes.contains(clazz) || getContainerType(clazz, value).isPresent();
+    }
+
+    public static boolean containsType(String type) {
+        return typeRegistry.containsKey(type);
     }
 
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class ProcessVariablesMapTypeRegistry {
 
+    private static final String OBJECT = "object";
     private static Map<String, Class<?>> typeRegistry = new HashMap<>();
     private static Map<Class<?>, String> classRegistry = new HashMap<>();
     private static List<Class<?>> scalarTypes = Arrays.asList(int.class,
@@ -79,7 +80,7 @@ public class ProcessVariablesMapTypeRegistry {
         typeRegistry.put("map", Map.class);
         typeRegistry.put("set", Set.class);
         typeRegistry.put("list", List.class);
-        typeRegistry.put("object", ObjectValue.class);
+        typeRegistry.put(OBJECT, ObjectValue.class);
 
         classRegistry.put(Byte.class, "byte");
         classRegistry.put(Character.class, "character");
@@ -98,7 +99,7 @@ public class ProcessVariablesMapTypeRegistry {
         classRegistry.put(List.class, "list");
         classRegistry.put(Set.class, "set");
         classRegistry.put(LocalDateTime.class, "localdatetime");
-        classRegistry.put(ObjectValue.class, "object");
+        classRegistry.put(ObjectValue.class, OBJECT);
     }
 
     public static Class<?> forType(String type) {
@@ -110,7 +111,7 @@ public class ProcessVariablesMapTypeRegistry {
     }
 
     public static String forClass(Class<?> clazz) {
-        return classRegistry.getOrDefault(clazz, "object");
+        return classRegistry.getOrDefault(clazz, OBJECT);
     }
 
     public static boolean isScalarType(Class<?> clazz) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessVariablesMapTypeRegistry.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 public class ProcessVariablesMapTypeRegistry {
 
-    private static final String OBJECT = "object";
+    public static final String OBJECT_TYPE_KEY = "object";
     private static Map<String, Class<?>> typeRegistry = new HashMap<>();
     private static Map<Class<?>, String> classRegistry = new HashMap<>();
     private static List<Class<?>> scalarTypes = Arrays.asList(int.class,
@@ -80,7 +80,7 @@ public class ProcessVariablesMapTypeRegistry {
         typeRegistry.put("map", Map.class);
         typeRegistry.put("set", Set.class);
         typeRegistry.put("list", List.class);
-        typeRegistry.put(OBJECT, ObjectValue.class);
+        typeRegistry.put(OBJECT_TYPE_KEY, ObjectValue.class);
 
         classRegistry.put(Byte.class, "byte");
         classRegistry.put(Character.class, "character");
@@ -99,7 +99,7 @@ public class ProcessVariablesMapTypeRegistry {
         classRegistry.put(List.class, "list");
         classRegistry.put(Set.class, "set");
         classRegistry.put(LocalDateTime.class, "localdatetime");
-        classRegistry.put(ObjectValue.class, OBJECT);
+        classRegistry.put(ObjectValue.class, OBJECT_TYPE_KEY);
     }
 
     public static Class<?> forType(String type) {
@@ -111,7 +111,7 @@ public class ProcessVariablesMapTypeRegistry {
     }
 
     public static String forClass(Class<?> clazz) {
-        return classRegistry.getOrDefault(clazz, OBJECT);
+        return classRegistry.getOrDefault(clazz, OBJECT_TYPE_KEY);
     }
 
     public static boolean isScalarType(Class<?> clazz) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import org.springframework.core.convert.converter.Converter;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@ProcessVariableTypeConverter
+public class StringToObjectValueConverter implements Converter<String, ObjectValue> {
+    private final ObjectMapper objectMapper;
+
+    public StringToObjectValueConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public ObjectValue convert(String source) {
+        try {
+
+            this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+            return objectMapper.readValue(source, ObjectValue.class);
+        } catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
@@ -17,7 +17,6 @@ package org.activiti.api.runtime.model.impl;
 
 import org.springframework.core.convert.converter.Converter;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ProcessVariableTypeConverter
@@ -31,9 +30,6 @@ public class StringToObjectValueConverter implements Converter<String, ObjectVal
     @Override
     public ObjectValue convert(String source) {
         try {
-
-            this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
-
             return objectMapper.readValue(source, ObjectValue.class);
         } catch (Exception cause) {
             throw new RuntimeException(cause);

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/StringToObjectValueConverter.java
@@ -17,6 +17,7 @@ package org.activiti.api.runtime.model.impl;
 
 import org.springframework.core.convert.converter.Converter;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 @ProcessVariableTypeConverter
@@ -30,6 +31,9 @@ public class StringToObjectValueConverter implements Converter<String, ObjectVal
     @Override
     public ObjectValue convert(String source) {
         try {
+
+            this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
             return objectMapper.readValue(source, ObjectValue.class);
         } catch (Exception cause) {
             throw new RuntimeException(cause);

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
@@ -42,7 +42,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -105,8 +104,7 @@ class IntegrationContextImplTest {
 
         @Bean
         public ObjectMapper objectMapper(Module customizeProcessModelObjectMapper) {
-            return new ObjectMapper().registerModule(customizeProcessModelObjectMapper)
-                                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            return new ObjectMapper().registerModule(customizeProcessModelObjectMapper);
         }
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
@@ -42,6 +42,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.context.annotation.Bean;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -104,7 +105,8 @@ class IntegrationContextImplTest {
 
         @Bean
         public ObjectMapper objectMapper(Module customizeProcessModelObjectMapper) {
-            return new ObjectMapper().registerModule(customizeProcessModelObjectMapper);
+            return new ObjectMapper().registerModule(customizeProcessModelObjectMapper)
+                                     .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         }
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/test/java/org/activiti/api/runtime/test/model/impl/IntegrationContextImplTest.java
@@ -26,6 +26,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.Currency;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.stream.Stream;
@@ -73,6 +74,7 @@ class IntegrationContextImplTest {
                                              Arguments.of(123.123, 123.123),
                                              Arguments.of(123.123f, 123.123f),
                                              Arguments.of(null, null),
+                                             Arguments.of(Currency.getInstance("USD"), "USD"),
                                              Arguments.of(Date.from(instant), Date.from(instant)),
                                              Arguments.of(LocalDate.ofInstant(instant, ZoneOffset.UTC), LocalDate.ofInstant(instant, ZoneOffset.UTC)),
                                              Arguments.of(LocalDateTime.ofInstant(instant, ZoneOffset.UTC), LocalDateTime.ofInstant(instant, ZoneOffset.UTC)),


### PR DESCRIPTION
Fixes #3316

This PR applies object type for serializing/deserializing integration request process variables that do not have registered type. 

The deserializer will fall back to regular key/value map in order to maintain backward compatibility with previous versions of Activiti Cloud integration context serialization using standard object mapper. 