### PR TITLE
Prevent circular dependency from happening

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/conf/impl/ProcessModelAutoConfiguration.java
@@ -111,6 +111,7 @@ public class ProcessModelAutoConfiguration {
 
     @Autowired(required = false)
     @ProcessVariableTypeConverter
+    @Lazy
     private Set<Converter<?, ?>> converters = Collections.emptySet();
 
 


### PR DESCRIPTION
Prevent application error context initialization errors like:

`Caused by: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'org.activiti.api.runtime.conf.impl.ProcessModelAutoConfiguration': Unsatisfied dependency expressed through field 'converters'; nested exception is org.springframework.beans.factory.BeanCurrentlyInCreationException: Error creating bean with name 'stringToMapConverter': Requested bean is currently in creation: Is there an unresolvable circular reference?`

