### PR TITLE
[#3919] variables in process definitions endpoint

### DIFF
--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/VariableDefinition.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/VariableDefinition.java
@@ -15,25 +15,20 @@
  */
 package org.activiti.api.process.model;
 
-import org.activiti.api.model.shared.model.ApplicationElement;
-
-import java.util.List;
-
-public interface ProcessDefinition extends ApplicationElement {
+public interface VariableDefinition {
 
     String getId();
 
     String getName();
 
-    String getKey();
-
     String getDescription();
 
-    int getVersion();
+    String getType();
 
-    String getFormKey();
+    boolean isRequired();
 
-    String getCategory();
+    Boolean getDisplay();
 
-    List<VariableDefinition> getVariableDefinitions();
+    String getDisplayName();
+
 }

--- a/activiti-api/activiti-api-process-runtime/src/main/java/org/activiti/api/process/runtime/ProcessRuntime.java
+++ b/activiti-api/activiti-api-process-runtime/src/main/java/org/activiti/api/process/runtime/ProcessRuntime.java
@@ -62,10 +62,22 @@ public interface ProcessRuntime {
     Page<ProcessDefinition> processDefinitions(Pageable pageable);
 
     /**
+     * Get all process definitions by pages with include parameter
+     */
+    Page<ProcessDefinition> processDefinitions(Pageable pageable, List<String> include);
+
+    /**
      * Get all process definitions by pages using payload filters
      */
     Page<ProcessDefinition> processDefinitions(Pageable pageable,
                                                GetProcessDefinitionsPayload getProcessDefinitionsPayload);
+
+    /**
+     * Get all process definitions by pages using payload filters and include parameter
+     */
+    Page<ProcessDefinition> processDefinitions(Pageable pageable,
+                                               GetProcessDefinitionsPayload getProcessDefinitionsPayload,
+                                               List<String> include);
 
 
     /**

--- a/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
+++ b/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
@@ -27,6 +27,10 @@ public class VariableDefinition {
 
     private boolean required;
 
+    private Boolean display;
+
+    private String displayName;
+
     public String getId() {
         return id;
     }
@@ -47,6 +51,14 @@ public class VariableDefinition {
         return required;
     }
 
+    public Boolean getDisplay() {
+        return display;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
     public void setId(String id) {
         this.id = id;
     }
@@ -65,5 +77,13 @@ public class VariableDefinition {
 
     public void setRequired(boolean required) {
         this.required = required;
+    }
+
+    public void setDisplay(Boolean display) {
+        this.display = display;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessDefinitionImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/ProcessDefinitionImpl.java
@@ -15,9 +15,12 @@
  */
 package org.activiti.api.runtime.model.impl;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.VariableDefinition;
 
 public class ProcessDefinitionImpl extends ApplicationElementImpl implements ProcessDefinition {
 
@@ -28,6 +31,7 @@ public class ProcessDefinitionImpl extends ApplicationElementImpl implements Pro
     private String key;
     private String formKey;
     private String category;
+    private List<VariableDefinition> variableDefinitions = new ArrayList<>();
 
     @Override
     public String getId() {
@@ -93,6 +97,15 @@ public class ProcessDefinitionImpl extends ApplicationElementImpl implements Pro
     }
 
     @Override
+    public List<VariableDefinition> getVariableDefinitions() {
+        return variableDefinitions;
+    }
+
+    public void setVariableDefinitions(List<VariableDefinition> variableDefinitions) {
+        this.variableDefinitions = variableDefinitions;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -114,7 +127,9 @@ public class ProcessDefinitionImpl extends ApplicationElementImpl implements Pro
                 Objects.equals(key,
                                that.key) &&
                 Objects.equals(formKey,
-                               that.formKey);
+                               that.formKey) &&
+                Objects.equals(variableDefinitions,
+                               that.variableDefinitions);
     }
 
     @Override
@@ -125,7 +140,8 @@ public class ProcessDefinitionImpl extends ApplicationElementImpl implements Pro
                             description,
                             version,
                             key,
-                            formKey);
+                            formKey,
+                            variableDefinitions);
     }
 
     @Override
