### PR TITLE
fix(GH-3425): Exception getting ProcessDefinitions with multple versions

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -473,6 +473,8 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         return deploymentConverter.from(
                 repositoryService
                     .createDeploymentQuery()
+                    .deploymentName("SpringAutoDeployment")
+                    .latestVersion()
                     .singleResult()
         );
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -473,7 +473,6 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         return deploymentConverter.from(
                 repositoryService
                     .createDeploymentQuery()
-                    .deploymentKey("ApplicationAutoDeployment")
                     .latest()
                     .singleResult()
         );

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -473,6 +473,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         return deploymentConverter.from(
                 repositoryService
                     .createDeploymentQuery()
+                    .latest()
                     .singleResult()
         );
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -473,6 +473,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         return deploymentConverter.from(
                 repositoryService
                     .createDeploymentQuery()
+                    .deploymentKey("ApplicationAutoDeployment")
                     .latest()
                     .singleResult()
         );

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -473,7 +473,6 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         return deploymentConverter.from(
                 repositoryService
                     .createDeploymentQuery()
-                    .latest()
                     .singleResult()
         );
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -17,7 +17,6 @@ package org.activiti.runtime.api.impl;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.activiti.api.model.shared.model.VariableInstance;
@@ -141,7 +140,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
     private void checkProcessDefinitionBelongsToLatestDeployment(org.activiti.engine.repository.ProcessDefinition processDefinition) {
         Integer appVersion = processDefinition.getAppVersion();
 
-        if (appVersion != null && !Objects.equals(selectLatestDeployment().getVersion(), appVersion)) {
+        if (appVersion != null && !selectLatestDeployment().getVersion().equals(appVersion)) {
             throw new UnprocessableEntityException("Process definition with the given id:'" + processDefinition.getId() + "' belongs to a different application version.");
         }
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -128,10 +128,8 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
     }
 
     private Optional<org.activiti.engine.repository.ProcessDefinition> findLatestProcessDefinitionByKey(String processDefinitionKey) {
-        Deployment deployment = selectLatestDeployment();
-
         return repositoryService.createProcessDefinitionQuery()
-            .deploymentId(deployment.getId())
+            .latestVersion()
             .processDefinitionKey(processDefinitionKey)
             .orderByProcessDefinitionAppVersion()
             .desc()
@@ -167,11 +165,10 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             getProcessDefinitionsPayload.setProcessDefinitionKeys(securityKeysInPayload.getProcessDefinitionKeys());
         }
 
-        Deployment deployment = selectLatestDeployment();
-
         ProcessDefinitionQuery processDefinitionQuery = repositoryService
                 .createProcessDefinitionQuery()
-                .deploymentId(deployment.getId());
+                .latestVersion();
+
         if (getProcessDefinitionsPayload.hasDefinitionKeys()) {
             processDefinitionQuery.processDefinitionKeys(getProcessDefinitionsPayload.getProcessDefinitionKeys());
         }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -158,8 +158,7 @@ public class ProcessRuntimeImplTest {
 
         given(deploymentConverter.from(any(Deployment.class))).willReturn(deployment);
 
-        given(commandExecutor.execute(any())).willReturn(new DeploymentEntityImpl())
-                                             .willReturn(findProcessDefinitionResult);
+        given(commandExecutor.execute(any())).willReturn(findProcessDefinitionResult);
         given(securityPoliciesManager.canRead(processDefinitionKey)).willReturn(true);
 
         processRuntime.processDefinition(processDefinitionId);
@@ -182,7 +181,6 @@ public class ProcessRuntimeImplTest {
 
         given(deploymentConverter.from(latestDeploymentEntity)).willReturn(latestDeployment);
         given(commandExecutor.execute(any()))
-            .willReturn(latestDeploymentEntity)
             .willReturn(findProcessDefinitionResult)
             .willReturn(latestDeploymentEntity)
             .willReturn(latestDeployment);
@@ -211,7 +209,6 @@ public class ProcessRuntimeImplTest {
 
         given(deploymentConverter.from(latestDeploymentEntity)).willReturn(deployment);
         given(commandExecutor.execute(any()))
-            .willReturn(latestDeploymentEntity)
             .willReturn(findProcessDefinitionResult)
             .willReturn(latestDeploymentEntity);
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -86,13 +87,11 @@ public class ProcessRuntimeImplTest {
     @Mock
     private APIProcessDefinitionConverter processDefinitionConverter;
 
-    private RepositoryServiceImpl repositoryService;
-
     @BeforeEach
     public void setUp() {
         initMocks(this);
 
-        repositoryService = spy(new RepositoryServiceImpl());
+        RepositoryServiceImpl repositoryService = new RepositoryServiceImpl();
         repositoryService.setCommandExecutor(commandExecutor);
 
         processRuntime = spy(new ProcessRuntimeImpl(repositoryService,
@@ -152,18 +151,13 @@ public class ProcessRuntimeImplTest {
         processDefinition.setAppVersion(null);
         List<ProcessDefinition> findProcessDefinitionResult = singletonList(processDefinition);
 
-        DeploymentImpl deployment = new DeploymentImpl();
-        deployment.setId("deploymentId");
-        deployment.setName("SpringAutoDeployment");
-
-        given(deploymentConverter.from(any(Deployment.class))).willReturn(deployment);
-
         given(commandExecutor.execute(any())).willReturn(findProcessDefinitionResult);
         given(securityPoliciesManager.canRead(processDefinitionKey)).willReturn(true);
 
         processRuntime.processDefinition(processDefinitionId);
 
         verify(processDefinitionConverter).from(processDefinition);
+        verifyZeroInteractions(deploymentConverter);
     }
 
     @Test
@@ -177,7 +171,6 @@ public class ProcessRuntimeImplTest {
         Deployment latestDeploymentEntity = new DeploymentEntityImpl();
         DeploymentImpl latestDeployment = new DeploymentImpl();
         latestDeployment.setVersion(2);
-        latestDeployment.setId("deploymentId");
 
         given(deploymentConverter.from(latestDeploymentEntity)).willReturn(latestDeployment);
         given(commandExecutor.execute(any()))
@@ -205,7 +198,6 @@ public class ProcessRuntimeImplTest {
         Deployment latestDeploymentEntity = new DeploymentEntityImpl();
         DeploymentImpl deployment = new DeploymentImpl();
         deployment.setVersion(1);
-        deployment.setId("deploymentId");
 
         given(deploymentConverter.from(latestDeploymentEntity)).willReturn(deployment);
         given(commandExecutor.execute(any()))

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
@@ -47,6 +47,7 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
   protected String processDefinitionKey;
   protected String processDefinitionKeyLike;
   protected boolean latest;
+  protected boolean latestVersion;
 
   public DeploymentQueryImpl() {
   }
@@ -169,6 +170,17 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
     return this;
   }
 
+  @Override
+  public DeploymentQuery latestVersion() {
+    if (name == null) {
+      throw new ActivitiIllegalArgumentException("latest version can only be used together with a deployment name");
+    }
+    
+    this.latestVersion = true;
+    
+    return this;
+  }  
+  
   // sorting ////////////////////////////////////////////////////////
 
   public DeploymentQuery orderByDeploymentId() {
@@ -241,5 +253,9 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
 
   public String getProcessDefinitionKeyLike() {
     return processDefinitionKeyLike;
+  }
+
+  public boolean isLatestVersion() {
+    return latestVersion;
   }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
@@ -20,7 +20,6 @@ package org.activiti.engine.impl;
 import java.io.Serializable;
 import java.util.List;
 
-import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
@@ -200,25 +199,6 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
   public List<Deployment> executeList(CommandContext commandContext, Page page) {
     checkQueryOk();
     return commandContext.getDeploymentEntityManager().findDeploymentsByQueryCriteria(this, page);
-  }
-
-  @Override
-  public Deployment executeSingleResult(CommandContext commandContext){
-
-    Deployment deployment = commandContext.getDeploymentEntityManager().selectLatestDeployment("SpringAutoDeployment");
-
-    if (deployment != null){
-      return deployment;
-    } else {
-      List<Deployment> results = executeList(commandContext, null);
-      if (results.size() == 1) {
-        return results.get(0);
-      } else if (results.size() > 1) {
-        throw new ActivitiException("Query return " + results.size() + " results instead of max 1");
-      }
-      return null;
-    }
-
   }
 
   // getters ////////////////////////////////////////////////////////

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/DeploymentQueryImpl.java
@@ -172,10 +172,6 @@ public class DeploymentQueryImpl extends AbstractQuery<DeploymentQuery, Deployme
 
   @Override
   public DeploymentQuery latestVersion() {
-    if (name == null) {
-      throw new ActivitiIllegalArgumentException("latest version can only be used together with a deployment name");
-    }
-    
     this.latestVersion = true;
     
     return this;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentQuery.java
@@ -19,7 +19,6 @@ package org.activiti.engine.repository;
 
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.api.internal.Internal;
-import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.query.Query;
 
 /**
@@ -106,6 +105,12 @@ public interface DeploymentQuery extends Query<DeploymentQuery, Deployment> {
    * Can only be used together with the deployment key.
    */
   DeploymentQuery latest();
+
+  /**
+   * Only select deployments where the deployment version is the latest value
+   * Can only be used together with the deployment name.
+   */
+  DeploymentQuery latestVersion();
 
   // sorting ////////////////////////////////////////////////////////
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/DeploymentQuery.java
@@ -108,7 +108,6 @@ public interface DeploymentQuery extends Query<DeploymentQuery, Deployment> {
 
   /**
    * Only select deployments where the deployment version is the latest value
-   * Can only be used together with the deployment name.
    */
   DeploymentQuery latestVersion();
 

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
@@ -149,6 +149,11 @@
 	         </if>
         )
       </if>
+      <if test="latestVersion">
+        and RES.VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT where NAME_ = RES.NAME_) 
+        and RES.PROJECT_RELEASE_VERSION_ IS NOT NULL 
+      </if>
+      
     </where>
   </sql>
     

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
@@ -151,7 +151,7 @@
       </if>
       <if test="latestVersion">
         and RES.VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT where NAME_ = RES.NAME_) 
-        and RES.PROJECT_RELEASE_VERSION_ IS NOT NULL 
+         
       </if>
       
     </where>

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
@@ -151,7 +151,6 @@
       </if>
       <if test="latestVersion">
         and RES.VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT where NAME_ = RES.NAME_) 
-         
       </if>
       
     </where>
@@ -169,7 +168,6 @@
     select * from ${prefix}ACT_RE_DEPLOYMENT
     where VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT)
     and NAME_ = #{name, jdbcType=VARCHAR}
-    and PROJECT_RELEASE_VERSION_ IS NOT NULL
   </select>
 
   <!-- mysql specific -->

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
@@ -165,8 +165,9 @@
   </select>
 
   <select id="selectLatestDeployment" parameterType="string" resultMap="deploymentResultMap">
-    select * from ${prefix}ACT_RE_DEPLOYMENT
-    where VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT and NAME_ = #{name, jdbcType=VARCHAR})
+    select * from ${prefix}ACT_RE_DEPLOYMENT RES
+    where VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT and NAME_ = RES.NAME_)
+    and RES.NAME_ = #{name, jdbcType=VARCHAR}
   </select>
 
   <!-- mysql specific -->

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Deployment.xml
@@ -166,8 +166,7 @@
 
   <select id="selectLatestDeployment" parameterType="string" resultMap="deploymentResultMap">
     select * from ${prefix}ACT_RE_DEPLOYMENT
-    where VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT)
-    and NAME_ = #{name, jdbcType=VARCHAR}
+    where VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_DEPLOYMENT and NAME_ = #{name, jdbcType=VARCHAR})
   </select>
 
   <!-- mysql specific -->

--- a/activiti-core/activiti-spring-app-process/src/main/java/org/activiti/application/deployer/ProcessEntryDeployer.java
+++ b/activiti-core/activiti-spring-app-process/src/main/java/org/activiti/application/deployer/ProcessEntryDeployer.java
@@ -34,7 +34,10 @@ public class ProcessEntryDeployer implements ApplicationEntryDeployer {
     @Override
     public void deployEntries(ApplicationContent application) {
         List<FileContent> processContents = application.getFileContents(ProcessEntryDiscovery.PROCESSES);
-        DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name("ApplicationAutoDeployment");
+        DeploymentBuilder deploymentBuilder = repositoryService.createDeployment()
+                                                               .enableDuplicateFiltering()
+                                                               .key("ApplicationAutoDeployment")
+                                                               .name("ApplicationAutoDeployment");
         for (FileContent processContent : processContents) {
             deploymentBuilder.addBytes(processContent.getName(), processContent.getContent());
         }

--- a/activiti-core/activiti-spring-app-process/src/main/java/org/activiti/application/deployer/ProcessEntryDeployer.java
+++ b/activiti-core/activiti-spring-app-process/src/main/java/org/activiti/application/deployer/ProcessEntryDeployer.java
@@ -34,10 +34,7 @@ public class ProcessEntryDeployer implements ApplicationEntryDeployer {
     @Override
     public void deployEntries(ApplicationContent application) {
         List<FileContent> processContents = application.getFileContents(ProcessEntryDiscovery.PROCESSES);
-        DeploymentBuilder deploymentBuilder = repositoryService.createDeployment()
-                                                               .enableDuplicateFiltering()
-                                                               .key("ApplicationAutoDeployment")
-                                                               .name("ApplicationAutoDeployment");
+        DeploymentBuilder deploymentBuilder = repositoryService.createDeployment().enableDuplicateFiltering().name("ApplicationAutoDeployment");
         for (FileContent processContent : processContents) {
             deploymentBuilder.addBytes(processContent.getName(), processContent.getContent());
         }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.Deployment;
 import org.activiti.api.process.model.ProcessDefinition;
@@ -185,6 +186,41 @@ public class ProcessRuntimeIT {
                 .contains(CATEGORIZE_PROCESS,
                         CATEGORIZE_HUMAN_PROCESS,
                         ONE_STEP_PROCESS);
+    }
+
+    @Test
+    public void shouldGetAvailableLatestDeployments() {
+
+        //when
+        List<org.activiti.engine.repository.Deployment> deployments = repositoryService.createDeploymentQuery()
+                                                                                       .latestVersion()
+                                                                                       .list();
+        //then
+        assertThat(deployments).hasSize(2)
+                               .extracting("name", "version", "projectReleaseVersion")
+                               .contains(tuple("SpringAutoDeployment", 1, "1"),
+                                         tuple("ApplicationAutoDeployment", 1, null));
+
+        //when
+        org.activiti.engine.repository.Deployment applicationAutoDeployment = repositoryService.createDeploymentQuery()
+                                                                                     .deploymentName("ApplicationAutoDeployment")
+                                                                                     .latestVersion()
+                                                                                     .singleResult();
+        //then
+        assertThat(applicationAutoDeployment).isNotNull()
+                                             .extracting("name", "version", "projectReleaseVersion")
+                                             .contains("ApplicationAutoDeployment", 1, null);
+
+        //when
+        org.activiti.engine.repository.Deployment springAutoDeployment = repositoryService.createDeploymentQuery()
+                                                                                     .deploymentName("SpringAutoDeployment")
+                                                                                     .latestVersion()
+                                                                                     .singleResult();
+        //then
+        assertThat(springAutoDeployment).isNotNull()
+                                        .extracting("name", "version", "projectReleaseVersion")
+                                        .contains("SpringAutoDeployment", 1, "1");
+
     }
 
     @Test


### PR DESCRIPTION
This PR tried to address issue https://github.com/Activiti/Activiti/issues/3425. I created a project to test deployment migration from M6 -> M9, but was not able to reproduce the problem.

- [x] Implemented latestVersion criteria in DeploymentQueryBuilder Api
- [x] Reverted DeploymentQueryBuilder singleResult override to use latestVersion from DeploymentQueryBuilder in ProcessRuntime.selectLatestDeployment
- [x] Removed existing project version from latest deployment query criteria 
- [x] Replaced process definition in-memory filtering with latest version query criteria
- [x] Fixed findLatestDeploymentVersion by name query criteria

During investigation, I discovered that the implementation of DeploymentQuery.singleResult api was overriding query builder criteria to fetch latest SpringAutoDeployment with existing project version. This may have been causing issues with deployment and process definition queries since Activiti Community does not require project manifest Json. I have removed single result override and implemented latest deployment version criteria in DeploymentQuery builder to be used in selectLatestDeployment Api. I have also removed project version criteria from latest deployment query without breaking any tests.

Another problem that I discovered was using in-memory results filtering for process definitions queries to filter latest deployments based on nullable app version field. This was causing to pick process definitions by key using previous deployment version. 

I have refactored the implementation to use latest version criteria in process definition query to always select latest definitions matching latest deployment version. 