### PR TITLE
Fix unhandled character in versions names

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -1212,10 +1212,9 @@ public class DbSqlSession implements Session {
                                                     nextVersion.length() - "-SNAPSHOT".length());
             }
 
-            dbVersion = dbVersion.replace(".",
-                                          "");
-            nextVersion = nextVersion.replace(".",
-                                              "");
+            dbVersion = dbVersion.replaceAll("[-.]","");
+            nextVersion = nextVersion.replaceAll("[-.]", "");
+            
             log.info("Upgrade needed: {} -> {}. Looking for schema update resource for component '{}'",
                      dbVersion,
                      nextVersion,


### PR DESCRIPTION
FIXES #3445

There were three choices to solve this issue, rename all the SQL files, rename the version without "-" or handle "-" when converting the version name to sql file name.

I've taken the third one because I guess it has less impacts.

Let me know if it should change.

Thanks