### PR TITLE
fix(GH-3957): add support for expressions in activity name for dispatched events

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ConnectorsAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ConnectorsAutoConfiguration.java
@@ -49,9 +49,10 @@ public class ConnectorsAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public IntegrationContextBuilder integrationContextBuilder(
-        ExtensionsVariablesMappingProvider variablesMappingProvider) {
-        return new IntegrationContextBuilder(variablesMappingProvider);
+    public IntegrationContextBuilder integrationContextBuilder(ExtensionsVariablesMappingProvider variablesMappingProvider,
+                                                               ExpressionManager expressionManager) {
+        return new IntegrationContextBuilder(variablesMappingProvider,
+                                             expressionManager);
     }
 
     @Bean(name = DefaultActivityBehaviorFactory.DEFAULT_SERVICE_TASK_BEAN_NAME)

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -39,10 +39,13 @@ public class IntegrationContextBuilder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(IntegrationContextBuilder.class);
 
-    private ExtensionsVariablesMappingProvider inboundVariablesProvider;
+    private final ExtensionsVariablesMappingProvider inboundVariablesProvider;
+    private final ExpressionManager expressionManager;
 
-    public IntegrationContextBuilder(ExtensionsVariablesMappingProvider inboundVariablesProvider) {
+    public IntegrationContextBuilder(ExtensionsVariablesMappingProvider inboundVariablesProvider,
+                                     ExpressionManager expressionManager) {
         this.inboundVariablesProvider = inboundVariablesProvider;
+        this.expressionManager = expressionManager;
     }
 
     public IntegrationContext from(IntegrationContextEntity integrationContextEntity,
@@ -103,9 +106,6 @@ public class IntegrationContextBuilder {
         String clientName = serviceTask.getName();
 
         if (StringUtils.isNotEmpty(clientName)) {
-            ProcessEngineConfigurationImpl processEngineConfiguration = Context.getProcessEngineConfiguration();
-            ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
-
             try {
                 return (String) expressionManager.createExpression(clientName)
                                                  .getValue(execution);

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/IntegrationContextBuilder.java
@@ -23,8 +23,6 @@ import org.activiti.api.runtime.model.impl.IntegrationContextImpl;
 import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
-import org.activiti.engine.impl.context.Context;
 import org.activiti.engine.impl.context.ExecutionContext;
 import org.activiti.engine.impl.el.ExpressionManager;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
@@ -78,7 +78,6 @@ public class IntegrationContextBuilderTest {
 
         given(processEngineConfiguration.getDeploymentManager()).willReturn(deploymentManager);
         given(deploymentManager.findDeployedProcessDefinitionById(PROCESS_DEFINITION_ID)).willReturn(processDefinition);
-        given(processEngineConfiguration.getExpressionManager()).willReturn(expressionManager);
 
         given(processDefinition.getKey()).willReturn(PROCESS_DEFINITION_KEY);
         given(processDefinition.getVersion()).willReturn(PROCESS_DEFINITION_VERSION);

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/connector/IntegrationContextBuilderTest.java
@@ -17,12 +17,10 @@ package org.activiti.runtime.api.connector;
 
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
@@ -40,7 +38,6 @@ import org.activiti.runtime.api.impl.ExtensionsVariablesMappingProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueMultiInstanceOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueMultiInstanceOperation.java
@@ -82,8 +82,7 @@ public class ContinueMultiInstanceOperation extends AbstractOperation {
 
       if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
         Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-            ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_STARTED, flowNode.getId(), flowNode.getName(), execution.getId(),
-                execution.getProcessInstanceId(), execution.getProcessDefinitionId(), flowNode));
+            ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_STARTED, execution, flowNode));
       }
 
       try {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
@@ -214,11 +214,7 @@ public class ContinueProcessOperation extends AbstractOperation {
                 !(activityBehavior instanceof MultiInstanceActivityBehavior)) {
             Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                     ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_STARTED,
-                                                             flowNode.getId(),
-                                                             flowNode.getName(),
-                                                             execution.getId(),
-                                                             execution.getProcessInstanceId(),
-                                                             execution.getProcessDefinitionId(),
+                                                             execution,
                                                              flowNode));
         }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/EndExecutionOperation.java
@@ -261,11 +261,7 @@ public class EndExecutionOperation extends AbstractOperation {
 
         Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                 ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPLETED,
-                                                         subProcess.getId(),
-                                                         subProcess.getName(),
-                                                         parentExecution.getId(),
-                                                         parentExecution.getProcessInstanceId(),
-                                                         parentExecution.getProcessDefinitionId(),
+                                                         parentExecution,
                                                          subProcess));
         return executionToContinue;
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
@@ -121,11 +121,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
             if (!(execution.getCurrentFlowElement() instanceof SubProcess) && !(flowNode.getBehavior() instanceof MultiInstanceActivityBehavior)) {
                 Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
                         ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPLETED,
-                                                                 flowNode.getId(),
-                                                                 flowNode.getName(),
-                                                                 execution.getId(),
-                                                                 execution.getProcessInstanceId(),
-                                                                 execution.getProcessDefinitionId(),
+                                                                 execution,
                                                                  flowNode));
             }
         }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ExclusiveGatewayActivityBehavior.java
@@ -61,8 +61,7 @@ public class ExclusiveGatewayActivityBehavior extends GatewayActivityBehavior {
 
     if (Context.getProcessEngineConfiguration() != null && Context.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
       Context.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-          ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPLETED, exclusiveGateway.getId(), exclusiveGateway.getName(), execution.getId(),
-              execution.getProcessInstanceId(), execution.getProcessDefinitionId(), exclusiveGateway));
+          ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPLETED, execution, exclusiveGateway));
     }
 
     SequenceFlow outgoingSequenceFlow = null;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MultiInstanceActivityBehavior.java
@@ -352,14 +352,12 @@ public abstract class MultiInstanceActivityBehavior extends FlowNodeActivityBeha
 
   protected void dispatchActivityCompletedEvent(DelegateExecution execution) {
     ExecutionEntity executionEntity = (ExecutionEntity) execution;
+    FlowElement flowElement = executionEntity.getCurrentFlowElement();
+
     getCommandContext().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createActivityEvent(
             ActivitiEventType.ACTIVITY_COMPLETED,
-            executionEntity.getActivityId(),
-            executionEntity.getName(),
-            executionEntity.getId(),
-            executionEntity.getProcessInstanceId(),
-            executionEntity.getProcessDefinitionId(),
-            executionEntity.getCurrentFlowElement()
+            executionEntity,
+            flowElement
     ));
   }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/event/CompensationEventHandler.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/event/CompensationEventHandler.java
@@ -72,8 +72,7 @@ public class CompensationEventHandler implements EventHandler {
 
         if (commandContext.getProcessEngineConfiguration().getEventDispatcher().isEnabled()) {
           commandContext.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(
-                ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPENSATE, flowElement.getId(), flowElement.getName(),
-                    compensatingExecution.getId(), compensatingExecution.getProcessInstanceId(), compensatingExecution.getProcessDefinitionId(), flowElement));
+                ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_COMPENSATE, compensatingExecution, flowElement));
         }
         compensatingExecution.setCurrentFlowElement(flowElement);
         Context.getAgenda().planContinueProcessInCompensation(compensatingExecution);


### PR DESCRIPTION
This PR add support for expressions in activity names to be able to resolve the placeholders during execution, i.e. multi-instance loop counter in the service task name:

```
<bpmn:serviceTask id="miCloudConnectorId" name="miCloudConnectorName-${loopCounter}" implementation="miCloudConnector">
```

Part of https://github.com/Activiti/Activiti/issues/3957