@@ -137,6 +153,7 @@ public class ProcessDefinitionImpl extends ApplicationElementImpl implements Pro
                 ", description='" + description + '\'' +
                 ", formKey='" + formKey + '\'' +
                 ", version=" + version +
+                ", variableDefinitions=" + variableDefinitions +
                 '}';
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
@@ -97,7 +97,13 @@ public class VariableDefinitionImpl implements VariableDefinition {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         VariableDefinitionImpl that = (VariableDefinitionImpl) o;
-        return required == that.required && display == that.display && Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(type, that.type) && Objects.equals(displayName, that.displayName);
+        return required == that.required &&
+            Objects.equals(display, that.display) &&
+            Objects.equals(id, that.id) &&
+            Objects.equals(name, that.name) &&
+            Objects.equals(description, that.description) &&
+            Objects.equals(type, that.type) &&
+            Objects.equals(displayName, that.displayName);
     }
 
     @Override

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.model.impl;
+
+import org.activiti.api.process.model.VariableDefinition;
+
+import java.util.Objects;
+
+public class VariableDefinitionImpl implements VariableDefinition {
+
+    private String id;
+    private String name;
+    private String description;
+    private String type;
+    private boolean required;
+    private Boolean display;
+    private String displayName;
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public boolean isRequired() {
+        return required;
+    }
+
+    public void setRequired(boolean required) {
+        this.required = required;
+    }
+
+    @Override
+    public Boolean getDisplay() {
+        return display;
+    }
+
+    public void setDisplay(Boolean display) {
+        this.display = display;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VariableDefinitionImpl that = (VariableDefinitionImpl) o;
+        return required == that.required && display == that.display && Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(description, that.description) && Objects.equals(type, that.type) && Objects.equals(displayName, that.displayName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, description, type, required, display, displayName);
+    }
+
+    @Override
+    public String toString() {
+        return "VariableDefinitionImpl{" +
+            "id='" + id + '\'' +
+            ", name='" + name + '\'' +
+            ", description='" + description + '\'' +
+            ", type='" + type + '\'' +
+            ", required=" + required +
+            ", display=" + display +
+            ", displayName='" + displayName + '\'' +
+            '}';
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
@@ -119,6 +119,8 @@ import org.activiti.runtime.api.impl.RuntimeSignalPayloadEventListener;
 import org.activiti.runtime.api.impl.VariableNameValidator;
 import org.activiti.runtime.api.impl.ExtensionsVariablesMappingProvider;
 import org.activiti.runtime.api.message.ReceiveMessagePayloadEventListener;
+import org.activiti.runtime.api.model.decorator.ProcessDefinitionDecorator;
+import org.activiti.runtime.api.model.decorator.ProcessDefinitionVariablesDecorator;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
@@ -183,7 +185,8 @@ public class ProcessRuntimeAutoConfiguration {
                                          ProcessRuntimeConfiguration processRuntimeConfiguration,
                                          ApplicationEventPublisher eventPublisher,
                                          ProcessVariablesPayloadValidator processVariablesValidator,
-                                         SecurityManager securityManager) {
+                                         SecurityManager securityManager,
+                                         List<ProcessDefinitionDecorator> processDefinitionDecorators) {
         return new ProcessRuntimeImpl(repositoryService,
                 processDefinitionConverter,
                 runtimeService,
@@ -195,7 +198,8 @@ public class ProcessRuntimeAutoConfiguration {
                 processRuntimeConfiguration,
                 eventPublisher,
                 processVariablesValidator,
-                securityManager);
+                securityManager,
+                processDefinitionDecorators);
     }
 
     @Bean
@@ -580,4 +584,11 @@ public class ProcessRuntimeAutoConfiguration {
                                                                                                       new ToMessageSubscriptionCancelledConverter(converter)),
                                                      ActivitiEventType.ENTITY_DELETED);
     }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProcessDefinitionVariablesDecorator processDefinitionVariablesDecorator(ProcessExtensionService processExtensionService) {
+        return new ProcessDefinitionVariablesDecorator(processExtensionService);
+    }
+
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -62,6 +62,7 @@ import org.activiti.engine.TaskService;
 import org.activiti.engine.repository.ProcessDefinitionQuery;
 import org.activiti.engine.runtime.ProcessInstanceBuilder;
 import org.activiti.engine.task.TaskQuery;
