### PR TITLE
fix(GH-3798): update spring-boot.version to 2.6.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Set preview version
         if: ${{ contains(github.head_ref, 'preview') }}
         run: |
-          BRANCH_NAME=${GITHUB_HEAD_REF#refs/heads/}
-          echo 0.0.1-${BRANCH_NAME/\//-}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION
+          GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
+          echo 0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION        
 
       - name: Set VERSION env variable
         if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ contains(github.head_ref, 'preview') }}
         run: |
           GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
-          echo 0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION        
+          echo 0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION
 
       - name: Set VERSION env variable
         if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
@@ -135,6 +135,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @AutoConfigureAfter(CommonRuntimeAutoConfiguration.class)
@@ -266,8 +267,8 @@ public class ProcessRuntimeAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public ProcessRuntimeConfiguration processRuntimeConfiguration(@Autowired(required = false) List<ProcessRuntimeEventListener<?>> processRuntimeEventListeners,
-                                                                   @Autowired(required = false) List<VariableEventListener<?>> variableEventListeners) {
+    public ProcessRuntimeConfiguration processRuntimeConfiguration(@Autowired(required = false) @Lazy List<ProcessRuntimeEventListener<?>> processRuntimeEventListeners,
+                                                                   @Autowired(required = false) @Lazy List<VariableEventListener<?>> variableEventListeners) {
         return new ProcessRuntimeConfigurationImpl(getInitializedListeners(processRuntimeEventListeners),
                 getInitializedListeners(variableEventListeners));
     }

--- a/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/conf/TaskRuntimeAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/conf/TaskRuntimeAutoConfiguration.java
@@ -77,6 +77,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 @Configuration
 @AutoConfigureAfter(CommonRuntimeAutoConfiguration.class)
@@ -141,8 +142,8 @@ public class TaskRuntimeAutoConfiguration {
     }
 
     @Bean
-    public TaskRuntimeConfiguration taskRuntimeConfiguration(@Autowired(required = false) List<TaskRuntimeEventListener<?>> taskRuntimeEventListeners,
-                                                             @Autowired(required = false) List<VariableEventListener<?>> variableEventListeners) {
+    public TaskRuntimeConfiguration taskRuntimeConfiguration(@Autowired(required = false) @Lazy List<TaskRuntimeEventListener<?>> taskRuntimeEventListeners,
+                                                             @Autowired(required = false) @Lazy List<VariableEventListener<?>> variableEventListeners) {
         return new TaskRuntimeConfigurationImpl(getInitializedTaskRuntimeEventListeners(taskRuntimeEventListeners),
                                                 getInitializedTaskRuntimeEventListeners(variableEventListeners));
     }

--- a/activiti-examples/activiti-api-basic-connector-example/src/main/java/org/activiti/examples/DemoApplication.java
+++ b/activiti-examples/activiti-api-basic-connector-example/src/main/java/org/activiti/examples/DemoApplication.java
@@ -36,45 +36,49 @@ import org.activiti.api.task.model.builders.TaskPayloadBuilder;
 import org.activiti.api.task.runtime.TaskRuntime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
-public class DemoApplication implements CommandLineRunner {
+public class DemoApplication {
 
     private Logger logger = LoggerFactory.getLogger(DemoApplication.class);
 
-    @Autowired
-    private ProcessRuntime processRuntime;
+    private final ProcessRuntime processRuntime;
 
-    @Autowired
-    private TaskRuntime taskRuntime;
+    private final TaskRuntime taskRuntime;
 
-    @Autowired
-    private SecurityUtil securityUtil;
+    private final SecurityUtil securityUtil;
 
     private List<VariableCreatedEvent> variableCreatedEvents = new ArrayList<>();
 
     private List<ProcessCompletedEvent> processCompletedEvents = new ArrayList<>();
+
+    public DemoApplication(ProcessRuntime processRuntime, TaskRuntime taskRuntime, SecurityUtil securityUtil) {
+        this.processRuntime = processRuntime;
+        this.taskRuntime = taskRuntime;
+        this.securityUtil = securityUtil;
+    }
 
     public static void main(String[] args) {
         SpringApplication.run(DemoApplication.class,
                               args);
     }
 
-    @Override
-    public void run(String... args) {
-        securityUtil.logInAs("reviewer");
+    @Bean
+    public CommandLineRunner commandLineRunner(){
+        return args -> {
+            securityUtil.logInAs("reviewer");
 
-        listAvailableProcesses();
-        ProcessInstance processInstance = startProcess();
-        listProcessVariables(processInstance);
-        completeAvailableTasks();
-        listAllCreatedVariables();
-        listCompletedProcesses();
+            listAvailableProcesses();
+            ProcessInstance processInstance = startProcess();
+            listProcessVariables(processInstance);
+            completeAvailableTasks();
+            listAllCreatedVariables();
+            listCompletedProcesses();
+        };
     }
 
     private void listCompletedProcesses() {

--- a/activiti-examples/activiti-api-web-example/src/main/java/org/activiti/examples/DemoApplicationConfiguration.java
+++ b/activiti-examples/activiti-api-web-example/src/main/java/org/activiti/examples/DemoApplicationConfiguration.java
@@ -31,6 +31,8 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.DelegatingPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 
@@ -60,17 +62,19 @@ public class DemoApplicationConfiguration extends WebSecurityConfigurerAdapter {
         InMemoryUserDetailsManager inMemoryUserDetailsManager = new InMemoryUserDetailsManager();
 
         String[][] usersGroupsAndRoles = {
-                {"bob", "password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
-                {"john", "password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
-                {"hannah", "password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
-                {"other", "password", "ROLE_ACTIVITI_USER", "GROUP_otherTeam"},
-                {"admin", "password", "ROLE_ACTIVITI_ADMIN"},
+                {"bob", "{bcrypt}password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
+                {"john", "{bcrypt}password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
+                {"hannah", "{bcrypt}password", "ROLE_ACTIVITI_USER", "GROUP_activitiTeam"},
+                {"other", "{bcrypt}password", "ROLE_ACTIVITI_USER", "GROUP_otherTeam"},
+                {"admin", "{bcrypt}password", "ROLE_ACTIVITI_ADMIN"},
         };
+
+        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
 
         for (String[] user : usersGroupsAndRoles) {
             List<String> authoritiesStrings = asList(Arrays.copyOfRange(user, 2, user.length));
             logger.info("> Registering new user: " + user[0] + " with the following Authorities[" + authoritiesStrings + "]");
-            inMemoryUserDetailsManager.createUser(new User(user[0], passwordEncoder().encode(user[1]),
+            inMemoryUserDetailsManager.createUser(new User(user[0], passwordEncoder.encode(user[1]),
                     authoritiesStrings.stream().map(s -> new SimpleGrantedAuthority(s)).collect(Collectors.toList())));
         }
 
@@ -90,8 +94,4 @@ public class DemoApplicationConfiguration extends WebSecurityConfigurerAdapter {
                 .httpBasic();
     }
 
-    @Bean
-    public static PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
 }

--- a/activiti-examples/activiti-api-web-example/src/main/java/org/activiti/examples/DemoApplicationConfiguration.java
+++ b/activiti-examples/activiti-api-web-example/src/main/java/org/activiti/examples/DemoApplicationConfiguration.java
@@ -43,14 +43,19 @@ public class DemoApplicationConfiguration extends WebSecurityConfigurerAdapter {
 
     private Logger logger = LoggerFactory.getLogger(DemoApplicationConfiguration.class);
 
-    @Override
     @Autowired
-    public void configure(AuthenticationManagerBuilder auth) throws Exception {
-        auth.userDetailsService(myUserDetailsService());
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService());
     }
 
-    @Bean
-    public UserDetailsService myUserDetailsService() {
+	@Bean
+    @Override
+	public UserDetailsService userDetailsServiceBean() throws Exception {
+        return super.userDetailsServiceBean();
+    }
+
+    @Override
+    public UserDetailsService userDetailsService() {
 
         InMemoryUserDetailsManager inMemoryUserDetailsManager = new InMemoryUserDetailsManager();
 
@@ -83,12 +88,10 @@ public class DemoApplicationConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticated()
                 .and()
                 .httpBasic();
-
-
     }
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
+    public static PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <spring-boot.version>2.5.3</spring-boot.version>
+    <spring-boot.version>2.6.2</spring-boot.version>
     <versions-maven-plugin.version>2.8.1</versions-maven-plugin.version>
 
     <!-- configuration properties for tests -->


### PR DESCRIPTION
This PR updates `spring-boot.version` to 2.6.2 release.

- [x] Removed circular dependencies in several auto configurations because Spring Boot 2.6+ started prohibiting circular references by default: https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#circular-references-prohibited-by-default

Part of https://github.com/Activiti/Activiti/issues/3798