### PR TITLE
Fix hard coding VERSION in ProcessEngine. Make it read version info from pom.

### DIFF
--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -118,6 +118,42 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.ibm.db2.jcc</groupId>
+      <artifactId>db2jcc</artifactId>
+      <version>db2jcc4</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <version>2.2.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>sqljdbc4</artifactId>
+      <version>4.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.46</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc10</artifactId>
+      <version>19.16.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>42.5.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -188,6 +224,12 @@
         </configuration>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
   </build>
 
 </project>

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ProcessEngine.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ProcessEngine.java
@@ -18,6 +18,7 @@ package org.activiti.engine;
 
 
 import org.activiti.engine.api.internal.Internal;
+import org.activiti.engine.impl.util.ProjectVersionUtils;
 
 /**
  * Provides access to all the services that expose the BPM and workflow operations.
@@ -43,7 +44,7 @@ import org.activiti.engine.api.internal.Internal;
 public interface ProcessEngine {
 
   /** the version of the activiti library */
-  public static String VERSION = "7.1.0-M6"; // Note the extra -x at the end. To cater for snapshot releases with different database changes
+  public static String VERSION = ProjectVersionUtils.getVersion();
 
   /**
    * The name as specified in 'process-engine-name' in the activiti.cfg.xml configuration file. The default name for a process engine is 'default

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
@@ -203,7 +203,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
                 for (int i = 1; i < outgoingSequenceFlows.size(); i++) {
 
                     ExecutionEntity parent = execution.getParentId() != null ? execution.getParent() : execution;
-                    ExecutionEntity outgoingExecutionEntity = commandContext.getExecutionEntityManager().createChildExecution(parent);
+                    ExecutionEntity outgoingExecutionEntity = executionEntityManager.createChildExecution(parent);
 
                     SequenceFlow outgoingSequenceFlow = outgoingSequenceFlows.get(i);
                     outgoingExecutionEntity.setCurrentFlowElement(outgoingSequenceFlow);

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -66,6 +66,7 @@ import org.activiti.engine.impl.persistence.entity.Entity;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.PropertyEntity;
 import org.activiti.engine.impl.util.IoUtil;
+import org.activiti.engine.impl.util.ProjectVersionUtils;
 import org.activiti.engine.impl.util.ReflectUtil;
 import org.apache.ibatis.session.SqlSession;
 import org.slf4j.Logger;
@@ -1279,6 +1280,10 @@ public class DbSqlSession implements Session {
             byte[] bytes = IoUtil.readInputStream(inputStream,
                                                   resourceName);
             String ddlStatements = new String(bytes);
+            if (operation.equals("create") && component.equals("engine")) {
+                ddlStatements = ddlStatements.replaceFirst("'schema.version', (.*?), 1\\)", "'schema.version', '" + ProjectVersionUtils.getVersion()+ "', 1)")
+                    .replaceFirst("'schema.history', (.*?), 1\\)", "'schema.history', 'create(" + ProjectVersionUtils.getVersion()+ ")', 1)");
+            }
 
             // Special DDL handling for certain databases
             try {
@@ -1306,7 +1311,7 @@ public class DbSqlSession implements Session {
                     log.debug(line.substring(2));
                 } else if (line.startsWith("-- ")) {
                     log.debug(line.substring(3));
-                } else if (line.startsWith("execute java ")) {
+                } else if (line.toLowerCase().startsWith("execute java ")) {
                     String upgradestepClassName = line.substring(13).trim();
                     DbUpgradeStep dbUpgradeStep = null;
                     try {
@@ -1325,7 +1330,7 @@ public class DbSqlSession implements Session {
                     }
                 } else if (line.length() > 0) {
 
-                    if (isOracle() && line.startsWith("begin")) {
+                    if (isOracle() && line.toLowerCase().startsWith("begin")) {
                         inOraclePlsqlBlock = true;
                         sqlStatement = addSqlStatementPiece(sqlStatement,
                                                             line);
@@ -1449,10 +1454,10 @@ public class DbSqlSession implements Session {
                 // ignore
             }
         }
-        if (org.activiti.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)
+        if (ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)
                 || ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_DROP_CREATE.equals(databaseSchemaUpdate) || ProcessEngineConfigurationImpl.DB_SCHEMA_UPDATE_CREATE.equals(databaseSchemaUpdate)) {
             dbSchemaCreate();
-        } else if (org.activiti.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_FALSE.equals(databaseSchemaUpdate)) {
+        } else if (ProcessEngineConfiguration.DB_SCHEMA_UPDATE_FALSE.equals(databaseSchemaUpdate)) {
             dbSchemaCheckVersion();
         } else if (ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE.equals(databaseSchemaUpdate)) {
             dbSchemaUpdate();
@@ -1461,7 +1466,7 @@ public class DbSqlSession implements Session {
 
     public void performSchemaOperationsProcessEngineClose() {
         String databaseSchemaUpdate = Context.getProcessEngineConfiguration().getDatabaseSchemaUpdate();
-        if (org.activiti.engine.ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)) {
+        if (ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP.equals(databaseSchemaUpdate)) {
             dbSchemaDrop();
         }
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProjectVersionUtils.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/ProjectVersionUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.util;
+
+import java.util.ResourceBundle;
+
+/**
+ * Get project version from projectVersion.properties file.
+ */
+public class ProjectVersionUtils {
+    public static String getVersion() {
+        ResourceBundle resourceBundle = ResourceBundle.getBundle("projectVersion");
+        return resourceBundle.getString("project.version");
+    }
+}