+import org.activiti.runtime.api.model.decorator.ProcessDefinitionDecorator;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
@@ -98,6 +99,8 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
 
     private final SecurityManager securityManager;
 
+    private final List<ProcessDefinitionDecorator> processDefinitionDecorators;
+
     public ProcessRuntimeImpl(RepositoryService repositoryService,
                               APIProcessDefinitionConverter processDefinitionConverter,
                               RuntimeService runtimeService,
@@ -109,7 +112,8 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
                               ProcessRuntimeConfiguration configuration,
                               ApplicationEventPublisher eventPublisher,
                               ProcessVariablesPayloadValidator processVariablesValidator,
-                              SecurityManager securityManager) {
+                              SecurityManager securityManager,
+                              List<ProcessDefinitionDecorator> processDefinitionDecorators) {
         this.repositoryService = repositoryService;
         this.processDefinitionConverter = processDefinitionConverter;
         this.runtimeService = runtimeService;
@@ -122,6 +126,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         this.eventPublisher = eventPublisher;
         this.processVariablesValidator = processVariablesValidator;
         this.securityManager = securityManager;
+        this.processDefinitionDecorators = processDefinitionDecorators;
     }
 
     @Override
@@ -170,13 +175,24 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
 
     @Override
     public Page<ProcessDefinition> processDefinitions(Pageable pageable) {
-        return processDefinitions(pageable,
-                ProcessPayloadBuilder.processDefinitions().build());
+        return processDefinitions(pageable, ProcessPayloadBuilder.processDefinitions().build(), List.of());
+    }
+
+    @Override
+    public Page<ProcessDefinition> processDefinitions(Pageable pageable, List<String> include) {
+        return processDefinitions(pageable, ProcessPayloadBuilder.processDefinitions().build(), include);
     }
 
     @Override
     public Page<ProcessDefinition> processDefinitions(Pageable pageable,
                                                       GetProcessDefinitionsPayload getProcessDefinitionsPayload) {
+        return processDefinitions(pageable, getProcessDefinitionsPayload, List.of());
+    }
+
+    @Override
+    public Page<ProcessDefinition> processDefinitions(Pageable pageable,
+                                                      GetProcessDefinitionsPayload getProcessDefinitionsPayload,
+                                                      List<String> include) {
         if (getProcessDefinitionsPayload == null) {
             throw new IllegalStateException("payload cannot be null");
         }
@@ -196,8 +212,25 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             processDefinitionQuery.processDefinitionKeys(getProcessDefinitionsPayload.getProcessDefinitionKeys());
         }
 
-        return new PageImpl<>(processDefinitionConverter.from(processDefinitionQuery.list()),
+        List<ProcessDefinition> processDefinitions = processDefinitionConverter.from(processDefinitionQuery.list());
+        List<ProcessDefinition> decoratedProcessDefinitions = decorate(processDefinitions, include);
+        return new PageImpl<>(decoratedProcessDefinitions,
                               Math.toIntExact(processDefinitionQuery.count()));
+    }
+
+    private List<ProcessDefinition> decorate(List<ProcessDefinition> processDefinitions, List<String> include) {
+        for (String param : include) {
+            processDefinitions = decorate(processDefinitions, param);
+        }
+        return processDefinitions;
+    }
+
+    private List<ProcessDefinition> decorate(List<ProcessDefinition> processDefinitions, String includeParam) {
+        return processDefinitionDecorators.stream()
+            .filter(decorator -> decorator.applies(includeParam))
+            .findFirst()
+            .map(decorator -> processDefinitions.stream().map(decorator::decorate).collect(Collectors.toList()))
+            .orElse(processDefinitions);
     }
 
     @Override

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -15,6 +15,7 @@
  */
 package org.activiti.runtime.api.impl;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -219,10 +220,11 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
     }
 
     private List<ProcessDefinition> decorate(List<ProcessDefinition> processDefinitions, List<String> include) {
+        List<ProcessDefinition> decoratedProcessDefinitions = new ArrayList<>(processDefinitions);
         for (String param : include) {
-            processDefinitions = decorate(processDefinitions, param);
+            decoratedProcessDefinitions = decorate(decoratedProcessDefinitions, param);
         }
-        return processDefinitions;
+        return decoratedProcessDefinitions;
     }
 
     private List<ProcessDefinition> decorate(List<ProcessDefinition> processDefinitions, String includeParam) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionDecorator.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionDecorator.java
