### PR TITLE
fix: Update ProcessModelAutoConfiguration to use internal Conversion Service

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
@@ -117,7 +117,7 @@ public class ProcessModelAutoConfiguration {
     //this bean will be automatically injected inside boot's ObjectMapper
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)
-    public Module customizeProcessModelObjectMapper(ObjectProvider<ConversionService> conversionServiceProvider) {
+    public Module customizeProcessModelObjectMapper() {
         SimpleModule module = new SimpleModule("mapProcessModelInterfaces",
                                                Version.unknownVersion());
         SimpleAbstractTypeResolver resolver = new SimpleAbstractTypeResolver() {
@@ -195,7 +195,7 @@ public class ProcessModelAutoConfiguration {
                                               MessageEventPayload.class.getSimpleName()));
         module.setAbstractTypes(resolver);
 
-        ConversionService conversionService = conversionServiceProvider.getIfUnique(this::conversionService);
+        ConversionService conversionService = this.conversionService();
 
         module.addSerializer(new ProcessVariablesMapSerializer(conversionService));
 


### PR DESCRIPTION
This PR removes injecting integration context variable converters into existing ConversionService to avoid conflicts with default Spring MVC ConversionService.