### PR TITLE
fix(GH-3814): add ability to customize subject and from in the email for task notifications

### DIFF
--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
@@ -20,6 +20,10 @@ import java.util.Objects;
 
 public class TaskTemplateDefinition {
 
+    private String from;
+
+    private String subject;
+
     private TemplateDefinition assignee;
 
     private TemplateDefinition candidate;
@@ -40,21 +44,38 @@ public class TaskTemplateDefinition {
         this.candidate = candidate;
     }
 
+    public String getFrom() {
+        return from;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         TaskTemplateDefinition that = (TaskTemplateDefinition) o;
-        return Objects.equals(assignee, that.assignee) && Objects
-            .equals(candidate, that.candidate);
+        return Objects.equals(from, that.from) &&
+            Objects.equals(subject, that.subject) &&
+            Objects.equals(assignee, that.assignee) &&
+            Objects.equals(candidate, that.candidate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(assignee, candidate);
+        return Objects.hash(from,
+                            subject,
+                            assignee,
+                            candidate);
     }
+
 }

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
@@ -20,8 +20,6 @@ import java.util.Objects;
 
 public class TaskTemplateDefinition {
 
-    private String from;
-
     private TemplateDefinition assignee;
 
     private TemplateDefinition candidate;
@@ -42,28 +40,19 @@ public class TaskTemplateDefinition {
         this.candidate = candidate;
     }
 
-    public String getFrom() {
-        return from;
-    }
-
-    public void setFrom(String from) {
-        this.from = from;
-    }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TaskTemplateDefinition that = (TaskTemplateDefinition) o;
-        return Objects.equals(from, that.from) &&
-            Objects.equals(assignee, that.assignee) &&
+        return Objects.equals(assignee, that.assignee) &&
             Objects.equals(candidate, that.candidate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(from,
-                            assignee,
+        return Objects.hash(assignee,
                             candidate);
     }
 

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TaskTemplateDefinition.java
@@ -22,8 +22,6 @@ public class TaskTemplateDefinition {
 
     private String from;
 
-    private String subject;
-
     private TemplateDefinition assignee;
 
     private TemplateDefinition candidate;
@@ -48,24 +46,16 @@ public class TaskTemplateDefinition {
         return from;
     }
 
-    public String getSubject() {
-        return subject;
-    }
-
     public void setFrom(String from) {
         this.from = from;
     }
 
-    public void setSubject(String subject) {
-        this.subject = subject;
-    }
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TaskTemplateDefinition that = (TaskTemplateDefinition) o;
         return Objects.equals(from, that.from) &&
-            Objects.equals(subject, that.subject) &&
             Objects.equals(assignee, that.assignee) &&
             Objects.equals(candidate, that.candidate);
     }
@@ -73,7 +63,6 @@ public class TaskTemplateDefinition {
     @Override
     public int hashCode() {
         return Objects.hash(from,
-                            subject,
                             assignee,
                             candidate);
     }

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TemplateDefinition.java
@@ -23,6 +23,9 @@ public class TemplateDefinition {
         VARIABLE,
         FILE;
     }
+
+    private String from;
+
     private String subject;
 
     private TemplateType type;
@@ -35,6 +38,14 @@ public class TemplateDefinition {
     public TemplateDefinition(TemplateType type, String value) {
         this.type = type;
         this.value = value;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
     }
 
     public String getSubject() {
@@ -62,29 +73,31 @@ public class TemplateDefinition {
     }
 
     @Override
-    public int hashCode() {
-        return Objects.hash(type, value);
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TemplateDefinition that = (TemplateDefinition) o;
+        return Objects.equals(from, that.from) &&
+            Objects.equals(subject, that.subject) &&
+            type == that.type &&
+            Objects.equals(value, that.value);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        TemplateDefinition other = (TemplateDefinition) obj;
-        return type == other.type && Objects.equals(value, other.value);
+    public int hashCode() {
+        return Objects.hash(from,
+                            subject,
+                            type,
+                            value);
     }
 
     @Override
     public String toString() {
-        StringBuilder builder = new StringBuilder();
-        builder.append("TemplateDefinition [type=").append(type).append(", value=").append(value).append("]");
-        return builder.toString();
+        return "TemplateDefinition{" +
+            "from='" + from + '\'' +
+            ", subject='" + subject + '\'' +
+            ", type=" + type +
+            ", value='" + value + '\'' +
+            '}';
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TemplateDefinition.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/model/TemplateDefinition.java
@@ -23,6 +23,8 @@ public class TemplateDefinition {
         VARIABLE,
         FILE;
     }
+    private String subject;
+
     private TemplateType type;
 
     private String value;
@@ -33,6 +35,14 @@ public class TemplateDefinition {
     public TemplateDefinition(TemplateType type, String value) {
         this.type = type;
         this.value = value;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
     }
 
     public String getValue() {

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
@@ -75,23 +75,28 @@ public class ProcessExtensionResourceReaderIT {
                 .isNotNull()
                 .extracting(
                     TemplateDefinition::getType,
-                    TemplateDefinition::getValue)
+                    TemplateDefinition::getValue,
+                    TemplateDefinition::getFrom,
+                    TemplateDefinition::getSubject)
                 .containsExactly(
                     FILE,
-                    "classpath:templates/email.html"
+                    "classpath:templates/email.html",
+                    FROM,
+                    "Default assignee subject"
                 );
             assertThat(defaultTemplate.getCandidate())
                 .isNotNull()
                 .extracting(
                     TemplateDefinition::getType,
-                    TemplateDefinition::getValue
+                    TemplateDefinition::getValue,
+                    TemplateDefinition::getFrom,
+                    TemplateDefinition::getSubject
                 ).containsExactly(
                 VARIABLE,
-                "myCandidateTemplateVariable"
+                "myCandidateTemplateVariable",
+                FROM,
+                "Default candidate subject"
             );
-            assertThat(defaultTemplate.getFrom()).isEqualTo(FROM);
-            assertThat(defaultTemplate.getAssignee().getSubject()).isEqualTo("Default assignee subject");
-            assertThat(defaultTemplate.getCandidate().getSubject()).isEqualTo("Default candidate subject");
 
             assertThat(templates.getTasks())
                 .containsOnlyKeys("myTaskId1", "myTaskId2", "myTaskId3");
@@ -100,20 +105,28 @@ public class ProcessExtensionResourceReaderIT {
                 .isNotNull()
                 .extracting(
                     TemplateDefinition::getType,
-                    TemplateDefinition::getValue)
+                    TemplateDefinition::getValue,
+                    TemplateDefinition::getFrom,
+                    TemplateDefinition::getSubject)
                 .containsExactly(
                     FILE,
-                    "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html"
+                    "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html",
+                    null,
+                    null
                 );
 
             assertThat(templates.getTasks().get("myTaskId1").getCandidate())
                 .isNotNull()
                 .extracting(
                     TemplateDefinition::getType,
-                    TemplateDefinition::getValue)
+                    TemplateDefinition::getValue,
+                    TemplateDefinition::getFrom,
+                    TemplateDefinition::getSubject)
                 .containsExactly(
                     FILE,
-                    "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html"
+                    "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html",
+                    null,
+                    null
                 );
 
             assertThat(templates.getTasks().get("myTaskId2").getAssignee())
@@ -127,7 +140,9 @@ public class ProcessExtensionResourceReaderIT {
                 );
             assertThat(templates.getTasks().get("myTaskId2").getCandidate())
                 .isNull();
-            assertThat(defaultTemplate.getFrom()).isEqualTo(FROM);
+            assertThat(templates.getTasks()
+                                .get("myTaskId2")
+                                .getAssignee().getFrom()).isEqualTo(FROM);
             assertThat(templates.getTasks()
                                 .get("myTaskId2")
                                 .getAssignee()
@@ -139,15 +154,15 @@ public class ProcessExtensionResourceReaderIT {
                 .isNotNull()
                 .extracting(
                     TemplateDefinition::getType,
-                    TemplateDefinition::getValue)
+                    TemplateDefinition::getValue,
+                    TemplateDefinition::getFrom,
+                    TemplateDefinition::getSubject)
                 .containsExactly(
                     VARIABLE,
-                    "myCandidateTemplateVariable"
+                    "myCandidateTemplateVariable",
+                    FROM,
+                    "myTaskId3 candidate subject"
                 );
-            assertThat(templates.getTasks()
-                                .get("myTaskId3")
-                                .getCandidate()
-                                .getSubject()).isEqualTo("myTaskId3 candidate subject");
         }
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
@@ -33,6 +33,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public class ProcessExtensionResourceReaderIT {
 
+    private static String FROM = "no-reply@activiti.org";
+
     @MockBean
     private RepositoryService repositoryService;
 
@@ -87,6 +89,10 @@ public class ProcessExtensionResourceReaderIT {
                 VARIABLE,
                 "myCandidateTemplateVariable"
             );
+            assertThat(defaultTemplate).extracting(TaskTemplateDefinition::getFrom,
+                                                   TaskTemplateDefinition::getSubject)
+                                           .containsExactly(FROM,
+                                                            "Default Subject");
 
             assertThat(templates.getTasks())
                 .containsOnlyKeys("myTaskId1", "myTaskId2", "myTaskId3");
@@ -110,6 +116,11 @@ public class ProcessExtensionResourceReaderIT {
                     FILE,
                     "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html"
                 );
+            assertThat(templates.getTasks()
+                                .get("myTaskId1")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId1 Subject");
 
             assertThat(templates.getTasks().get("myTaskId2").getAssignee())
                 .isNotNull()
@@ -122,6 +133,11 @@ public class ProcessExtensionResourceReaderIT {
                 );
             assertThat(templates.getTasks().get("myTaskId2").getCandidate())
                 .isNull();
+            assertThat(templates.getTasks()
+                                .get("myTaskId2")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId2 Subject");
 
             assertThat(templates.getTasks().get("myTaskId3").getAssignee())
                 .isNull();
@@ -134,6 +150,11 @@ public class ProcessExtensionResourceReaderIT {
                     VARIABLE,
                     "myCandidateTemplateVariable"
                 );
+            assertThat(templates.getTasks()
+                                .get("myTaskId3")).extracting(TaskTemplateDefinition::getFrom,
+                                                              TaskTemplateDefinition::getSubject)
+                                                  .containsExactly(FROM,
+                                                                   "myTaskId3 Subject");
         }
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionResourceReaderIT.java
@@ -89,10 +89,9 @@ public class ProcessExtensionResourceReaderIT {
                 VARIABLE,
                 "myCandidateTemplateVariable"
             );
-            assertThat(defaultTemplate).extracting(TaskTemplateDefinition::getFrom,
-                                                   TaskTemplateDefinition::getSubject)
-                                           .containsExactly(FROM,
-                                                            "Default Subject");
+            assertThat(defaultTemplate.getFrom()).isEqualTo(FROM);
+            assertThat(defaultTemplate.getAssignee().getSubject()).isEqualTo("Default assignee subject");
+            assertThat(defaultTemplate.getCandidate().getSubject()).isEqualTo("Default candidate subject");
 
             assertThat(templates.getTasks())
                 .containsOnlyKeys("myTaskId1", "myTaskId2", "myTaskId3");
@@ -116,11 +115,6 @@ public class ProcessExtensionResourceReaderIT {
                     FILE,
                     "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html"
                 );
-            assertThat(templates.getTasks()
-                                .get("myTaskId1")).extracting(TaskTemplateDefinition::getFrom,
-                                                              TaskTemplateDefinition::getSubject)
-                                                  .containsExactly(FROM,
-                                                                   "myTaskId1 Subject");
 
             assertThat(templates.getTasks().get("myTaskId2").getAssignee())
                 .isNotNull()
@@ -133,11 +127,11 @@ public class ProcessExtensionResourceReaderIT {
                 );
             assertThat(templates.getTasks().get("myTaskId2").getCandidate())
                 .isNull();
+            assertThat(defaultTemplate.getFrom()).isEqualTo(FROM);
             assertThat(templates.getTasks()
-                                .get("myTaskId2")).extracting(TaskTemplateDefinition::getFrom,
-                                                              TaskTemplateDefinition::getSubject)
-                                                  .containsExactly(FROM,
-                                                                   "myTaskId2 Subject");
+                                .get("myTaskId2")
+                                .getAssignee()
+                                .getSubject()).isEqualTo("myTaskId2 assignee subject");
 
             assertThat(templates.getTasks().get("myTaskId3").getAssignee())
                 .isNull();
@@ -151,10 +145,9 @@ public class ProcessExtensionResourceReaderIT {
                     "myCandidateTemplateVariable"
                 );
             assertThat(templates.getTasks()
-                                .get("myTaskId3")).extracting(TaskTemplateDefinition::getFrom,
-                                                              TaskTemplateDefinition::getSubject)
-                                                  .containsExactly(FROM,
-                                                                   "myTaskId3 Subject");
+                                .get("myTaskId3")
+                                .getCandidate()
+                                .getSubject()).isEqualTo("myTaskId3 candidate subject");
         }
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
+++ b/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
@@ -5,6 +5,8 @@
       "templates": {
         "tasks": {
           "myTaskId1": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId1 Subject",
             "assignee": {
               "type": "file",
               "value": "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html"
@@ -15,12 +17,16 @@
             }
           },
           "myTaskId2": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId2 Subject",
             "assignee": {
               "type": "variable",
               "value": "myAssigneeTemplateVariable"
             }
           },
           "myTaskId3": {
+            "from": "no-reply@activiti.org",
+            "subject": "myTaskId3 Subject",
             "candidate": {
               "type": "variable",
               "value": "myCandidateTemplateVariable"
@@ -28,6 +34,8 @@
           }
         },
         "default": {
+          "from": "no-reply@activiti.org",
+          "subject": "Default Subject",
           "assignee": {
             "type": "file",
             "value": "classpath:templates/email.html"

--- a/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
+++ b/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
@@ -5,8 +5,6 @@
       "templates": {
         "tasks": {
           "myTaskId1": {
-            "from": "no-reply@activiti.org",
-            "subject": "myTaskId1 Subject",
             "assignee": {
               "type": "file",
               "value": "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html"
@@ -18,16 +16,16 @@
           },
           "myTaskId2": {
             "from": "no-reply@activiti.org",
-            "subject": "myTaskId2 Subject",
             "assignee": {
+              "subject": "myTaskId2 assignee subject",
               "type": "variable",
               "value": "myAssigneeTemplateVariable"
             }
           },
           "myTaskId3": {
             "from": "no-reply@activiti.org",
-            "subject": "myTaskId3 Subject",
             "candidate": {
+              "subject": "myTaskId3 candidate subject",
               "type": "variable",
               "value": "myCandidateTemplateVariable"
             }
@@ -35,12 +33,13 @@
         },
         "default": {
           "from": "no-reply@activiti.org",
-          "subject": "Default Subject",
           "assignee": {
+            "subject": "Default assignee subject",
             "type": "file",
             "value": "classpath:templates/email.html"
           },
           "candidate": {
+            "subject": "Default candidate subject",
             "type": "variable",
             "value": "myCandidateTemplateVariable"
           }

--- a/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
+++ b/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/template-mapping-extensions.json
@@ -15,16 +15,16 @@
             }
           },
           "myTaskId2": {
-            "from": "no-reply@activiti.org",
             "assignee": {
+              "from": "no-reply@activiti.org",
               "subject": "myTaskId2 assignee subject",
               "type": "variable",
               "value": "myAssigneeTemplateVariable"
             }
           },
           "myTaskId3": {
-            "from": "no-reply@activiti.org",
             "candidate": {
+              "from": "no-reply@activiti.org",
               "subject": "myTaskId3 candidate subject",
               "type": "variable",
               "value": "myCandidateTemplateVariable"
@@ -32,13 +32,14 @@
           }
         },
         "default": {
-          "from": "no-reply@activiti.org",
           "assignee": {
+            "from": "no-reply@activiti.org",
             "subject": "Default assignee subject",
             "type": "file",
             "value": "classpath:templates/email.html"
           },
           "candidate": {
+            "from": "no-reply@activiti.org",
             "subject": "Default candidate subject",
             "type": "variable",
             "value": "myCandidateTemplateVariable"


### PR DESCRIPTION
This PR extends task template definition with from and subject fields to be able to customize task notification emails, i.e.

```json
{
  "id": "emailTemplateMapping",
  "extensions": {
    "processDefinitionId": {
      "templates": {
        "tasks": {
          "myTaskId1": {
            "assignee": {
              "type": "file",
              "value": "https://github.com/leemunroe/responsive-html-email-template/blob/master/email.html"
            },
            "candidate": {
              "type": "file",
              "value": "https://github.com/leemunroe/responsive-html-email-template/blob/master/email-inlined.html"
            }
          },
          "myTaskId2": {
            "assignee": {
              "from": "no-reply@activiti.org",
              "subject": "myTaskId2 assignee subject",
              "type": "variable",
              "value": "myAssigneeTemplateVariable"
            }
          },
          "myTaskId3": {
            "candidate": {
              "from": "no-reply@activiti.org",
              "subject": "myTaskId3 candidate subject",
              "type": "variable",
              "value": "myCandidateTemplateVariable"
            }
          }
        },
        "default": {
          "assignee": {
            "from": "no-reply@activiti.org",
            "subject": "Default assignee subject",
            "type": "file",
            "value": "classpath:templates/email.html"
          },
          "candidate": {
            "from": "no-reply@activiti.org",
            "subject": "Default candidate subject",
            "type": "variable",
            "value": "myCandidateTemplateVariable"
          }
        }
      }
    }
  }
}
```



Part of https://github.com/Activiti/Activiti/issues/3814