### PR TITLE
fix(GH-3980): Add support for analytics variable extension property in Activiti engine

### DIFF
--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/VariableDefinition.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/VariableDefinition.java
@@ -31,4 +31,6 @@ public interface VariableDefinition {
 
     String getDisplayName();
 
+    boolean isAnalytics();
+
 }

--- a/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
+++ b/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
@@ -31,6 +31,8 @@ public class VariableDefinition {
 
     private String displayName;
 
+    private boolean analytics;
+
     public String getId() {
         return id;
     }
@@ -85,5 +87,13 @@ public class VariableDefinition {
 
     public void setDisplayName(String displayName) {
         this.displayName = displayName;
+    }
+
+    public boolean isAnalytics() {
+        return analytics;
+    }
+
+    public void setAnalytics(boolean analytics) {
+        this.analytics = analytics;
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/model/impl/VariableDefinitionImpl.java
@@ -28,6 +28,7 @@ public class VariableDefinitionImpl implements VariableDefinition {
     private boolean required;
     private Boolean display;
     private String displayName;
+    private boolean analytics;
 
     @Override
     public String getId() {
@@ -93,6 +94,15 @@ public class VariableDefinitionImpl implements VariableDefinition {
     }
 
     @Override
+    public boolean isAnalytics() {
+        return analytics;
+    }
+
+    public void setAnalytics(boolean analytics) {
+        this.analytics = analytics;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -103,12 +113,13 @@ public class VariableDefinitionImpl implements VariableDefinition {
             Objects.equals(name, that.name) &&
             Objects.equals(description, that.description) &&
             Objects.equals(type, that.type) &&
-            Objects.equals(displayName, that.displayName);
+            Objects.equals(displayName, that.displayName) &&
+            Objects.equals(analytics, that.analytics);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, name, description, type, required, display, displayName);
+        return Objects.hash(id, name, description, type, required, display, displayName, analytics);
     }
 
     @Override
@@ -121,6 +132,8 @@ public class VariableDefinitionImpl implements VariableDefinition {
             ", required=" + required +
             ", display=" + display +
             ", displayName='" + displayName + '\'' +
+            ", analytics='" + analytics + '\'' +
             '}';
     }
+
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/initial-vars-extensions.json
+++ b/activiti-core/activiti-spring-process-extensions/src/test/resources/processes/initial-vars-extensions.json
@@ -44,6 +44,21 @@
               "type": "file",
               "required": false,
               "value": {}
+            },
+            "379dc1a1-481d-4617-a027-ef39fdadf6667": {
+              "id": "379dc1a1-481d-4617-a027-ef39fdadf6667",
+              "name": "trackedId",
+              "type": "integer",
+              "required": false,
+              "value": 0,
+              "analytics": true
+            },
+            "379dc1a1-481d-4617-a027-ef39fdadf6668": {
+              "id": "379dc1a1-481d-4617-a027-ef39fdadf6668",
+              "name": "notTrackedId",
+              "type": "integer",
+              "required": false,
+              "value": 0
             }
           }
         }


### PR DESCRIPTION
This PR adds `analytics` Boolean property for variable definition extension.

Part of https://github.com/Activiti/Activiti/issues/3980