### PR TITLE
[AAE-9212] Allow APPLICATION_MANAGER access Processes and tasks

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -53,7 +53,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.transaction.annotation.Transactional;
 
-@PreAuthorize("hasRole('ACTIVITI_ADMIN')")
+@PreAuthorize("hasAnyRole('ACTIVITI_ADMIN','APPLICATION_MANAGER')")
 public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
 
     private final RepositoryService repositoryService;

--- a/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-task-runtime-impl/src/main/java/org/activiti/runtime/api/impl/TaskAdminRuntimeImpl.java
@@ -47,7 +47,7 @@ import org.activiti.runtime.api.model.impl.APIVariableInstanceConverter;
 import org.activiti.runtime.api.query.impl.PageImpl;
 import org.springframework.security.access.prepost.PreAuthorize;
 
-@PreAuthorize("hasRole('ACTIVITI_ADMIN')")
+@PreAuthorize("hasAnyRole('ACTIVITI_ADMIN','APPLICATION_MANAGER')")
 public class TaskAdminRuntimeImpl implements TaskAdminRuntime {
 
     private final TaskService taskService;

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/RuntimeTestConfiguration.java
@@ -120,6 +120,13 @@ public class RuntimeTestConfiguration {
                                                                "password",
                                                                deanAuthorities));
 
+        List<GrantedAuthority> managerAuthorities = new ArrayList<>();
+        managerAuthorities.add(new SimpleGrantedAuthority("ROLE_APPLICATION_MANAGER"));
+
+        extendedInMemoryUserDetailsManager.createUser(new User("manager",
+            "password",
+            managerAuthorities));
+
         return extendedInMemoryUserDetailsManager;
     }
 

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -994,4 +994,14 @@ public class ProcessRuntimeIT {
         assertThat(processInstancePage.getContent()).hasSize(1);
         assertThat(processInstancePage.getContent().get(0).getId()).isEqualTo(processInstance.getId());
     }
+
+    @Test
+    public void should_returnProcessesWhenUserIsApplicationManager() {
+        securityUtil.logInAs("manager");
+
+        Page<ProcessInstance> processInstancePage = processAdminRuntime.processInstances(Pageable.of(0,
+            50));
+
+        assertThat(processInstancePage).isNotNull();
+    }
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeUnAuthorizedTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeUnAuthorizedTest.java
@@ -86,4 +86,14 @@ public class TaskRuntimeUnAuthorizedTest {
                 .isInstanceOf(NotFoundException.class);
     }
 
+    @Test
+    public void shouldGetTasksAsApplicationManager() {
+        securityUtil.logInAs("manager");
+
+        Page<Task> tasks = taskAdminRuntime.tasks(Pageable.of(0,
+            50));
+
+        assertThat(tasks.getContent()).hasSize(0);
+    }
+
 }


### PR DESCRIPTION
Allow users with the role APPLICATION_MANAGER to access process and tasks admin services used by RB admin APIs
Required by: https://github.com/Alfresco/alfresco-process/pull/931