### PR TITLE
[bug-fix]fix NPE when parsing some legal bpmn xml files

### DIFF
--- a/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/ExtensionElementsParser.java
+++ b/activiti-core/activiti-bpmn-converter/src/main/java/org/activiti/bpmn/converter/parser/ExtensionElementsParser.java
@@ -55,7 +55,9 @@ public class ExtensionElementsParser implements BpmnXMLConstants {
           new PotentialStarterParser().parse(xtr, activeProcess);
         } else {
           ExtensionElement extensionElement = BpmnXMLUtil.parseExtensionElement(xtr);
-          parentElement.addExtensionElement(extensionElement);
+          if (parentElement != null) {
+              parentElement.addExtensionElement(extensionElement);
+          }
         }
 
       } else if (xtr.isEndElement()) {

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/CollaborationExtensionElementsConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/CollaborationExtensionElementsConverterTest.java
@@ -16,8 +16,10 @@
 package org.activiti.editor.language.xml;
 
 import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.Pool;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CollaborationExtensionElementsConverterTest extends AbstractConverterTest {
 
@@ -25,6 +27,13 @@ public class CollaborationExtensionElementsConverterTest extends AbstractConvert
   public void convertXMLToModel() throws Exception {
     BpmnModel bpmnModel = readXMLFile();
     Assertions.assertNotNull(bpmnModel);
+    assertThat(bpmnModel.getPools()).isNotEmpty();
+    Pool pool1 = bpmnModel.getPool("BP01");
+    Assertions.assertNotNull(pool1);
+    Assertions.assertEquals("Pool", pool1.getName());
+    Pool pool2 = bpmnModel.getPool("BP02");
+    Assertions.assertNotNull(pool2);
+    Assertions.assertEquals("Pool2", pool2.getName());
   }
 
   protected String getResource() {

--- a/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/CollaborationExtensionElementsConverterTest.java
+++ b/activiti-core/activiti-bpmn-converter/src/test/java/org/activiti/editor/language/xml/CollaborationExtensionElementsConverterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.editor.language.xml;
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CollaborationExtensionElementsConverterTest extends AbstractConverterTest {
+
+  @Test
+  public void convertXMLToModel() throws Exception {
+    BpmnModel bpmnModel = readXMLFile();
+    Assertions.assertNotNull(bpmnModel);
+  }
+
+  protected String getResource() {
+    return "collaborationExtensionElements.bpmn";
+  }
+}

--- a/activiti-core/activiti-bpmn-converter/src/test/resources/collaborationExtensionElements.bpmn
+++ b/activiti-core/activiti-bpmn-converter/src/test/resources/collaborationExtensionElements.bpmn
@@ -1,0 +1,370 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions exporter="Visual Paradigm" exporterVersion="1" id="Definition" targetNamespace="http://www.omg.org/bpmn20" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:vp="http://www.visual-paradigm.com/bpmn/vpspecificcontent" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL http://www.omg.org/spec/BPMN/20100501/BPMN20.xsd">
+  <collaboration id="collaboration-_1">
+    <extensionElements>
+      <vp:Extensions>
+        <vp:DiagramExtension Idref="diagram-_1">
+          <vp:VpId Value="TjYrOB6FYHQgAQWK"/>
+          <vp:DiagramProperties>
+            <vp:StringProperty Name="userID" Value="1"/>
+            <vp:StringProperty Name="pmCreateDateTime" Value="1615391386737"/>
+            <vp:StringProperty Name="pmLastModified" Value="1615391424183"/>
+            <vp:DoubleProperty Name="teamworkCreateDateTime" Value="0"/>
+            <vp:StringProperty Name="documentation_html" Value="&lt;html&gt;&#13;&#10;  &lt;head&gt;&#13;&#10;    &lt;style type=&quot;text/css&quot;&gt;&#10;      &lt;!--&#10;        body { color: #000000; font-family: Dialog; font-size: 12px }&#10;      --&gt;&#10;    &lt;/style&gt;&#13;&#10;    &#13;&#10;  &lt;/head&gt;&#13;&#10;  &lt;body&gt;&#13;&#10;    &lt;p&gt;&#13;&#10;      &#13;&#10;    &lt;/p&gt;&#13;&#10;  &lt;/body&gt;&#13;&#10;&lt;/html&gt;&#13;&#10;"/>
+            <vp:IntegerProperty Name="connectorStyle" Value="5"/>
+            <vp:IntegerProperty Name="connectionPointStyle" Value="1"/>
+            <vp:BooleanProperty Name="maximized" Value="true"/>
+            <vp:IntegerProperty Name="x" Value="0"/>
+            <vp:IntegerProperty Name="y" Value="0"/>
+            <vp:IntegerProperty Name="width" Value="982"/>
+            <vp:IntegerProperty Name="height" Value="597"/>
+            <vp:StringArrayProperty Name="customizedSortDiagramElementIds">
+              <vp:Values>
+                <vp:Value Value="ID_65415653_1601_7205_3007_204000200006"/>
+                <vp:Value Value="ID_65415653_1601_7205_3007_204000200007"/>
+              </vp:Values>
+            </vp:StringArrayProperty>
+          </vp:DiagramProperties>
+        </vp:DiagramExtension>
+        <vp:DiagramElementExtension Idref="ID_51415653_1601_7205_3007_204000200001">
+          <vp:VpId Value="q_ErOB6FYHQgAQWk"/>
+          <vp:ShapeType Value="BPStartEvent"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="6"/>
+            <vp:ColorProperty Name="background" Value="-8728587"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="parentConnectorHeaderLength" Value="40"/>
+            <vp:IntegerProperty Name="parentConnectorLineLength" Value="10"/>
+            <vp:BooleanProperty Name="connectToPoint" Value="true"/>
+            <vp:DoubleProperty Name="parentConnectorDTheta" Value="0.0"/>
+            <vp:BooleanProperty Name="coverConnector" Value="false"/>
+            <vp:BooleanProperty Name="requestDefaultSize" Value="false"/>
+            <vp:IntegerProperty Name="0cpPlct" Value="10"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="0" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="1" Visible="true" Width="20" X="122" Y="251"/>
+          <vp:FillColor Color1="-3934854" Style="1" Transparency="0" Type="1"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_71415653_1601_7205_3007_204000200002">
+          <vp:VpId Value="iZkrOB6FYHQgAQWt"/>
+          <vp:ShapeType Value="BPTask"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="4"/>
+            <vp:ColorProperty Name="background" Value="-8728587"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="parentConnectorHeaderLength" Value="40"/>
+            <vp:IntegerProperty Name="parentConnectorLineLength" Value="10"/>
+            <vp:BooleanProperty Name="connectToPoint" Value="true"/>
+            <vp:DoubleProperty Name="parentConnectorDTheta" Value="0.0"/>
+            <vp:BooleanProperty Name="coverConnector" Value="false"/>
+            <vp:BooleanProperty Name="requestDefaultSize" Value="false"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="40" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="12" Visible="true" Width="50" X="0" Y="0"/>
+          <vp:FillColor Color1="-1116806" Style="1" Transparency="0" Type="1"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_05415653_1601_7205_3007_204000200003">
+          <vp:VpId Value="Q_krOB6FYHQgAQXB"/>
+          <vp:ShapeType Value="BPSequenceFlow"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="12"/>
+            <vp:IntegerProperty Name="x" Value="82"/>
+            <vp:IntegerProperty Name="y" Value="197"/>
+            <vp:IntegerProperty Name="width" Value="206"/>
+            <vp:IntegerProperty Name="height" Value="123"/>
+            <vp:ColorProperty Name="background" Value="-16777216"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="fromShapeXDiff" Value="0"/>
+            <vp:IntegerProperty Name="fromShapeYDiff" Value="0"/>
+            <vp:IntegerProperty Name="toShapeXDiff" Value="0"/>
+            <vp:IntegerProperty Name="toShapeYDiff" Value="0"/>
+            <vp:IntegerProperty Name="fromConnectType" Value="0"/>
+            <vp:IntegerProperty Name="toConnectType" Value="0"/>
+            <vp:BooleanProperty Name="useFromShapeCenter" Value="true"/>
+            <vp:BooleanProperty Name="useToShapeCenter" Value="true"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="0" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="1" Visible="true" Width="20" X="175" Y="269"/>
+          <vp:ConnectorStyle Value="3"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_45415653_1601_7205_3007_204000200004">
+          <vp:VpId Value="jJUrOB6FYHQgAQXN"/>
+          <vp:ShapeType Value="BPEndEvent"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="2"/>
+            <vp:ColorProperty Name="background" Value="-8728587"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="parentConnectorHeaderLength" Value="40"/>
+            <vp:IntegerProperty Name="parentConnectorLineLength" Value="10"/>
+            <vp:BooleanProperty Name="connectToPoint" Value="true"/>
+            <vp:DoubleProperty Name="parentConnectorDTheta" Value="0.0"/>
+            <vp:BooleanProperty Name="coverConnector" Value="false"/>
+            <vp:BooleanProperty Name="requestDefaultSize" Value="false"/>
+            <vp:IntegerProperty Name="0cpPlct" Value="10"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="3.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="0" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="1" Visible="true" Width="20" X="381" Y="302"/>
+          <vp:FillColor Color1="-689542" Style="1" Transparency="0" Type="1"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_25415653_1601_7205_3007_204000200005">
+          <vp:VpId Value="C_UrOB6FYHQgAQXe"/>
+          <vp:ShapeType Value="BPSequenceFlow"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="14"/>
+            <vp:IntegerProperty Name="x" Value="239"/>
+            <vp:IntegerProperty Name="y" Value="220"/>
+            <vp:IntegerProperty Name="width" Value="201"/>
+            <vp:IntegerProperty Name="height" Value="108"/>
+            <vp:ColorProperty Name="background" Value="-16777216"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="fromShapeXDiff" Value="0"/>
+            <vp:IntegerProperty Name="fromShapeYDiff" Value="0"/>
+            <vp:IntegerProperty Name="toShapeXDiff" Value="0"/>
+            <vp:IntegerProperty Name="toShapeYDiff" Value="0"/>
+            <vp:IntegerProperty Name="fromConnectType" Value="0"/>
+            <vp:IntegerProperty Name="toConnectType" Value="0"/>
+            <vp:BooleanProperty Name="useFromShapeCenter" Value="true"/>
+            <vp:BooleanProperty Name="useToShapeCenter" Value="true"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="0" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="1" Visible="true" Width="20" X="329" Y="269"/>
+          <vp:ConnectorStyle Value="3"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_65415653_1601_7205_3007_204000200006">
+          <vp:VpId Value="yb4rOB6FYHQgAQWV"/>
+          <vp:ShapeType Value="BPPool"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="10"/>
+            <vp:ModelRefProperty Name="metaModelElement">
+              <vp:ModelRef Id="BP01" ModelType="BPPool" Name="Pool"/>
+            </vp:ModelRefProperty>
+            <vp:IntegerProperty Name="x" Value="30"/>
+            <vp:IntegerProperty Name="y" Value="176"/>
+            <vp:IntegerProperty Name="width" Value="728"/>
+            <vp:IntegerProperty Name="height" Value="150"/>
+            <vp:ColorProperty Name="background" Value="-8728587"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:StringArrayProperty Name="customizedSortDiagramElementIds">
+              <vp:Values>
+                <vp:Value Value="ID_51415653_1601_7205_3007_204000200001"/>
+                <vp:Value Value="ID_71415653_1601_7205_3007_204000200002"/>
+                <vp:Value Value="ID_05415653_1601_7205_3007_204000200003"/>
+                <vp:Value Value="ID_45415653_1601_7205_3007_204000200004"/>
+                <vp:Value Value="ID_25415653_1601_7205_3007_204000200005"/>
+              </vp:Values>
+            </vp:StringArrayProperty>
+            <vp:IntegerProperty Name="parentConnectorHeaderLength" Value="40"/>
+            <vp:IntegerProperty Name="parentConnectorLineLength" Value="10"/>
+            <vp:BooleanProperty Name="connectToPoint" Value="true"/>
+            <vp:DoubleProperty Name="parentConnectorDTheta" Value="0.0"/>
+            <vp:BooleanProperty Name="coverConnector" Value="false"/>
+            <vp:BooleanProperty Name="requestDefaultSize" Value="false"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="150" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="8" Visible="true" Width="17" X="0" Y="0"/>
+          <vp:FillColor Color1="-7873291" Style="1" Transparency="0" Type="1"/>
+        </vp:DiagramElementExtension>
+        <vp:DiagramElementExtension Idref="ID_65415653_1601_7205_3007_204000200007">
+          <vp:VpId Value="fyErOB6FYHQgAQWb"/>
+          <vp:ShapeType Value="BPPool"/>
+          <vp:DiagramElementProperties>
+            <vp:IntegerProperty Name="zOrder" Value="8"/>
+            <vp:ModelRefProperty Name="metaModelElement">
+              <vp:ModelRef Id="BP02" ModelType="BPPool" Name="Pool2"/>
+            </vp:ModelRefProperty>
+            <vp:IntegerProperty Name="x" Value="30"/>
+            <vp:IntegerProperty Name="y" Value="394"/>
+            <vp:IntegerProperty Name="width" Value="728"/>
+            <vp:IntegerProperty Name="height" Value="150"/>
+            <vp:ColorProperty Name="background" Value="-8728587"/>
+            <vp:ColorProperty Name="foreground" Value="-16777216"/>
+            <vp:IntegerProperty Name="parentConnectorHeaderLength" Value="40"/>
+            <vp:IntegerProperty Name="parentConnectorLineLength" Value="10"/>
+            <vp:BooleanProperty Name="connectToPoint" Value="true"/>
+            <vp:DoubleProperty Name="parentConnectorDTheta" Value="0.0"/>
+            <vp:BooleanProperty Name="coverConnector" Value="false"/>
+            <vp:BooleanProperty Name="requestDefaultSize" Value="false"/>
+          </vp:DiagramElementProperties>
+          <vp:ElementFont Color="-16777216" Name="Dialog" Size="11" Style="0"/>
+          <vp:Line Cap="0" Color="-16777216" Transparency="0" Weight="1.0">
+            <vp:Stroke/>
+          </vp:Line>
+          <vp:Caption Height="150" InternalHeight="-2147483648" InternalWidth="-2147483648" Side="8" Visible="true" Width="17" X="0" Y="0"/>
+          <vp:FillColor Color1="-7873291" Style="1" Transparency="0" Type="1"/>
+        </vp:DiagramElementExtension>
+      </vp:Extensions>
+    </extensionElements>
+    <participant id="BP01" name="Pool" processRef="process-BP01">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="Kb4rOB6FYHQgAQWW"/>
+            <vp:ModelType Value="BPPool"/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391391124"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434202"/>
+              <vp:StringProperty Name="userID" Value="BP01"/>
+              <vp:IntegerProperty Name="userIDLastNumericValue" Value="5"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+    </participant>
+    <participant id="BP02" name="Pool2" processRef="process-BP02">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="fyErOB6FYHQgAQWc"/>
+            <vp:ModelType Value="BPPool"/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391393022"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434203"/>
+              <vp:StringProperty Name="userID" Value="BP02"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+    </participant>
+  </collaboration>
+  <process id="process-BP01" isExecutable="false" name="Pool">
+    <extensionElements/>
+    <startEvent id="BP01_BP01" name="">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="a_ErOB6FYHQgAQWl"/>
+            <vp:ModelType Value="BPStartEvent"/>
+            <vp:ParentRef Idref="BP01"/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391395798"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434198"/>
+              <vp:StringProperty Name="userID" Value="BP01"/>
+              <vp:StringProperty Name="userIDParent" Value="Kb4rOB6FYHQgAQWW"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+      <outgoing>BP01_BP03</outgoing>
+    </startEvent>
+    <task completionQuantity="1" id="BP01_BP02" isForCompensation="false" name="Task" startQuantity="1">
+      <extensionElements>
+        <vp:bounds height="40" width="50" x="239" y="250"/>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="SZkrOB6FYHQgAQWu"/>
+            <vp:ModelType Value="BPTask"/>
+            <vp:ParentRef Idref="BP01"/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391398290"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434203"/>
+              <vp:StringProperty Name="userID" Value="BP02"/>
+              <vp:StringProperty Name="userIDParent" Value="Kb4rOB6FYHQgAQWW"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+      <incoming>BP01_BP03</incoming>
+      <outgoing>BP01_BP05</outgoing>
+    </task>
+    <sequenceFlow id="BP01_BP03" name="" sourceRef="BP01_BP01" targetRef="BP01_BP02">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="_fkrOB6FYHQgAQXA"/>
+            <vp:ModelType Value="BPSequenceFlow"/>
+            <vp:ParentRef/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391399871"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434198"/>
+              <vp:StringProperty Name="userID" Value="BP03"/>
+              <vp:StringProperty Name="userIDParent" Value="Kb4rOB6FYHQgAQWW"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+    </sequenceFlow>
+    <endEvent id="BP01_BP04" name="">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="jJUrOB6FYHQgAQXO"/>
+            <vp:ModelType Value="BPEndEvent"/>
+            <vp:ParentRef Idref="BP01"/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391402289"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434202"/>
+              <vp:StringProperty Name="userID" Value="BP04"/>
+              <vp:StringProperty Name="userIDParent" Value="Kb4rOB6FYHQgAQWW"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+      <incoming>BP01_BP05</incoming>
+    </endEvent>
+    <sequenceFlow id="BP01_BP05" name="" sourceRef="BP01_BP02" targetRef="BP01_BP04">
+      <extensionElements>
+        <vp:Extensions>
+          <vp:ModelExtension>
+            <vp:VpId Value="c_UrOB6FYHQgAQXd"/>
+            <vp:ModelType Value="BPSequenceFlow"/>
+            <vp:ParentRef/>
+            <vp:ModelProperties>
+              <vp:StringProperty Name="pmCreateDateTime" Value="1615391403982"/>
+              <vp:StringProperty Name="pmLastModified" Value="1615391434202"/>
+              <vp:StringProperty Name="userID" Value="BP05"/>
+              <vp:StringProperty Name="userIDParent" Value="Kb4rOB6FYHQgAQWW"/>
+            </vp:ModelProperties>
+          </vp:ModelExtension>
+        </vp:Extensions>
+      </extensionElements>
+    </sequenceFlow>
+  </process>
+  <process id="process-BP02" isExecutable="false" name="Pool2"/>
+  <bpmndi:BPMNDiagram id="diagram-_1" name="Business Process Diagram1">
+    <bpmndi:BPMNPlane bpmnElement="collaboration-_1" id="plane-_1">
+      <bpmndi:BPMNShape bpmnElement="BP01_BP01" id="ID_51415653_1601_7205_3007_204000200001">
+        <omgdc:Bounds height="20" width="20" x="122" y="227"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="BP01_BP02" id="ID_71415653_1601_7205_3007_204000200002">
+        <omgdc:Bounds height="40" width="50" x="239" y="250"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="BP01_BP03" id="ID_05415653_1601_7205_3007_204000200003">
+        <omgdi:waypoint x="132" y="247"/>
+        <omgdi:waypoint x="132" y="270"/>
+        <omgdi:waypoint x="238" y="270"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="BP01_BP04" id="ID_45415653_1601_7205_3007_204000200004">
+        <omgdc:Bounds height="20" width="20" x="381" y="278"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="BP01_BP05" id="ID_25415653_1601_7205_3007_204000200005">
+        <omgdi:waypoint x="289" y="270"/>
+        <omgdi:waypoint x="390" y="270"/>
+        <omgdi:waypoint x="390" y="278"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="BP01" id="ID_65415653_1601_7205_3007_204000200006" isHorizontal="true">
+        <omgdc:Bounds height="150" width="728" x="30" y="176"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="BP02" id="ID_65415653_1601_7205_3007_204000200007" isHorizontal="true">
+        <omgdc:Bounds height="150" width="728" x="30" y="394"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
Hi.
Bpmn allows `<collaboration>` under `<definition>`.
and when `<collaboration>`  have `<extesionElements>`, activiti will throw an NPE.
This is because activiti THOUGHT all  `<extesionElements>` be under some process, but that is, actually, nonsence.