### PR TITLE
Process Candidate starters

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -99,7 +99,7 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
             .stream()
             .findFirst()
             .orElseThrow(() ->
-                new ActivitiObjectNotFoundException("Unable to find process definition for the given id:'" + processDefinitionId + "'"));
+                new ActivitiObjectNotFoundException("Unable to find process definition for the given id or key:'" + processDefinitionId + "'"));
 
         return processDefinitionConverter.from(processDefinition);
     }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -99,7 +99,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
 
     private final SecurityManager securityManager;
 
-    @Value("${spring.activiti.candidateStarter.enabled:false}")
+    @Value("${activiti.candidateStarter.enabled:false}")
     private boolean candidateStartersEnabled;
 
     public ProcessRuntimeImpl(RepositoryService repositoryService,
@@ -135,12 +135,12 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
 
         org.activiti.engine.repository.ProcessDefinition processDefinition = findLatestProcessDefinition(processDefinitionQuery)
             .orElseThrow(() ->
-                new ActivitiObjectNotFoundException("Unable to find process definition for the given id:'" + processDefinitionId + "'"));
+                new ActivitiObjectNotFoundException("Unable to find process definition for the given id or key:'" + processDefinitionId + "'"));
 
         checkProcessDefinitionBelongsToLatestDeployment(processDefinition);
 
         if (!securityPoliciesManager.canRead(processDefinition.getKey())) {
-            throw new ActivitiObjectNotFoundException("Unable to find process definition for the given id:'" + processDefinitionId + "'");
+            throw new ActivitiObjectNotFoundException("Unable to find process definition for the given id or key:'" + processDefinitionId + "'");
         }
 
         return processDefinitionConverter.from(processDefinition);

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -232,7 +232,7 @@ public class ProcessRuntimeImplTest {
 
         assertThat(exception)
             .isInstanceOf(ActivitiObjectNotFoundException.class)
-            .hasMessage("Unable to find process definition for the given id:'processDefinitionId'");
+            .hasMessage("Unable to find process definition for the given id or key:'processDefinitionId'");
     }
 
     @Test

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -46,6 +46,7 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
     private String deploymentId;
     private Set<String> deploymentIds;
     private String key;
+    private String idOrKey;
     private String keyLike;
     private Set<String> keys;
     private String resourceName;
@@ -149,6 +150,15 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
             throw new ActivitiIllegalArgumentException("key is null");
         }
         this.key = key;
+        return this;
+    }
+
+    @Override
+    public ProcessDefinitionQuery processDefinitionIdOrKey(String idOrKey) {
+        if (idOrKey == null) {
+            throw new ActivitiIllegalArgumentException("processDefinitionIdOrKey is null");
+        }
+        this.idOrKey = idOrKey;
         return this;
     }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessDefinitionQueryImpl.java
@@ -394,6 +394,10 @@ public class ProcessDefinitionQueryImpl extends AbstractQuery<ProcessDefinitionQ
         return key;
     }
 
