### PR TITLE
fix: Ability to set subject and from for task notifications

### DIFF
--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
@@ -20,6 +20,10 @@ import java.util.Objects;
 
 public class TaskTemplateDefinition {
 
+    private String from;
+
+    private String subject;
+
     private TemplateDefinition assignee;
 
     private TemplateDefinition candidate;
@@ -40,21 +44,38 @@ public class TaskTemplateDefinition {
         this.candidate = candidate;
     }
 
+    public String getFrom() {
+        return from;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TaskTemplateDefinition that = (TaskTemplateDefinition) o;
-        return Objects.equals(assignee, that.assignee) && Objects
-            .equals(candidate, that.candidate);
+        return Objects.equals(from, that.from) &&
+            Objects.equals(subject, that.subject) &&
+            Objects.equals(assignee, that.assignee) &&
+            Objects.equals(candidate, that.candidate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(assignee, candidate);
+        return Objects.hash(from,
+                            subject,
+                            assignee,
+                            candidate);
     }
+
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
@@ -33,6 +33,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public class ProcessExtensionResourceReaderIT {
 
+    private static String FROM = "no-reply@activiti.org";
+
     @MockBean
     private RepositoryService repositoryService;
 
@@ -87,6 +89,10 @@ public class ProcessExtensionResourceReaderIT {
                 VARIABLE,
                 "myCandidateTemplateVariable"
             );
+            assertThat(defaultTemplate).extracting(TaskTemplateDefinition::getFrom,
+                                                   TaskTemplateDefinition::getSubject)
+                                           .containsExactly(FROM,
+                                                            "Default Subject");
 
             assertThat(templates.getTasks())
                 .containsOnlyKeys("myTaskId1", "myTaskId2", "myTaskId3");
@@ -110,6 +116,11 @@ public class ProcessExtensionResourceReaderIT {
                     FILE,
                     "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html"
                 );
+            assertThat(templates.getTasks()
+                                .get("myTaskId1")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId1 Subject");
 
             assertThat(templates.getTasks().get("myTaskId2").getAssignee())
                 .isNotNull()
@@ -122,6 +133,11 @@ public class ProcessExtensionResourceReaderIT {
                 );
             assertThat(templates.getTasks().get("myTaskId2").getCandidate())
                 .isNull();
+            assertThat(templates.getTasks()
+                                .get("myTaskId2")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId2 Subject");
 
             assertThat(templates.getTasks().get("myTaskId3").getAssignee())
                 .isNull();
@@ -134,6 +150,11 @@ public class ProcessExtensionResourceReaderIT {
                     VARIABLE,
                     "myCandidateTemplateVariable"
                 );
+            assertThat(templates.getTasks()
+                                .get("myTaskId3")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId3 Subject");
         }
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
+++ b/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
@@ -5,6 +5,8 @@
       "templates": {
         "tasks": {
           "myTaskId1": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId1 Subject",
             "assignee": {
               "type": "file",
               "value": "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html"
@@ -15,12 +17,16 @@
             }
           },
           "myTaskId2": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId2 Subject",
             "assignee": {
               "type": "variable",
               "value": "myAssigneeTemplateVariable"
             }
           },
           "myTaskId3": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId3 Subject",
             "candidate": {
               "type": "variable",
               "value": "myCandidateTemplateVariable"
@@ -28,6 +34,8 @@
           }
         },
         "default": {
+          "from": "no-reply@activiti.org",
+          "subject": "Default Subject",
           "assignee": {
             "type": "file",
             "value": "classpath:templates/email.html"


### PR DESCRIPTION
This PR extends task template definition with from and subject attributes to be able to customize task notification emails in the Modeler and Process Runtime