### PR TITLE
#3296 add processDefinitionId to variable created event

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/VariableCreatedEventImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-model-shared-impl/src/main/java/org/activiti/api/runtime/event/impl/VariableCreatedEventImpl.java
@@ -24,9 +24,10 @@ public class VariableCreatedEventImpl extends VariableEventImpl implements Varia
     public VariableCreatedEventImpl() {
     }
 
-    public VariableCreatedEventImpl(VariableInstance entity) {
+    public VariableCreatedEventImpl(VariableInstance entity, String processDefinitionId) {
         super(entity);
         setProcessInstanceId(entity.getProcessInstanceId());
+        setProcessDefinitionId(processDefinitionId);
     }
 
     @Override

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableCreatedConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableCreatedConverter.java
@@ -31,6 +31,6 @@ public class ToVariableCreatedConverter implements EventConverter<VariableCreate
                                                                                    internalEvent.getVariableValue(),
                                                                                    internalEvent.getProcessInstanceId(),
                                                                                    internalEvent.getTaskId());
-        return Optional.of(new VariableCreatedEventImpl(variableInstance));
+        return Optional.of(new VariableCreatedEventImpl(variableInstance, internalEvent.getProcessDefinitionId()));
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/impl/ToVariableCreatedConverterTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/impl/ToVariableCreatedConverterTest.java
@@ -37,6 +37,7 @@ class ToVariableCreatedConverterTest {
         ActivitiVariableEventImpl internalEvent = new ActivitiVariableEventImpl(ActivitiEventType.VARIABLE_CREATED);
         internalEvent.setVariableName("variableName");
         internalEvent.setProcessInstanceId("processInstanceId");
+        internalEvent.setProcessDefinitionId("processDefinitionId");
         internalEvent.setTaskId("taskId");
         VariableType variableType = new StringType(100);
         internalEvent.setVariableType(variableType);
@@ -49,6 +50,7 @@ class ToVariableCreatedConverterTest {
         VariableCreatedEvent actualEvent = result.get();
         assertThat(actualEvent.getEventType()).isEqualTo(VariableEvents.VARIABLE_CREATED);
         assertThat(actualEvent.getProcessInstanceId()).isEqualTo("processInstanceId");
+        assertThat(actualEvent.getProcessDefinitionId()).isEqualTo("processDefinitionId");
         VariableInstance actualEntity = actualEvent.getEntity();
         assertThat(actualEntity.getName()).isEqualTo("variableName");
         assertThat(actualEntity.getProcessInstanceId()).isEqualTo("processInstanceId");


### PR DESCRIPTION
Adding process definition id to variable created event to later use it to retrieve variable definition id in order to store it on query service database.
Ref: https://github.com/Activiti/Activiti/issues/3926