+    public String getIdOrKey() {
+        return idOrKey;
+    }
+
     public String getKeyLike() {
         return keyLike;
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/ProcessDefinitionQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/repository/ProcessDefinitionQuery.java
@@ -90,6 +90,11 @@ public interface ProcessDefinitionQuery extends Query<ProcessDefinitionQuery, Pr
     ProcessDefinitionQuery processDefinitionKeyLike(String processDefinitionKeyLike);
 
     /**
+     * Selects process definitions with id or key equals to processDefinitionIdOrKey
+     */
+    ProcessDefinitionQuery processDefinitionIdOrKey(String processDefinitionIdOrKey);
+
+    /**
      * Only select process definition with a certain version. Particulary useful when used in combination with {@link #processDefinitionKey(String)}
      */
     ProcessDefinitionQuery processDefinitionVersion(Integer processDefinitionVersion);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/ProcessDefinition.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/ProcessDefinition.xml
@@ -179,6 +179,9 @@
       <if test="key != null">
         and RES.KEY_ = #{key}
       </if>
+      <if test="idOrKey != null">
+        and (RES.ID_ = #{idOrKey} or RES.KEY_ = #{idOrKey})
+      </if>
       <if test="keyLike != null">
         and RES.KEY_ like #{keyLike}${wildcardEscapeClause}
       </if>

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/repository/ProcessDefinitionQueryTest.java
@@ -27,16 +27,10 @@ import org.activiti.engine.repository.ProcessDefinitionQuery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/**
-
- */
 public class ProcessDefinitionQueryTest extends PluggableActivitiTestCase {
 
   private String deploymentOneId;
@@ -129,6 +123,21 @@ public class ProcessDefinitionQueryTest extends PluggableActivitiTestCase {
 
     // process two
     query = repositoryService.createProcessDefinitionQuery().processDefinitionKey("two");
+    verifyQueryResults(query, 1);
+  }
+
+  public void testQueryByIdOrKey() {
+    ProcessDefinitionQuery query = repositoryService.createProcessDefinitionQuery().processDefinitionIdOrKey("one");
+    verifyQueryResults(query, 2);
+
+    ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
+        .processDefinitionKey("one")
+        .list()
+        .stream()
+        .findFirst()
+        .get();
+
+    query = repositoryService.createProcessDefinitionQuery().processDefinitionIdOrKey(processDefinition.getId());
     verifyQueryResults(query, 1);
   }
 

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.spring.boot.process;
+
+import org.activiti.api.process.model.ProcessDefinition;
+import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.runtime.ProcessRuntime;
+import org.activiti.api.runtime.shared.query.Page;
+import org.activiti.api.runtime.shared.query.Pageable;
+import org.activiti.engine.ActivitiObjectNotFoundException;
+import org.activiti.spring.boot.security.util.SecurityUtil;
+import org.activiti.spring.boot.test.util.ProcessCleanUpUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@TestPropertySource("classpath:application-with-candidate-starters-enabled.properties")
+public class ProcessRuntimeCandidateStartersIT {
+
+    private static final String RESTRICTED_PROCESS_DEFINITION_KEY = "SingleTaskProcessRestricted";
+    private static final Pageable PAGEABLE = Pageable.of(0,
+        50);
+
+    @Autowired
+    private ProcessRuntime processRuntime;
+
+    @Autowired
+    private SecurityUtil securityUtil;
+
+    @Autowired
+    private ProcessCleanUpUtil processCleanUpUtil;
+
+    @AfterEach
+    public void cleanUp(){
+        processCleanUpUtil.cleanUpWithAdmin();
+    }
+
+    @Test
+    public void candidateStarterUser_should_getProcessDefinitions() {
+        securityUtil.logInAs("user");
+
+        Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
+                                                                                                      50));
+        assertThat(processDefinitionPage.getContent()).isNotNull();
+        assertThat(processDefinitionPage.getContent()).hasSize(1);
+        assertThat(processDefinitionPage.getContent().get(0).getKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+    @Test
+    public void candidateStarterGroupMembers_should_getProcessDefinitions() {
+        securityUtil.logInAs("john");
+
+        Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
+            50));
+        assertThat(processDefinitionPage.getContent()).isNotNull();
+        assertThat(processDefinitionPage.getContent()).hasSize(1);
+        assertThat(processDefinitionPage.getContent().get(0).getKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+    @Test
+    public void nonCandidateStarters_shouldNot_getProcessDefinitions() {
+        securityUtil.logInAs("garth");
+
+        Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
+            50));
+        assertThat(processDefinitionPage.getContent()).isNotNull();
+        assertThat(processDefinitionPage.getContent()).hasSize(0);
+    }
+
+
+    @Test
+    public void candidateStarterUser_should_getProcessDefinition() {
+        securityUtil.logInAs("user");
+
+        ProcessDefinition processDefinition = processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY);
+        assertThat(processDefinition).isNotNull();
+        assertThat(processDefinition.getKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+    @Test
+    public void candidateStarterGroupMembers_should_getProcessDefinition() {
+        securityUtil.logInAs("john");
+
+        ProcessDefinition processDefinition = processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY);
+        assertThat(processDefinition).isNotNull();
+        assertThat(processDefinition.getKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+    @Test
+    public void nonCandidateStarters_shouldNot_getProcessDefinition() {
+        securityUtil.logInAs("garth");
+
+        Throwable throwable = catchThrowable(() -> processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY));
+
+        assertThat(throwable)
+            .isInstanceOf(ActivitiObjectNotFoundException.class)
+            .hasMessage("Unable to find process definition for the given id:'" + RESTRICTED_PROCESS_DEFINITION_KEY + "'");
+    }
+
+    @Test
+    public void candidateStarterUser_can_startProcess() {
+        securityUtil.logInAs("user");
+
+        Page<ProcessInstance> processInstancePage = processRuntime.processInstances(PAGEABLE);
+
+        assertThat(processInstancePage).isNotNull();
+        assertThat(processInstancePage.getContent()).isEmpty();
+
+        ProcessInstance processInstance = processRuntime.start(ProcessPayloadBuilder.start()
+            .withProcessDefinitionKey(RESTRICTED_PROCESS_DEFINITION_KEY)
+            .build());
+
+        assertThat(processInstance).isNotNull();
+        assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCandidateStartersIT.java
@@ -38,8 +38,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 public class ProcessRuntimeCandidateStartersIT {
 
     private static final String RESTRICTED_PROCESS_DEFINITION_KEY = "SingleTaskProcessRestricted";
-    private static final Pageable PAGEABLE = Pageable.of(0,
-        50);
 
     @Autowired
     private ProcessRuntime processRuntime;
@@ -57,7 +55,7 @@ public class ProcessRuntimeCandidateStartersIT {
 
     @Test
     public void candidateStarterUser_should_getProcessDefinitions() {
-        securityUtil.logInAs("user");
+        loginAsUserCandidateStarter();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
                                                                                                       50));
@@ -68,7 +66,7 @@ public class ProcessRuntimeCandidateStartersIT {
 
     @Test
     public void candidateStarterGroupMembers_should_getProcessDefinitions() {
-        securityUtil.logInAs("john");
+        loginAsGroupMemberCandidateStarter();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
             50));
@@ -79,18 +77,18 @@ public class ProcessRuntimeCandidateStartersIT {
 
     @Test
     public void nonCandidateStarters_shouldNot_getProcessDefinitions() {
-        securityUtil.logInAs("garth");
+        loginAsANonCandidateStarter();
 
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
             50));
         assertThat(processDefinitionPage.getContent()).isNotNull();
-        assertThat(processDefinitionPage.getContent()).hasSize(0);
+        assertThat(processDefinitionPage.getContent()).isEmpty();
     }
 
 
     @Test
     public void candidateStarterUser_should_getProcessDefinition() {
-        securityUtil.logInAs("user");
+        loginAsUserCandidateStarter();
 
         ProcessDefinition processDefinition = processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY);
         assertThat(processDefinition).isNotNull();
@@ -99,7 +97,7 @@ public class ProcessRuntimeCandidateStartersIT {
 
     @Test
     public void candidateStarterGroupMembers_should_getProcessDefinition() {
-        securityUtil.logInAs("john");
+        loginAsGroupMemberCandidateStarter();
 
         ProcessDefinition processDefinition = processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY);
         assertThat(processDefinition).isNotNull();
@@ -108,23 +106,18 @@ public class ProcessRuntimeCandidateStartersIT {
 
     @Test
     public void nonCandidateStarters_shouldNot_getProcessDefinition() {
-        securityUtil.logInAs("garth");
+        loginAsANonCandidateStarter();
 
         Throwable throwable = catchThrowable(() -> processRuntime.processDefinition(RESTRICTED_PROCESS_DEFINITION_KEY));
 
         assertThat(throwable)
             .isInstanceOf(ActivitiObjectNotFoundException.class)
-            .hasMessage("Unable to find process definition for the given id:'" + RESTRICTED_PROCESS_DEFINITION_KEY + "'");
+            .hasMessage("Unable to find process definition for the given id or key:'" + RESTRICTED_PROCESS_DEFINITION_KEY + "'");
     }
 
     @Test
     public void candidateStarterUser_can_startProcess() {
-        securityUtil.logInAs("user");
-
-        Page<ProcessInstance> processInstancePage = processRuntime.processInstances(PAGEABLE);
-
-        assertThat(processInstancePage).isNotNull();
-        assertThat(processInstancePage.getContent()).isEmpty();
+        loginAsUserCandidateStarter();
 
         ProcessInstance processInstance = processRuntime.start(ProcessPayloadBuilder.start()
             .withProcessDefinitionKey(RESTRICTED_PROCESS_DEFINITION_KEY)
@@ -132,6 +125,18 @@ public class ProcessRuntimeCandidateStartersIT {
 
         assertThat(processInstance).isNotNull();
         assertThat(processInstance.getProcessDefinitionKey()).isEqualTo(RESTRICTED_PROCESS_DEFINITION_KEY);
+    }
+
+    private void loginAsUserCandidateStarter() {
+        securityUtil.logInAs("user");
+    }
+
+    private void loginAsGroupMemberCandidateStarter() {
+        securityUtil.logInAs("john");
+    }
+
+    private void loginAsANonCandidateStarter() {
+        securityUtil.logInAs("garth");
     }
 
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -372,6 +372,17 @@ public class ProcessRuntimeIT {
     }
 
     @Test
+    public void shouldGetProcessDefinitionById() {
+        ProcessDefinition categorizeHumanProcess = processRuntime.processDefinition(CATEGORIZE_HUMAN_PROCESS);
+        assertThat(categorizeHumanProcess).isNotNull();
+
+        categorizeHumanProcess = processRuntime.processDefinition(categorizeHumanProcess.getId());
+
+        assertThat(categorizeHumanProcess).isNotNull();
+        assertThat(categorizeHumanProcess.getName()).isEqualTo(CATEGORIZE_HUMAN_PROCESS);
+    }
+
+    @Test
     public void getProcessInstances() {
         //when
         Page<ProcessInstance> processInstancePage = processRuntime.processInstances(PAGEABLE);

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeSecurityPoliciesIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeSecurityPoliciesIT.java
@@ -18,7 +18,6 @@ package org.activiti.spring.boot.process;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
 import org.activiti.api.process.runtime.ProcessRuntime;
-import org.activiti.api.process.runtime.conf.ProcessRuntimeConfiguration;
 import org.activiti.api.runtime.shared.query.Page;
 import org.activiti.api.runtime.shared.query.Pageable;
 import org.activiti.spring.boot.security.util.SecurityUtil;
@@ -27,8 +26,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithUserDetails;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestPropertySource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,14 +56,10 @@ public class ProcessRuntimeSecurityPoliciesIT {
 
         securityUtil.logInAs("user");
 
-        ProcessRuntimeConfiguration configuration = processRuntime.configuration(); //@TODO: I should get the security policies defined here.
-        assertThat(configuration).isNotNull();
         Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(Pageable.of(0,
                                                                                                       50));
         assertThat(processDefinitionPage.getContent()).isNotNull();
         assertThat(processDefinitionPage.getContent()).hasSize(2);
-
-
 
     }
 
@@ -82,12 +75,11 @@ public class ProcessRuntimeSecurityPoliciesIT {
                 .extracting(ProcessDefinition::getKey)
                 .contains("categorizeProcessConnectors",
                           "categorizeHumanProcess",
+                          "SingleTaskProcessRestricted",
                           "categorizeProcess",
                           "integrationGatewayProcess",
                           "waiter");
 
     }
-
-
 
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/application-with-candidate-starters-enabled.properties
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/application-with-candidate-starters-enabled.properties
@@ -1,2 +1,2 @@
 spring.application.name=candidate-starters-app
-spring.activiti.candidateStarter.enabled=true
+activiti.candidateStarter.enabled=true

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/application-with-candidate-starters-enabled.properties
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/application-with-candidate-starters-enabled.properties
@@ -1,0 +1,2 @@
+spring.application.name=candidate-starters-app
+spring.activiti.candidateStarter.enabled=true

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/SingleTaskProcessRestricted.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/SingleTaskProcessRestricted.bpmn20.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:activiti="http://activiti.org/bpmn" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="SingleTaskProcessRestricted" name="single-task-restricted" activiti:candidateStarterUsers="user" activiti:candidateStarterGroups="activitiTeam" isExecutable="true">
+    <bpmn2:startEvent id="StartEvent_1" activiti:formKey="startForm">
+      <bpmn2:outgoing>SequenceFlow_1tec9n0</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1tec9n0" sourceRef="StartEvent_1" targetRef="Task_03l0zc2" />
+    <bpmn2:endEvent id="EndEvent_00jfcl0">
+      <bpmn2:incoming>SequenceFlow_00ryslt</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_00ryslt" sourceRef="Task_03l0zc2" targetRef="EndEvent_00jfcl0" />
+    <bpmn2:userTask id="Task_03l0zc2" name="my-task" activiti:assignee="garth" activiti:candidateUsers="firstCandidateUser, secondCandidateUser"
+                    activiti:candidateGroups="firstCandidateGroup, secondCandidateGroup" activiti:formKey="taskForm">
+      <bpmn2:incoming>SequenceFlow_1tec9n0</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_00ryslt</bpmn2:outgoing>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SingleTaskProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tec9n0_di" bpmnElement="SequenceFlow_1tec9n0">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="498" y="258" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="473" y="236.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_00jfcl0_di" bpmnElement="EndEvent_00jfcl0">
+        <dc:Bounds x="648" y="240" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="666" y="279" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_00ryslt_di" bpmnElement="SequenceFlow_00ryslt">
+        <di:waypoint x="598" y="258" />
+        <di:waypoint x="648" y="258" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="623" y="236.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_07zs0fg_di" bpmnElement="Task_03l0zc2">
+        <dc:Bounds x="498" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
Ref #3968 

- To enable candidate starters restriction set `activiti.candidateStarter.enabled=true`
- To add candidate starters to a process definition use `activiti:candidateStarterUsers` and `activiti:candidateStarterGroups` attributes to the process element. For example
`<bpmn2:process id="simple" name="Simple" activiti:candidateStarterUsers="user" activiti:candidateStarterGroups="activitiTeam" isExecutable="true">`
- When enabled, only process definitions that the current user is a candidate starter of should be accessible to the user. Additionally, the user can't start any process where he's not a candidate starter.
