### PR TITLE
fix(AAE-2166): CommandContext close listener being called inside the transaction

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultJobManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultJobManager.java
@@ -423,7 +423,6 @@ public class DefaultJobManager implements JobManager {
 
   protected void hintAsyncExecutor(JobEntity job) {
     AsyncJobAddedNotification jobAddedNotification = new AsyncJobAddedNotification(job, getAsyncExecutor());
-    //getCommandContext().addCloseListener(jobAddedNotification);
     TransactionContext transactionContext = Context.getTransactionContext();
 
     transactionContext.addTransactionListener(TransactionState.COMMITTED, new TransactionListener() {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultJobManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/asyncexecutor/DefaultJobManager.java
@@ -37,6 +37,9 @@ import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.calendar.BusinessCalendar;
 import org.activiti.engine.impl.calendar.CycleBusinessCalendar;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.cfg.TransactionContext;
+import org.activiti.engine.impl.cfg.TransactionListener;
+import org.activiti.engine.impl.cfg.TransactionState;
 import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.el.NoExecutionVariableScope;
 import org.activiti.engine.impl.interceptor.CommandContext;
@@ -420,7 +423,15 @@ public class DefaultJobManager implements JobManager {
 
   protected void hintAsyncExecutor(JobEntity job) {
     AsyncJobAddedNotification jobAddedNotification = new AsyncJobAddedNotification(job, getAsyncExecutor());
-    getCommandContext().addCloseListener(jobAddedNotification);
+    //getCommandContext().addCloseListener(jobAddedNotification);
+    TransactionContext transactionContext = Context.getTransactionContext();
+
+    transactionContext.addTransactionListener(TransactionState.COMMITTED, new TransactionListener() {
+        @Override
+        public void execute(CommandContext commandContext) {
+            jobAddedNotification.closed(commandContext);
+        }
+    });
   }
 
   protected JobEntity internalCreateAsyncJob(ExecutionEntity execution, boolean exclusive) {


### PR DESCRIPTION
This PR investigated close listener for async job notifications via CommandContextListener.close method. Using CommandContext.close method may not work 100% for async executions since it schedules a task in new transaction to execute async continuation behavior while parent transaction is still active. There is a  chance for race conditions because async job transaction starts in a different thread while parent spring transaction may not be committed yet. This problem is hard to reproduce because thread scheduling is not deterministic.

The proposed async job notification implementation should use different approach to register transaction listener instead of command context listener, so that job always scheduled after parent transaction committed.