### PR TITLE
ci: set tag pattern to be watched when generating next version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,7 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           git fetch --tags -q
-          echo $(jx-release-version -next-version increment) > VERSION
+          echo $(jx-release-version -previous-version=from-tag:7.1 -next-version increment) > VERSION
 
       - name: Set preview version
         if: ${{ contains(github.head_ref, 'preview') }}


### PR DESCRIPTION
This avoids generating internal releases with the pattern `7.x.y` while we migrate to the new versioning system.

Part of https://github.com/Activiti/Activiti/issues/3825