### PR TITLE
Fix the propagation of variable created event

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/pom.xml
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/pom.xml
@@ -38,5 +38,20 @@
       <groupId>org.activiti</groupId>
       <artifactId>activiti-engine</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/conf/CommonRuntimeAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/conf/CommonRuntimeAutoConfiguration.java
@@ -13,12 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.activiti.runtime.api.conf;
 
 import static java.util.Collections.emptyList;
 
 import java.util.List;
-
 import org.activiti.api.model.shared.event.VariableCreatedEvent;
 import org.activiti.api.model.shared.event.VariableUpdatedEvent;
 import org.activiti.api.runtime.shared.events.VariableEventListener;
@@ -27,6 +27,7 @@ import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.runtime.api.event.impl.ToVariableCreatedConverter;
 import org.activiti.runtime.api.event.impl.ToVariableUpdatedConverter;
 import org.activiti.runtime.api.event.internal.VariableCreatedListenerDelegate;
+import org.activiti.runtime.api.event.internal.VariableEventFilter;
 import org.activiti.runtime.api.event.internal.VariableUpdatedListenerDelegate;
 import org.activiti.runtime.api.impl.VariableNameValidator;
 import org.activiti.runtime.api.model.impl.APIVariableInstanceConverter;
@@ -44,9 +45,18 @@ public class CommonRuntimeAutoConfiguration {
     }
 
     @Bean
