### PR TITLE
ci: change the pattern used by internal releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.0
-      - id: next-release
-        name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
-
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1
         with:
@@ -64,6 +58,12 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+
+      - uses: actions/setup-python@v2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.0
+      - id: next-release
+        name: Calculate next internal release
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
 
       - name: Update VERSION file
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,15 +71,10 @@ jobs:
       - name: Build with Maven
         run: mvn -B verify
 
-      - name: Install jx-release-version
-        if: ${{ github.event_name == 'push' }}
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-jx-release-version@v1.1.0
-
-      - name: Bump version with jx-release-version
+      - name: Update VERSION file
         if: ${{ github.event_name == 'push' }}
         run: |
-          git fetch --tags -q
-          echo $(jx-release-version -previous-version=from-tag:7.1 -next-version increment) > VERSION
+          echo ${{steps.next-release.outputs.next-prerelease}} > VERSION
 
       - name: Set preview version
         if: ${{ contains(github.head_ref, 'preview') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
 
       - name: Display next release version
-        run: echo Next release version ${{steps.next-release.outputs.next-release}}
+        run: echo Next release version ${{steps.next-release.outputs.next-prerelease}}
 
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,14 +90,6 @@ jobs:
       - name: Build with Maven
         run: mvn -B verify
 
-      - name: Deploy with Maven
-        if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}
-        run: |
-          mvn -B -s settings.xml deploy -DskipTests
-        env:
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
       - name: Configure git user
         if: ${{ github.event_name == 'push' }}
         run: |
@@ -112,6 +104,14 @@ jobs:
           git commit -am "Release $VERSION" --allow-empty
           git tag -fa $VERSION -m "Release version $VERSION"
           git push -f -q origin $VERSION
+
+      - name: Deploy with Maven
+        if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}
+        run: |
+          mvn -B -s settings.xml deploy -DskipTests
+        env:
+          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
       - name: Install updatebot
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@aee-7390-pysemver
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.0
       - id: next-release
         name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
 
       - name: Display next release version
         run: echo Next release version ${{steps.next-release.outputs.next-prerelease}}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Install updatebot
         if: ${{ github.event_name == 'push' }}
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatebot@v1.1.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatebot@v1.2.0
 
       - name: Run updatebot
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@aee-7390-pysemver
       - id: next-release
         name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver\
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
 
       - name: Display next release version
         run: echo Next release version ${{steps.next-release.outputs.next-release}}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,8 +113,8 @@ jobs:
         if: ${{ github.event_name == 'push' }}
         run: |
           git commit -am "Release $VERSION" --allow-empty
-          git tag -fa v$VERSION -m "Release version $VERSION"
-          git push -f -q origin v$VERSION
+          git tag -fa $VERSION -m "Release version $VERSION"
+          git push -f -q origin $VERSION
 
       - name: Install updatebot
         if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: pre-commit
     steps:
+      - name: Calculate next internal release
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
 
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,8 +60,11 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - uses: actions/setup-python@v2
+        if: ${{ github.event_name == 'push' }}
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.0
+        if: ${{ github.event_name == 'push' }}
       - id: next-release
+        if: ${{ github.event_name == 'push' }}
         name: Calculate next internal release
         uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,12 @@ jobs:
 
       - uses: actions/setup-python@v2
       - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@aee-7390-pysemver
-      - name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
+      - id: next-release
+        name: Calculate next internal release
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver\
+
+      - name: Display next release version
+        run: echo Next release version ${{steps.next-release.outputs.next-release}}
 
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,8 +27,6 @@ jobs:
     runs-on: ubuntu-20.04
     needs: pre-commit
     steps:
-      - name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
 
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.8.0
@@ -37,6 +35,11 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@aee-7390-pysemver
+      - name: Calculate next internal release
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@aee-7390-pysemver
 
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,6 @@ jobs:
         name: Calculate next internal release
         uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
 
-      - name: Display next release version
-        run: echo Next release version ${{steps.next-release.outputs.next-prerelease}}
-
       - name: Setup Java JDK 11
         uses: actions/setup-java@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,9 +68,6 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: Build with Maven
-        run: mvn -B verify
-
       - name: Update VERSION file
         if: ${{ github.event_name == 'push' }}
         run: |
@@ -89,10 +86,16 @@ jobs:
           echo set VERSION=$VERSION
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
+      - name: Update pom files to the new version
+        if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}
+        run: mvn -B versions:set -DnewVersion=$VERSION -DprocessAllModules=true -DgenerateBackupPoms=false
+
+      - name: Build with Maven
+        run: mvn -B verify
+
       - name: Deploy with Maven
         if: ${{ github.event_name == 'push' || contains(github.head_ref, 'preview') }}
         run: |
-          mvn -B versions:set -DnewVersion=$VERSION -DprocessAllModules=true -DgenerateBackupPoms=false
           mvn -B -s settings.xml deploy -DskipTests
         env:
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}


### PR DESCRIPTION
Previously, Activiti was creating internal releases (created every the CI builds on the `develop` branch) with the pattern
`MAJOR.MINOR.PATCH`. However, these are actually pre-releases, so better to use prereleases suffixes, such as `alpha`.
At the same time we are moving from Semver to Calver: the next main releases are going to have the pattern `YY.MINOR.PATCH` and so the internal releases are going to have the pattern `YY.MINOR.PATCH-alpha.COUNTER`

Part of https://github.com/Activiti/Activiti/issues/3825