### PR TITLE
Bump spring-boot to 2.6.6 due to CVE-2022-22965

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <maven-site-plugin.version>3.11.0</maven-site-plugin.version>
     <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-    <spring-boot.version>2.6.4</spring-boot.version>
+    <spring-boot.version>2.6.6</spring-boot.version>
     <versions-maven-plugin.version>2.9.0</versions-maven-plugin.version>
 
     <!-- configuration properties for tests -->


### PR DESCRIPTION
See details:

https://spring.io/blog/2022/03/31/spring-boot-2-6-6-available-now

https://tanzu.vmware.com/security/cve-2022-22965