@@ -13,27 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.activiti.api.process.model;
+package org.activiti.runtime.api.model.decorator;
 
-import org.activiti.api.model.shared.model.ApplicationElement;
+import org.activiti.api.process.model.ProcessDefinition;
+import org.apache.commons.lang3.StringUtils;
 
-import java.util.List;
+public interface ProcessDefinitionDecorator {
 
-public interface ProcessDefinition extends ApplicationElement {
+    String getHandledValue();
 
-    String getId();
+    ProcessDefinition decorate(ProcessDefinition processDefinition);
 
-    String getName();
+    default boolean applies(String include){
+        return StringUtils.equalsIgnoreCase(getHandledValue(), include);
+    }
 
-    String getKey();
-
-    String getDescription();
-
-    int getVersion();
-
-    String getFormKey();
-
-    String getCategory();
-
-    List<VariableDefinition> getVariableDefinitions();
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionVariablesDecorator.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionVariablesDecorator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.runtime.api.model.decorator;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.runtime.model.impl.VariableDefinitionImpl;
+import org.activiti.spring.process.ProcessExtensionService;
+import org.activiti.spring.process.model.VariableDefinition;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ProcessDefinitionVariablesDecorator implements ProcessDefinitionDecorator {
+
+    private static final String HANDLED_VALUE = "variables";
+
+    private final ProcessExtensionService processExtensionService;
+
+    public ProcessDefinitionVariablesDecorator(ProcessExtensionService processExtensionService) {
+        this.processExtensionService = processExtensionService;
+    }
+
+    @Override
+    public String getHandledValue() {
+        return HANDLED_VALUE;
+    }
+
+    @Override
+    public ProcessDefinition decorate(ProcessDefinition processDefinition) {
+        Map<String, VariableDefinition> variables =
+            processExtensionService.getExtensionsForId(processDefinition.getId()).getProperties();
+        processDefinition.getVariableDefinitions().addAll(variables.values().stream()
+            .filter(variableDefinition -> Boolean.TRUE.equals(variableDefinition.getDisplay()))
+            .map(this::convert)
+            .collect(Collectors.toList()));
+        return processDefinition;
+    }
+
+    private org.activiti.api.process.model.VariableDefinition convert(VariableDefinition variableDefinition) {
+        VariableDefinitionImpl variableDefinitionImpl = new VariableDefinitionImpl();
+        variableDefinitionImpl.setId(variableDefinition.getId());
+        variableDefinitionImpl.setName(variableDefinition.getName());
+        variableDefinitionImpl.setDescription(variableDefinition.getDescription());
+        variableDefinitionImpl.setType(variableDefinition.getType());
+        variableDefinitionImpl.setRequired(variableDefinition.isRequired());
+        variableDefinitionImpl.setDisplay(variableDefinition.getDisplay());
+        variableDefinitionImpl.setDisplayName(variableDefinition.getDisplayName());
+        return variableDefinitionImpl;
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -56,7 +56,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Arrays;
@@ -364,7 +363,7 @@ public class ProcessRuntimeImplTest {
         List<VariableDefinition> variableDefinitions = processDefinitions.get(0).getVariableDefinitions();
         assertThat(variableDefinitions).hasSize(1);
         assertThat(variableDefinitions.get(0)).isEqualTo(variableDefinition);
-        Mockito.verify(processDefinitionDecorator).decorate(processDefinition);
+        verify(processDefinitionDecorator).decorate(processDefinition);
     }
 
     @ParameterizedTest
@@ -387,7 +386,7 @@ public class ProcessRuntimeImplTest {
             processRuntime.processDefinitions(Pageable.of(0, 50), include).getContent();
 
         assertThat(processDefinitions).hasSize(1);
-        Mockito.verify(processDefinitionDecorator, never()).decorate(any());
+        verify(processDefinitionDecorator, never()).decorate(any());
     }
 
     private static Stream<Arguments> emptyIncludeVariables() {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionVariablesDecoratorTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/model/decorator/ProcessDefinitionVariablesDecoratorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.runtime.api.model.decorator;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.runtime.model.impl.ProcessDefinitionImpl;
+import org.activiti.spring.process.ProcessExtensionService;
+import org.activiti.spring.process.model.Extension;
+import org.activiti.spring.process.model.VariableDefinition;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProcessDefinitionVariablesDecoratorTest {
+
+    @InjectMocks
+    private ProcessDefinitionVariablesDecorator processDefinitionVariablesDecorator;
+
+    @Mock
+    private ProcessExtensionService processExtensionService;
+
+    @ParameterizedTest
+    @CsvSource({"variables, true", "VARIABLES, true", "else, false"})
+    void should_applyToVariablesParam(String includeParam, boolean shouldApply) {
+        boolean applies = processDefinitionVariablesDecorator.applies(includeParam);
+        assertThat(applies).isEqualTo(shouldApply);
+    }
+
+    @Test
+    void should_decorateProcessDefinitions() {
+        ProcessDefinitionImpl givenProcessDefinition = new ProcessDefinitionImpl();
+        givenProcessDefinition.setId("PROC_ID");
+        Extension extension = new Extension();
+        VariableDefinition givenVariableDefinition = new VariableDefinition();
+        givenVariableDefinition.setId("VAR_ID");
+        givenVariableDefinition.setName("var1");
+        givenVariableDefinition.setDescription("Variable no 1");
+        givenVariableDefinition.setType("string");
+        givenVariableDefinition.setRequired(true);
+        givenVariableDefinition.setDisplay(true);
+        givenVariableDefinition.setDisplayName("Variable 1");
+        extension.setProperties(Map.of("var1", givenVariableDefinition));
+
+        when(processExtensionService.getExtensionsForId("PROC_ID")).thenReturn(extension);
+
+        ProcessDefinition decoratedProcessDefinition = processDefinitionVariablesDecorator.decorate(givenProcessDefinition);
+
+        assertThat(decoratedProcessDefinition.getVariableDefinitions()).hasSize(1);
+        org.activiti.api.process.model.VariableDefinition variableDefinition = decoratedProcessDefinition.getVariableDefinitions().get(0);
+        assertThat(variableDefinition.getId()).isEqualTo("VAR_ID");
+        assertThat(variableDefinition.getName()).isEqualTo("var1");
+        assertThat(variableDefinition.getDescription()).isEqualTo("Variable no 1");
+        assertThat(variableDefinition.getType()).isEqualTo("string");
+        assertThat(variableDefinition.isRequired()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplay()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplayName()).isEqualTo("Variable 1");
+    }
+
+    @Test
+    void should_decorateProcessDefinitionsWithDisplayableVariables() {
+        ProcessDefinitionImpl givenProcessDefinition = new ProcessDefinitionImpl();
+        givenProcessDefinition.setId("PROC_ID");
+        Extension extension = new Extension();
+        VariableDefinition givenVariableDefinition1 = new VariableDefinition();
+        givenVariableDefinition1.setDisplay(false);
+        givenVariableDefinition1.setDisplayName("Variable 1");
+        VariableDefinition givenVariableDefinition2 = new VariableDefinition();
+        givenVariableDefinition1.setDisplay(true);
+        givenVariableDefinition1.setDisplayName("Variable 2");
+        extension.setProperties(Map.of("var1", givenVariableDefinition1, "var2", givenVariableDefinition2));
+
+        when(processExtensionService.getExtensionsForId("PROC_ID")).thenReturn(extension);
+
+        ProcessDefinition decoratedProcessDefinition = processDefinitionVariablesDecorator.decorate(givenProcessDefinition);
+
+        assertThat(decoratedProcessDefinition.getVariableDefinitions()).hasSize(1);
+        org.activiti.api.process.model.VariableDefinition variableDefinition = decoratedProcessDefinition.getVariableDefinitions().get(0);
+        assertThat(variableDefinition.getDisplay()).isEqualTo(true);
+        assertThat(variableDefinition.getDisplayName()).isEqualTo("Variable 2");
+    }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
@@ -32,7 +32,6 @@ import org.activiti.runtime.api.impl.ProcessAdminRuntimeImpl;
 import org.activiti.runtime.api.impl.ProcessRuntimeImpl;
 import org.activiti.runtime.api.impl.ProcessVariablesPayloadValidator;
 import org.activiti.runtime.api.model.decorator.ProcessDefinitionDecorator;
-import org.activiti.runtime.api.model.decorator.ProcessDefinitionVariablesDecorator;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/HistoryConfigurationTest.java
@@ -31,6 +31,8 @@ import org.activiti.engine.TaskService;
 import org.activiti.runtime.api.impl.ProcessAdminRuntimeImpl;
 import org.activiti.runtime.api.impl.ProcessRuntimeImpl;
 import org.activiti.runtime.api.impl.ProcessVariablesPayloadValidator;
+import org.activiti.runtime.api.model.decorator.ProcessDefinitionDecorator;
+import org.activiti.runtime.api.model.decorator.ProcessDefinitionVariablesDecorator;
 import org.activiti.runtime.api.model.impl.APIDeploymentConverter;
 import org.activiti.runtime.api.model.impl.APIProcessDefinitionConverter;
 import org.activiti.runtime.api.model.impl.APIProcessInstanceConverter;
@@ -44,6 +46,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @TestPropertySource("classpath:application-history.properties")
@@ -99,6 +103,8 @@ public class HistoryConfigurationTest {
     @Autowired
     private SecurityManager securityManager;
 
+    @Autowired
+    private List<ProcessDefinitionDecorator> processDefinitionDecorators;
 
     @AfterEach
     public void cleanUp(){
@@ -120,7 +126,8 @@ public class HistoryConfigurationTest {
                      configuration,
                      eventPublisher,
                      processVariablesValidator,
-                     securityManager));
+                     securityManager,
+                     processDefinitionDecorators));
 
         spy(new ProcessAdminRuntimeImpl(repositoryService,
                      processDefinitionConverter,

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/displayed-vars-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/displayed-vars-extensions.json
@@ -1,0 +1,42 @@
+{
+  "id":"displayedVarsProcess",
+  "extensions":{
+    "Process_displayedVarsProcess": {
+      "properties":{
+        "d440ff7b-0ac8-4a97-b163-51a6ec49faa1":{
+          "id":"d440ff7b-0ac8-4a97-b163-51a6ec49faa1",
+          "name":"age",
+          "type":"integer",
+          "required":true,
+          "display": true,
+          "displayName": "Age"
+        },
+        "bbcf2eee-3e4a-45f3-b9b7-42be5dcb10bf":{
+          "id":"bbcf2eee-3e4a-45f3-b9b7-42be5dcb10bf",
+          "name":"name",
+          "type":"string",
+          "required":true,
+          "value":"Nobody",
+          "display": true,
+          "displayName": "Full name"
+        },
+        "379dc1a1-481d-4617-a027-ef39fdadf224":{
+          "id":"379dc1a1-481d-4617-a027-ef39fdadf224",
+          "name":"subscribe",
+          "required":false,
+          "type":"boolean",
+          "display": true,
+          "displayName": "Subscribe"
+        },
+        "379dc1a1-481d-4617-a027-ef39fdadf225":{
+          "id":"379dc1a1-481d-4617-a027-ef39fdadf225",
+          "name":"birth",
+          "type":"date",
+          "required":false,
+          "display": true,
+          "displayName": "Date of birth"
+        }
+      }
+    }
+  }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/displayed-vars.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/displayed-vars.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="processDefinitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="processDefinitions">
+
+    <process id="Process_displayedVarsProcess">
+
+        <startEvent id="start"/>
+
+        <sequenceFlow id="flow1" sourceRef="start" targetRef="userTask"/>
+
+        <userTask id="userTask"/>
+
+        <sequenceFlow id="flow2" sourceRef="userTask" targetRef="end"/>
+
+        <endEvent id="end"/>
+
+    </process>
+
+</definitions>


### PR DESCRIPTION
With this PR I'm adding variableDefinitions to processDefinitions endpoint if a `include=variables` query param is provided in GET request.
Ref: https://github.com/Activiti/Activiti/issues/3919