### PR TITLE
fix(AAE-7055): Override Id References in Flow Elements from Subprocess and Process

### DIFF
--- a/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/Process.java
+++ b/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/Process.java
@@ -23,7 +23,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
 
-public class Process extends BaseElement implements FlowElementsContainer, HasExecutionListeners {
+public class Process extends BaseElement implements FlowElementsContainer, HasExecutionListeners, AcceptUpdates {
 
   protected String name;
   protected boolean executable = true;
@@ -429,6 +429,11 @@ public class Process extends BaseElement implements FlowElementsContainer, HasEx
 
   public void setInitialFlowElement(FlowElement initialFlowElement) {
     this.initialFlowElement = initialFlowElement;
+  }
+
+  @Override
+  public void accept(ReferenceOverrider referenceOverrider) {
+    getFlowElements().forEach(flowElement -> flowElement.accept(referenceOverrider));
   }
 
 }

--- a/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/SubProcess.java
+++ b/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/SubProcess.java
@@ -178,4 +178,10 @@ public class SubProcess extends Activity implements FlowElementsContainer {
   public void setDataObjects(List<ValuedDataObject> dataObjects) {
     this.dataObjects = dataObjects;
   }
+
+  @Override
+  public void accept(ReferenceOverrider referenceOverrider) {
+    getFlowElements().forEach(flowElement -> flowElement.accept(referenceOverrider));
+  }
+
 }


### PR DESCRIPTION
This PR implements AcceptUpdates interface for SubProcess and Process BPMN models in order to support ReferenceOverrider accept method for flow elements containers. 