### PR TITLE
ci: use semver for internal prereleases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,14 @@ jobs:
 
       - uses: actions/setup-python@v2
         if: ${{ github.event_name == 'push' }}
-      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/setup-pysemver@v1.2.1
         if: ${{ github.event_name == 'push' }}
       - id: next-release
         if: ${{ github.event_name == 'push' }}
         name: Calculate next internal release
-        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/calculate-next-internal-version@v1.2.1
+        with:
+          next-version: 7.2.0
 
       - name: Update VERSION file
         if: ${{ github.event_name == 'push' }}
@@ -118,7 +120,7 @@ jobs:
 
       - name: Install updatebot
         if: ${{ github.event_name == 'push' }}
-        uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatebot@v1.2.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/setup-updatebot@v1.2.1
 
       - name: Run updatebot
         if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
- prereleases will use the pattern MAJOR.MINOR.PATCH-alpha.COUNTER
- the next main release it's going to be `7.2.0` and so prereleases are going to be `7.2.0-alpha.1`, `7.2.0-alpha.2`, etc

Part of https://github.com/Activiti/Activiti/issues/3825