### PR TITLE
fix(GH-3674): publish only latest process definitions for deployed processes

### DIFF
--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/ProcessDeployedEventProducer.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/ProcessDeployedEventProducer.java
@@ -51,7 +51,7 @@ public class ProcessDeployedEventProducer extends AbstractActivitiSmartLifeCycle
 
     @Override
     public void doStart() {
-        List<ProcessDefinition> processDefinitions = converter.from(repositoryService.createProcessDefinitionQuery().list());
+        List<ProcessDefinition> processDefinitions = converter.from(repositoryService.createProcessDefinitionQuery().latestVersion().list());
         List<ProcessDeployedEvent> processDeployedEvents = new ArrayList<>();
         for (ProcessDefinition processDefinition : processDefinitions) {
             try (InputStream inputStream = repositoryService.getProcessModel(processDefinition.getId())) {

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
@@ -32,7 +32,6 @@ import org.activiti.engine.repository.DeploymentQuery;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
@@ -69,7 +69,7 @@ public class ApplicationDeployedEventProducerTest {
     @Test
     public void shouldPublishEventsWhenApplicationIsDeployed() {
         DeploymentQuery deploymentQuery = mock(DeploymentQuery.class);
-        given(repositoryService.createDeploymentQuery()).willReturn(deploymentQuery);
+        given(repositoryService.createDeploymentQuery().latestVersion()).willReturn(deploymentQuery);
 
         List<Deployment> internalDeployment = asList(mock(Deployment.class),
                 mock(Deployment.class));

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
@@ -32,6 +32,7 @@ import org.activiti.engine.repository.DeploymentQuery;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
@@ -69,7 +70,7 @@ public class ApplicationDeployedEventProducerTest {
     @Test
     public void shouldPublishEventsWhenApplicationIsDeployed() {
         DeploymentQuery deploymentQuery = mock(DeploymentQuery.class);
-        given(repositoryService.createDeploymentQuery().latestVersion()).willReturn(deploymentQuery);
+        given(repositoryService.createDeploymentQuery()).willReturn(deploymentQuery);
 
         List<Deployment> internalDeployment = asList(mock(Deployment.class),
                 mock(Deployment.class));

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
@@ -71,7 +71,7 @@ public class ProcessDeployedEventProducerTest {
     public void shouldCallRegisteredListenersWhenWebApplicationTypeIsServlet() {
         //given
         ProcessDefinitionQuery definitionQuery = mock(ProcessDefinitionQuery.class);
-        given(repositoryService.createProcessDefinitionQuery()).willReturn(definitionQuery);
+        given(repositoryService.createProcessDefinitionQuery().latestVersion()).willReturn(definitionQuery);
 
         List<ProcessDefinition> internalProcessDefinitions = asList(mock(ProcessDefinition.class),
                                                                     mock(ProcessDefinition.class));

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ProcessDeployedEventProducerTest.java
@@ -35,6 +35,7 @@ import org.activiti.engine.repository.ProcessDefinitionQuery;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
@@ -43,7 +44,7 @@ public class ProcessDeployedEventProducerTest {
 
     private ProcessDeployedEventProducer producer;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private RepositoryService repositoryService;
 
     @Mock


### PR DESCRIPTION
Part of https://github.com/Activiti/Activiti/issues/3674