--- a/activiti-core/activiti-engine/src/main/resources/projectVersion.properties
+++ b/activiti-core/activiti-engine/src/main/resources/projectVersion.properties
@@ -1,0 +1,1 @@
+project.version = @project.version@

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/initialization/ProcessEngineInitializationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/initialization/ProcessEngineInitializationTest.java
@@ -90,4 +90,71 @@ public class ProcessEngineInitializationTest extends AbstractTestCase {
     // closing the original process engine to drop the db tables
     processEngine.close();
   }
+
+  public void testAutoObtainedVersionMatchInDb2() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/db2.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInH2() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/h2.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInHsql() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/hsql.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInMssql() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/mssql.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInMysql() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/mysql.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInOracle() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/oracle.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  public void testAutoObtainedVersionMatchInPostgres() {
+    ProcessEngineImpl processEngine = (ProcessEngineImpl) ProcessEngineConfiguration.createProcessEngineConfigurationFromResource("org/activiti/standalone/initialization/postgre.notables.activiti.cfg.xml").setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP).buildProcessEngine();
+    DbSqlSessionFactory dbSqlSessionFactory = (DbSqlSessionFactory) processEngine.getProcessEngineConfiguration().getSessionFactories().get(DbSqlSession.class);
+    SqlSessionFactory sqlSessionFactory = dbSqlSessionFactory.getSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    compareVersionOfSchema_ProcessEngine(sqlSession);
+  }
+
+  private void compareVersionOfSchema_ProcessEngine(SqlSession sqlSession) {
+    try {
+      Object schemaVersion = sqlSession.selectOne("selectDbSchemaVersion");
+      if (schemaVersion instanceof String) {
+        assertThat(schemaVersion).isEqualTo(ProcessEngine.VERSION);
+      }
+    } finally {
+      sqlSession.close();
+    }
+  }
 }

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/db2.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/db2.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:db2://192.168.1.2:50000/activiti" />
+    <property name="jdbcUsername" value="db2admin" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/h2.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/h2.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:h2:tcp://192.168.1.2/D:/H2/h2Database/activiti" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/hsql.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/hsql.notables.activiti.cfg.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:hsqldb:hsql://192.168.1.2/" />
+    <property name="jdbcUsername" value="sa" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/mssql.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/mssql.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:sqlserver://192.168.1.2:1433;databaseName=activiti" />
+    <property name="jdbcUsername" value="sa" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/mysql.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/mysql.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:mysql://192.168.1.1:3306/activiti" />
+    <property name="jdbcUsername" value="root" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/oracle.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/oracle.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:oracle:thin:@192.168.1.2:1521/XE" />
+    <property name="jdbcUsername" value="scott" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/postgre.notables.activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/standalone/initialization/postgre.notables.activiti.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+  <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration">
+
+    <!-- Database configurations -->
+    <property name="databaseSchemaUpdate" value="false" />
+    <property name="jdbcUrl" value="jdbc:postgresql://192.168.1.2:5432/postgres" />
+    <property name="jdbcUsername" value="postgres" />
+    <property name="jdbcPassword" value="123456" />
+
+    <!-- job executor configurations -->
+    <property name="asyncExecutorActivate" value="false" />
+
+  </bean>
+
+</beans>


### PR DESCRIPTION
Fixes #3940. 

* Change the hardcoding of version in `ProcessEngine` to fetch from the pom file automatically.
  Use `<resources>` configuration provided by maven and `@project.version@` in projectVersion.properties file to get project version from `<version>` in the pom.

* Use string replacement based on regex to modify the SQL fragment in the scripts that initializes the Table `act_ge_property` data, so that it can apply the process engine's version in the application when the SQL script is executed by Activiti.