+    public VariableEventFilter variableEventFilter() {
+        return new VariableEventFilter();
+    }
+
+    @Bean
     public InitializingBean registerVariableCreatedListenerDelegate(RuntimeService runtimeService,
-                                                                    @Autowired(required = false) List<VariableEventListener<VariableCreatedEvent>> listeners) {
-        return () -> runtimeService.addEventListener(new VariableCreatedListenerDelegate(getInitializedListeners(listeners), new ToVariableCreatedConverter()), ActivitiEventType.VARIABLE_CREATED);
+        @Autowired(required = false) List<VariableEventListener<VariableCreatedEvent>> listeners,
+        VariableEventFilter variableEventFilter) {
+        return () -> runtimeService.addEventListener(
+            new VariableCreatedListenerDelegate(getInitializedListeners(listeners),
+                new ToVariableCreatedConverter(),
+                variableEventFilter), ActivitiEventType.VARIABLE_CREATED);
     }
 
     private <T> List<T> getInitializedListeners(List<T> eventListeners) {
@@ -55,8 +65,12 @@ public class CommonRuntimeAutoConfiguration {
 
     @Bean
     public InitializingBean registerVariableUpdatedListenerDelegate(RuntimeService runtimeService,
-                                                                    @Autowired(required = false) List<VariableEventListener<VariableUpdatedEvent>> listeners) {
-        return () -> runtimeService.addEventListener(new VariableUpdatedListenerDelegate(getInitializedListeners(listeners), new ToVariableUpdatedConverter()), ActivitiEventType.VARIABLE_UPDATED);
+        @Autowired(required = false) List<VariableEventListener<VariableUpdatedEvent>> listeners,
+        VariableEventFilter variableEventFilter) {
+        return () -> runtimeService.addEventListener(
+            new VariableUpdatedListenerDelegate(getInitializedListeners(listeners),
+                new ToVariableUpdatedConverter(),
+                variableEventFilter), ActivitiEventType.VARIABLE_UPDATED);
     }
 
     @Bean

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/internal/VariableCreatedListenerDelegate.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/internal/VariableCreatedListenerDelegate.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.activiti.runtime.api.event.internal;
 
 import org.activiti.api.model.shared.event.VariableCreatedEvent;
@@ -30,23 +31,31 @@ public class VariableCreatedListenerDelegate implements ActivitiEventListener {
 
     private final ToVariableCreatedConverter converter;
 
-    public VariableCreatedListenerDelegate(List<VariableEventListener<VariableCreatedEvent>> listeners,
-                                           ToVariableCreatedConverter converter) {
+    private final VariableEventFilter variableEventFilter;
+
+    public VariableCreatedListenerDelegate(
+        List<VariableEventListener<VariableCreatedEvent>> listeners,
+        ToVariableCreatedConverter converter,
+        VariableEventFilter variableEventFilter) {
         this.listeners = listeners;
         this.converter = converter;
+        this.variableEventFilter = variableEventFilter;
     }
 
     @Override
     public void onEvent(ActivitiEvent event) {
         if (event instanceof ActivitiVariableEvent) {
-            converter.from((ActivitiVariableEvent) event)
+            ActivitiVariableEvent internalEvent = (ActivitiVariableEvent) event;
+            if (variableEventFilter.shouldEmmitEvent(internalEvent)) {
+                converter.from(internalEvent)
                     .ifPresent(convertedEvent -> {
                         if (listeners != null) {
-                            for ( VariableEventListener<VariableCreatedEvent> listener : listeners ) {
+                            for (VariableEventListener<VariableCreatedEvent> listener : listeners) {
                                 listener.onEvent(convertedEvent);
                             }
                         }
                     });
+            }
         }
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/internal/VariableEventFilter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/internal/VariableEventFilter.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.event.internal;
+
+import org.activiti.engine.delegate.event.ActivitiVariableEvent;
+
+public class VariableEventFilter {
+
+    public boolean shouldEmmitEvent(ActivitiVariableEvent event) {
+        return event.getExecutionId().equals(event.getProcessInstanceId()) || event.getTaskId() != null;
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableCreatedListenerDelegateTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableCreatedListenerDelegateTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.event.internal;
+
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Arrays;
+import java.util.Optional;
+import org.activiti.api.model.shared.event.VariableCreatedEvent;
+import org.activiti.api.runtime.shared.events.VariableEventListener;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
+import org.activiti.runtime.api.event.impl.ToVariableCreatedConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class VariableCreatedListenerDelegateTest {
+
+    private VariableCreatedListenerDelegate variableCreatedListenerDelegate;
+
+    @Mock
+    private VariableEventListener<VariableCreatedEvent> firstListener;
+
+    @Mock
+    private VariableEventListener<VariableCreatedEvent> secondListener;
+
+    @Mock
+    private ToVariableCreatedConverter converter;
+
+    @Mock
+    private VariableEventFilter variableEventFilter;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+
+        variableCreatedListenerDelegate = new VariableCreatedListenerDelegate(
+            Arrays.asList(firstListener, secondListener), converter, variableEventFilter);
+    }
+
+    @Test
+    public void onEvent_should_callListenersWhenItsVariableEventAndItsNotFiltered() {
+        //given
+        ActivitiVariableEventImpl internalEvent = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_CREATED);
+        given(variableEventFilter.shouldEmmitEvent(internalEvent)).willReturn(true);
+        VariableCreatedEvent apiEvent = mock(VariableCreatedEvent.class);
+        given(converter.from(internalEvent)).willReturn(Optional.of(
+            apiEvent));
+
+        //when
+        variableCreatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verify(firstListener).onEvent(apiEvent);
+        verify(secondListener).onEvent(apiEvent);
+    }
+
+    @Test
+    public void onEvent_shouldNot_callListenersWhenItsNotAVariableEvent() {
+        //given
+        ActivitiEvent internalEvent = mock(ActivitiEvent.class);
+
+        //when
+        variableCreatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verifyNoInteractions(firstListener);
+        verifyNoInteractions(secondListener);
+    }
+
+    @Test
+    public void onEvent_shouldNot_callListenersWhenItsFiltered() {
+        //given
+        ActivitiVariableEventImpl internalEvent = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_CREATED);
+        given(variableEventFilter.shouldEmmitEvent(internalEvent)).willReturn(false);
+        VariableCreatedEvent apiEvent = mock(VariableCreatedEvent.class);
+        given(converter.from(internalEvent)).willReturn(Optional.of(
+            apiEvent));
+
+        //when
+        variableCreatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verifyNoInteractions(firstListener);
+        verifyNoInteractions(secondListener);
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableEventFilterTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableEventFilterTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.event.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
+import org.junit.jupiter.api.Test;
+
+public class VariableEventFilterTest {
+
+    private VariableEventFilter variableEventFilter = new VariableEventFilter();
+
+    @Test
+    public void should_emmitEvent_when_executionIdIsEqualsToProcessInstanceId() {
+        //given
+        ActivitiVariableEventImpl event = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_CREATED);
+        event.setExecutionId("id");
+        event.setProcessInstanceId("id");
+
+        //when
+        boolean shouldEmmitEvent = variableEventFilter.shouldEmmitEvent(
+            event);
+
+        //then
+        assertThat(shouldEmmitEvent).isTrue();
+    }
+
+    @Test
+    public void shouldNot_emmitEvent_when_executionIdIsNotEqualsToProcessInstanceIdAndTaskIdIsNotSet() {
+        //given
+        ActivitiVariableEventImpl event = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_CREATED);
+        event.setExecutionId("id");
+        event.setProcessInstanceId("anotherId");
+
+        //when
+        boolean shouldEmmitEvent = variableEventFilter.shouldEmmitEvent(
+            event);
+
+        //then
+        assertThat(shouldEmmitEvent).isFalse();
+    }
+
+    @Test
+    public void should_EmmitEvent_when_taskIdIsSet() {
+        //given
+        ActivitiVariableEventImpl event = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_CREATED);
+        event.setExecutionId("id");
+        event.setProcessInstanceId("anotherId");
+        event.setTaskId("taskId");
+
+        //when
+        boolean shouldEmmitEvent = variableEventFilter.shouldEmmitEvent(event);
+
+        //then
+        assertThat(shouldEmmitEvent).isTrue();
+    }
+
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableUpdatedListenerDelegateTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/internal/VariableUpdatedListenerDelegateTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.runtime.api.event.internal;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.Arrays;
+import java.util.Optional;
+import org.activiti.api.model.shared.event.VariableUpdatedEvent;
+import org.activiti.api.runtime.shared.events.VariableEventListener;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiVariableEventImpl;
+import org.activiti.runtime.api.event.impl.ToVariableUpdatedConverter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+public class VariableUpdatedListenerDelegateTest {
+
+    private VariableUpdatedListenerDelegate variableUpdatedListenerDelegate;
+
+    @Mock
+    private VariableEventListener<VariableUpdatedEvent> firstListener;
+
+    @Mock
+    private VariableEventListener<VariableUpdatedEvent> secondListener;
+
+    @Mock
+    private ToVariableUpdatedConverter converter;
+
+    @Mock
+    private VariableEventFilter variableEventFilter;
+
+    @BeforeEach
+    public void setUp() {
+        initMocks(this);
+        variableUpdatedListenerDelegate = new VariableUpdatedListenerDelegate(
+            Arrays.asList(firstListener, secondListener), converter, variableEventFilter);
+    }
+
+    @Test
+    public void onEvent_should_callListenersWhenItsVariableEventAndItsNotFiltered() {
+        //given
+        ActivitiVariableEventImpl internalEvent = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_UPDATED);
+        given(variableEventFilter.shouldEmmitEvent(internalEvent)).willReturn(true);
+        VariableUpdatedEvent apiEvent = mock(VariableUpdatedEvent.class);
+        given(converter.from(internalEvent)).willReturn(Optional.of(
+            apiEvent));
+
+        //when
+        variableUpdatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verify(firstListener).onEvent(apiEvent);
+        verify(secondListener).onEvent(apiEvent);
+    }
+
+    @Test
+    public void onEvent_shouldNot_callListenersWhenItsNotAVariableEvent() {
+        //given
+        ActivitiEvent internalEvent = mock(ActivitiEvent.class);
+
+        //when
+        variableUpdatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verifyNoInteractions(firstListener);
+        verifyNoInteractions(secondListener);
+    }
+
+    @Test
+    public void onEvent_shouldNot_callListenersWhenItsFiltered() {
+        //given
+        ActivitiVariableEventImpl internalEvent = new ActivitiVariableEventImpl(
+            ActivitiEventType.VARIABLE_UPDATED);
+        given(variableEventFilter.shouldEmmitEvent(internalEvent)).willReturn(false);
+        VariableUpdatedEvent apiEvent = mock(VariableUpdatedEvent.class);
+        given(converter.from(internalEvent)).willReturn(Optional.of(
+            apiEvent));
+
+        //when
+        variableUpdatedListenerDelegate.onEvent(internalEvent);
+
+        //then
+        verifyNoInteractions(firstListener);
+        verifyNoInteractions(secondListener);
+    }
+
+}

--- a/activiti-core/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/ConformanceServiceTaskModifyVariableTest.java
+++ b/activiti-core/activiti-spring-conformance-tests/activiti-spring-conformance-set1/src/test/java/org/activiti/spring/conformance/set1/ConformanceServiceTaskModifyVariableTest.java
@@ -116,7 +116,6 @@ public class ConformanceServiceTaskModifyVariableTest {
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                         BPMNSequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_STARTED,
-                        VariableEvent.VariableEvents.VARIABLE_CREATED,
                         VariableEvent.VariableEvents.VARIABLE_UPDATED,
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                         BPMNSequenceFlowTakenEvent.SequenceFlowEvents.SEQUENCE_FLOW_TAKEN,
@@ -124,7 +123,7 @@ public class ConformanceServiceTaskModifyVariableTest {
                         BPMNActivityEvent.ActivityEvents.ACTIVITY_COMPLETED,
                         ProcessRuntimeEvent.ProcessEvents.PROCESS_COMPLETED);
 
-        assertThat((String)((VariableUpdatedEvent)RuntimeTestConfiguration.collectedEvents.get(8)).getEntity().getValue()).isEqualTo("value1-modified");
+        assertThat((String)((VariableUpdatedEvent)RuntimeTestConfiguration.collectedEvents.get(7)).getEntity().getValue()).isEqualTo("value1-modified");
 
     }
 


### PR DESCRIPTION
Only publish events when it's a process variable or a task variable. This excludes other execution variables as we are not exposing the notion of execution in the new APIs and in audit and query service.

Ref https://github.com/Activiti/Activiti/pull/3393