### PR TITLE
I think it should not be forced to overwrite assignee

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
@@ -90,7 +90,7 @@ public class TaskRuntimeImpl implements TaskRuntime {
     public Task task(String taskId) {
         return taskConverter.fromWithCandidates(taskRuntimeHelper.getInternalTaskWithChecks(taskId));
     }
-    
+
     private Task reassignedTask(String taskId) {
         return taskConverter.fromWithCandidates(taskRuntimeHelper.getInternalTask(taskId));
     }
@@ -185,7 +185,12 @@ public class TaskRuntimeImpl implements TaskRuntime {
         }
 
         String authenticatedUserId = securityManager.getAuthenticatedUserId();
-        claimTaskPayload.setAssignee(authenticatedUserId);
+        // I think it should not be forced to overwrite assignee
+        // only if the claimTaskPayload assignee is not set, the current login person is the default assignee
+        if (claimTaskPayload.getAssignee() == null || claimTaskPayload.getAssignee().isEmpty()) {
+            claimTaskPayload.setAssignee(authenticatedUserId);
+        }
+        if (claimTaskPayload.get)
         taskService.claim(claimTaskPayload.getTaskId(),
                 claimTaskPayload.getAssignee());
 
@@ -454,27 +459,27 @@ public class TaskRuntimeImpl implements TaskRuntime {
         }
         throw new IllegalStateException("There is no authenticated user, we need a user authenticated to find tasks");
     }
-    
+
     private void assertAssigneeIsACandidateUser(String taskId, String assignee) {
         List<String> userCandidates = userCandidates(taskId);
         if(!userCandidates.contains(assignee)){
             throw new IllegalStateException("You cannot assign a task to " + assignee + " due it is not a candidate for it");
         }
     }
-    
+
     private void reassignTask(String taskId, String assignee) {
         releaseTask(taskId);
         taskService.claim(taskId, assignee);
     }
-    
+
     private void releaseTask(String taskId) {
         assertCanReleaseTask(taskId);
         taskService.unclaim(taskId);
     }
-    
+
     private void assertCanReleaseTask(String taskId) {
         Task task = task(taskId);
-        
+
         if (task.getAssignee() == null || task.getAssignee().isEmpty()) {
             throw new IllegalStateException("You cannot release a task that is not claimed");
         }

--- a/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskRuntimeImpl.java
@@ -190,7 +190,6 @@ public class TaskRuntimeImpl implements TaskRuntime {
         if (claimTaskPayload.getAssignee() == null || claimTaskPayload.getAssignee().isEmpty()) {
             claimTaskPayload.setAssignee(authenticatedUserId);
         }
-        if (claimTaskPayload.get)
         taskService.claim(claimTaskPayload.getTaskId(),
                 claimTaskPayload.getAssignee());
 


### PR DESCRIPTION
only if the claimTaskPayload assignee is not set, the current login person is the default assignee