### PR TITLE
  Activiti/Activiti#3398 - added processDefinitionName to Task

### DIFF
--- a/activiti-api/activiti-api-task-model/src/main/java/org/activiti/api/task/model/Task.java
+++ b/activiti-api/activiti-api-task-model/src/main/java/org/activiti/api/task/model/Task.java
@@ -74,4 +74,6 @@ public interface Task extends ApplicationElement {
     List<String> getCandidateUsers();
 
     List<String> getCandidateGroups();
+
+    String getProcessDefinitionName();
 }

--- a/activiti-core/activiti-api-impl/activiti-api-task-model-impl/src/main/java/org/activiti/api/task/model/impl/TaskImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-task-model-impl/src/main/java/org/activiti/api/task/model/impl/TaskImpl.java
@@ -45,6 +45,7 @@ public class TaskImpl extends ApplicationElementImpl implements Task {
     private String taskDefinitionKey;
     private List<String> candidateUsers;
     private List<String> candidateGroups;
+    private String processDefinitionName;
 
     public TaskImpl() {
     }
@@ -252,6 +253,15 @@ public class TaskImpl extends ApplicationElementImpl implements Task {
     }
     
     @Override
+    public String getProcessDefinitionName() {
+        return processDefinitionName;
+    }
+
+    public void setProcessDefinitionName(String processDefinitionName) {
+        this.processDefinitionName = processDefinitionName;
+    }
+    
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -298,7 +308,9 @@ public class TaskImpl extends ApplicationElementImpl implements Task {
                 Objects.equals(businessKey,
                                task.businessKey) &&
                 Objects.equals(taskDefinitionKey,
-                               task.taskDefinitionKey);
+                               task.taskDefinitionKey) &&
+                Objects.equals(processDefinitionName,
+                        task.processDefinitionName);
     }
 
     @Override
@@ -322,7 +334,8 @@ public class TaskImpl extends ApplicationElementImpl implements Task {
                             duration,
                             processDefinitionVersion,
                             businessKey,
-                            taskDefinitionKey);
+                            taskDefinitionKey,
+                            processDefinitionName);
     }
 
     @Override
@@ -345,6 +358,7 @@ public class TaskImpl extends ApplicationElementImpl implements Task {
                 ", processDefinitionVersion=" + processDefinitionVersion +
                 ", businessKey=" + businessKey +
                 ", taskDefinitionKey=" + taskDefinitionKey +
+                ", processDefinitionName=" + processDefinitionName +
                 '}';
     }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityImpl.java
@@ -100,6 +100,8 @@ public class TaskEntityImpl extends VariableScopeImpl implements TaskEntity, Ser
 
   protected String businessKey;
 
+  protected String processDefinitionName;
+
   public TaskEntityImpl() {
 
   }
@@ -441,6 +443,14 @@ public class TaskEntityImpl extends VariableScopeImpl implements TaskEntity, Ser
 
   public void setProcessDefinitionId(String processDefinitionId) {
     this.processDefinitionId = processDefinitionId;
+  }
+
+  public String getProcessDefinitionName() {
+    return processDefinitionName;
+  }
+
+  public void setProcessDefinitionName(String processDefinitionName) {
+    this.processDefinitionName = processDefinitionName;
   }
 
   public String getAssignee() {


### PR DESCRIPTION
Added processDefinitionNama to Task interface. 
As described in the issue [#3398](https://github.com/Activiti/Activiti/issues/3398) we need to return this value in the task api