### PR TITLE
return processes to involved users

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -262,11 +262,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         org.activiti.engine.runtime.ProcessInstanceQuery internalQuery = runtimeService.createProcessInstanceQuery();
 
         String currentUserId = securityManager.getAuthenticatedUserId();
-        internalQuery
-            .or()
-            .startedBy(currentUserId)
-            .involvedUser(currentUserId)
-            .endOr();
+        internalQuery.involvedUser(currentUserId);
 
         if (!securityKeysInPayload.getProcessDefinitionKeys().isEmpty()) {
             getProcessInstancesPayload.setProcessDefinitionKeys(securityKeysInPayload.getProcessDefinitionKeys());

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -262,7 +262,11 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         org.activiti.engine.runtime.ProcessInstanceQuery internalQuery = runtimeService.createProcessInstanceQuery();
 
         String currentUserId = securityManager.getAuthenticatedUserId();
-        internalQuery.startedBy(currentUserId);
+        internalQuery
+            .or()
+            .startedBy(currentUserId)
+            .involvedUser(currentUserId)
+            .endOr();
 
         if (!securityKeysInPayload.getProcessDefinitionKeys().isEmpty()) {
             getProcessInstancesPayload.setProcessDefinitionKeys(securityKeysInPayload.getProcessDefinitionKeys());

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -309,12 +309,17 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
     subProcessInstance.setSuperExecution(superExecutionEntity);
     subProcessInstance.setRootProcessInstanceId(superExecutionEntity.getRootProcessInstanceId());
     subProcessInstance.setScope(true); // process instance is always a scope for all child executions
-    subProcessInstance.setStartUserId(Authentication.getAuthenticatedUserId());
     subProcessInstance.setBusinessKey(businessKey);
     subProcessInstance.setAppVersion(processDefinition.getAppVersion());
+    String authenticatedUserId = Authentication.getAuthenticatedUserId();
+    subProcessInstance.setStartUserId(authenticatedUserId);
 
     // Store in database
     insert(subProcessInstance, false);
+
+    if (authenticatedUserId != null) {
+      getIdentityLinkEntityManager().addIdentityLink(subProcessInstance, authenticatedUserId, null, IdentityLinkType.STARTER);
+    }
 
     if (logger.isDebugEnabled()) {
       logger.debug("Child execution {} created with super execution {}", subProcessInstance, superExecutionEntity.getId());

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -908,6 +908,9 @@
           <if test="orQueryObject.involvedUser != null">
             or EXISTS(select ID_ from ${prefix}ACT_RU_IDENTITYLINK I where I.PROC_INST_ID_ = RES.ID_ and I.USER_ID_ = #{orQueryObject.involvedUser})
           </if>
+          <if test="orQueryObject.startedBy != null">
+            or RES.START_USER_ID_ = #{orQueryObject.startedBy}
+          </if>
           <!-- PLEASE NOTE: If you change anything have a look into the HistoricVariableInstance & HistoricProcessInstance, the same query object is used there! -->
           <foreach collection="orQueryObject.queryVariableValues" index="index" item="queryVariableValue">
             or

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -1836,4 +1836,21 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
 
     assertThat(processInstances).hasSize(1);
   }
+
+  @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+  public void testOrQueryByStartedBy() throws Exception {
+    final String authenticatedUser = "user1";
+    Authentication.setAuthenticatedUserId(authenticatedUser);
+    ProcessInstance expectedProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+    ProcessInstance actualProcessInstance = runtimeService.createProcessInstanceQuery()
+        .or()
+        .startedBy(authenticatedUser)
+        .processDefinitionKey("notTheProcessDefinitionKey")
+        .endOr()
+        .singleResult();
+
+    assertThat(actualProcessInstance.getProcessInstanceId())
+        .isEqualTo(expectedProcessInstance.getProcessInstanceId());
+    }
 }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -1850,6 +1850,7 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
         .endOr()
         .singleResult();
 
+    assertThat(actualProcessInstance).isNotNull();
     assertThat(actualProcessInstance.getProcessInstanceId())
         .isEqualTo(expectedProcessInstance.getProcessInstanceId());
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/ProcessInstanceQueryTest.java
@@ -1843,6 +1843,9 @@ public class ProcessInstanceQueryTest extends PluggableActivitiTestCase {
     Authentication.setAuthenticatedUserId(authenticatedUser);
     ProcessInstance expectedProcessInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
 
+    Authentication.setAuthenticatedUserId("user2");
+    runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
     ProcessInstance actualProcessInstance = runtimeService.createProcessInstanceQuery()
         .or()
         .startedBy(authenticatedUser)

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -981,4 +981,40 @@ public class ProcessRuntimeIT {
         assertThat(deletedProcessInstance).isNotNull();
         assertThat(deletedProcessInstance.getStatus()).isEqualTo(ProcessInstance.ProcessInstanceStatus.CANCELLED);
     }
+
+    @Test
+    public void should_returnProcessesToTaskCandidates() {
+        //given
+        ProcessInstance processInstance = processRuntime.start(ProcessPayloadBuilder.start()
+            .withProcessDefinitionKey(TWO_TASKS_PROCESS)
+            .build());
+
+        securityUtil.logInAs("garth");
+
+        //when
+        Page<ProcessInstance> processInstancePage = processRuntime.processInstances(PAGEABLE);
+
+        //then
+        assertThat(processInstancePage).isNotNull();
+        assertThat(processInstancePage.getContent()).hasSize(1);
+        assertThat(processInstancePage.getContent().get(0).getId()).isEqualTo(processInstance.getId());
+    }
+
+    @Test
+    public void should_returnProcessesToTaskAssignees() {
+        //given
+        ProcessInstance processInstance = processRuntime.start(ProcessPayloadBuilder.start()
+            .withProcessDefinitionKey(SINGLE_TASK_PROCESS)
+            .build());
+
+        securityUtil.logInAs("garth");
+
+        //when
+        Page<ProcessInstance> processInstancePage = processRuntime.processInstances(PAGEABLE);
+
+        //then
+        assertThat(processInstancePage).isNotNull();
+        assertThat(processInstancePage.getContent()).hasSize(1);
+        assertThat(processInstancePage.getContent().get(0).getId()).isEqualTo(processInstance.getId());
+    }
 }


### PR DESCRIPTION
#3887

- Candidate groups:
    -  Identity links are not added to groups at runtime same way they are added to user i.e.  [task assignee](https://github.com/Activiti/Activiti/blob/develop/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/TaskEntityManagerImpl.java#L166)
    - Process instance query doesn’t have a way to filter results by involved groups similar to what available to [users](https://github.com/Activiti/Activiti/blob/develop/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstanceQuery.java#L127)
- [Fixed] Process instance query `involvedUser()` doesn’t work for subprocesses. Seems that an identitylink isn't added at runtime to subprocesses like normal [parent processes](https://github.com/Activiti/Activiti/blob/develop/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java#L250) (workaround to use `or()` - startedBy or involved user)
- Or startedBy clause was missing in mybatis XML - fixed in this PR
