### PR TITLE
force path to be UTF-8 encoded when parsing BPMN20.xsd

### DIFF
--- a/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
+++ b/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/BpmnXMLConverter.java
@@ -20,6 +20,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -227,11 +229,11 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
     SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
     Schema schema = null;
     if (classloader != null) {
-      schema = factory.newSchema(classloader.getResource(BPMN_XSD));
+      schema = createSchema(factory, classloader.getResource(BPMN_XSD));
     }
 
     if (schema == null) {
-      schema = factory.newSchema(BpmnXMLConverter.class.getClassLoader().getResource(BPMN_XSD));
+      schema = createSchema(factory, BpmnXMLConverter.class.getClassLoader().getResource(BPMN_XSD));
     }
 
     if (schema == null) {
@@ -240,6 +242,15 @@ public class BpmnXMLConverter implements BpmnXMLConstants {
     return schema;
   }
 
+  protected Schema createSchema(SchemaFactory factory, URL schemaUrl) throws SAXException {
+    try {
+      return factory.newSchema(
+              new StreamSource(schemaUrl.toURI().toASCIIString()));
+    } catch (URISyntaxException e) {
+      throw new XMLException("BPMN XSD could not be found", e);
+    }
+  }
+  
   public BpmnModel convertToBpmnModel(InputStreamProvider inputStreamProvider, boolean validateSchema, boolean enableSafeBpmnXml) {
     return convertToBpmnModel(inputStreamProvider, validateSchema, enableSafeBpmnXml, DEFAULT_ENCODING);
   }

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
@@ -1,0 +1,40 @@
+package org.activiti.bpmn.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import org.junit.jupiter.api.Test;
+
+public class BpmnXMLConverterTest {
+    
+    private BpmnXMLConverter bpmnXMLConverter = new BpmnXMLConverter();
+    SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+    @Test
+    public void should_createSchema_when_pathContainsDecodedUTF8Characters() throws Exception {
+        assertThatCode(() -> {
+            bpmnXMLConverter.createSchema(factory, getDecodedUrl("你好/Main.xsd"));
+        }).doesNotThrowAnyException();
+    }
+
+    private URL getDecodedUrl(String path) throws MalformedURLException {
+        URL resource = getClass().getClassLoader().getResource(path);
+        String decodedURL = URLDecoder.decode(resource.toExternalForm(), StandardCharsets.UTF_8);
+        return new URL(decodedURL);
+    }
+
+    @Test
+    public void should_createSchema() throws Exception { 
+        Schema schema = bpmnXMLConverter.createSchema(factory, getClass().getClassLoader()
+                .getResource("org/activiti/impl/bpmn/parser/BPMN20.xsd"));
+        assertThat(schema).isNotNull();
+    }
+    
+}

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.bpmn.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/bpmn/converter/BpmnXMLConverterTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class BpmnXMLConverterTest {
     
     private BpmnXMLConverter bpmnXMLConverter = new BpmnXMLConverter();
-    SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    private SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
     @Test
     public void should_createSchema_when_pathContainsDecodedUTF8Characters() throws Exception {

--- a/activiti-core/activiti-bpmn-converter/src/test/resources/你好/Included.xsd
+++ b/activiti-core/activiti-bpmn-converter/src/test/resources/你好/Included.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+	<xsd:element name="extension" type="tExtension"/>
+	<xsd:complexType name="tExtension">
+		<xsd:attribute name="definition" type="xsd:QName"/>
+		<xsd:attribute name="mustUnderstand" type="xsd:boolean" use="optional" default="false"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/activiti-core/activiti-bpmn-converter/src/test/resources/你好/Main.xsd
+++ b/activiti-core/activiti-bpmn-converter/src/test/resources/你好/Main.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"	
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+	<xsd:include schemaLocation="Included.xsd"/>
+
+	<xsd:element name="definitions" type="tDefinitions"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:sequence>
+			<xsd:element ref="extension" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
Ref <https://github.com/Activiti/Activiti/issues/3571> The issue happened when using ACS with Tomcat so it is also in Activiti 5.x and not only in Activiti 7. 
I tried to add a unit test that replicates the behavior we have on Tomcat. The test itself is more related to the Xerces library than to the Activiti code, but I tried to add them to keep track of the error.