### PR TITLE
commit process random jump  process modify

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -30,14 +30,7 @@ import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
 import org.activiti.engine.delegate.event.ActivitiEventListener;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.impl.persistence.entity.VariableInstance;
-import org.activiti.engine.runtime.DataObject;
-import org.activiti.engine.runtime.Execution;
-import org.activiti.engine.runtime.ExecutionQuery;
-import org.activiti.engine.runtime.NativeExecutionQuery;
-import org.activiti.engine.runtime.NativeProcessInstanceQuery;
-import org.activiti.engine.runtime.ProcessInstance;
-import org.activiti.engine.runtime.ProcessInstanceBuilder;
-import org.activiti.engine.runtime.ProcessInstanceQuery;
+import org.activiti.engine.runtime.*;
 import org.activiti.engine.task.Event;
 import org.activiti.engine.task.IdentityLink;
 import org.activiti.engine.task.IdentityLinkType;
@@ -1233,6 +1226,11 @@ public interface RuntimeService {
    *          id of the execution that has an ad-hoc sub process as current flow element
    */
   void completeAdhocSubProcess(String executionId);
+
+    /**
+     * Create a {@link ChangeActivityStateBuilder}, that allows to set various options for changing the state of a process instance.
+     */
+    ChangeActivityStateBuilder createChangeActivityStateBuilder();
 
   /** The all events related to the given Process Instance. */
   List<Event> getProcessInstanceEvents(String processInstanceId);

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/dynamic/DynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/dynamic/DynamicStateManager.java
@@ -1,0 +1,13 @@
+package org.activiti.engine.dynamic;
+
+
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
+
+/**
+ * @author LoveMyOrange
+ */
+public interface DynamicStateManager {
+
+    void moveExecutionState(ChangeActivityStateBuilderImpl changeActivityStateBuilder, CommandContext commandContext);
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/dynamic/DynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/dynamic/DynamicStateManager.java
@@ -4,9 +4,7 @@ package org.activiti.engine.dynamic;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
 
-/**
- * @author LoveMyOrange
- */
+
 public interface DynamicStateManager {
 
     void moveExecutionState(ChangeActivityStateBuilderImpl changeActivityStateBuilder, CommandContext commandContext);

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -63,15 +63,9 @@ import org.activiti.engine.impl.cmd.TriggerCmd;
 import org.activiti.engine.impl.cmd.GetProcessInstanceEventsCmd;
 import org.activiti.engine.impl.cmd.AddIdentityLinkForProcessInstanceCmd;
 import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
 import org.activiti.engine.impl.runtime.ProcessInstanceBuilderImpl;
-import org.activiti.engine.runtime.DataObject;
-import org.activiti.engine.runtime.Execution;
-import org.activiti.engine.runtime.ExecutionQuery;
-import org.activiti.engine.runtime.NativeExecutionQuery;
-import org.activiti.engine.runtime.NativeProcessInstanceQuery;
-import org.activiti.engine.runtime.ProcessInstance;
-import org.activiti.engine.runtime.ProcessInstanceBuilder;
-import org.activiti.engine.runtime.ProcessInstanceQuery;
+import org.activiti.engine.runtime.*;
 import org.activiti.engine.task.Event;
 import org.activiti.engine.task.IdentityLink;
 import org.activiti.engine.task.IdentityLinkType;
@@ -525,6 +519,10 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
         return new ProcessInstanceBuilderImpl(this);
     }
 
+    @Override
+    public ChangeActivityStateBuilder createChangeActivityStateBuilder() {
+        return new ChangeActivityStateBuilderImpl(this);
+    }
     @Override
     public ProcessInstance startCreatedProcessInstance(ProcessInstance createdProcessInstance, Map<String, Object> variables) {
         return commandExecutor.execute(new StartCreatedProcessInstanceCmd<>(createdProcessInstance, variables));

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ChangeActivityStateCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ChangeActivityStateCmd.java
@@ -8,9 +8,7 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
 
-/**
- * @author LoveMyOrange
- */
+
 public class ChangeActivityStateCmd implements Command<Void> {
 
     protected ChangeActivityStateBuilderImpl changeActivityStateBuilder;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ChangeActivityStateCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/ChangeActivityStateCmd.java
@@ -1,0 +1,36 @@
+package org.activiti.engine.impl.cmd;
+
+
+import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.dynamic.DynamicStateManager;
+import org.activiti.engine.impl.dynamic.DefaultDynamicStateManager;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
+
+/**
+ * @author LoveMyOrange
+ */
+public class ChangeActivityStateCmd implements Command<Void> {
+
+    protected ChangeActivityStateBuilderImpl changeActivityStateBuilder;
+
+    public ChangeActivityStateCmd(ChangeActivityStateBuilderImpl changeActivityStateBuilder) {
+        this.changeActivityStateBuilder = changeActivityStateBuilder;
+    }
+
+    @Override
+    public Void execute(CommandContext commandContext) {
+        if (changeActivityStateBuilder.getMoveExecutionIdList().size() == 0 && changeActivityStateBuilder.getMoveActivityIdList().size() == 0) {
+            throw new ActivitiIllegalArgumentException("No move execution or activity ids provided");
+
+        } else if (changeActivityStateBuilder.getMoveActivityIdList().size() > 0 && changeActivityStateBuilder.getProcessInstanceId() == null) {
+            throw new ActivitiIllegalArgumentException("Process instance id is required");
+        }
+
+        DynamicStateManager dynamicStateManager = new DefaultDynamicStateManager();
+        dynamicStateManager.moveExecutionState(changeActivityStateBuilder, commandContext);
+
+        return null;
+    }
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -1,0 +1,1010 @@
+package org.activiti.engine.impl.dynamic;
+
+import org.activiti.bpmn.constants.BpmnXMLConstants;
+import org.activiti.bpmn.model.Process;
+import org.activiti.bpmn.model.*;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.delegate.ActivityBehavior;
+import org.activiti.engine.impl.el.ExpressionManager;
+import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.history.HistoryManager;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
+import org.activiti.engine.impl.persistence.entity.*;
+import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
+import org.activiti.engine.impl.runtime.MoveActivityIdContainer;
+import org.activiti.engine.impl.runtime.MoveExecutionIdContainer;
+import org.activiti.engine.impl.util.CollectionUtil;
+import org.activiti.engine.impl.util.CommandContextUtil;
+import org.activiti.engine.impl.util.ProcessDefinitionUtil;
+import org.activiti.engine.impl.util.ProcessInstanceHelper;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author LoveMyOrange
+ */
+public abstract class AbstractDynamicStateManager {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    //-- Move container preparation section start
+    public List<MoveExecutionEntityContainer> resolveMoveExecutionEntityContainers(ChangeActivityStateBuilderImpl changeActivityStateBuilder, Optional<String> migrateToProcessDefinitionId, Map<String, Object> variables, CommandContext commandContext) {
+        List<MoveExecutionEntityContainer> moveExecutionEntityContainerList = new ArrayList<>();
+        if (changeActivityStateBuilder.getMoveExecutionIdList().size() > 0) {
+            for (MoveExecutionIdContainer executionContainer : changeActivityStateBuilder.getMoveExecutionIdList()) {
+                //Executions belonging to the same parent should move together - i.e multipleExecution to single activity
+                Map<String, List<ExecutionEntity>> executionsByParent = new HashMap<>();
+                for (String executionId : executionContainer.getExecutionIds()) {
+                    ExecutionEntity execution = resolveActiveExecution(executionId, commandContext);
+                    List<ExecutionEntity> executionEntities = executionsByParent.computeIfAbsent(execution.getParentId(), k -> new ArrayList<>());
+                    executionEntities.add(execution);
+                }
+                executionsByParent.values().forEach(executions -> {
+                    MoveExecutionEntityContainer moveExecutionEntityContainer = new MoveExecutionEntityContainer(executions, executionContainer.getMoveToActivityIds());
+                    executionContainer.getNewAssigneeId().ifPresent(moveExecutionEntityContainer::setNewAssigneeId);
+                    moveExecutionEntityContainerList.add(moveExecutionEntityContainer);
+                });
+            }
+        }
+
+        if (changeActivityStateBuilder.getMoveActivityIdList().size() > 0) {
+            for (MoveActivityIdContainer activityContainer : changeActivityStateBuilder.getMoveActivityIdList()) {
+                Map<String, List<ExecutionEntity>> activitiesExecutionsByMultiInstanceParentId = new HashMap<>();
+                List<ExecutionEntity> activitiesExecutionsNotInMultiInstanceParent = new ArrayList<>();
+
+                for (String activityId : activityContainer.getActivityIds()) {
+                    List<ExecutionEntity> activityExecutions = resolveActiveExecutions(changeActivityStateBuilder.getProcessInstanceId(), activityId, commandContext);
+                    if (!activityExecutions.isEmpty()) {
+
+                        // check for a multi instance root execution
+                        ExecutionEntity miExecution = null;
+                        boolean isInsideMultiInstance = false;
+                        for (ExecutionEntity possibleMIExecution : activityExecutions) {
+                            if (possibleMIExecution.isMultiInstanceRoot()) {
+                                miExecution = possibleMIExecution;
+                                isInsideMultiInstance = true;
+                                break;
+                            }
+
+                            if (isExecutionInsideMultiInstance(possibleMIExecution)) {
+                                isInsideMultiInstance = true;
+                            }
+                        }
+
+                        //If inside a multiInstance, we create one container for each execution
+                        if (isInsideMultiInstance) {
+
+                            //We group by the parentId (executions belonging to the same parent execution instance
+                            // i.e. gateways nested in MultiInstance subProcesses, need to be in the same move container)
+                            Stream<ExecutionEntity> executionEntitiesStream = activityExecutions.stream();
+                            if (miExecution != null) {
+                                executionEntitiesStream = executionEntitiesStream.filter(ExecutionEntity::isMultiInstanceRoot);
+                            }
+
+                            executionEntitiesStream.forEach(childExecution -> {
+                                String parentId = childExecution.isMultiInstanceRoot() ? childExecution.getId() : childExecution.getParentId();
+                                List<ExecutionEntity> executionEntities = activitiesExecutionsByMultiInstanceParentId.computeIfAbsent(parentId, k -> new ArrayList<>());
+                                executionEntities.add(childExecution);
+                            });
+
+                        } else {
+                            ExecutionEntity execution = activityExecutions.iterator().next();
+                            activitiesExecutionsNotInMultiInstanceParent.add(execution);
+                        }
+                    }
+                }
+
+                //Create a move container for each execution group (executionList)
+                Stream.concat(activitiesExecutionsByMultiInstanceParentId.values().stream(), Stream.of(activitiesExecutionsNotInMultiInstanceParent))
+                    .filter(executions -> executions != null && !executions.isEmpty())
+                    .forEach(executions -> moveExecutionEntityContainerList.add(createMoveExecutionEntityContainer(activityContainer, executions, commandContext)));
+            }
+        }
+
+        return moveExecutionEntityContainerList;
+    }
+
+    protected ExecutionEntity resolveActiveExecution(String executionId, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+        ExecutionEntity execution = executionEntityManager.findById(executionId);
+
+        if (execution == null) {
+            throw new ActivitiException("Execution could not be found with id " + executionId);
+        }
+
+        return execution;
+    }
+
+    protected List<ExecutionEntity> resolveActiveExecutions(String processInstanceId, String activityId, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+        ExecutionEntity processExecution = executionEntityManager.findById(processInstanceId);
+
+        if (processExecution == null) {
+            throw new ActivitiException("Execution could not be found with id " + processInstanceId);
+        }
+
+        if (!processExecution.isProcessInstanceType()) {
+            throw new ActivitiException("Execution is not a process instance type execution for id " + processInstanceId);
+        }
+
+        List<ExecutionEntity> childExecutions = executionEntityManager.findChildExecutionsByProcessInstanceId(processExecution.getId());
+
+        List<ExecutionEntity> executions = childExecutions.stream()
+            .filter(e -> e.getCurrentActivityId() != null)
+            .filter(e -> e.getCurrentActivityId().equals(activityId))
+            .collect(Collectors.toList());
+
+        if (executions.isEmpty()) {
+            throw new ActivitiException("Active execution could not be found with activity id " + activityId);
+        }
+
+        return executions;
+    }
+
+    protected MoveExecutionEntityContainer createMoveExecutionEntityContainer(MoveActivityIdContainer activityContainer, List<ExecutionEntity> executions, CommandContext commandContext) {
+        MoveExecutionEntityContainer moveExecutionEntityContainer = new MoveExecutionEntityContainer(executions, activityContainer.getMoveToActivityIds());
+        activityContainer.getNewAssigneeId().ifPresent(moveExecutionEntityContainer::setNewAssigneeId);
+
+        if (activityContainer.isMoveToParentProcess()) {
+            ExecutionEntity processInstanceExecution = executions.get(0).getProcessInstance();
+            ExecutionEntity superExecution = processInstanceExecution.getSuperExecution();
+            if (superExecution == null) {
+                throw new ActivitiException("No parent process found for execution with activity id " + executions.get(0).getCurrentActivityId());
+            }
+
+            moveExecutionEntityContainer.setMoveToParentProcess(true);
+            moveExecutionEntityContainer.setSuperExecution(superExecution);
+
+        } else if (activityContainer.isMoveToSubProcessInstance()) {
+            moveExecutionEntityContainer.setMoveToSubProcessInstance(true);
+            moveExecutionEntityContainer.setCallActivityId(activityContainer.getCallActivityId());
+            moveExecutionEntityContainer.setCallActivitySubProcessVersion(activityContainer.getCallActivitySubProcessVersion());
+        }
+        return moveExecutionEntityContainer;
+    }
+
+    protected void prepareMoveExecutionEntityContainer(MoveExecutionEntityContainer moveExecutionContainer, Optional<String> migrateToProcessDefinitionId, CommandContext commandContext) {
+        ExpressionManager expressionManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getExpressionManager();
+
+        Optional<BpmnModel> bpmnModelToMigrateTo = migrateToProcessDefinitionId.map(ProcessDefinitionUtil::getBpmnModel);
+        boolean canContainerDirectMigrate = (moveExecutionContainer.getMoveToActivityIds().size() == 1) && (moveExecutionContainer.getExecutions().size() == 1);
+        for (String activityId : moveExecutionContainer.getMoveToActivityIds()) {
+            FlowElement currentFlowElement;
+            FlowElement newFlowElement;
+            String currentActivityId;
+            if (moveExecutionContainer.isMoveToParentProcess()) {
+                String parentProcessDefinitionId = moveExecutionContainer.getSuperExecution().getProcessDefinitionId();
+                BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(parentProcessDefinitionId);
+                BpmnModel modelOfCallActivity = ProcessDefinitionUtil.getBpmnModel(moveExecutionContainer.getExecutions().get(0).getProcessDefinitionId());
+                currentActivityId = moveExecutionContainer.getExecutions().get(0).getCurrentActivityId();
+                currentFlowElement = resolveFlowElementFromBpmnModel(modelOfCallActivity, currentActivityId);
+                newFlowElement = resolveFlowElementFromBpmnModel(bpmnModelToMigrateTo.orElse(bpmnModel), activityId);
+                canContainerDirectMigrate = false;
+
+            } else if (moveExecutionContainer.isMoveToSubProcessInstance()) {
+                //The subProcess model is defined in the callActivity of the current processDefinition or the migrateProcessDefinition if defined
+                ExecutionEntity firstExecution = moveExecutionContainer.getExecutions().get(0);
+                BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(firstExecution.getProcessDefinitionId());
+                currentActivityId = firstExecution.getCurrentActivityId();
+                currentFlowElement = resolveFlowElementFromBpmnModel(bpmnModel, currentActivityId);
+
+                String processDefinitionIdOfCallActivity = migrateToProcessDefinitionId.orElse(firstExecution.getProcessDefinitionId());
+                CallActivity callActivity = (CallActivity) resolveFlowElementFromBpmnModel(bpmnModelToMigrateTo.orElse(bpmnModel), moveExecutionContainer.getCallActivityId());
+
+                moveExecutionContainer.setCallActivity(callActivity);
+                ProcessDefinition callActivityProcessDefinition = ProcessDefinitionUtil.getProcessDefinition(processDefinitionIdOfCallActivity);
+                String tenantId = callActivityProcessDefinition.getTenantId();
+                Integer calledProcessVersion = moveExecutionContainer.getCallActivitySubProcessVersion();
+                String calledProcessDefKey = callActivity.getCalledElement();
+                if (isExpression(calledProcessDefKey)) {
+                    try {
+                        calledProcessDefKey = expressionManager.createExpression(calledProcessDefKey).getValue(firstExecution.getProcessInstance()).toString();
+                    } catch (ActivitiException e) {
+                        throw new ActivitiException("Cannot resolve calledElement expression '" + calledProcessDefKey + "' of callActivity '" + callActivity.getId() + "'", e);
+                    }
+                }
+                moveExecutionContainer.setSubProcessDefKey(calledProcessDefKey);
+                ProcessDefinition subProcessDefinition = resolveProcessDefinition(calledProcessDefKey, calledProcessVersion, tenantId, commandContext);
+                BpmnModel subProcessModel = ProcessDefinitionUtil.getBpmnModel(subProcessDefinition.getId());
+                moveExecutionContainer.setSubProcessDefinition(subProcessDefinition);
+                moveExecutionContainer.setSubProcessModel(subProcessModel);
+
+                newFlowElement = resolveFlowElementFromBpmnModel(subProcessModel, activityId);
+                canContainerDirectMigrate = false;
+
+            } else {
+                // Get first execution to get process definition id
+                ExecutionEntity firstExecution = moveExecutionContainer.getExecutions().get(0);
+                BpmnModel bpmnModel = ProcessDefinitionUtil.getBpmnModel(firstExecution.getProcessDefinitionId());
+                currentActivityId = firstExecution.getCurrentActivityId();
+                currentFlowElement = resolveFlowElementFromBpmnModel(bpmnModel, currentActivityId);
+                newFlowElement = resolveFlowElementFromBpmnModel(bpmnModelToMigrateTo.orElse(bpmnModel), activityId);
+            }
+
+            moveExecutionContainer.addMoveToFlowElement(activityId, currentFlowElement, newFlowElement);
+            canContainerDirectMigrate = canContainerDirectMigrate && isDirectFlowElementExecutionMigration(currentFlowElement, newFlowElement);
+        }
+
+        moveExecutionContainer.setDirectExecutionMigration(canContainerDirectMigrate && migrateToProcessDefinitionId.isPresent());
+    }
+
+    protected FlowElement resolveFlowElementFromBpmnModel(BpmnModel bpmnModel, String activityId) {
+        FlowElement flowElement = bpmnModel.getFlowElement(activityId);
+        if (flowElement == null) {
+            throw new ActivitiException("Cannot find activity '" + activityId + "' in process definition with id '" + bpmnModel.getMainProcess().getId() + "'");
+        }
+        return flowElement;
+    }
+    //-- Move container preparation section end
+
+    protected void doMoveExecutionState(ProcessInstanceChangeState processInstanceChangeState, CommandContext commandContext) {
+
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+        Map<String, List<ExecutionEntity>> activeEmbeddedSubProcesses = resolveActiveEmbeddedSubProcesses(processInstanceChangeState.getProcessInstanceId(), commandContext);
+        processInstanceChangeState.setProcessInstanceActiveEmbeddedExecutions(activeEmbeddedSubProcesses);
+
+        //Set the processInstance variables first so they are available during te change state
+        ExecutionEntity processInstanceExecution = executionEntityManager.findById(processInstanceChangeState.getProcessInstanceId());
+        processInstanceExecution.setVariables(processInstanceChangeState.getProcessInstanceVariables());
+
+        for (MoveExecutionEntityContainer moveExecutionContainer : processInstanceChangeState.getMoveExecutionEntityContainers()) {
+            prepareMoveExecutionEntityContainer(moveExecutionContainer, processInstanceChangeState.getProcessDefinitionToMigrateTo().map(ProcessDefinition::getId), commandContext);
+            // Action the moves (changeState)
+            if (moveExecutionContainer.isMoveToParentProcess()) {
+                String callActivityInstanceId = moveExecutionContainer.getExecutions().get(0).getProcessInstanceId();
+                String deleteReason = "";
+                if (StringUtils.isNotBlank(processInstanceChangeState.getJumpReason())) {
+                    deleteReason = processInstanceChangeState.getJumpReason();
+                } else {
+                    deleteReason = "Change activity to parent process activity ids: " + printFlowElementIds(moveExecutionContainer.getMoveToFlowElements());
+                }
+                safeDeleteSubProcessInstance(callActivityInstanceId, moveExecutionContainer.getExecutions(), deleteReason, commandContext);
+            }
+
+            List<ExecutionEntity> executionsToMove;
+            if (moveExecutionContainer.isMoveToParentProcess()) {
+                executionsToMove = Collections.singletonList(moveExecutionContainer.getSuperExecution());
+            } else {
+                executionsToMove = moveExecutionContainer.getExecutions();
+            }
+
+            Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements;
+            if (moveExecutionContainer.isMoveToSubProcessInstance()) {
+                moveToFlowElements = Collections.singletonList(new MoveExecutionEntityContainer.FlowElementMoveEntry(moveExecutionContainer.getCallActivity(), moveExecutionContainer.getCallActivity()));
+            } else {
+                moveToFlowElements = moveExecutionContainer.getMoveToFlowElements();
+            }
+
+            String flowElementIdsLine = printFlowElementIds(moveToFlowElements);
+            Collection<String> executionIdsNotToDelete = new HashSet<>();
+            for (ExecutionEntity execution : executionsToMove) {
+                executionIdsNotToDelete.add(execution.getId());
+
+                executionEntityManager.deleteChildExecutions(execution, "Change parent activity to " + flowElementIdsLine/*, true*/);
+                if (!moveExecutionContainer.isDirectExecutionMigration()) {
+                    String deleteReason = "";
+                    String jumpReason = processInstanceChangeState.getJumpReason();
+                    if (StringUtils.isNotBlank(jumpReason)) {
+                        deleteReason = jumpReason;
+                    } else {
+                        deleteReason = "Change activity to " + flowElementIdsLine;
+                    }
+                    executionEntityManager.deleteExecutionAndRelatedData(execution, deleteReason/* ,  true*/);
+                }
+
+                // Make sure we are not moving the root execution
+                if (execution.getParentId() == null) {
+                    throw new ActivitiException("Execution has no parent execution " + execution.getParentId());
+                }
+
+                // Delete the parent executions for each current execution when the move to activity id has the same subProcess scope
+                ExecutionEntity continueParentExecution;
+                if (processInstanceChangeState.getProcessDefinitionToMigrateTo().isPresent()) {
+                    continueParentExecution = deleteDirectParentExecutions(execution.getParentId(), moveToFlowElements, executionIdsNotToDelete, commandContext, processInstanceChangeState.getJumpReason());
+                } else {
+                    continueParentExecution = deleteParentExecutions(execution.getParentId(), moveToFlowElements, executionIdsNotToDelete, commandContext, processInstanceChangeState.getJumpReason());
+                }
+                moveExecutionContainer.addContinueParentExecution(execution.getId(), continueParentExecution);
+            }
+
+            List<ExecutionEntity> newChildExecutions = createEmbeddedSubProcessAndExecutions(moveToFlowElements, executionsToMove, moveExecutionContainer, processInstanceChangeState, commandContext);
+
+            if (moveExecutionContainer.isMoveToSubProcessInstance()) {
+                CallActivity callActivity = moveExecutionContainer.getCallActivity();
+                Process subProcess = moveExecutionContainer.getSubProcessModel().getProcessById(moveExecutionContainer.getSubProcessDefKey());
+                ExecutionEntity callActivityInstanceExecution = createCallActivityInstance(callActivity, moveExecutionContainer.getSubProcessDefinition(), newChildExecutions.get(0), subProcess.getInitialFlowElement().getId(), commandContext);
+                List<ExecutionEntity> moveExecutions = moveExecutionContainer.getExecutions();
+                MoveExecutionEntityContainer subProcessMoveExecutionEntityContainer = new MoveExecutionEntityContainer(moveExecutions, moveExecutionContainer.getMoveToActivityIds());
+                subProcessMoveExecutionEntityContainer.setNewAssigneeId(moveExecutionContainer.getNewAssigneeId());
+                moveExecutions.forEach(executionEntity -> subProcessMoveExecutionEntityContainer.addContinueParentExecution(executionEntity.getId(), callActivityInstanceExecution));
+                newChildExecutions = createEmbeddedSubProcessAndExecutions(moveExecutionContainer.getMoveToFlowElements(), moveExecutions, subProcessMoveExecutionEntityContainer, new ProcessInstanceChangeState(), commandContext);
+            }
+
+            if (!processInstanceChangeState.getLocalVariables().isEmpty()) {
+                Map<String, Map<String, Object>> localVariables = processInstanceChangeState.getLocalVariables();
+                Iterator<ExecutionEntity> newChildExecutionsIterator = newChildExecutions.iterator();
+                while (newChildExecutionsIterator.hasNext()) {
+                    //With changeState Api we can set local variables to the parents of moved executions (i.e. subProcesses created during the move)
+                    //Thus we traverse up in the hierarchy from the newly created executions
+                    ExecutionEntity execution = newChildExecutionsIterator.next();
+                    while (execution != null) {
+                        if (execution.getActivityId() != null && localVariables.containsKey(execution.getActivityId())) {
+                            if (execution.isScope() || execution.getCurrentFlowElement() instanceof UserTask) {
+                                execution.setVariablesLocal(localVariables.get(execution.getActivityId()));
+                            } else {
+                                ExecutionEntity scopedExecutionCandidate = execution;
+                                while (scopedExecutionCandidate.getParent() != null) {
+                                    ExecutionEntity parentExecution = scopedExecutionCandidate.getParent();
+                                    if (parentExecution.isScope()) {
+                                        parentExecution.setVariablesLocal(localVariables.get(execution.getActivityId()));
+                                        break;
+                                    }
+
+                                    scopedExecutionCandidate = scopedExecutionCandidate.getParent();
+                                }
+                            }
+                        }
+                        execution = execution.getParent();
+                    }
+                }
+            }
+
+            if (!moveExecutionContainer.isDirectExecutionMigration()) {
+                for (ExecutionEntity newChildExecution : newChildExecutions) {
+                    if (moveExecutionContainer.getNewAssigneeId() != null && moveExecutionContainer.hasNewExecutionId(newChildExecution.getId())) {
+//                        MigrationContext migrationContext = new MigrationContext();
+//                        migrationContext.setAssignee(moveExecutionContainer.getNewAssigneeId());
+//                        CommandContextUtil.getAgenda(commandContext).planContinueProcessOperation();
+//                        CommandContextUtil.getAgenda(commandContext).planContinueProcessWithMigrationContextOperation(newChildExecution, migrationContext);
+                        CommandContextUtil.getAgenda(commandContext).planContinueProcessOperation(newChildExecution);
+                    } else {
+
+                        CommandContextUtil.getAgenda(commandContext).planContinueProcessOperation(newChildExecution);
+                    }
+                }
+            }
+        }
+
+        processPendingEventSubProcessesStartEvents(processInstanceChangeState, commandContext);
+    }
+
+    protected void processPendingEventSubProcessesStartEvents(ProcessInstanceChangeState processInstanceChangeState, CommandContext commandContext) {
+        ProcessInstanceHelper processInstanceHelper = CommandContextUtil.getProcessEngineConfiguration(commandContext).getProcessInstanceHelper();
+        for (Map.Entry<? extends StartEvent, ExecutionEntity> pendingStartEventEntry : processInstanceChangeState.getPendingEventSubProcessesStartEvents().entrySet()) {
+            StartEvent startEvent = pendingStartEventEntry.getKey();
+            ExecutionEntity parentExecution = pendingStartEventEntry.getValue();
+            if (!processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(startEvent.getSubProcess().getId())) {
+                throw new ActivitiException("The current version does not support it, please wait");
+            }
+        }
+    }
+
+
+    protected abstract Map<String, List<ExecutionEntity>> resolveActiveEmbeddedSubProcesses(String processInstanceId, CommandContext commandContext);
+
+    protected abstract boolean isDirectFlowElementExecutionMigration(FlowElement currentFlowElement, FlowElement newFlowElement);
+
+    protected void safeDeleteSubProcessInstance(String processInstanceId, List<ExecutionEntity> executionsPool, String deleteReason, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+
+        //Confirm that all the subProcessExecutions are in the executionsPool
+        List<ExecutionEntity> subProcessExecutions = executionEntityManager.findChildExecutionsByProcessInstanceId(processInstanceId);
+        HashSet<String> executionIdsToMove = executionsPool.stream().map(ExecutionEntity::getId).collect(Collectors.toCollection(HashSet::new));
+        Optional<ExecutionEntity> notIncludedExecution = subProcessExecutions.stream().filter(e -> !executionIdsToMove.contains(e.getId())).findAny();
+        if (notIncludedExecution.isPresent()) {
+            throw new ActivitiException("Execution of sub process instance is not moved " + notIncludedExecution.get().getId());
+        }
+
+        // delete the sub process instance
+        executionEntityManager.deleteProcessInstance(processInstanceId, deleteReason, true);
+    }
+
+    protected ExecutionEntity deleteParentExecutions(String parentExecutionId, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements, CommandContext commandContext, String jumpReason) {
+        return deleteParentExecutions(parentExecutionId, moveToFlowElements, null, commandContext, jumpReason);
+    }
+
+    protected ExecutionEntity deleteParentExecutions(String parentExecutionId, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements, Collection<String> executionIdsNotToDelete, CommandContext commandContext, String jumpReason) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+
+        ExecutionEntity parentExecution = executionEntityManager.findById(parentExecutionId);
+        if (parentExecution != null && parentExecution.getCurrentFlowElement() instanceof SubProcess) {
+            SubProcess parentSubProcess = (SubProcess) parentExecution.getCurrentFlowElement();
+            if (!isSubProcessAncestorOfAnyNewFlowElements(parentSubProcess.getId(), moveToFlowElements)) {
+                ExecutionEntity toDeleteParentExecution = resolveParentExecutionToDelete(parentExecution, moveToFlowElements);
+                ExecutionEntity finalDeleteExecution = null;
+                if (toDeleteParentExecution != null) {
+                    finalDeleteExecution = toDeleteParentExecution;
+                } else {
+                    finalDeleteExecution = parentExecution;
+                }
+
+                parentExecution = finalDeleteExecution.getParent();
+
+                String flowElementIdsLine = printFlowElementIds(moveToFlowElements);
+
+                String deleteReason = "";
+                if (StringUtils.isNotBlank(jumpReason)) {
+                    deleteReason = jumpReason;
+                } else {
+                    deleteReason = "Change activity to " + flowElementIdsLine;
+                }
+
+                executionEntityManager.deleteChildExecutions(finalDeleteExecution, deleteReason/*, true*/);
+                executionEntityManager.deleteExecutionAndRelatedData(finalDeleteExecution, deleteReason/*, true*/);
+            }
+        }
+
+        return parentExecution;
+    }
+
+    protected ExecutionEntity deleteDirectParentExecutions(String parentExecutionId, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements, Collection<String> executionIdsNotToDelete, CommandContext commandContext, String jumpReason) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+
+        ExecutionEntity parentExecution = executionEntityManager.findById(parentExecutionId);
+        if (parentExecution.getCurrentFlowElement() instanceof SubProcess) {
+            SubProcess parentSubProcess = (SubProcess) parentExecution.getCurrentFlowElement();
+            if (!isSubProcessContainerOfAnyFlowElement(parentSubProcess.getId(), moveToFlowElements)) {
+                ExecutionEntity toDeleteParentExecution = resolveParentExecutionToDelete(parentExecution, moveToFlowElements);
+                ExecutionEntity finalDeleteExecution = null;
+                if (toDeleteParentExecution != null) {
+                    finalDeleteExecution = toDeleteParentExecution;
+                } else {
+                    finalDeleteExecution = parentExecution;
+                }
+
+                parentExecution = finalDeleteExecution.getParent();
+                String flowElementIdsLine = printFlowElementIds(moveToFlowElements);
+                String deleteReason = "";
+                if (StringUtils.isNotBlank(jumpReason)) {
+                    deleteReason = jumpReason;
+                } else {
+                    deleteReason = "Change activity to " + flowElementIdsLine;
+                }
+                executionEntityManager.deleteChildExecutions(finalDeleteExecution, deleteReason/*, true*/);
+                executionEntityManager.deleteExecutionAndRelatedData(finalDeleteExecution, deleteReason/*, true*/);
+            }
+        }
+
+        return parentExecution;
+    }
+
+    protected boolean isSubProcessContainerOfAnyFlowElement(String subProcessId, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements) {
+        Optional<SubProcess> isUsed = moveToFlowElements.stream()
+            .map(MoveExecutionEntityContainer.FlowElementMoveEntry::getNewFlowElement)
+            .map(FlowElement::getSubProcess)
+            .filter(Objects::nonNull)
+            .filter(elementSubProcess -> elementSubProcess.getId().equals(subProcessId))
+            .findAny();
+
+        return isUsed.isPresent();
+    }
+
+    protected ExecutionEntity resolveParentExecutionToDelete(ExecutionEntity execution, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements) {
+        ExecutionEntity parentExecution = execution.getParent();
+
+        if (parentExecution.isProcessInstanceType()) {
+            return null;
+        }
+
+        if (!isSubProcessContainerOfAnyFlowElement(parentExecution.getActivityId(), moveToFlowElements)) {
+            ExecutionEntity subProcessParentExecution = resolveParentExecutionToDelete(parentExecution, moveToFlowElements);
+            if (subProcessParentExecution != null) {
+                return subProcessParentExecution;
+            } else {
+                return parentExecution;
+            }
+        }
+
+        return null;
+    }
+
+    protected List<ExecutionEntity> createEmbeddedSubProcessAndExecutions(Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> moveToFlowElements, List<ExecutionEntity> movingExecutions,
+                                                                          MoveExecutionEntityContainer moveExecutionEntityContainer, ProcessInstanceChangeState processInstanceChangeState, CommandContext commandContext) {
+
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
+        ExecutionEntityManager executionEntityManager = processEngineConfiguration.getExecutionEntityManager();
+
+        // Resolve the sub process elements that need to be created for each move to flow element
+        HashMap<String, SubProcess> subProcessesToCreate = new HashMap<>();
+        for (MoveExecutionEntityContainer.FlowElementMoveEntry flowElementMoveEntry : moveToFlowElements) {
+            FlowElement newFlowElement = flowElementMoveEntry.getNewFlowElement();
+            SubProcess subProcess = newFlowElement.getSubProcess();
+            //If the new flowElement is the StartEvent of and EventSubProcess, we skip the subProcess creation, the startEvent is contained in a level above
+            if (isEventSubProcessStart(newFlowElement)) {
+                subProcess = subProcess.getSubProcess();
+            }
+            while (subProcess != null) {
+                if (!processInstanceChangeState.getProcessInstanceActiveEmbeddedExecutions().containsKey(subProcess.getId()) && !isSubProcessAncestorOfAnyExecution(subProcess.getId(), movingExecutions)) {
+                    subProcessesToCreate.put(subProcess.getId(), subProcess);
+                }
+                subProcess = subProcess.getSubProcess();
+            }
+        }
+
+        // The default parent execution is retrieved from the match with the first source execution
+        ExecutionEntity defaultContinueParentExecution = moveExecutionEntityContainer.getContinueParentExecution(movingExecutions.get(0).getId());
+        Set<String> movingExecutionIds = movingExecutions.stream().map(ExecutionEntity::getId).collect(Collectors.toSet());
+
+        //Build the subProcess hierarchy
+        for (SubProcess subProcess : subProcessesToCreate.values()) {
+            if (!processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(subProcess.getId())) {
+                ExecutionEntity embeddedSubProcess = createEmbeddedSubProcessHierarchy(subProcess, defaultContinueParentExecution, subProcessesToCreate, movingExecutionIds, processInstanceChangeState, commandContext);
+                processInstanceChangeState.addCreatedEmbeddedSubProcess(subProcess.getId(), embeddedSubProcess);
+            }
+        }
+
+        //Adds the execution (leaf) to the subProcess
+        List<ExecutionEntity> newChildExecutions = new ArrayList<>();
+        for (MoveExecutionEntityContainer.FlowElementMoveEntry flowElementMoveEntry : moveToFlowElements) {
+            FlowElement newFlowElement = flowElementMoveEntry.getNewFlowElement();
+            ExecutionEntity parentExecution;
+            if (newFlowElement.getSubProcess() != null && processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(newFlowElement.getSubProcess().getId())) {
+                parentExecution = processInstanceChangeState.getCreatedEmbeddedSubProcesses().get(newFlowElement.getSubProcess().getId());
+            } else {
+                parentExecution = defaultContinueParentExecution;
+            }
+
+            if (isEventSubProcessStart(newFlowElement)) {
+                //EventSubProcessStarts are created later if the eventSubProcess was not created already during another move
+                processInstanceChangeState.addPendingEventSubProcessStartEvent((StartEvent) newFlowElement, parentExecution);
+            } else {
+                ExecutionEntity newChildExecution;
+                if (moveExecutionEntityContainer.isDirectExecutionMigration() && isDirectFlowElementExecutionMigration(flowElementMoveEntry.originalFlowElement, flowElementMoveEntry.newFlowElement)) {
+                    newChildExecution = migrateExecutionEntity(parentExecution, movingExecutions.get(0), newFlowElement, commandContext);
+                } else {
+                    newChildExecution = executionEntityManager.createChildExecution(parentExecution);
+                    newChildExecution.setCurrentFlowElement(newFlowElement);
+                    moveExecutionEntityContainer.addNewExecutionId(newChildExecution.getId());
+                }
+
+                if (newChildExecution != null) {
+                    if (moveExecutionEntityContainer.getNewAssigneeId() != null && newFlowElement instanceof UserTask &&
+                        !moveExecutionEntityContainer.hasNewExecutionId(newChildExecution.getId())) {
+
+                        handleUserTaskNewAssignee(newChildExecution, moveExecutionEntityContainer.getNewAssigneeId(), commandContext);
+                    }
+
+                    if (newFlowElement instanceof CallActivity) {
+                        processEngineConfiguration.getHistoryManager().recordActivityStart(newChildExecution);
+
+                        ActivitiEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
+                        if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+                            eventDispatcher.dispatchEvent(
+                                ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_STARTED, newFlowElement.getId(), newFlowElement.getName(), newChildExecution.getId(),
+                                    newChildExecution.getProcessInstanceId(), newChildExecution.getProcessDefinitionId(), newFlowElement));
+                        }
+                    }
+
+                    newChildExecutions.add(newChildExecution);
+                }
+
+                // Parallel gateway joins needs each incoming execution to enter the gateway naturally as it checks the number of executions to be able to progress/continue
+                // If we have multiple executions going into a gateway, usually into a gateway join using xxxToSingleActivityId
+                if (newFlowElement instanceof Gateway) {
+                    //Skip one that was already added
+                    movingExecutions.stream().skip(1).forEach(e -> {
+                        ExecutionEntity childExecution = executionEntityManager.createChildExecution(defaultContinueParentExecution);
+                        childExecution.setCurrentFlowElement(newFlowElement);
+                        newChildExecutions.add(childExecution);
+                    });
+                }
+            }
+        }
+
+        return newChildExecutions;
+    }
+
+    protected boolean isSubProcessAncestorOfAnyExecution(String subProcessId, List<ExecutionEntity> executions) {
+        for (ExecutionEntity execution : executions) {
+            FlowElement executionElement = execution.getCurrentFlowElement();
+
+            if (isSubProcessAncestor(subProcessId, executionElement)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean isSubProcessAncestorOfAnyNewFlowElements(String subProcessId, Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> flowElements) {
+        for (MoveExecutionEntityContainer.FlowElementMoveEntry flowElementMoveEntry : flowElements) {
+            if (isSubProcessAncestor(subProcessId, flowElementMoveEntry.getNewFlowElement())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSubProcessAncestor(String subProcessId, FlowElement flowElement) {
+        while (flowElement.getSubProcess() != null) {
+            String execElemSubProcessId = flowElement.getSubProcess().getId();
+            if (execElemSubProcessId != null && execElemSubProcessId.equals(subProcessId)) {
+                return true;
+            }
+            flowElement = flowElement.getSubProcess();
+        }
+        return false;
+    }
+
+    protected List<FlowElement> getFlowElementsInSubProcess(SubProcess subProcess, Collection<FlowElement> flowElements) {
+        return flowElements.stream()
+            .filter(e -> e.getSubProcess() != null)
+            .filter(e -> e.getSubProcess().getId().equals(subProcess.getId()))
+            .collect(Collectors.toList());
+    }
+
+    protected ExecutionEntity createEmbeddedSubProcessHierarchy(SubProcess subProcess, ExecutionEntity defaultParentExecution, Map<String, SubProcess> subProcessesToCreate, Set<String> movingExecutionIds, ProcessInstanceChangeState processInstanceChangeState, CommandContext commandContext) {
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
+        if (processInstanceChangeState.getProcessInstanceActiveEmbeddedExecutions().containsKey(subProcess.getId())) {
+            return processInstanceChangeState.getProcessInstanceActiveEmbeddedExecutions().get(subProcess.getId()).get(0);
+        }
+
+        if (processInstanceChangeState.getCreatedEmbeddedSubProcesses().containsKey(subProcess.getId())) {
+            return processInstanceChangeState.getCreatedEmbeddedSubProcesses().get(subProcess.getId());
+        }
+
+        //Create the parent, if needed
+        ExecutionEntity parentSubProcess = defaultParentExecution;
+        if (subProcess.getSubProcess() != null) {
+            parentSubProcess = createEmbeddedSubProcessHierarchy(subProcess.getSubProcess(), defaultParentExecution, subProcessesToCreate, movingExecutionIds, processInstanceChangeState, commandContext);
+            processInstanceChangeState.getCreatedEmbeddedSubProcesses().put(subProcess.getSubProcess().getId(), parentSubProcess);
+        }
+        ExecutionEntityManager executionEntityManager = processEngineConfiguration.getExecutionEntityManager();
+
+        ExecutionEntity subProcessExecution = executionEntityManager.createChildExecution(parentSubProcess);
+        subProcessExecution.setCurrentFlowElement(subProcess);
+        subProcessExecution.setScope(true);
+
+        ActivitiEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
+        if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+            eventDispatcher.dispatchEvent(
+                ActivitiEventBuilder.createActivityEvent(ActivitiEventType.ACTIVITY_STARTED, subProcess.getId(), subProcess.getName(), subProcessExecution.getId(),
+                    subProcessExecution.getProcessInstanceId(), subProcessExecution.getProcessDefinitionId(), subProcess));
+        }
+
+        subProcessExecution.setVariablesLocal(processDataObjects(subProcess.getDataObjects()));
+
+        processEngineConfiguration.getHistoryManager().recordActivityStart(subProcessExecution);
+
+        List<BoundaryEvent> boundaryEvents = subProcess.getBoundaryEvents();
+        if (CollectionUtil.isNotEmpty(boundaryEvents)) {
+            executeBoundaryEvents(boundaryEvents, subProcessExecution);
+        }
+
+        if (subProcess instanceof EventSubProcess) {
+            processCreatedEventSubProcess((EventSubProcess) subProcess, subProcessExecution, movingExecutionIds, commandContext);
+        }
+
+        ProcessInstanceHelper processInstanceHelper = processEngineConfiguration.getProcessInstanceHelper();
+
+        //Process containing child Event SubProcesses not contained in this creation hierarchy
+
+//        List<EventSubProcess> childEventSubProcesses = subProcess.findAllSubFlowElementInFlowMapOfType(EventSubProcess.class);
+//        childEventSubProcesses.stream()
+//                .filter(childEventSubProcess -> !subProcessesToCreate.containsKey(childEventSubProcess.getId()))
+//                .forEach(childEventSubProcess -> processInstanceHelper.processEventSubProcess(subProcessExecution, childEventSubProcess, commandContext));
+
+        return subProcessExecution;
+    }
+
+    protected Map<String, Object> processDataObjects(Collection<ValuedDataObject> dataObjects) {
+        Map<String, Object> variablesMap = new HashMap<>();
+        // convert data objects to process variables
+        if (dataObjects != null) {
+            variablesMap = new HashMap<>(dataObjects.size());
+            for (ValuedDataObject dataObject : dataObjects) {
+                variablesMap.put(dataObject.getName(), dataObject.getValue());
+            }
+        }
+        return variablesMap;
+    }
+
+    protected void executeBoundaryEvents(Collection<BoundaryEvent> boundaryEvents, ExecutionEntity execution) {
+
+        // The parent execution becomes a scope, and a child execution is created for each of the boundary events
+        for (BoundaryEvent boundaryEvent : boundaryEvents) {
+
+            if (CollectionUtil.isEmpty(boundaryEvent.getEventDefinitions())
+                || (boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition)) {
+                continue;
+            }
+
+            // A Child execution of the current execution is created to represent the boundary event being active
+            ExecutionEntity childExecutionEntity = CommandContextUtil.getExecutionEntityManager().createChildExecution(execution);
+            childExecutionEntity.setParentId(execution.getId());
+            childExecutionEntity.setCurrentFlowElement(boundaryEvent);
+            childExecutionEntity.setScope(false);
+
+            CommandContextUtil.getProcessEngineConfiguration().getHistoryManager().recordActivityStart(childExecutionEntity);
+
+            ActivityBehavior boundaryEventBehavior = ((ActivityBehavior) boundaryEvent.getBehavior());
+            LOGGER.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), childExecutionEntity.getId());
+            boundaryEventBehavior.execute(childExecutionEntity);
+        }
+    }
+
+    protected ExecutionEntity createCallActivityInstance(CallActivity callActivity, ProcessDefinition subProcessDefinition, ExecutionEntity parentExecution, String initialActivityId, CommandContext commandContext) {
+
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
+        ExpressionManager expressionManager = processEngineConfiguration.getExpressionManager();
+        ExecutionEntityManager executionEntityManager = processEngineConfiguration.getExecutionEntityManager();
+
+        Process subProcess = ProcessDefinitionUtil.getProcess(subProcessDefinition.getId());
+        if (subProcess == null) {
+            throw new ActivitiException("Cannot start a sub process instance. Process model " + subProcessDefinition.getName() + " (id = " + subProcessDefinition.getId() + ") could not be found");
+        }
+
+        String businessKey = null;
+
+        if (!StringUtils.isEmpty(callActivity.getBusinessKey())) {
+            Expression expression = expressionManager.createExpression(callActivity.getBusinessKey());
+            businessKey = expression.getValue(parentExecution).toString();
+
+        } else if (callActivity.isInheritBusinessKey()) {
+            ExecutionEntity processInstance = executionEntityManager.findById(parentExecution.getProcessInstanceId());
+            businessKey = processInstance.getBusinessKey();
+        }
+
+        ExecutionEntity subProcessInstance = executionEntityManager.createSubprocessInstance(subProcessDefinition, parentExecution, businessKey);
+
+//        EntityLinkUtil.createEntityLinks(parentExecution.getProcessInstanceId(), parentExecution.getId(), callActivity.getId(),
+//                subProcessInstance.getId(), ScopeTypes.BPMN);
+        CommandContextUtil.getHistoryManager().recordSubProcessInstanceStart(parentExecution, subProcessInstance, callActivity);
+
+        ActivitiEventDispatcher eventDispatcher = processEngineConfiguration.getEventDispatcher();
+        if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+            CommandContextUtil.getProcessEngineConfiguration().getEventDispatcher().dispatchEvent(ActivitiEventBuilder.createEntityEvent(
+                ActivitiEventType.PROCESS_STARTED, subProcessInstance));
+        }
+
+        // process template-defined data objects
+        subProcessInstance.setVariables(processDataObjects(subProcess.getDataObjects()));
+
+        Map<String, Object> variables = new HashMap<>();
+
+        if (callActivity.isInheritVariables()) {
+            Map<String, Object> executionVariables = parentExecution.getVariables();
+            for (Map.Entry<String, Object> entry : executionVariables.entrySet()) {
+                variables.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // copy process variables
+        for (IOParameter ioParameter : callActivity.getInParameters()) {
+            Object value;
+            if (StringUtils.isNotEmpty(ioParameter.getSourceExpression())) {
+                Expression expression = expressionManager.createExpression(ioParameter.getSourceExpression().trim());
+                value = expression.getValue(parentExecution);
+
+            } else {
+                value = parentExecution.getVariable(ioParameter.getSource());
+            }
+            variables.put(ioParameter.getTarget(), value);
+        }
+
+        if (!variables.isEmpty()) {
+            subProcessInstance.setVariables(variables);
+        }
+
+        if (eventDispatcher != null && eventDispatcher.isEnabled()) {
+            eventDispatcher.dispatchEvent(ActivitiEventBuilder.createEntityEvent(ActivitiEventType.ENTITY_INITIALIZED, subProcessInstance));
+        }
+
+        return subProcessInstance;
+    }
+
+    protected ExecutionEntity migrateExecutionEntity(ExecutionEntity parentExecutionEntity, ExecutionEntity childExecution, FlowElement newFlowElement, CommandContext commandContext) {
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
+        TaskService taskService = processEngineConfiguration.getTaskService();
+
+        // manage the bidirectional parent-child relation
+        childExecution.setProcessInstanceId(parentExecutionEntity.getProcessInstanceId());
+        childExecution.setProcessInstance(parentExecutionEntity.getProcessInstance());
+        childExecution.setProcessDefinitionId(parentExecutionEntity.getProcessDefinitionId());
+        ExecutionEntity oldParent = childExecution.getParent();
+        if (oldParent != null && !oldParent.getId().equals(parentExecutionEntity.getId())) {
+            oldParent.getExecutions().remove(childExecution);
+        }
+        childExecution.setParent(parentExecutionEntity);
+        parentExecutionEntity.addChildExecution(childExecution);
+
+        //Additional changes if the new activity Id doesn't match
+        String oldActivityId = childExecution.getCurrentActivityId();
+        if (!childExecution.getCurrentActivityId().equals(newFlowElement.getId())) {
+            ExecutionEntityImpl childExecution1 = (ExecutionEntityImpl) childExecution;
+            childExecution1.setCurrentFlowElement(newFlowElement);
+        }
+
+        // If we are moving a UserTask we need to update its processDefinition references
+        if (newFlowElement instanceof UserTask) {
+            TaskEntityImpl task = (TaskEntityImpl) taskService.createTaskQuery()
+                .executionId(childExecution.getId()).singleResult();
+            task.setProcessDefinitionId(childExecution.getProcessDefinitionId());
+            task.setTaskDefinitionKey(newFlowElement.getId());
+            task.setName(newFlowElement.getName());
+            task.setProcessInstanceId(childExecution.getProcessInstanceId());
+
+            //Sync history
+            syncUserTaskExecutionActivityInstance(childExecution, oldActivityId, newFlowElement);
+
+            updateActivity(processEngineConfiguration, childExecution, oldActivityId, newFlowElement, task, new Date());
+        }
+
+        // Boundary Events - only applies to Activities and up to this point we have a UserTask or ReceiveTask execution, both are Activities
+        List<BoundaryEvent> boundaryEvents = ((Activity) newFlowElement).getBoundaryEvents();
+        if (boundaryEvents != null && !boundaryEvents.isEmpty()) {
+            List<ExecutionEntity> boundaryEventsExecutions = createBoundaryEvents(boundaryEvents, childExecution, commandContext);
+            executeBoundaryEvents(boundaryEvents, boundaryEventsExecutions);
+        }
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Child execution {} updated with parent {}", childExecution, parentExecutionEntity.getId());
+        }
+        return childExecution;
+    }
+
+    public void updateActivity(ProcessEngineConfigurationImpl processEngineConfiguration, ExecutionEntity childExecution, String oldActivityId, FlowElement newFlowElement, TaskEntity task, Date updateTime) {
+
+        HistoryManager historyManager = processEngineConfiguration.getHistoryManager();
+        if (historyManager.isHistoryLevelAtLeast(HistoryLevel.ACTIVITY)) {
+            HistoricActivityInstanceEntityManager historicActivityInstanceEntityManager = CommandContextUtil.getHistoricActivityInstanceEntityManager();
+            List<HistoricActivityInstanceEntity> historicActivityInstances = historicActivityInstanceEntityManager.findUnfinishedHistoricActivityInstancesByExecutionAndActivityId(childExecution.getId(), oldActivityId);
+            for (HistoricActivityInstanceEntity historicActivityInstance : historicActivityInstances) {
+                historicActivityInstance.setProcessDefinitionId(childExecution.getProcessDefinitionId());
+                historicActivityInstance.setActivityId(childExecution.getActivityId());
+                historicActivityInstance.setActivityName(newFlowElement.getName());
+            }
+        }
+
+        if (historyManager.isHistoryLevelAtLeast(HistoryLevel.AUDIT)) {
+            historyManager.recordTaskAssigneeChange(task.getId(), task.getAssignee());
+        }
+
+    }
+
+    protected void syncUserTaskExecutionActivityInstance(ExecutionEntity childExecution, String oldActivityId,
+                                                         FlowElement newFlowElement) {
+        HistoricActivityInstanceEntityManager activityInstanceEntityManager = CommandContextUtil.getActivityInstanceEntityManager();
+        List<HistoricActivityInstanceEntity> activityInstances = activityInstanceEntityManager.findUnfinishedHistoricActivityInstancesByExecutionAndActivityId(childExecution.getId(), oldActivityId);
+        for (HistoricActivityInstanceEntity activityInstance : activityInstances) {
+            activityInstance.setProcessDefinitionId(childExecution.getProcessDefinitionId());
+            activityInstance.setActivityId(childExecution.getActivityId());
+            activityInstance.setActivityName(newFlowElement.getName());
+        }
+    }
+
+    protected void handleUserTaskNewAssignee(ExecutionEntity taskExecution, String newAssigneeId, CommandContext commandContext) {
+        ProcessEngineConfigurationImpl processEngineConfiguration = CommandContextUtil.getProcessEngineConfiguration(commandContext);
+        TaskService taskService = processEngineConfiguration.getTaskService();
+        TaskEntityImpl task = (TaskEntityImpl) taskService.createTaskQuery()
+            .executionId(taskExecution.getId()).singleResult();
+        if (task != null) {
+            taskService.setAssignee(task.getId(), newAssigneeId);
+        }
+    }
+
+    protected boolean isEventSubProcessStart(FlowElement flowElement) {
+        return flowElement instanceof StartEvent && flowElement.getSubProcess() != null && flowElement.getSubProcess() instanceof EventSubProcess;
+    }
+
+    protected List<ExecutionEntity> createBoundaryEvents(List<BoundaryEvent> boundaryEvents, ExecutionEntity execution, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+
+        List<ExecutionEntity> boundaryEventExecutions = new ArrayList<>(boundaryEvents.size());
+
+        // The parent execution becomes a scope, and a child execution is created for each of the boundary events
+        for (BoundaryEvent boundaryEvent : boundaryEvents) {
+
+            if (CollectionUtil.isEmpty(boundaryEvent.getEventDefinitions())
+                || (boundaryEvent.getEventDefinitions().get(0) instanceof CompensateEventDefinition)) {
+                continue;
+            }
+
+            // A Child execution of the current execution is created to represent the boundary event being active
+            ExecutionEntity childExecutionEntity = executionEntityManager.createChildExecution(execution);
+            childExecutionEntity.setParentId(execution.getId());
+            childExecutionEntity.setCurrentFlowElement(boundaryEvent);
+            childExecutionEntity.setScope(false);
+            boundaryEventExecutions.add(childExecutionEntity);
+        }
+
+        return boundaryEventExecutions;
+    }
+
+    protected void executeBoundaryEvents(List<BoundaryEvent> boundaryEvents, List<ExecutionEntity> boundaryEventExecutions) {
+        if (!CollectionUtil.isEmpty(boundaryEventExecutions)) {
+            Iterator<BoundaryEvent> boundaryEventsIterator = boundaryEvents.iterator();
+            Iterator<ExecutionEntity> boundaryEventExecutionsIterator = boundaryEventExecutions.iterator();
+
+            while (boundaryEventsIterator.hasNext() && boundaryEventExecutionsIterator.hasNext()) {
+                BoundaryEvent boundaryEvent = boundaryEventsIterator.next();
+                ExecutionEntity boundaryEventExecution = boundaryEventExecutionsIterator.next();
+                ActivityBehavior boundaryEventBehavior = ((ActivityBehavior) boundaryEvent.getBehavior());
+                LOGGER.debug("Executing boundary event activityBehavior {} with execution {}", boundaryEventBehavior.getClass(), boundaryEventExecution.getId());
+                boundaryEventBehavior.execute(boundaryEventExecution);
+            }
+        }
+    }
+
+    protected boolean isExecutionInsideMultiInstance(ExecutionEntity execution) {
+        return getFlowElementMultiInstanceParentId(execution.getCurrentFlowElement()).isPresent();
+    }
+
+    protected Optional<String> getFlowElementMultiInstanceParentId(FlowElement flowElement) {
+        FlowElementsContainer parentContainer = flowElement.getParentContainer();
+        while (parentContainer instanceof Activity) {
+            if (isFlowElementMultiInstance((Activity) parentContainer)) {
+                return Optional.of(((Activity) parentContainer).getId());
+            }
+            parentContainer = ((Activity) parentContainer).getParentContainer();
+        }
+        return Optional.empty();
+    }
+
+    protected boolean isFlowElementMultiInstance(FlowElement flowElement) {
+        if (flowElement instanceof Activity) {
+            return ((Activity) flowElement).getLoopCharacteristics() != null;
+        }
+        return false;
+    }
+
+    protected void processCreatedEventSubProcess(EventSubProcess eventSubProcess, ExecutionEntity eventSubProcessExecution, Set<String> movingExecutionIds, CommandContext commandContext) {
+        // @todo如果后续使用到 EventSubProcess,则需要拓展
+    }
+
+    protected boolean isOnlyRemainingExecutionAtParentScope(ExecutionEntity executionEntity, Set<String> ignoreExecutionIds, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+        List<ExecutionEntity> siblingExecutions = executionEntityManager.findChildExecutionsByParentExecutionId(executionEntity.getParentId());
+        return siblingExecutions.stream()
+            .filter(ExecutionEntity::isActive)
+            .filter(execution -> !execution.getId().equals(executionEntity.getId()))
+            .filter(execution -> !ignoreExecutionIds.contains(execution.getId()))
+            .count() == 0;
+    }
+
+    protected boolean isExpression(String variableName) {
+        return variableName.startsWith("${") || variableName.startsWith("#{");
+    }
+
+    protected ProcessDefinition resolveProcessDefinition(String processDefinitionKey, Integer processDefinitionVersion, String tenantId, CommandContext commandContext) {
+        ProcessDefinitionEntityManager processDefinitionEntityManager = CommandContextUtil.getProcessDefinitionEntityManager(commandContext);
+        ProcessDefinition processDefinition;
+        if (processDefinitionVersion != null) {
+            processDefinition = processDefinitionEntityManager.findProcessDefinitionByKeyAndVersionAndTenantId(processDefinitionKey, processDefinitionVersion, tenantId);
+        } else {
+            if (tenantId == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(tenantId)) {
+                processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKey(processDefinitionKey);
+            } else {
+                processDefinition = processDefinitionEntityManager.findLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, tenantId);
+            }
+        }
+
+        if (processDefinition == null) {
+            DeploymentManager deploymentManager = CommandContextUtil.getProcessEngineConfiguration(commandContext).getDeploymentManager();
+            if (tenantId == null || ProcessEngineConfiguration.NO_TENANT_ID.equals(tenantId)) {
+                processDefinition = deploymentManager.findDeployedLatestProcessDefinitionByKey(processDefinitionKey);
+            } else {
+                processDefinition = deploymentManager.findDeployedLatestProcessDefinitionByKeyAndTenantId(processDefinitionKey, tenantId);
+            }
+        }
+        return processDefinition;
+    }
+
+    private String printFlowElementIds(Collection<MoveExecutionEntityContainer.FlowElementMoveEntry> flowElements) {
+        return flowElements.stream().map(MoveExecutionEntityContainer.FlowElementMoveEntry::getNewFlowElement).map(FlowElement::getId).collect(Collectors.joining(","));
+    }
+}
+

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -32,9 +32,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * @author LoveMyOrange
- */
+
 public abstract class AbstractDynamicStateManager {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/AbstractDynamicStateManager.java
@@ -23,7 +23,6 @@ import org.activiti.engine.impl.runtime.MoveExecutionIdContainer;
 import org.activiti.engine.impl.util.CollectionUtil;
 import org.activiti.engine.impl.util.CommandContextUtil;
 import org.activiti.engine.impl.util.ProcessDefinitionUtil;
-import org.activiti.engine.impl.util.ProcessInstanceHelper;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/DefaultDynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/DefaultDynamicStateManager.java
@@ -1,0 +1,58 @@
+package org.activiti.engine.impl.dynamic;
+
+
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.engine.dynamic.DynamicStateManager;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntityManager;
+import org.activiti.engine.impl.runtime.ChangeActivityStateBuilderImpl;
+import org.activiti.engine.impl.util.CommandContextUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * @author LoveMyOrange
+ */
+public class DefaultDynamicStateManager extends AbstractDynamicStateManager implements DynamicStateManager {
+
+    @Override
+    public void moveExecutionState(ChangeActivityStateBuilderImpl changeActivityStateBuilder, CommandContext commandContext) {
+        List<MoveExecutionEntityContainer> moveExecutionEntityContainerList = resolveMoveExecutionEntityContainers(changeActivityStateBuilder, Optional.empty(), changeActivityStateBuilder.getProcessInstanceVariables(), commandContext);
+        List<ExecutionEntity> executions = moveExecutionEntityContainerList.iterator().next().getExecutions();
+        String processInstanceId = executions.iterator().next().getProcessInstanceId();
+
+        ProcessInstanceChangeState processInstanceChangeState = new ProcessInstanceChangeState()
+            .setProcessInstanceId(processInstanceId)
+            .setMoveExecutionEntityContainers(moveExecutionEntityContainerList)
+            .setLocalVariables(changeActivityStateBuilder.getLocalVariables())
+            .setProcessInstanceVariables(changeActivityStateBuilder.getProcessInstanceVariables())
+            .setJumpReason(changeActivityStateBuilder.getJumpReason());
+
+
+        doMoveExecutionState(processInstanceChangeState, commandContext);
+    }
+
+    @Override
+    protected Map<String, List<ExecutionEntity>> resolveActiveEmbeddedSubProcesses(String processInstanceId, CommandContext commandContext) {
+        ExecutionEntityManager executionEntityManager = CommandContextUtil.getExecutionEntityManager(commandContext);
+        List<ExecutionEntity> childExecutions = executionEntityManager.findChildExecutionsByProcessInstanceId(processInstanceId);
+
+        Map<String, List<ExecutionEntity>> activeSubProcessesByActivityId = childExecutions.stream()
+            .filter(ExecutionEntity::isActive)
+            .filter(executionEntity -> executionEntity.getCurrentFlowElement() instanceof SubProcess)
+            .collect(Collectors.groupingBy(ExecutionEntity::getActivityId));
+        return activeSubProcessesByActivityId;
+    }
+
+    @Override
+    protected boolean isDirectFlowElementExecutionMigration(FlowElement currentFlowElement, FlowElement newFlowElement) {
+        return false;
+    }
+
+}
+

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/DefaultDynamicStateManager.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/DefaultDynamicStateManager.java
@@ -15,9 +15,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-/**
- * @author LoveMyOrange
- */
+
 public class DefaultDynamicStateManager extends AbstractDynamicStateManager implements DynamicStateManager {
 
     @Override

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/MoveExecutionEntityContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/MoveExecutionEntityContainer.java
@@ -1,0 +1,207 @@
+package org.activiti.engine.impl.dynamic;
+
+
+import org.activiti.bpmn.model.BpmnModel;
+import org.activiti.bpmn.model.CallActivity;
+import org.activiti.bpmn.model.FlowElement;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.repository.ProcessDefinition;
+
+import java.util.*;
+
+/**
+ * @author LoveMyOrange
+ */
+public class MoveExecutionEntityContainer {
+
+    protected List<ExecutionEntity> executions;
+    protected List<String> moveToActivityIds;
+    protected boolean moveToParentProcess;
+    protected boolean moveToSubProcessInstance;
+    protected boolean directExecutionMigration;
+    protected String callActivityId;
+    protected Integer callActivitySubProcessVersion;
+    protected CallActivity callActivity;
+    protected String subProcessDefKey;
+    protected ProcessDefinition subProcessDefinition;
+    protected BpmnModel subProcessModel;
+    protected BpmnModel processModel;
+    protected ExecutionEntity superExecution;
+    protected String newAssigneeId;
+    protected Map<String, ExecutionEntity> continueParentExecutionMap = new HashMap<>();
+    protected Map<String, FlowElementMoveEntry> moveToFlowElementMap = new LinkedHashMap<>();
+    protected List<String> newExecutionIds = new ArrayList<>();
+
+    public MoveExecutionEntityContainer(List<ExecutionEntity> executions, List<String> moveToActivityIds) {
+        this.executions = executions;
+        this.moveToActivityIds = moveToActivityIds;
+    }
+
+    public List<ExecutionEntity> getExecutions() {
+        return executions;
+    }
+
+    public List<String> getMoveToActivityIds() {
+        return moveToActivityIds;
+    }
+
+    public boolean isMoveToParentProcess() {
+        return moveToParentProcess;
+    }
+
+    public void setMoveToParentProcess(boolean moveToParentProcess) {
+        this.moveToParentProcess = moveToParentProcess;
+    }
+
+    public boolean isMoveToSubProcessInstance() {
+        return moveToSubProcessInstance;
+    }
+
+    public void setMoveToSubProcessInstance(boolean moveToSubProcessInstance) {
+        this.moveToSubProcessInstance = moveToSubProcessInstance;
+    }
+
+    public boolean isDirectExecutionMigration() {
+        return directExecutionMigration;
+    }
+
+    public void setDirectExecutionMigration(boolean directMigrateUserTask) {
+        this.directExecutionMigration = directMigrateUserTask;
+    }
+
+    public String getCallActivityId() {
+        return callActivityId;
+    }
+
+    public void setCallActivityId(String callActivityId) {
+        this.callActivityId = callActivityId;
+    }
+
+    public Integer getCallActivitySubProcessVersion() {
+        return callActivitySubProcessVersion;
+    }
+
+    public void setCallActivitySubProcessVersion(Integer callActivitySubProcessVersion) {
+        this.callActivitySubProcessVersion = callActivitySubProcessVersion;
+    }
+
+    public CallActivity getCallActivity() {
+        return callActivity;
+    }
+
+    public void setCallActivity(CallActivity callActivity) {
+        this.callActivity = callActivity;
+    }
+
+    public String getSubProcessDefKey() {
+        return subProcessDefKey;
+    }
+
+    public void setSubProcessDefKey(String subProcessDefKey) {
+        this.subProcessDefKey = subProcessDefKey;
+    }
+
+    public ProcessDefinition getSubProcessDefinition() {
+        return subProcessDefinition;
+    }
+
+    public void setSubProcessDefinition(ProcessDefinition subProcessDefinition) {
+        this.subProcessDefinition = subProcessDefinition;
+    }
+
+    public BpmnModel getProcessModel() {
+        return processModel;
+    }
+
+    public void setProcessModel(BpmnModel processModel) {
+        this.processModel = processModel;
+    }
+
+    public BpmnModel getSubProcessModel() {
+        return subProcessModel;
+    }
+
+    public void setSubProcessModel(BpmnModel subProcessModel) {
+        this.subProcessModel = subProcessModel;
+    }
+
+    public ExecutionEntity getSuperExecution() {
+        return superExecution;
+    }
+
+    public void setNewAssigneeId(String newAssigneeId) {
+        this.newAssigneeId = newAssigneeId;
+    }
+
+    public String getNewAssigneeId() {
+        return newAssigneeId;
+    }
+
+    public void setSuperExecution(ExecutionEntity superExecution) {
+        this.superExecution = superExecution;
+    }
+
+    public void addContinueParentExecution(String executionId, ExecutionEntity continueParentExecution) {
+        continueParentExecutionMap.put(executionId, continueParentExecution);
+    }
+
+    public ExecutionEntity getContinueParentExecution(String executionId) {
+        return continueParentExecutionMap.get(executionId);
+    }
+
+    public void addMoveToFlowElement(String activityId, FlowElementMoveEntry flowElementMoveEntry) {
+        moveToFlowElementMap.put(activityId, flowElementMoveEntry);
+    }
+
+    public void addMoveToFlowElement(String activityId, FlowElement originalFlowElement, FlowElement newFlowElement) {
+        moveToFlowElementMap.put(activityId, new FlowElementMoveEntry(originalFlowElement, newFlowElement));
+    }
+
+    public void addMoveToFlowElement(String activityId, FlowElement originalFlowElement) {
+        moveToFlowElementMap.put(activityId, new FlowElementMoveEntry(originalFlowElement, originalFlowElement));
+    }
+
+    public FlowElementMoveEntry getMoveToFlowElement(String activityId) {
+        return moveToFlowElementMap.get(activityId);
+    }
+
+    public List<FlowElementMoveEntry> getMoveToFlowElements() {
+        return new ArrayList<>(moveToFlowElementMap.values());
+    }
+
+    public List<String> getNewExecutionIds() {
+        return newExecutionIds;
+    }
+
+    public boolean hasNewExecutionId(String executionId) {
+        return newExecutionIds.contains(executionId);
+    }
+
+    public void setNewExecutionIds(List<String> newExecutionIds) {
+        this.newExecutionIds = newExecutionIds;
+    }
+
+    public void addNewExecutionId(String executionId) {
+        this.newExecutionIds.add(executionId);
+    }
+
+    public static class FlowElementMoveEntry {
+
+        protected FlowElement originalFlowElement;
+        protected FlowElement newFlowElement;
+
+        public FlowElementMoveEntry(FlowElement originalFlowElement, FlowElement newFlowElement) {
+            this.originalFlowElement = originalFlowElement;
+            this.newFlowElement = newFlowElement;
+        }
+
+        public FlowElement getOriginalFlowElement() {
+            return originalFlowElement;
+        }
+
+        public FlowElement getNewFlowElement() {
+            return newFlowElement;
+        }
+    }
+}
+

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/MoveExecutionEntityContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/MoveExecutionEntityContainer.java
@@ -9,9 +9,7 @@ import org.activiti.engine.repository.ProcessDefinition;
 
 import java.util.*;
 
-/**
- * @author LoveMyOrange
- */
+
 public class MoveExecutionEntityContainer {
 
     protected List<ExecutionEntity> executions;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/ProcessInstanceChangeState.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/ProcessInstanceChangeState.java
@@ -1,0 +1,120 @@
+package org.activiti.engine.impl.dynamic;
+
+
+import org.activiti.bpmn.model.StartEvent;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.repository.ProcessDefinition;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author LoveMyOrange
+ */
+public class ProcessInstanceChangeState {
+
+    protected String processInstanceId;
+    protected ProcessDefinition processDefinitionToMigrateTo;
+    protected Map<String, Object> processVariables = new HashMap<>();
+    protected Map<String, Map<String, Object>> localVariables = new HashMap<>();
+    protected Map<String, List<ExecutionEntity>> processInstanceActiveEmbeddedExecutions;
+    protected List<MoveExecutionEntityContainer> moveExecutionEntityContainers;
+    protected HashMap<String, ExecutionEntity> createdEmbeddedSubProcess = new HashMap<>();
+    protected HashMap<StartEvent, ExecutionEntity> pendingEventSubProcessesStartEvents = new HashMap<>();
+    protected String jumpReason;
+
+
+    public ProcessInstanceChangeState() {
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public String getJumpReason() {
+        return jumpReason;
+    }
+
+    public ProcessInstanceChangeState setJumpReason(String jumpReason) {
+        this.jumpReason = jumpReason;
+        return this;
+    }
+
+    public ProcessInstanceChangeState setProcessInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+        return this;
+    }
+
+    public Optional<ProcessDefinition> getProcessDefinitionToMigrateTo() {
+        return Optional.ofNullable(processDefinitionToMigrateTo);
+    }
+
+    public ProcessInstanceChangeState setProcessDefinitionToMigrateTo(ProcessDefinition processDefinitionToMigrateTo) {
+        this.processDefinitionToMigrateTo = processDefinitionToMigrateTo;
+        return this;
+    }
+
+    public boolean isMigrateToProcessDefinition() {
+        return getProcessDefinitionToMigrateTo().isPresent();
+    }
+
+    public Map<String, Object> getProcessInstanceVariables() {
+        return processVariables;
+    }
+
+    public ProcessInstanceChangeState setProcessInstanceVariables(Map<String, Object> processVariables) {
+        this.processVariables = processVariables;
+        return this;
+    }
+
+    public Map<String, Map<String, Object>> getLocalVariables() {
+        return localVariables;
+    }
+
+    public ProcessInstanceChangeState setLocalVariables(Map<String, Map<String, Object>> localVariables) {
+        this.localVariables = localVariables;
+        return this;
+    }
+
+    public List<MoveExecutionEntityContainer> getMoveExecutionEntityContainers() {
+        return moveExecutionEntityContainers;
+    }
+
+    public ProcessInstanceChangeState setMoveExecutionEntityContainers(List<MoveExecutionEntityContainer> moveExecutionEntityContainers) {
+        this.moveExecutionEntityContainers = moveExecutionEntityContainers;
+        return this;
+    }
+
+    public HashMap<String, ExecutionEntity> getCreatedEmbeddedSubProcesses() {
+        return createdEmbeddedSubProcess;
+    }
+
+    public Optional<ExecutionEntity> getCreatedEmbeddedSubProcessByKey(String key) {
+        return Optional.ofNullable(createdEmbeddedSubProcess.get(key));
+    }
+
+    public void addCreatedEmbeddedSubProcess(String key, ExecutionEntity executionEntity) {
+        this.createdEmbeddedSubProcess.put(key, executionEntity);
+    }
+
+    public Map<String, List<ExecutionEntity>> getProcessInstanceActiveEmbeddedExecutions() {
+        return processInstanceActiveEmbeddedExecutions;
+    }
+
+    public ProcessInstanceChangeState setProcessInstanceActiveEmbeddedExecutions(Map<String, List<ExecutionEntity>> processInstanceActiveEmbeddedExecutions) {
+        this.processInstanceActiveEmbeddedExecutions = processInstanceActiveEmbeddedExecutions;
+        return this;
+    }
+
+    public HashMap<StartEvent, ExecutionEntity> getPendingEventSubProcessesStartEvents() {
+        return pendingEventSubProcessesStartEvents;
+    }
+
+    public void addPendingEventSubProcessStartEvent(StartEvent startEvent, ExecutionEntity eventSubProcessParent) {
+        this.pendingEventSubProcessesStartEvents.put(startEvent, eventSubProcessParent);
+    }
+
+}
+

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/ProcessInstanceChangeState.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/dynamic/ProcessInstanceChangeState.java
@@ -10,9 +10,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * @author LoveMyOrange
- */
+
 public class ProcessInstanceChangeState {
 
     protected String processInstanceId;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
@@ -13,9 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author LoveMyOrange
- */
+
 public class ChangeActivityStateBuilderImpl implements ChangeActivityStateBuilder {
 
     protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/ChangeActivityStateBuilderImpl.java
@@ -1,0 +1,268 @@
+package org.activiti.engine.impl.runtime;
+
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.impl.RuntimeServiceImpl;
+import org.activiti.engine.impl.cmd.ChangeActivityStateCmd;
+import org.activiti.engine.runtime.ChangeActivityStateBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author LoveMyOrange
+ */
+public class ChangeActivityStateBuilderImpl implements ChangeActivityStateBuilder {
+
+    protected final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
+
+    protected RuntimeServiceImpl runtimeService;
+
+    protected String processInstanceId;
+    protected List<MoveExecutionIdContainer> moveExecutionIdList = new ArrayList<>();
+    protected List<MoveActivityIdContainer> moveActivityIdList = new ArrayList<>();
+    protected Map<String, Object> processVariables = new HashMap<>();
+    protected Map<String, Map<String, Object>> localVariables = new HashMap<>();
+    protected String jumpReason;
+
+    public ChangeActivityStateBuilderImpl() {
+    }
+
+    public ChangeActivityStateBuilderImpl(RuntimeServiceImpl runtimeService) {
+        this.runtimeService = runtimeService;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder processInstanceId(String processInstanceId) {
+        this.processInstanceId = processInstanceId;
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveExecutionToActivityId(String executionId, String activityId) {
+        return moveExecutionToActivityId(executionId, activityId, null);
+    }
+
+    public ChangeActivityStateBuilder moveExecutionToActivityId(String executionId, String activityId, String newAssigneeId) {
+        moveExecutionIdList.add(new MoveExecutionIdContainer(executionId, activityId, newAssigneeId));
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveExecutionsToSingleActivityId(List<String> executionIds, String activityId) {
+        return moveExecutionsToSingleActivityId(executionIds, activityId, null);
+    }
+
+    public ChangeActivityStateBuilder moveExecutionsToSingleActivityId(List<String> executionIds, String activityId, String newAssigneeId) {
+        moveExecutionIdList.add(new MoveExecutionIdContainer(executionIds, activityId, newAssigneeId));
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveSingleExecutionToActivityIds(String executionId, List<String> activityIds) {
+        return moveSingleExecutionToActivityIds(executionId, activityIds, null);
+    }
+
+    public ChangeActivityStateBuilder moveSingleExecutionToActivityIds(String executionId, List<String> activityIds, String newAssigneeId) {
+        moveExecutionIdList.add(new MoveExecutionIdContainer(executionId, activityIds, newAssigneeId));
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveActivityIdTo(String currentActivityId, String newActivityId) {
+        return moveActivityIdTo(currentActivityId, newActivityId, null);
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdTo(String currentActivityId, String newActivityId, String newAssigneeId) {
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Change activity processInstanceId:[{}]  from: [{}] to: [{}] assigneeId: [{}], start", processInstanceId, currentActivityId, newActivityId, newAssigneeId);
+        }
+        moveActivityIdList.add(new MoveActivityIdContainer(currentActivityId, newActivityId, newAssigneeId));
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Change activity processInstanceId:[{}] from: [{}] to: [{}] assigneeId: [{}], end", processInstanceId, currentActivityId, newActivityId, newAssigneeId);
+        }
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveActivityIdsToSingleActivityId(List<String> activityIds, String activityId) {
+        return moveActivityIdsToSingleActivityId(activityIds, activityId, null);
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdsToSingleActivityId(List<String> activityIds, String activityId, String newAssigneeId) {
+        moveActivityIdList.add(new MoveActivityIdContainer(activityIds, activityId, newAssigneeId));
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveSingleActivityIdToActivityIds(String currentActivityId, List<String> newActivityIds) {
+        return moveSingleActivityIdToActivityIds(currentActivityId, newActivityIds, null);
+    }
+
+    public ChangeActivityStateBuilder moveSingleActivityIdToActivityIds(String currentActivityId, List<String> newActivityIds, String newAssigneeId) {
+        moveActivityIdList.add(new MoveActivityIdContainer(currentActivityId, newActivityIds, newAssigneeId));
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveActivityIdToParentActivityId(String currentActivityId, String newActivityId) {
+        return moveActivityIdToParentActivityId(currentActivityId, newActivityId, null);
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdToParentActivityId(String currentActivityId, String newActivityId, String newAssigneeId) {
+        MoveActivityIdContainer moveActivityIdContainer = new MoveActivityIdContainer(currentActivityId, newActivityId, newAssigneeId);
+        moveActivityIdContainer.setMoveToParentProcess(true);
+        moveActivityIdList.add(moveActivityIdContainer);
+        return this;
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdsToParentActivityId(List<String> currentActivityIds, String newActivityId, String newAssigneeId) {
+        MoveActivityIdContainer moveActivityIdContainer = new MoveActivityIdContainer(currentActivityIds, newActivityId, newAssigneeId);
+        moveActivityIdContainer.setMoveToParentProcess(true);
+        moveActivityIdList.add(moveActivityIdContainer);
+        return this;
+    }
+
+    public ChangeActivityStateBuilder moveSingleActivityIdToParentActivityIds(String currentActivityId, List<String> newActivityIds) {
+        MoveActivityIdContainer moveActivityIdContainer = new MoveActivityIdContainer(currentActivityId, newActivityIds);
+        moveActivityIdContainer.setMoveToParentProcess(true);
+        moveActivityIdList.add(moveActivityIdContainer);
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveActivityIdToSubProcessInstanceActivityId(String currentActivityId, String newActivityId, String callActivityId) {
+        return moveActivityIdToSubProcessInstanceActivityId(currentActivityId, newActivityId, callActivityId, null, null);
+    }
+
+    @Override
+    public ChangeActivityStateBuilder moveActivityIdToSubProcessInstanceActivityId(String currentActivityId, String newActivityId, String callActivityId, Integer subProcessDefinitionVersion) {
+        return moveActivityIdToSubProcessInstanceActivityId(currentActivityId, newActivityId, callActivityId, subProcessDefinitionVersion, null);
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdToSubProcessInstanceActivityId(String currentActivityId, String newActivityId, String callActivityId, Integer callActivitySubProcessVersion, String newAssigneeId) {
+        MoveActivityIdContainer moveActivityIdContainer = new MoveActivityIdContainer(currentActivityId, newActivityId, newAssigneeId);
+        moveActivityIdContainer.setMoveToSubProcessInstance(true);
+        moveActivityIdContainer.setCallActivityId(callActivityId);
+        moveActivityIdContainer.setCallActivitySubProcessVersion(callActivitySubProcessVersion);
+        moveActivityIdList.add(moveActivityIdContainer);
+        return this;
+    }
+
+    public ChangeActivityStateBuilder moveActivityIdsToSubProcessInstanceActivityId(List<String> activityIds, String newActivityId, String callActivityId, Integer callActivitySubProcessVersion, String newAssigneeId) {
+        MoveActivityIdContainer moveActivityIdsContainer = new MoveActivityIdContainer(activityIds, newActivityId, newAssigneeId);
+        moveActivityIdsContainer.setMoveToSubProcessInstance(true);
+        moveActivityIdsContainer.setCallActivityId(callActivityId);
+        moveActivityIdsContainer.setCallActivitySubProcessVersion(callActivitySubProcessVersion);
+        moveActivityIdList.add(moveActivityIdsContainer);
+        return this;
+    }
+
+    public ChangeActivityStateBuilder moveSingleActivityIdToSubProcessInstanceActivityIds(String currentActivityId, List<String> newActivityIds, String callActivityId, Integer callActivitySubProcessVersion) {
+        MoveActivityIdContainer moveActivityIdsContainer = new MoveActivityIdContainer(currentActivityId, newActivityIds);
+        moveActivityIdsContainer.setMoveToSubProcessInstance(true);
+        moveActivityIdsContainer.setCallActivityId(callActivityId);
+        moveActivityIdsContainer.setCallActivitySubProcessVersion(callActivitySubProcessVersion);
+        moveActivityIdList.add(moveActivityIdsContainer);
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder processVariable(String processVariableName, Object processVariableValue) {
+        if (this.processVariables == null) {
+            this.processVariables = new HashMap<>();
+        }
+
+        this.processVariables.put(processVariableName, processVariableValue);
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder processVariables(Map<String, Object> processVariables) {
+        this.processVariables = processVariables;
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder localVariable(String startActivityId, String localVariableName, Object localVariableValue) {
+        if (this.localVariables == null) {
+            this.localVariables = new HashMap<>();
+        }
+
+        Map<String, Object> localVariableMap = null;
+        if (localVariables.containsKey(startActivityId)) {
+            localVariableMap = localVariables.get(startActivityId);
+        } else {
+            localVariableMap = new HashMap<>();
+        }
+
+        localVariableMap.put(localVariableName, localVariableValue);
+
+        this.localVariables.put(startActivityId, localVariableMap);
+
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder localVariables(String startActivityId, Map<String, Object> localVariables) {
+        if (this.localVariables == null) {
+            this.localVariables = new HashMap<>();
+        }
+
+        this.localVariables.put(startActivityId, localVariables);
+
+        return this;
+    }
+
+    @Override
+    public ChangeActivityStateBuilder jumpReason(String jumpReason) {
+        this.jumpReason = jumpReason;
+        return this;
+    }
+
+    @Override
+    public void changeState() {
+        if (runtimeService == null) {
+            throw new ActivitiException("RuntimeService cannot be null, Obtain your builder instance from the RuntimeService to access this feature");
+        }
+
+        changeActivityState(this);
+    }
+
+    public void changeActivityState(ChangeActivityStateBuilderImpl changeActivityStateBuilder) {
+        runtimeService.getCommandExecutor().execute(new ChangeActivityStateCmd(changeActivityStateBuilder));
+    }
+
+    public String getProcessInstanceId() {
+        return processInstanceId;
+    }
+
+    public List<MoveExecutionIdContainer> getMoveExecutionIdList() {
+        return moveExecutionIdList;
+    }
+
+    public List<MoveActivityIdContainer> getMoveActivityIdList() {
+        return moveActivityIdList;
+    }
+
+    public Map<String, Object> getProcessInstanceVariables() {
+        return processVariables;
+    }
+
+    public Map<String, Map<String, Object>> getLocalVariables() {
+        return localVariables;
+    }
+
+    public String getJumpReason() {
+        return jumpReason;
+    }
+
+    public void setJumpReason(String jumpReason) {
+        this.jumpReason = jumpReason;
+    }
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveActivityIdContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveActivityIdContainer.java
@@ -5,9 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * @author LoveMyOrange
- */
+
 public class MoveActivityIdContainer {
 
     protected List<String> activityIds;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveActivityIdContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveActivityIdContainer.java
@@ -1,0 +1,94 @@
+package org.activiti.engine.impl.runtime;
+
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author LoveMyOrange
+ */
+public class MoveActivityIdContainer {
+
+    protected List<String> activityIds;
+    protected List<String> moveToActivityIds;
+    protected boolean moveToParentProcess;
+    protected boolean moveToSubProcessInstance;
+    protected String callActivityId;
+    protected Integer callActivitySubProcessVersion;
+    protected String newAssigneeId;
+
+    public MoveActivityIdContainer(String singleActivityId, String moveToActivityId) {
+        this(singleActivityId, moveToActivityId, null);
+    }
+
+    public MoveActivityIdContainer(String singleActivityId, String moveToActivityId, String newAssigneeId) {
+        this.activityIds = Collections.singletonList(singleActivityId);
+        this.moveToActivityIds = Collections.singletonList(moveToActivityId);
+        this.newAssigneeId = newAssigneeId;
+    }
+
+    public MoveActivityIdContainer(List<String> activityIds, String moveToActivityId) {
+        this(activityIds, moveToActivityId, null);
+    }
+
+    public MoveActivityIdContainer(List<String> activityIds, String moveToActivityId, String newAssigneeId) {
+        this.activityIds = activityIds;
+        this.moveToActivityIds = Collections.singletonList(moveToActivityId);
+        this.newAssigneeId = newAssigneeId;
+    }
+
+    public MoveActivityIdContainer(String singleActivityId, List<String> moveToActivityIds) {
+        this(singleActivityId, moveToActivityIds, null);
+    }
+
+    public MoveActivityIdContainer(String singleActivityId, List<String> moveToActivityIds, String newAssigneeId) {
+        this.activityIds = Collections.singletonList(singleActivityId);
+        this.moveToActivityIds = moveToActivityIds;
+        this.newAssigneeId = newAssigneeId;
+    }
+
+    public List<String> getActivityIds() {
+        return Optional.ofNullable(activityIds).orElse(Collections.emptyList());
+    }
+
+    public List<String> getMoveToActivityIds() {
+        return Optional.ofNullable(moveToActivityIds).orElse(Collections.emptyList());
+    }
+
+    public boolean isMoveToParentProcess() {
+        return moveToParentProcess;
+    }
+
+    public void setMoveToParentProcess(boolean moveToParentProcess) {
+        this.moveToParentProcess = moveToParentProcess;
+    }
+
+    public boolean isMoveToSubProcessInstance() {
+        return moveToSubProcessInstance;
+    }
+
+    public void setMoveToSubProcessInstance(boolean moveToSubProcessInstance) {
+        this.moveToSubProcessInstance = moveToSubProcessInstance;
+    }
+
+    public String getCallActivityId() {
+        return callActivityId;
+    }
+
+    public void setCallActivityId(String callActivityId) {
+        this.callActivityId = callActivityId;
+    }
+
+    public Integer getCallActivitySubProcessVersion() {
+        return callActivitySubProcessVersion;
+    }
+
+    public void setCallActivitySubProcessVersion(Integer callActivitySubProcessVersion) {
+        this.callActivitySubProcessVersion = callActivitySubProcessVersion;
+    }
+
+    public Optional<String> getNewAssigneeId() {
+        return Optional.ofNullable(newAssigneeId);
+    }
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveExecutionIdContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveExecutionIdContainer.java
@@ -1,0 +1,59 @@
+package org.activiti.engine.impl.runtime;
+
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * @author LoveMyOrange
+ */
+public class MoveExecutionIdContainer {
+
+    protected List<String> executionIds;
+    protected List<String> moveToActivityIds;
+    protected Optional<String> newAssigneeId;
+
+    public MoveExecutionIdContainer(String singleExecutionId, String moveToActivityId) {
+        this(singleExecutionId, moveToActivityId, null);
+    }
+
+    public MoveExecutionIdContainer(String singleExecutionId, String moveToActivityId, String newAssigneeId) {
+        this.executionIds = Collections.singletonList(singleExecutionId);
+        this.moveToActivityIds = Collections.singletonList(moveToActivityId);
+        this.newAssigneeId = Optional.ofNullable(newAssigneeId);
+    }
+
+    public MoveExecutionIdContainer(List<String> executionIds, String moveToActivityId) {
+        this(executionIds, moveToActivityId, null);
+
+    }
+
+    public MoveExecutionIdContainer(List<String> executionIds, String moveToActivityId, String newAssigneeId) {
+        this.executionIds = executionIds;
+        this.moveToActivityIds = Collections.singletonList(moveToActivityId);
+        this.newAssigneeId = Optional.ofNullable(newAssigneeId);
+    }
+
+    public MoveExecutionIdContainer(String singleExecutionId, List<String> moveToActivityIds) {
+        this(singleExecutionId, moveToActivityIds, null);
+    }
+
+    public MoveExecutionIdContainer(String singleExecutionId, List<String> moveToActivityIds, String newAssigneeId) {
+        this.executionIds = Collections.singletonList(singleExecutionId);
+        this.moveToActivityIds = moveToActivityIds;
+        this.newAssigneeId = Optional.ofNullable(newAssigneeId);
+    }
+
+    public List<String> getExecutionIds() {
+        return Optional.ofNullable(executionIds).orElse(Collections.emptyList());
+    }
+
+    public List<String> getMoveToActivityIds() {
+        return Optional.ofNullable(moveToActivityIds).orElse(Collections.emptyList());
+    }
+
+    public Optional<String> getNewAssigneeId() {
+        return newAssigneeId;
+    }
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveExecutionIdContainer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/runtime/MoveExecutionIdContainer.java
@@ -5,9 +5,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * @author LoveMyOrange
- */
+
 public class MoveExecutionIdContainer {
 
     protected List<String> executionIds;

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/CommandContextUtil.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/CommandContextUtil.java
@@ -16,9 +16,7 @@ import org.activiti.engine.impl.persistence.entity.*;
 import java.util.HashMap;
 import java.util.Map;
 
-/**
- * @author LoveMyOrange
- */
+
 public class CommandContextUtil {
 
     public static final String ATTRIBUTE_INVOLVED_EXECUTIONS = "ctx.attribute.involvedExecutions";

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/CommandContextUtil.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/util/CommandContextUtil.java
@@ -1,0 +1,263 @@
+package org.activiti.engine.impl.util;
+
+
+import org.activiti.engine.ActivitiEngineAgenda;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.db.DbSqlSession;
+import org.activiti.engine.impl.history.HistoryManager;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.jobexecutor.FailedJobCommandFactory;
+import org.activiti.engine.impl.persistence.cache.EntityCache;
+import org.activiti.engine.impl.persistence.entity.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author LoveMyOrange
+ */
+public class CommandContextUtil {
+
+    public static final String ATTRIBUTE_INVOLVED_EXECUTIONS = "ctx.attribute.involvedExecutions";
+
+    public static ProcessEngineConfigurationImpl getProcessEngineConfiguration() {
+        return getProcessEngineConfiguration(getCommandContext());
+    }
+
+    public static ProcessEngineConfigurationImpl getProcessEngineConfiguration(CommandContext commandContext) {
+        if (commandContext != null) {
+            return (ProcessEngineConfigurationImpl) commandContext.getProcessEngineConfiguration().getProcessEngineConfiguration();
+        }
+        return null;
+    }
+
+
+    public static TaskService getTaskService() {
+        return getTaskService(getCommandContext());
+    }
+
+    public static TaskService getTaskService(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getTaskService();
+    }
+
+    public static ActivitiEngineAgenda getAgenda() {
+        return getAgenda(getCommandContext());
+    }
+
+    public static ActivitiEngineAgenda getAgenda(CommandContext commandContext) {
+        return commandContext.getAgenda();
+        //return commandContext.getSession(ActivitiEngineAgenda.class);
+    }
+
+    public static DbSqlSession getDbSqlSession() {
+        return getDbSqlSession(getCommandContext());
+    }
+
+    public static DbSqlSession getDbSqlSession(CommandContext commandContext) {
+        return commandContext.getSession(DbSqlSession.class);
+    }
+
+    public static EntityCache getEntityCache() {
+        return getEntityCache(getCommandContext());
+    }
+
+    public static EntityCache getEntityCache(CommandContext commandContext) {
+        return commandContext.getSession(EntityCache.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static void addInvolvedExecution(CommandContext commandContext, ExecutionEntity executionEntity) {
+        if (executionEntity.getId() != null) {
+            Map<String, ExecutionEntity> involvedExecutions = null;
+            Object obj = commandContext.getAttribute(ATTRIBUTE_INVOLVED_EXECUTIONS);
+            if (obj != null) {
+                involvedExecutions = (Map<String, ExecutionEntity>) obj;
+            } else {
+                involvedExecutions = new HashMap<>();
+                commandContext.addAttribute(ATTRIBUTE_INVOLVED_EXECUTIONS, involvedExecutions);
+            }
+            involvedExecutions.put(executionEntity.getId(), executionEntity);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, ExecutionEntity> getInvolvedExecutions(CommandContext commandContext) {
+        Object obj = commandContext.getAttribute(ATTRIBUTE_INVOLVED_EXECUTIONS);
+        if (obj != null) {
+            return (Map<String, ExecutionEntity>) obj;
+        }
+        return null;
+    }
+
+    public static boolean hasInvolvedExecutions(CommandContext commandContext) {
+        return getInvolvedExecutions(commandContext) != null;
+    }
+
+    public static TableDataManager getTableDataManager() {
+        return getTableDataManager(getCommandContext());
+    }
+
+    public static TableDataManager getTableDataManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getTableDataManager();
+    }
+
+    public static ByteArrayEntityManager getByteArrayEntityManager() {
+        return getByteArrayEntityManager(getCommandContext());
+    }
+
+    public static ByteArrayEntityManager getByteArrayEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getByteArrayEntityManager();
+    }
+
+    public static ResourceEntityManager getResourceEntityManager() {
+        return getResourceEntityManager(getCommandContext());
+    }
+
+    public static ResourceEntityManager getResourceEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getResourceEntityManager();
+    }
+
+    public static DeploymentEntityManager getDeploymentEntityManager() {
+        return getDeploymentEntityManager(getCommandContext());
+    }
+
+    public static DeploymentEntityManager getDeploymentEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getDeploymentEntityManager();
+    }
+
+    public static PropertyEntityManager getPropertyEntityManager() {
+        return getPropertyEntityManager(getCommandContext());
+    }
+
+    public static PropertyEntityManager getPropertyEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getPropertyEntityManager();
+    }
+
+    public static ProcessDefinitionEntityManager getProcessDefinitionEntityManager() {
+        return getProcessDefinitionEntityManager(getCommandContext());
+    }
+
+    public static ProcessDefinitionEntityManager getProcessDefinitionEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getProcessDefinitionEntityManager();
+    }
+
+    public static ProcessDefinitionInfoEntityManager getProcessDefinitionInfoEntityManager() {
+        return getProcessDefinitionInfoEntityManager(getCommandContext());
+    }
+
+    public static ProcessDefinitionInfoEntityManager getProcessDefinitionInfoEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getProcessDefinitionInfoEntityManager();
+    }
+
+    public static ExecutionEntityManager getExecutionEntityManager() {
+        return getExecutionEntityManager(getCommandContext());
+    }
+
+    public static ExecutionEntityManager getExecutionEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getExecutionEntityManager();
+    }
+
+    public static CommentEntityManager getCommentEntityManager() {
+        return getCommentEntityManager(getCommandContext());
+    }
+
+    public static CommentEntityManager getCommentEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getCommentEntityManager();
+    }
+
+    public static ModelEntityManager getModelEntityManager() {
+        return getModelEntityManager(getCommandContext());
+    }
+
+    public static ModelEntityManager getModelEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getModelEntityManager();
+    }
+
+    public static HistoryManager getHistoryManager() {
+        return getHistoryManager(getCommandContext());
+    }
+
+    public static HistoricProcessInstanceEntityManager getHistoricProcessInstanceEntityManager() {
+        return getHistoricProcessInstanceEntityManager(getCommandContext());
+    }
+
+    public static HistoricProcessInstanceEntityManager getHistoricProcessInstanceEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getHistoricProcessInstanceEntityManager();
+    }
+
+    public static HistoricActivityInstanceEntityManager getActivityInstanceEntityManager() {
+        return getActivityInstanceEntityManager(getCommandContext());
+    }
+
+    public static HistoricActivityInstanceEntityManager getActivityInstanceEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getHistoricActivityInstanceEntityManager();
+    }
+
+    public static HistoricActivityInstanceEntityManager getHistoricActivityInstanceEntityManager() {
+        return getHistoricActivityInstanceEntityManager(getCommandContext());
+    }
+
+    public static HistoricActivityInstanceEntityManager getHistoricActivityInstanceEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getHistoricActivityInstanceEntityManager();
+    }
+
+    public static HistoryManager getHistoryManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getHistoryManager();
+    }
+
+    public static HistoricDetailEntityManager getHistoricDetailEntityManager() {
+        return getHistoricDetailEntityManager(getCommandContext());
+    }
+
+    public static HistoricDetailEntityManager getHistoricDetailEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getHistoricDetailEntityManager();
+    }
+
+    public static AttachmentEntityManager getAttachmentEntityManager() {
+        return getAttachmentEntityManager(getCommandContext());
+    }
+
+    public static AttachmentEntityManager getAttachmentEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getAttachmentEntityManager();
+    }
+
+    public static EventLogEntryEntityManager getEventLogEntryEntityManager() {
+        return getEventLogEntryEntityManager(getCommandContext());
+    }
+
+    public static EventLogEntryEntityManager getEventLogEntryEntityManager(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getEventLogEntryEntityManager();
+    }
+
+    public static ActivitiEventDispatcher getEventDispatcher() {
+        return getEventDispatcher(getCommandContext());
+    }
+
+    public static ActivitiEventDispatcher getEventDispatcher(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getEventDispatcher();
+    }
+
+    public static FailedJobCommandFactory getFailedJobCommandFactory() {
+        return getFailedJobCommandFactory(getCommandContext());
+    }
+
+    public static FailedJobCommandFactory getFailedJobCommandFactory(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getFailedJobCommandFactory();
+    }
+
+    public static ProcessInstanceHelper getProcessInstanceHelper() {
+        return getProcessInstanceHelper(getCommandContext());
+    }
+
+    public static ProcessInstanceHelper getProcessInstanceHelper(CommandContext commandContext) {
+        return getProcessEngineConfiguration(commandContext).getProcessInstanceHelper();
+    }
+
+    public static CommandContext getCommandContext() {
+        return Context.getCommandContext();
+    }
+}
+

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ChangeActivityStateBuilder.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ChangeActivityStateBuilder.java
@@ -4,9 +4,7 @@ package org.activiti.engine.runtime;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author LoveMyOrange
- */
+
 public interface ChangeActivityStateBuilder {
 
     /**

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ChangeActivityStateBuilder.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ChangeActivityStateBuilder.java
@@ -1,0 +1,103 @@
+package org.activiti.engine.runtime;
+
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author LoveMyOrange
+ */
+public interface ChangeActivityStateBuilder {
+
+    /**
+     * Set the id of the process instance
+     **/
+    ChangeActivityStateBuilder processInstanceId(String processInstanceId);
+
+    /**
+     * Set the id of the execution for which the activity should be changed
+     **/
+    ChangeActivityStateBuilder moveExecutionToActivityId(String executionId, String activityId);
+
+    /**
+     * Set the ids of the executions which should be changed to a single execution with the provided activity id.
+     * This can be used for parallel execution like parallel/inclusive gateways, multiinstance, event sub processes etc.
+     **/
+    ChangeActivityStateBuilder moveExecutionsToSingleActivityId(List<String> executionIds, String activityId);
+
+    /**
+     * Set the id of an execution which should be changed to multiple executions with the provided activity ids.
+     * This can be used for parallel execution like parallel/inclusive gateways, multiinstance, event sub processes etc.
+     **/
+    ChangeActivityStateBuilder moveSingleExecutionToActivityIds(String executionId, List<String> activityId);
+
+    /**
+     * Moves the execution with the current activity id to the provided new activity id
+     */
+    ChangeActivityStateBuilder moveActivityIdTo(String currentActivityId, String newActivityId);
+
+    /**
+     * Set the activity ids that should be changed to a single activity id.
+     * This can be used for parallel execution like parallel/inclusive gateways, multiinstance, event sub processes etc.
+     */
+    ChangeActivityStateBuilder moveActivityIdsToSingleActivityId(List<String> currentActivityIds, String newActivityId);
+
+    /**
+     * Set the activity id that should be changed to multiple activity ids.
+     * This can be used for parallel execution like parallel/inclusive gateways, multiinstance, event sub processes etc.
+     */
+    ChangeActivityStateBuilder moveSingleActivityIdToActivityIds(String currentActivityId, List<String> newActivityIds);
+
+    /**
+     * Moves the execution with the current activity id to an activity id in the parent process instance.
+     * The sub process instance will be terminated, so all sub process instance executions need to be moved.
+     */
+    ChangeActivityStateBuilder moveActivityIdToParentActivityId(String currentActivityId, String newActivityId);
+
+    /**
+     * Moves the execution with the current activity id to an activity id in a new sub process instance for the provided call activity id.
+     */
+    ChangeActivityStateBuilder moveActivityIdToSubProcessInstanceActivityId(String currentActivityId, String newActivityId, String callActivityId);
+
+    /**
+     * Moves the execution with the current activity id to an activity id in a new sub process instance of the specific definition version for the provided call activity id.
+     */
+    ChangeActivityStateBuilder moveActivityIdToSubProcessInstanceActivityId(String currentActivityId, String newActivityId, String callActivityId, Integer subProcessDefinitionVersion);
+
+    /**
+     * Sets a process scope variable
+     */
+    ChangeActivityStateBuilder processVariable(String processVariableName, Object processVariableValue);
+
+    /**
+     * Sets multiple process scope variables
+     */
+    ChangeActivityStateBuilder processVariables(Map<String, Object> processVariables);
+
+    /**
+     * Sets a local scope variable for a start activity id
+     */
+    ChangeActivityStateBuilder localVariable(String startActivityId, String localVariableName, Object localVariableValue);
+
+    /**
+     * Sets multiple local scope variables for a start activity id
+     */
+    ChangeActivityStateBuilder localVariables(String startActivityId, Map<String, Object> localVariables);
+
+    /**
+     * 跳转原因
+     *
+     * @param jumpReason
+     * @return
+     */
+    ChangeActivityStateBuilder jumpReason(String jumpReason);
+
+    /**
+     * Start the process instance
+     *
+     * @throws org.activiti.engine.ActivitiObjectNotFoundException when no process instance is found
+     * @throws org.activiti.engine.ActivitiException               activity could not be canceled or started
+     **/
+    void changeState();
+
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
@@ -21,9 +21,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-/**
- * @author LoveMyOrange
- */
+
 public class ChangeStateEventListener implements ActivitiEventListener {
     private List<ActivitiEvent> events = new ArrayList<>();
     private static final Logger logger = LoggerFactory.getLogger(ChangeStateEventListener.class);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
@@ -28,10 +28,6 @@ public class ChangeStateEventListener implements ActivitiEventListener {
     private List<ActivitiEvent> events = new ArrayList<>();
     private static final Logger logger = LoggerFactory.getLogger(ChangeStateEventListener.class);
 
-    public ChangeStateEventListener() {
-
-    }
-
     @Override
     public void onEvent(ActivitiEvent event) {
         ActivitiEventType type = event.getType();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateEventListener.java
@@ -1,0 +1,119 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.runtime.changestate;
+
+import org.activiti.engine.delegate.event.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * @author LoveMyOrange
+ */
+public class ChangeStateEventListener implements ActivitiEventListener {
+    private List<ActivitiEvent> events = new ArrayList<>();
+    private static final Logger logger = LoggerFactory.getLogger(ChangeStateEventListener.class);
+
+    public ChangeStateEventListener() {
+
+    }
+
+    @Override
+    public void onEvent(ActivitiEvent event) {
+        ActivitiEventType type = event.getType();
+        if (ActivitiEventType.ACTIVITY_STARTED.name().equals(type.name())) {
+            ActivitiActivityEvent activitiActivityEvent = (ActivitiActivityEvent) event;
+            List<String> types = Arrays.asList("userTask", "subProcess", "callActivity");
+            if (types.contains(activitiActivityEvent.getActivityType())) {
+                events.add(event);
+                logger.info("ACTIVITY_STARTED.....");
+            }
+        }
+
+        if (ActivitiEventType.ACTIVITY_CANCELLED.name().equals(type.name())) {
+            ActivitiActivityCancelledEvent activitiActivityCancelledEvent = (ActivitiActivityCancelledEvent) event;
+            List<String> types = Arrays.asList("userTask", "subProcess", "callActivity");
+
+            if (types.contains(activitiActivityCancelledEvent.getActivityType())) {
+                events.add(event);
+                logger.info("ACTIVITY_CANCELLED.....");
+            }
+        }
+        if (ActivitiEventType.TIMER_SCHEDULED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("TIMER_SCHEDULED.....");
+        }
+        if (ActivitiEventType.PROCESS_STARTED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("PROCESS_STARTED.....");
+        }
+        if (ActivitiEventType.JOB_CANCELED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("JOB_CANCELED.....");
+        }
+        if (ActivitiEventType.PROCESS_CANCELLED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("PROCESS_CANCELLED.....");
+        }
+        if (ActivitiEventType.VARIABLE_UPDATED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("VARIABLE_UPDATED.....");
+        }
+        if (ActivitiEventType.VARIABLE_CREATED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("VARIABLE_CREATED.....");
+        }
+        if (ActivitiEventType.ACTIVITY_SIGNALED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("ACTIVITY_SIGNALED.....");
+        }
+        if (ActivitiEventType.ACTIVITY_MESSAGE_WAITING.name().equals(type.name())) {
+            events.add(event);
+            logger.info("ACTIVITY_MESSAGE_WAITING.....");
+        }
+        if (ActivitiEventType.ACTIVITY_MESSAGE_RECEIVED.name().equals(type.name())) {
+            events.add(event);
+            logger.info("ACTIVITY_MESSAGE_RECEIVED.....");
+        }
+    }
+
+    public void clear() {
+        events.clear();
+    }
+
+    public Iterator<ActivitiEvent> iterator() {
+        return events.iterator();
+    }
+
+    public List<ActivitiEvent> getEvents() {
+        return events;
+    }
+
+    public boolean hasEvents() {
+        return !events.isEmpty();
+    }
+
+    public int eventCount() {
+        return events.size();
+    }
+
+    @Override
+    public boolean isFailOnException() {
+        return true;
+    }
+}
+

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -26,9 +26,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
-/**
-    @author LoveMyOrange
- */
+
 public class ChangeStateForCallActivityTest extends PluggableActivitiTestCase {
 
     private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -1,0 +1,360 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.api.runtime.changestate;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.history.HistoricTaskInstance;
+import org.activiti.engine.impl.history.HistoryLevel;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.repository.ProcessDefinition;
+import org.activiti.engine.runtime.Execution;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+    @author LoveMyOrange
+ */
+public class ChangeStateForCallActivityTest extends PluggableActivitiTestCase {
+
+    private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();
+
+    @Override
+    protected void setUp() {
+        processEngine.getRuntimeService().addEventListener(changeStateEventListener);
+    }
+
+    @Override
+    protected void tearDown() {
+        processEngine.getRuntimeService().removeEventListener(changeStateEventListener);
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksParentProcess.bpmn20.xml", "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInParentProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
+
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        taskService.complete(task.getId());
+
+
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+        assertThat(subProcessInstance).isNotNull();
+
+        task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(subProcessInstance.getId())
+                .moveActivityIdToParentActivityId("theTask", "secondTask")
+                .changeState();
+
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksParentProcessV2.bpmn20.xml", "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInParentProcessV2() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
+
+
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+        taskService.complete(task.getId());
+
+
+
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+        assertThat(subProcessInstance).isNotNull();
+
+        task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+        taskService.complete(task.getId());
+
+
+
+        task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(subProcessInstance.getId())
+                .moveActivityIdToParentActivityId("secondTask", "secondTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+            HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(task.getId()).singleResult();
+            assertThat(historicTaskInstance.getTaskDefinitionKey()).isEqualTo("secondTask");
+        }
+
+        assertThat(runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksParentProcess.bpmn20.xml", "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInSubProcessInstance() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
+
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
+                .changeState();
+
+
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+        assertThat(subProcessInstance).isNotNull();
+
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
+
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+
+        task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+        taskService.complete(task.getId());
+
+
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksParentProcessV2.bpmn20.xml", "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInSubProcessInstanceV2() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
+
+
+        Task firstTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(firstTask.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdToSubProcessInstanceActivityId("firstTask", "secondTask", "callActivity")
+                .changeState();
+
+        ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+        assertThat(subProcessInstance).isNotNull();
+
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
+        assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
+
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+        assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+
+        Task firstSecondTask = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+        assertThat(firstSecondTask.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        if (processEngineConfiguration.getHistoryLevel().isAtLeast(HistoryLevel.ACTIVITY)) {
+            HistoricTaskInstance historicTaskInstance = historyService.createHistoricTaskInstanceQuery().taskId(firstSecondTask.getId()).singleResult();
+            assertThat(historicTaskInstance.getTaskDefinitionKey()).isEqualTo("secondTask");
+        }
+
+
+
+        taskService.complete(firstSecondTask.getId());
+
+
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+        Task secondTask = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(secondTask.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        taskService.complete(secondTask.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/variables/callActivityWithCalledElementExpression.bpmn20.xml" })
+    public void testSetCurrentActivityInSubProcessInstanceWithCalledElementExpression() {
+        try {
+            //Deploy second version of the process definition
+            deployProcessDefinition("my deploy", "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml");
+
+            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("calledElementExpression");
+
+
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+            //First change state attempt fails as the calledElement expression cannot be evaluated
+            assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
+                    .processInstanceId(processInstance.getId())
+                    .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
+                    .changeState())
+                    .isExactlyInstanceOf(ActivitiException.class)
+                    .hasMessage("Cannot resolve calledElement expression '${subProcessDefId}' of callActivity 'callActivity'");
+
+            //Change state specifying the variable with the value
+            runtimeService.createChangeActivityStateBuilder()
+                    .processInstanceId(processInstance.getId())
+                    .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
+                    .processVariable("subProcessDefId", "oneTaskProcess")
+                    .changeState();
+
+
+            ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+            assertThat(subProcessInstance).isNotNull();
+
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
+
+            assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+            assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+
+            task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+            taskService.complete(task.getId());
+
+
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+            task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+
+            taskService.complete(task.getId());
+
+            assertProcessEnded(processInstance.getId());
+
+        } finally {
+            deleteDeployments();
+        }
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksParentProcess.bpmn20.xml", "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInSubProcessInstanceSpecificVersion() {
+        try {
+            // Deploy second version of the process definition
+            ProcessDefinition processDefinition = deployProcessDefinition("my deploy", "org/activiti/engine/test/api/oneTaskProcessV2.bpmn20.xml");
+
+            ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
+
+
+
+            Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+            assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
+                    .processInstanceId(processInstance.getId())
+                    .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity")
+                    .changeState())
+                    .isExactlyInstanceOf(ActivitiException.class)
+                    .hasMessage("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'");
+
+            //Invalid "unExistent" process definition version
+            assertThatThrownBy(() -> runtimeService.createChangeActivityStateBuilder()
+                    .processInstanceId(processInstance.getId())
+                    .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 5)
+                    .changeState())
+                    .isExactlyInstanceOf(ActivitiException.class)
+                    .hasMessage("Cannot find activity 'theTask' in process definition with id 'oneTaskProcess'");
+
+            //Change state specifying the first version
+            runtimeService.createChangeActivityStateBuilder()
+                    .processInstanceId(processInstance.getId())
+                    .moveActivityIdToSubProcessInstanceActivityId("firstTask", "theTask", "callActivity", 1)
+                    .changeState();
+
+
+
+            ProcessInstance subProcessInstance = runtimeService.createProcessInstanceQuery().superProcessInstanceId(processInstance.getId()).singleResult();
+            assertThat(subProcessInstance).isNotNull();
+
+            assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).count()).isZero();
+            assertThat(taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).count()).isEqualTo(1);
+
+            assertThat(runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+            assertThat(runtimeService.createExecutionQuery().processInstanceId(subProcessInstance.getId()).onlyChildExecutions().count()).isEqualTo(1);
+
+            task = taskService.createTaskQuery().processInstanceId(subProcessInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("theTask");
+            taskService.complete(task.getId());
+
+
+            assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(subProcessInstance.getId()).count()).isZero();
+
+            task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+            assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+            taskService.complete(task.getId());
+
+            assertProcessEnded(processInstance.getId());
+
+        } finally {
+            deleteDeployments();
+        }
+    }
+
+    protected ProcessDefinition deployProcessDefinition(String name, String path) {
+        org.activiti.engine.repository.Deployment deployment = repositoryService.createDeployment()
+            .name(name)
+            .addClasspathResource(path)
+            .deploy();
+
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery()
+            .deploymentId(deployment.getId()).singleResult();
+
+        return processDefinition;
+    }
+
+    protected void deleteDeployments() {
+        for (org.activiti.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+            repositoryService.deleteDeployment(deployment.getId(), true);
+        }
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForCallActivityTest.java
@@ -280,7 +280,7 @@ public class ChangeStateForCallActivityTest extends PluggableActivitiTestCase {
     public void testSetCurrentActivityInSubProcessInstanceSpecificVersion() {
         try {
             // Deploy second version of the process definition
-            ProcessDefinition processDefinition = deployProcessDefinition("my deploy", "org/activiti/engine/test/api/oneTaskProcessV2.bpmn20.xml");
+            deployProcessDefinition("my deploy", "org/activiti/engine/test/api/oneTaskProcessV2.bpmn20.xml");
 
             ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksParentProcess");
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -1,0 +1,1457 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.api.runtime.changestate;
+
+import org.activiti.engine.delegate.event.ActivitiActivityEvent;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.Execution;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+    @author LoveMyOrange
+ */
+public class ChangeStateForGatewaysTest extends PluggableActivitiTestCase {
+
+    private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();
+
+    @Override
+    protected void setUp() {
+        processEngine.getRuntimeService().addEventListener(changeStateEventListener);
+    }
+
+    @Override
+    protected void tearDown() {
+        processEngine.getRuntimeService().removeEventListener(changeStateEventListener);
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetCurrentActivityToMultipleActivitiesForParallelGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("task1");
+        newActivityIds.add("task2");
+
+        changeStateEventListener.clear();
+
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("parallelJoin");
+
+        //Complete one task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        // Verify events
+
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("task1");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("task2");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
+
+        assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleActivitiesToSingleActivityAfterParallelGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        List<String> currentActivityIds = new ArrayList<>();
+        currentActivityIds.add("task1");
+        currentActivityIds.add("task2");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("taskAfter");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleActivitiesIntoSynchronizingParallelGateway() {
+
+        //Move all parallelGateway activities to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsOnlyKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "parallelJoin")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleGatewayActivitiesAndSynchronizingParallelGatewayAfterGateway() {
+
+        //Move all parallelGateway activities to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        //Complete task1
+        for (Task t : tasks) {
+            if ("task1".equals(t.getTaskDefinitionKey())) {
+                taskService.complete(t.getId());
+            }
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsKey("task2");
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions).containsKey("parallelJoin");
+        assertThat(classifiedExecutions.get("parallelJoin")).hasSize(1);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "parallelJoin"), "taskAfter")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetActivityIntoSynchronizingParallelGatewayFirst() {
+
+        //Move one task to the synchronizing gateway, then complete the remaining task
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task1", "parallelJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetActivityIntoSynchronizingParallelGatewayLast() {
+
+        //Complete one task and then move the last remaining task to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        //Complete task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .doesNotContainKey("task1")
+                .containsKeys("task2", "parallelJoin");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        //Move task2
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task2", "parallelJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetCurrentExecutionToMultipleActivitiesForParallelGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        Execution taskBeforeExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("task1");
+        newActivityIds.add("task2");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("parallelJoin");
+
+        //Complete one task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
+
+        assertThat(((ExecutionEntity) executionsByActivity.get("parallelJoin").get(0)).isActive()).isFalse();
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleExecutionsToSingleActivityAfterParallelGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        List<String> currentExecutionIds = new ArrayList<>();
+        currentExecutionIds.add(executions.get(0).getId());
+        currentExecutionIds.add(executions.get(1).getId());
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleExecutionsIntoSynchronizingParallelGateway() {
+
+        //Move all gateway executions to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(executionIds, "parallelJoin")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetMultipleGatewayExecutionsAndSynchronizingParallelGatewayAfterGateway() {
+
+        //Move all gateway executions to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        //Complete task1
+        for (Task t : tasks) {
+            if ("task1".equals(t.getTaskDefinitionKey())) {
+                taskService.complete(t.getId());
+            }
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsKey("task2");
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions).containsKey("parallelJoin");
+        assertThat(classifiedExecutions.get("parallelJoin")).hasSize(1);
+
+        List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetExecutionIntoSynchronizingParallelGatewayFirst() {
+
+        //Move one task to the synchronizing gateway, then complete the remaining task
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        String executionId = executions.stream().filter(e -> "task1".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "parallelJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelTask.bpmn20.xml" })
+    public void testSetExecutionIntoSynchronizingParallelGatewayLast() {
+
+        //Complete one task and then move the last remaining task to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        //Complete task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "parallelJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        //Move task2 execution
+        String executionId = executions.stream().filter(e -> "task2".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "parallelJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetCurrentActivityToMultipleActivitiesForInclusiveGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("task1");
+        newActivityIds.add("task2");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).
+                containsKeys("task1", "task2")
+                .doesNotContainKey("gwJoin");
+
+        //Complete one task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleActivitiesToSingleActivityAfterInclusiveGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        List<String> currentActivityIds = new ArrayList<>();
+        currentActivityIds.add("task1");
+        currentActivityIds.add("task2");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleActivitiesIntoSynchronizingInclusiveGateway() {
+
+        //Move all parallelGateway activities to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task1", "task2"), "gwJoin")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleGatewayActivitiesAndSynchronizingInclusiveGatewayAfterGateway() {
+
+        //Move all parallelGateway activities to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        //Complete task1
+        for (Task t : tasks) {
+            if ("task1".equals(t.getTaskDefinitionKey())) {
+                taskService.complete(t.getId());
+            }
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsKey("task2");
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions).containsKey("gwJoin");
+        assertThat(classifiedExecutions.get("gwJoin")).hasSize(1);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("task2", "gwJoin"), "taskAfter")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetActivityIntoSynchronizingParallelInclusiveFirst() {
+
+        //Move one task to the synchronizing gateway, then complete the remaining task
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task1", "gwJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetActivityIntoSynchronizingParallelInclusiveLast() {
+
+        //Complete one task and then move the last remaining task to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        //Complete task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        //Move task2
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("task2", "gwJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetCurrentExecutionToMultipleActivitiesForInclusiveGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        Execution taskBeforeExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("task1");
+        newActivityIds.add("task2");
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleExecutionToActivityIds(taskBeforeExecution.getId(), newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task1", "task2")
+                .doesNotContainKey("gwJoin");
+
+        //Complete one task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        assertThat(((ExecutionEntity) executionsByActivity.get("gwJoin").get(0)).isActive()).isFalse();
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleExecutionsToSingleActivityAfterInclusiveGateway() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        List<String> currentExecutionIds = new ArrayList<>();
+        currentExecutionIds.add(executions.get(0).getId());
+        currentExecutionIds.add(executions.get(1).getId());
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(currentExecutionIds, "taskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleExecutionsIntoSynchronizingInclusiveGateway() {
+
+        //Move all gateway executions to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(executionIds, "gwJoin")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetMultipleGatewayExecutionsAndSynchronizingInclusiveGatewayAfterGateway() {
+
+        //Move all gateway executions to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity).containsKeys("task1", "task2");
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        //Complete task1
+        for (Task t : tasks) {
+            if ("task1".equals(t.getTaskDefinitionKey())) {
+                taskService.complete(t.getId());
+            }
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsKey("task2");
+        assertThat(classifiedExecutions.get("task2")).hasSize(1);
+        assertThat(classifiedExecutions).containsKey("gwJoin");
+        assertThat(classifiedExecutions.get("gwJoin")).hasSize(1);
+
+        List<String> executionIds = executions.stream().map(Execution::getId).collect(Collectors.toList());
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(executionIds, "taskAfter")
+                .changeState();
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().singleResult();
+        assertThat(execution.getActivityId()).isEqualTo("taskAfter");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetExecutionIntoSynchronizingInclusiveGatewayFirst() {
+
+        //Move one task to the synchronizing gateway, then complete the remaining task
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        String executionId = executions.stream().filter(e -> "task1".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "gwJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml" })
+    public void testSetExecutionIntoSynchronizingInclusiveGatewayLast() {
+
+        //Complete one task and then move the last remaining task to the synchronizing gateway
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startInclusiveGwProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        //Complete task1
+        Optional<Task> task1 = tasks.stream().filter(t -> "task1".equals(t.getTaskDefinitionKey())).findFirst();
+        if (task1.isPresent()) {
+            taskService.complete(task1.get().getId());
+        }
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+        Map<String, List<Execution>> executionsByActivity = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(executionsByActivity)
+                .containsKeys("task2", "gwJoin")
+                .doesNotContainKey("task1");
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("task2");
+
+        //Move task2 execution
+        String executionId = executions.stream().filter(e -> "task2".equals(e.getActivityId())).findFirst().map(Execution::getId).get();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "gwJoin")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelSubProcesses.bpmn20.xml" })
+    public void testSetCurrentActivityToMultipleActivitiesForParallelSubProcesses() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("subtask");
+        newActivityIds.add("subtask2");
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(4);
+
+        Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> "parallelJoin".equals(e.getActivityId())).findFirst();
+        assertThat(parallelJoinExecution).isNotPresent();
+
+        taskService.complete(tasks.get(0).getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(3);
+
+        parallelJoinExecution = executions.stream().filter(e -> "parallelJoin".equals(e.getActivityId())).findFirst();
+        assertThat(parallelJoinExecution).isPresent();
+        assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelSubProcesses.bpmn20.xml" })
+    public void testSetMultipleActivitiesToSingleActivityAfterParallelSubProcesses() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(4);
+
+        List<String> currentActivityIds = new ArrayList<>();
+        currentActivityIds.add("subtask");
+        currentActivityIds.add("subtask2");
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelSubProcessesMultipleTasks.bpmn20.xml" })
+    public void testMoveCurrentActivityInParallelSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(4);
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess1")
+                .singleResult();
+        String subProcessExecutionId = subProcessExecution.getId();
+        runtimeService.setVariableLocal(subProcessExecutionId, "subProcessVar", "test");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subtask", "subtask2")
+                .changeState();
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(4);
+
+        subProcessExecution = runtimeService.createExecutionQuery().executionId(subProcessExecutionId).singleResult();
+        assertThat(subProcessExecution).isNotNull();
+        assertThat(runtimeService.getVariableLocal(subProcessExecutionId, "subProcessVar")).isEqualTo("test");
+
+        taskService.complete(tasks.get(0).getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(3);
+
+        taskService.complete(tasks.get(0).getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
+    public void testSetCurrentActivityToMultipleActivitiesForInclusiveAndParallelSubProcesses() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", Collections.singletonMap("var1", "test2"));
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<String> newActivityIds = new ArrayList<>();
+        newActivityIds.add("taskInclusive3");
+        newActivityIds.add("subtask");
+        newActivityIds.add("subtask3");
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("taskBefore", newActivityIds)
+                .changeState();
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(5);
+
+        Optional<Execution> parallelJoinExecution = executions.stream().filter(e -> "parallelJoin".equals(e.getActivityId())).findFirst();
+        assertThat(parallelJoinExecution).isNotPresent();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
+        taskService.complete(task.getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask2").singleResult();
+        taskService.complete(task.getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(4);
+
+        parallelJoinExecution = executions.stream().filter(e -> "parallelJoin".equals(e.getActivityId())).findFirst();
+        assertThat(parallelJoinExecution).isPresent();
+        assertThat(((ExecutionEntity) parallelJoinExecution.get()).isActive()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
+    public void testSetCurrentActivitiesToSingleActivityForInclusiveAndParallelSubProcesses() {
+        Map<String, Object> variableMap = new HashMap<>();
+        variableMap.put("var1", "test2");
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", variableMap);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
+        assertThat(task).isNotNull();
+        taskService.complete(task.getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count()).isEqualTo(1);
+
+        List<String> currentActivityIds = new ArrayList<>();
+        currentActivityIds.add("taskInclusive3");
+        currentActivityIds.add("subtask");
+        currentActivityIds.add("subtask3");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskAfter")
+                .changeState();
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(1);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(1);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/multipleParallelSubProcesses.bpmn20.xml" })
+    public void testSetCurrentActivitiesToSingleActivityInInclusiveGateway() {
+        Map<String, Object> variableMap = new HashMap<>();
+        variableMap.put("var1", "test2");
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startParallelProcess", variableMap);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        taskService.complete(task.getId());
+
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
+        assertThat(task).isNotNull();
+        taskService.complete(task.getId());
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").count()).isEqualTo(1);
+        assertThat(taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").count()).isEqualTo(1);
+
+        List<String> currentActivityIds = new ArrayList<>();
+        currentActivityIds.add("subtask");
+        currentActivityIds.add("subtask3");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(currentActivityIds, "taskInclusive1")
+                .changeState();
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive3").singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("taskInclusive1").singleResult();
+        taskService.complete(task.getId());
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(5);
+
+        Optional<Execution> inclusiveJoinExecution = executions.stream().filter(e -> "inclusiveJoin".equals(e.getActivityId())).findFirst();
+        assertThat(inclusiveJoinExecution).isPresent();
+        assertThat(((ExecutionEntity) inclusiveJoinExecution.get()).isActive()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask3").singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask").singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).taskDefinitionKey("subtask2").singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+    protected static<T> Map<String, List<T>> groupListContentBy(List<T> source, Function<T, String> classifier) {
+        return source.stream().collect(Collectors.groupingBy(classifier));
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForGatewaysTest.java
@@ -29,9 +29,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
-    @author LoveMyOrange
- */
+
 public class ChangeStateForGatewaysTest extends PluggableActivitiTestCase {
 
     private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
@@ -1,0 +1,1146 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.api.runtime.changestate;
+
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ChangeActivityStateBuilder;
+import org.activiti.engine.runtime.Execution;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+import org.assertj.core.api.Condition;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author LoveMyOrange
+ */
+public class ChangeStateForMultiInstanceTest extends PluggableActivitiTestCase {
+
+    private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();
+
+    @Override
+    protected void setUp() {
+        processEngine.getRuntimeService().addEventListener(changeStateEventListener);
+    }
+
+    @Override
+    protected void tearDown() {
+        processEngine.getRuntimeService().removeEventListener(changeStateEventListener);
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceSequential.bpmn20.xml")
+    public void testSetCurrentActivityToSequentialMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("beforeMultiInstance");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("beforeMultiInstance");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeMultiInstance", "seqTasks")
+                .changeState();
+
+        //First in the loop
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        //One MI root and one seq Execution
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+
+        Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
+        Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 0, 3);
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("seqTasks");
+        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(0);
+
+        taskService.complete(tasks.get(0).getId());
+
+        //Second in the loop
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        //One MI root and one seq Execution
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("seqTasks", "seqTasks");
+
+        miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
+        miRootVars = runtimeService.getVariables(miRoot.getId());
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(1, 1, 3);
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("seqTasks");
+        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(1);
+
+        //Complete second and third
+        taskService.complete(tasks.get(0).getId());
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        taskService.complete(tasks.get(0).getId());
+
+        //After the MI
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("nextTask");
+        assertThat((ExecutionEntity) executions.get(0))
+                .extracting(ExecutionEntity::isMultiInstanceRoot)
+                .isEqualTo(false);
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().singleResult();
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
+
+        //Complete the process
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceSequential.bpmn20.xml")
+    public void testSetCurrentActivityOfSequentialMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
+                .variable("nrOfLoops", 5)
+                .start();
+
+        completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
+
+        List<Execution> seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(seqExecutions).hasSize(2);
+        List<Task> activeSeqTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeSeqTasks).hasSize(1);
+
+        //First in the loop
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
+        taskService.complete(task.getId());
+
+        //Second in the loop
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("seqTasks", "nextTask")
+                .changeState();
+
+        seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(seqExecutions).hasSize(1);
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceSequential.bpmn20.xml")
+    public void testSetCurrentParentExecutionOfSequentialMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("sequentialMultiInstance")
+                .variable("nrOfLoops", 5)
+                .start();
+
+        completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
+
+        List<Execution> seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(seqExecutions).hasSize(2);
+        List<Task> activeSeqTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeSeqTasks).hasSize(1);
+
+        //First in the loop
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(0);
+        taskService.complete(task.getId());
+
+        //Second in the loop
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("seqTasks");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isEqualTo(1);
+
+        //move the parent execution - otherwise the parent multi instance execution remains, although active==false.
+        String parentExecutionId = runtimeService.createExecutionQuery().executionId(task.getExecutionId()).singleResult().getParentId();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(parentExecutionId, "nextTask")
+                .changeState();
+
+        seqExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(seqExecutions).hasSize(1);
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallel.bpmn20.xml")
+    public void testSetCurrentActivityToParallelMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("beforeMultiInstance");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("beforeMultiInstance");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeMultiInstance", "parallelTasks")
+                .changeState();
+
+        //First in the loop
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        //One MI root and 3 parallel Executions
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+
+        Execution miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
+        Map<String, Object> miRootVars = runtimeService.getVariables(miRoot.getId());
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(3, 0, 3);
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks");
+        assertThat(tasks)
+                .extracting(task -> taskService.getVariable(task.getId(), "loopCounter"))
+                .isNotNull();
+        //        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isNotNull()
+
+        //Complete one execution
+        taskService.complete(tasks.get(0).getId());
+
+        //Confirm new state
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("parallelTasks", "parallelTasks", "parallelTasks", "parallelTasks");
+
+        miRoot = executions.stream().filter(e -> ((ExecutionEntity) e).isMultiInstanceRoot()).findFirst().get();
+        miRootVars = runtimeService.getVariables(miRoot.getId());
+        assertThat(miRootVars)
+                .extracting("nrOfActiveInstances", "nrOfCompletedInstances", "nrOfLoops")
+                .containsExactly(2, 1, 3);
+
+        //Two executions are inactive, the completed before and the MI root
+        assertThat(executions)
+                .haveExactly(2, new Condition<>((Execution execution) -> !((ExecutionEntity) execution).isActive(), "inactive"));
+
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(tasks)
+                .extracting(Task::getTaskDefinitionKey)
+                .containsExactly("parallelTasks", "parallelTasks");
+        assertThat(taskService.getVariable(tasks.get(0).getId(), "loopCounter")).isEqualTo(1);
+
+        //Complete the rest of the Tasks
+        tasks.forEach(this::completeTask);
+
+        //After the MI
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactly("nextTask");
+        assertThat((ExecutionEntity) executions.get(0))
+                .extracting(ExecutionEntity::isMultiInstanceRoot).isEqualTo(false);
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().singleResult();
+        assertThat(task)
+                .extracting(Task::getTaskDefinitionKey)
+                .isEqualTo("nextTask");
+        assertThat(taskService.getVariable(task.getId(), "loopCounter")).isNull();
+
+        //Complete the process
+        taskService.complete(task.getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallel.bpmn20.xml")
+    public void testSetCurrentActivityOfParallelMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
+
+        List<Execution> parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(4);
+        List<Task> activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeParallelTasks).hasSize(3);
+
+        //Complete one of the tasks
+        taskService.complete(activeParallelTasks.get(1).getId());
+        parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(4);
+        activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeParallelTasks).hasSize(2);
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelTasks", "nextTask")
+                .changeState();
+
+        parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(1);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallel.bpmn20.xml")
+    public void testSetCurrentParentExecutionOfParallelMultiInstanceTask() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstance")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        completeTask(taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult());
+
+        List<Execution> parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(4);
+        List<Task> activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeParallelTasks).hasSize(3);
+
+        //Complete one of the tasks
+        taskService.complete(activeParallelTasks.get(1).getId());
+        parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(4);
+        activeParallelTasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).active().list();
+        assertThat(activeParallelTasks).hasSize(2);
+
+        //Fetch the parent execution of the multi instance task execution
+        String parentExecutionId = runtimeService.createExecutionQuery().executionId(activeParallelTasks.get(0).getExecutionId()).singleResult().getParentId();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(parentExecutionId, "nextTask")
+                .changeState();
+
+        parallelExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(parallelExecutions).hasSize(1);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nextTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
+    public void testSetCurrentExecutionWithinMultiInstanceParallelSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        //One of the child executions is the parent of the multiInstance "loop"
+        long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Move one of the executions within the multiInstance subProcess
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(subTask1Executions.get(0).getId(), "subTask2")
+                .changeState();
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(2);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(1);
+
+        //Complete one of the parallel subProcesses "subTask2"
+        Task task = taskService.createTaskQuery().executionId(subTask2Executions.get(0).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(5);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(2);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(2);
+        subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).isEmpty();
+
+        //Move the other two executions, one by one
+        ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
+        subTask1Executions.forEach(e -> changeActivityStateBuilder.moveExecutionToActivityId(e.getId(), "subTask2"));
+        changeActivityStateBuilder.changeState();
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(5);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(2);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).isEmpty();
+        subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(2);
+
+        //Complete the rest of the SubProcesses
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(2);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        //There's no multiInstance anymore
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
+    public void testSetCurrentActivityWithinMultiInstanceParallelSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        //One of the child executions is the parent of the multiInstance "loop"
+        long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Move one of the executions within the multiInstance subProcess
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask1", "subTask2")
+                .changeState();
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).isEmpty();
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(3);
+
+        //Complete the parallel subProcesses "subTask2"
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        //There's no multiInstance anymore
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(1);
+
+        Task task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
+    public void testSetCurrentExecutionWithinNestedMultiInstanceParallelSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Start the nested subProcesses by completing the first task of the outer subProcess
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
+        // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
+        // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
+        // Grand Total ->
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(9);
+
+        //Move one of the executions within of the nested multiInstance subProcesses
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(0).getId(), "nestedSubTask2")
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(3).getId(), "nestedSubTask2")
+                .moveExecutionToActivityId(nestedSubTask1Executions.get(6).getId(), "nestedSubTask2")
+                .changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(3);
+
+        //Complete one of the outer subProcesses
+        Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        //One less task execution and one less nested instance
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(23);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(8);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(2);
+
+        //Move the rest of the nestedSubTask1 executions
+        ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
+        nestedSubTask1Executions.forEach(e -> changeActivityStateBuilder.moveExecutionToActivityId(e.getId(), "nestedSubTask2"));
+        changeActivityStateBuilder.changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(23);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(8);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).isEmpty();
+        nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(8);
+
+        //Complete all the nestedSubTask2
+        tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
+        assertThat(tasks).hasSize(8);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        //Nested subProcesses have completed, only outer subProcess remain
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(3);
+
+        //Complete the outer subProcesses
+        tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
+    public void testSetCurrentActivityWithinNestedMultiInstanceParallelSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Start the nested subProcesses by completing the first task of the outer subProcess
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
+        // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
+        // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
+        // Grand Total ->
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(9);
+
+        //Complete one task for each nestedSubProcess
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(3).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(3);
+
+        //Moving the nestedSubTask1 activity should move all its executions
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask1", "nestedSubTask2")
+                .changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).isEmpty();
+        nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(9);
+
+        //Complete all the nestedSubTask2
+        tasks = taskService.createTaskQuery().taskDefinitionKey("nestedSubTask2").list();
+        assertThat(tasks).hasSize(9);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        //Nested subProcesses have completed, only outer subProcess remain
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(3);
+
+        //Complete the outer subProcesses
+        tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+
+        Task task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
+    public void testSetCurrentMultiInstanceSubProcessParentExecutionWithinProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        //One of the child executions is the parent of the multiInstance "loop"
+        long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Complete one of the Tasks
+        Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(2);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(1);
+
+        //Move the parallelSubProcess via the parentExecution Ids
+        String ParallelSubProcessParentExecutionId = runtimeService.createExecutionQuery()
+                .processInstanceId(processInstance.getId())
+                .activityId("parallelSubProcess")
+                .list()
+                .stream()
+                .findFirst()
+                .map(Execution::getParentId)
+                .get();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(ParallelSubProcessParentExecutionId, "lastTask")
+                .changeState();
+
+        //There's no multiInstance anymore
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml")
+    public void testSetCurrentMultiInstanceSubProcessParentActivityWithinProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelMultiInstanceSubProcess")
+                .variable("nrOfLoops", 3)
+                .start();
+
+        //One of the child executions is the parent of the multiInstance "loop"
+        long executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Complete one of the Tasks
+        Task task = taskService.createTaskQuery().executionId(subTask1Executions.get(1).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(2);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(1);
+
+        //Move the parallelSubProcess
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelSubProcess", "lastTask")
+                .changeState();
+
+        //There's no multiInstance anymore
+        executionsCount = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(executionsCount).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
+    public void testSetCurrentMultiInstanceNestedSubProcessParentExecutionWithinSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Start the nested subProcesses by completing the first task of the outer subProcess
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
+        // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
+        // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
+        // Grand Total ->
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(9);
+
+        //Complete some of the Nested tasks
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(3).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(3);
+
+        //Complete one of the nested subProcesses
+        Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        //One less task execution and one less nested instance
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(23);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(8);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(2);
+
+        //Move each nested multiInstance parent
+        Stream<String> parallelNestedSubProcessesParentIds = runtimeService.createExecutionQuery()
+                .processInstanceId(processInstance.getId())
+                .activityId("parallelNestedSubProcess")
+                .list()
+                .stream()
+                .map(Execution::getParentId)
+                .distinct();
+
+        parallelNestedSubProcessesParentIds.forEach(parentId -> {
+            runtimeService.createChangeActivityStateBuilder()
+                    .moveExecutionToActivityId(parentId, "subTask2")
+                    .changeState();
+        });
+
+        //Nested subProcesses have completed, only outer subProcess remain
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(3);
+
+        //Complete the outer subProcesses
+        tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = "org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml")
+    public void testSetCurrentMultiInstanceNestedSubProcessParentActivityWithinSubProcess() {
+        ProcessInstance processInstance = runtimeService.createProcessInstanceBuilder().processDefinitionKey("parallelNestedMultiInstanceSubProcesses").start();
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask1Executions = runtimeService.createExecutionQuery().activityId("subTask1").list();
+        assertThat(subTask1Executions).hasSize(3);
+
+        //Start the nested subProcesses by completing the first task of the outer subProcess
+        List<Task> tasks = taskService.createTaskQuery().taskDefinitionKey("subTask1").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        // 3 instances of the outerSubProcess and each have 3 instances of a nestedSubProcess, for a total of 9 nestedSubTask executions
+        // 9 nestedSubProcess instances and 3 outerSubProcesses instances -> 12 executions
+        // 1 Parent execution for the outerSubProcess and 1 parent for each nestedSubProcess -> 4 extra parent executions
+        // Grand Total ->
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        List<Execution> nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(9);
+
+        //Complete some of the Nested tasks
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(0).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(3).getId()).singleResult().getId());
+        taskService.complete(taskService.createTaskQuery().executionId(nestedSubTask1Executions.get(6).getId()).singleResult().getId());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(25);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(9);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        List<Execution> nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(3);
+
+        //Complete one of the nested subProcesses
+        Task task = taskService.createTaskQuery().executionId(nestedSubTask2Executions.get(0).getId()).singleResult();
+        taskService.complete(task.getId());
+
+        //One less task execution and one less nested instance
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(23);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelNestedSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(8);
+        nestedSubTask1Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask1").list();
+        assertThat(nestedSubTask1Executions).hasSize(6);
+        nestedSubTask2Executions = runtimeService.createExecutionQuery().activityId("nestedSubTask2").list();
+        assertThat(nestedSubTask2Executions).hasSize(2);
+
+        //Move the activity nested multiInstance parent
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("parallelNestedSubProcess", "subTask2")
+                .changeState();
+
+        //Nested subProcesses have completed, only outer subProcess remain
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcessOuter").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> subTask2Executions = runtimeService.createExecutionQuery().activityId("subTask2").list();
+        assertThat(subTask2Executions).hasSize(3);
+
+        //Complete the outer subProcesses
+        tasks = taskService.createTaskQuery().taskDefinitionKey("subTask2").list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+
+        task = taskService.createTaskQuery().active().singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivitiesUsingParallelGatewayNestedInMultiInstanceSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> preForkTaskExecutions = runtimeService.createExecutionQuery().activityId("preForkTask").list();
+        assertThat(preForkTaskExecutions).hasSize(3);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("preForkTask");
+
+        //Move a task before the fork within the multiInstance subProcess
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveSingleActivityIdToActivityIds("preForkTask", Arrays.asList("forkTask1", "forkTask2"))
+                .changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(10);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> forkTask1Executions = runtimeService.createExecutionQuery().activityId("forkTask1").list();
+        assertThat(forkTask1Executions).hasSize(3);
+        List<Execution> forkTask2Executions = runtimeService.createExecutionQuery().activityId("forkTask2").list();
+        assertThat(forkTask2Executions).hasSize(3);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(6);
+        Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
+        assertThat(taskGroups)
+                .containsOnlyKeys("forkTask1", "forkTask2");
+        assertThat(taskGroups.get("forkTask1")).hasSize(3);
+        assertThat(taskGroups.get("forkTask2")).hasSize(3);
+
+        //Move the parallel gateway task forward
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdsToSingleActivityId(Arrays.asList("forkTask1", "forkTask2"), "parallelJoin")
+                .changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
+        assertThat(postForkTaskExecutions).hasSize(3);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
+
+        //Complete one of the tasks
+        taskService.complete(tasks.get(1).getId());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(5);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(2);
+        postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
+        assertThat(postForkTaskExecutions).hasSize(2);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
+
+        //Finish the rest since we cannot move out of a multiInstance subProcess
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionsUsingParallelGatewayNestedInMultiInstanceSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("parallelGatewayInsideMultiInstanceSubProcess");
+
+        long totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        long parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> preForkTaskExecutions = runtimeService.createExecutionQuery().activityId("preForkTask").list();
+        assertThat(preForkTaskExecutions).hasSize(3);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+        assertThat(tasks.get(0).getTaskDefinitionKey()).isEqualTo("preForkTask");
+
+        //Move a task before the fork within the multiInstance subProcess
+        preForkTaskExecutions.forEach(e -> runtimeService.createChangeActivityStateBuilder()
+                .moveSingleExecutionToActivityIds(e.getId(), Arrays.asList("forkTask1", "forkTask2"))
+                .changeState());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(10);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> forkTask1Executions = runtimeService.createExecutionQuery().activityId("forkTask1").list();
+        assertThat(forkTask1Executions).hasSize(3);
+        List<Execution> forkTask2Executions = runtimeService.createExecutionQuery().activityId("forkTask2").list();
+        assertThat(forkTask2Executions).hasSize(3);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(6);
+        Map<String, List<Task>> taskGroups = tasks.stream().collect(Collectors.groupingBy(Task::getTaskDefinitionKey));
+        assertThat(taskGroups)
+                .containsOnlyKeys("forkTask1", "forkTask2");
+        assertThat(taskGroups.get("forkTask1")).hasSize(3);
+        assertThat(taskGroups.get("forkTask2")).hasSize(3);
+
+        //Move the parallel gateway task forward
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionsToSingleActivityId(
+                        Stream.concat(forkTask1Executions.stream().map(Execution::getId), forkTask2Executions.stream().map(Execution::getId))
+                                .collect(Collectors.toList()), "postForkTask")
+                .changeState();
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(7);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(3);
+        List<Execution> postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
+        assertThat(postForkTaskExecutions).hasSize(3);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(3);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
+
+        //Complete one of the tasks
+        taskService.complete(tasks.get(1).getId());
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(5);
+        parallelSubProcessCount = runtimeService.createExecutionQuery().activityId("parallelSubProcess").count();
+        assertThat(parallelSubProcessCount).isEqualTo(2);
+        postForkTaskExecutions = runtimeService.createExecutionQuery().activityId("postForkTask").list();
+        assertThat(postForkTaskExecutions).hasSize(2);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).hasSize(2);
+        tasks.forEach(t -> assertThat(t.getTaskDefinitionKey()).isEqualTo("postForkTask"));
+
+        //Finish the rest since we cannot move out of a multiInstance subProcess
+        tasks.forEach(t -> taskService.complete(t.getId()));
+
+        totalChildExecutions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().count();
+        assertThat(totalChildExecutions).isEqualTo(1);
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("lastTask");
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+    protected void completeTask(Task task) {
+        taskService.complete(task.getId());
+    }
+
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateForMultiInstanceTest.java
@@ -30,9 +30,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- * @author LoveMyOrange
- */
+
 public class ChangeStateForMultiInstanceTest extends PluggableActivitiTestCase {
 
     private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -30,9 +30,7 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.*;
 
-/**
-    @author LoveMyOrange
- */
+
 public class ChangeStateTest extends PluggableActivitiTestCase {
 
     private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/changestate/ChangeStateTest.java
@@ -1,0 +1,3109 @@
+/* Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.test.api.runtime.changestate;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.activiti.engine.delegate.event.*;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.*;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.test.Deployment;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+    @author LoveMyOrange
+ */
+public class ChangeStateTest extends PluggableActivitiTestCase {
+
+    private ChangeStateEventListener changeStateEventListener = new ChangeStateEventListener();
+
+    @Override
+    protected void setUp() {
+        processEngine.getRuntimeService().addEventListener(changeStateEventListener);
+    }
+
+    @Override
+    protected void tearDown() {
+        processEngine.getRuntimeService().removeEventListener(changeStateEventListener);
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentActivityBackwardForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("secondTask", "firstTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("firstTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionBackwardForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("firstTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentActivityForwardForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("secondTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionForwardForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
+                .changeState();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("secondTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentActivityWithTimerForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
+        managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
+
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("secondTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentExecutionWithTimerForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "secondTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("secondTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentActivityToActivityWithTimerForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("secondTask", "firstTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("firstTask");
+
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentExecutionToActivityWithTimerForSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcess");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "firstTask")
+                .changeState();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("firstTask");
+
+
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/twoTasksProcessWithTimers.bpmn20.xml" })
+    public void testSetCurrentActivityWithTimerToActivityWithTimerSimpleProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoTasksProcessWithTimers");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("firstTask");
+        Execution execution = runtimeService.createExecutionQuery().parentId(task.getExecutionId()).singleResult();
+        Job timerJob1 = managementService.createTimerJobQuery().executionId(execution.getId()).singleResult();
+        assertThat(timerJob1).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("firstTask", "secondTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("secondTask");
+        Job timerJob2 = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob2).isNotNull();
+        assertThat(timerJob1.getExecutionId()).isNotEqualTo(timerJob2.getExecutionId());
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("firstTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        entityEvent = (ActivitiEntityEvent) event;
+        timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("secondTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("secondTask");
+
+
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        Job job = managementService.moveTimerToExecutableJob(timerJob2.getId());
+        managementService.executeJob(job.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("thirdTask");
+
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityOutOfSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionOutOfSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityIntoSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityIntoSubProcessWithModeledDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoSubProcessWithModeledDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
+
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentActivityOutOfSubProcessWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentExecutionOutOfSubProcessWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("taskBefore");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentActivityToTaskInSubProcessWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(4);
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentExecutionToTaskInSubProcessWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(4);
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml" })
+    public void testSetCurrentActivityToTaskInSubProcessAndExecuteTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        Job executableJob = managementService.moveTimerToExecutableJob(timerJob.getId());
+        managementService.executeJob(executableJob.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityOutOfSubProcessTaskWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "subTask2")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask2");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionOutOfSubProcessTaskWithTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask2")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.JOB_CANCELED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask2");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityToTaskWithTimerInSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(4);
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionToTaskWithTimerInSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(4);
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask2");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityToTaskWithTimerInSubProcessAndExecuteTimer() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(4);
+        Job timerJob = managementService.createTimerJobQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(timerJob).isNotNull();
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.TIMER_SCHEDULED);
+        ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
+        Job timer = (Job) entityEvent.getEntity();
+        assertThat(getJobActivityId(timer)).isEqualTo("boundaryTimerEvent");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        Job executableTimerJob = managementService.moveTimerToExecutableJob(timerJob.getId());
+        managementService.executeJob(executableTimerJob.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityIntoNestedSubProcessExecutionFromRoot() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml" })
+    public void testSetCurrentActivityIntoNestedSubProcessExecutionFromRootWithDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromRoot() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromRootWithDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityIntoNestedSubProcessExecutionFromOuter() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml" })
+    public void testSetCurrentActivityIntoNestedSubProcessExecutionFromOuterWithDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromOuter() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml" })
+    public void testSetCurrentExecutionIntoNestedSubProcessExecutionFromOuterWithDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions).hasSize(2);
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "nestedSubTask")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        assertThat(executions)
+                .extracting(Execution::getActivityId)
+                .containsExactlyInAnyOrder("subProcess", "nestedSubProcess", "nestedSubTask");
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        Execution nestedSubProcess = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("nestedSubProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(nestedSubProcess.getId(), "name", String.class)).isNotNull();
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(nestedSubProcess.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+
+
+
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubProcess");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.VARIABLE_CREATED);
+        assertThat(((ActivitiVariableEvent) event).getVariableName()).isEqualTo("name");
+        assertThat(((ActivitiVariableEvent) event).getVariableValue()).isEqualTo("John");
+
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("nestedSubTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityOutOfNestedSubProcessExecution() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask", "subTaskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionOutOfNestedSubProcessExecution() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTaskAfter")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTaskAfter");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("nestedSubTask", "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionOutOfNestedSubProcessExecutionIntoContainingSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startNestedSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subTask")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subTask");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("nestedSubTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTaskAfter");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/taskTwoSubProcesses.bpmn20.xml" })
+    public void testSetCurrentActivityFromSubProcessToAnotherSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subtask", "subtask2")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask2");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+
+
+
+
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess2");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subtask2");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/taskTwoSubProcesses.bpmn20.xml" })
+    public void testSetCurrentExecutionFromSubProcessToAnotherSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("twoSubProcesses");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "subtask2")
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subtask2");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        // Verify events
+        Iterator<ActivitiEvent> iterator = changeStateEventListener.iterator();
+        assertThat(iterator.hasNext()).isTrue();
+        ActivitiEvent event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subProcess2");
+
+        assertThat(iterator.hasNext()).isTrue();
+        event = iterator.next();
+        assertThat(event.getType()).isEqualTo(ActivitiEventType.ACTIVITY_STARTED);
+        assertThat(((ActivitiActivityEvent) event).getActivityId()).isEqualTo("subtask2");
+
+        assertThat(iterator.hasNext()).isFalse();
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityForSubProcessWithVariables() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("subTask", "taskBefore")
+                .processVariable("processVar1", "test")
+                .processVariable("processVar2", 10)
+                .localVariable("taskBefore", "localVar1", "test2")
+                .localVariable("taskBefore", "localVar2", 20)
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
+        assertThat(processVariables)
+                .contains(
+                        entry("processVar1", "test"),
+                        entry("processVar2", 10)
+                )
+                .doesNotContainKeys("localVar1", "localVar2");
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();
+        Map<String, Object> localVariables = runtimeService.getVariablesLocal(execution.getId());
+        assertThat(localVariables)
+                .contains(
+                        entry("localVar1", "test2"),
+                        entry("localVar2", 20)
+                );
+
+        // Verify events
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(ActivitiEvent::getType)
+                .containsExactly(
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.ACTIVITY_STARTED
+                );
+
+        assertThat(changeStateEventListener.getEvents())
+                .filteredOn(stateEvent -> stateEvent instanceof ActivitiVariableEvent)
+                .extracting(
+                        stateEvent -> ((ActivitiVariableEvent) stateEvent).getVariableName(),
+                        stateEvent -> ((ActivitiVariableEvent) stateEvent).getVariableValue()
+                )
+                .containsExactlyInAnyOrder(
+                        tuple("processVar1", "test"),
+                        tuple("processVar2", 10),
+                        tuple("localVar1", "test2"),
+                        tuple("localVar2", 20)
+                );
+
+        assertThat(changeStateEventListener.getEvents())
+                .filteredOn(stateEvent -> stateEvent instanceof ActivitiActivityEvent)
+                .extracting(stateEvent -> ((ActivitiActivityEvent) stateEvent).getActivityId())
+                .containsExactlyInAnyOrder(
+                        "taskBefore"
+                );
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentExecutionForSubProcessWithVariables() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        changeStateEventListener.clear();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(task.getExecutionId(), "taskBefore")
+                .processVariable("processVar1", "test")
+                .processVariable("processVar2", 10)
+                .localVariable("taskBefore", "localVar1", "test2")
+                .localVariable("taskBefore", "localVar2", 20)
+                .changeState();
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskBefore");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(2);
+
+        Map<String, Object> processVariables = runtimeService.getVariables(processInstance.getId());
+        assertThat(processVariables)
+                .contains(
+                        entry("processVar1", "test"),
+                        entry("processVar2", 10)
+                )
+                .doesNotContainKeys("localVar1", "localVar2");
+
+        Execution execution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("taskBefore").singleResult();
+        Map<String, Object> localVariables = runtimeService.getVariablesLocal(execution.getId());
+        assertThat(localVariables)
+                .contains(
+                        entry("localVar1", "test2"),
+                        entry("localVar2", 20)
+                );
+
+        // Verify events
+        assertThat(changeStateEventListener.getEvents())
+                .extracting(ActivitiEvent::getType)
+                .containsExactly(
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.VARIABLE_CREATED,
+                        ActivitiEventType.ACTIVITY_STARTED
+                );
+
+        assertThat(changeStateEventListener.getEvents())
+                .filteredOn(stateEvent -> stateEvent instanceof ActivitiVariableEvent)
+                .extracting(
+                        stateEvent -> ((ActivitiVariableEvent) stateEvent).getVariableName(),
+                        stateEvent -> ((ActivitiVariableEvent) stateEvent).getVariableValue()
+                )
+                .containsExactlyInAnyOrder(
+                        tuple("processVar1", "test"),
+                        tuple("processVar2", 10),
+                        tuple("localVar1", "test2"),
+                        tuple("localVar2", 20)
+                );
+
+        assertThat(changeStateEventListener.getEvents())
+                .filteredOn(stateEvent -> stateEvent instanceof ActivitiActivityEvent)
+                .extracting(stateEvent -> ((ActivitiActivityEvent) stateEvent).getActivityId())
+                .containsExactlyInAnyOrder(
+                        "taskBefore"
+                );
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInUnstartedSubProcessWithModeledDataObject() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .changeState();
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
+
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("John");
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml" })
+    public void testSetCurrentActivityInUnstartedSubProcessWithLocalVariableOnSubProcess() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("startSimpleSubProcess");
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("taskBefore", "subTask")
+                .localVariable("subProcess", "name", "Joe")
+                .changeState();
+
+        Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("subTask");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(executions).hasSize(3);
+
+        Execution subProcessExecution = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).activityId("subProcess")
+                .singleResult();
+        assertThat(runtimeService.getVariableLocal(subProcessExecution.getId(), "name", String.class)).isNotNull();
+
+        DataObject nameDataObject = runtimeService.getDataObjectLocal(subProcessExecution.getId(), "name");
+        assertThat(nameDataObject).isNotNull();
+        assertThat(nameDataObject.getValue()).isEqualTo("Joe");
+
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("taskAfter");
+        taskService.complete(task.getId());
+
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityToIntermediateSignalCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+        //Move to catchEvent
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+        //Trigger the event
+        runtimeService.signalEventReceived("someSignal");
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionToIntermediateSignalCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+        //Move to catchEvent
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Trigger the event
+        runtimeService.signalEventReceived("someSignal");
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityFromIntermediateSignalCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
+
+        //Complete initial task
+        taskService.complete(task.getId());
+
+        //Process is waiting for event invocation
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+
+        //Move back to the initial task
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
+                .changeState();
+
+        //Process is in the initial state, no subscriptions exists
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Complete the task once more
+        taskService.complete(tasks.get(0).getId());
+
+        //Process is waiting for signal again
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move forward from the event catch
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
+                .changeState();
+
+        //Process is on the last task
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionFromIntermediateSignalCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
+
+        //Complete initial task
+        taskService.complete(task.getId());
+
+        //Process is waiting for event invocation
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move back to the initial task
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
+                .changeState();
+
+        //Process is in the initial state, no subscriptions exists
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Complete the task once more
+        taskService.complete(tasks.get(0).getId());
+
+        //Process is waiting for signal again
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move forward from the event catch
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
+                .changeState();
+
+        //Process is on the last task
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityToIntermediateMessageCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+        //Move to catchEvent
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Trigger the event
+        String messageCatchingExecutionId = classifiedExecutions.get("intermediateCatchEvent").get(0).getId();
+        runtimeService.messageEventReceived("someMessage", messageCatchingExecutionId);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionToIntermediateMessageCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+        //Move to catchEvent
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("beforeCatchEvent").get(0).getId(), "intermediateCatchEvent")
+                .changeState();
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Trigger the event
+        String messageCatchingExecutionId = classifiedExecutions.get("intermediateCatchEvent").get(0).getId();
+        runtimeService.messageEventReceived("someMessage", messageCatchingExecutionId);
+
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityFromIntermediateMessageCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
+
+        //Complete initial task
+        taskService.complete(task.getId());
+
+        //Process is waiting for event invocation
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move back to the initial task
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "beforeCatchEvent")
+                .changeState();
+
+        //Process is in the initial state, no subscriptions exists
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Complete the task once more
+        taskService.complete(tasks.get(0).getId());
+
+        //Process is waiting for signal again
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move forward from the event catch
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance.getId())
+                .moveActivityIdTo("intermediateCatchEvent", "afterCatchEvent")
+                .changeState();
+
+        //Process is on the last task
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionFromIntermediateMessageCatchEvent() {
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task).isNotNull();
+        assertThat(task.getTaskDefinitionKey()).isEqualTo("beforeCatchEvent");
+
+        //Complete initial task
+        taskService.complete(task.getId());
+
+        //Process is waiting for event invocation
+        List<Execution> executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move back to the initial task
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "beforeCatchEvent")
+                .changeState();
+
+        //Process is in the initial state, no subscriptions exists
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("beforeCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks).hasSize(1);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Complete the task once more
+        taskService.complete(tasks.get(0).getId());
+
+        //Process is waiting for signal again
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Move forward from the event catch
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(classifiedExecutions.get("intermediateCatchEvent").get(0).getId(), "afterCatchEvent")
+                .changeState();
+
+        //Process is on the last task
+        executions = runtimeService.createExecutionQuery().processInstanceId(processInstance.getId()).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processInstance.getId()).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //Complete the process
+        taskService.complete(tasks.get(0).getId());
+        assertProcessEnded(processInstance.getId());
+    }
+
+    protected void checkInitialStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
+        executionsByProcessInstance.forEach((processId, executions) -> {
+            Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+            assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+            List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+            Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+            assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+        });
+    }
+
+    protected void checkWaitStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
+        executionsByProcessInstance.forEach((processId, executions) -> {
+            Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+            assertThat(classifiedExecutions).hasSize(1);
+            assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+            List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+            assertThat(tasks).isEmpty();
+
+
+        });
+    }
+
+    protected void checkFinalStateForMultipleProcessesWithSimpleEventCatch(Map<String, List<Execution>> executionsByProcessInstance) {
+        executionsByProcessInstance.forEach((processId, executions) -> {
+            Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+            assertThat(classifiedExecutions).hasSize(1);
+            assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+            List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+            Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+            assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+        });
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityToIntermediateCatchEventForMultipleProcessesTriggerSimultaneously() {
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Move both processes to the eventCatch
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance1.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance2.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkWaitStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Trigger signal
+        runtimeService.signalEventReceived("someSignal");
+
+        //Both processes should be on the final task execution
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Complete the remaining tasks for both processes
+        taskService.createTaskQuery().list().forEach(this::completeTask);
+        assertProcessEnded(processInstance1.getId());
+        assertProcessEnded(processInstance2.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionToIntermediateCatchEventForMultipleProcessesTriggerSimultaneously() {
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Move both processes to the eventCatch
+        ChangeActivityStateBuilder changeActivityStateBuilder = runtimeService.createChangeActivityStateBuilder();
+        allExecutions.stream()
+                .filter(e -> "beforeCatchEvent".equals(e.getActivityId()))
+                .map(Execution::getId)
+                .forEach(id -> changeActivityStateBuilder.moveExecutionToActivityId(id, "intermediateCatchEvent"));
+        changeActivityStateBuilder.changeState();
+
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkWaitStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Trigger signal
+        runtimeService.signalEventReceived("someSignal");
+
+        //Both processes should be on the final task execution
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Complete the remaining tasks for both processes
+        taskService.createTaskQuery().list().forEach(this::completeTask);
+        assertProcessEnded(processInstance1.getId());
+        assertProcessEnded(processInstance2.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentActivityToIntermediateCatchEventForMultipleProcessesTriggerDiffered() {
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Move one process to the eventCatch
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance1.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        //ProcessInstance1 waiting for event
+        String processId = processInstance1.getId();
+        List<Execution> executions = executionsByProcessInstance.get(processId);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        assertThat(tasks).isEmpty();
+
+
+
+        //processInstance2 Execution still on initial state
+        processId = processInstance2.getId();
+        executions = executionsByProcessInstance.get(processId);
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Trigger signal
+        runtimeService.signalEventReceived("someSignal");
+
+        //Move the second process to the eventCatch
+        runtimeService.createChangeActivityStateBuilder()
+                .processInstanceId(processInstance2.getId())
+                .moveActivityIdTo("beforeCatchEvent", "intermediateCatchEvent")
+                .changeState();
+
+        //ProcessInstance1 is on the postEvent task
+        processId = processInstance1.getId();
+        executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //ProcessInstance2 is waiting for the event
+        processId = processInstance2.getId();
+        executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        assertThat(tasks).isEmpty();
+
+
+        //Fire the event once more
+        runtimeService.signalEventReceived("someSignal");
+
+        //Both process should be on the postEvent task execution
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Complete the remaining tasks for both processes
+        taskService.createTaskQuery().list().forEach(this::completeTask);
+        assertProcessEnded(processInstance1.getId());
+        assertProcessEnded(processInstance2.getId());
+    }
+
+
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml" })
+    public void testSetCurrentExecutionToIntermediateCatchEventForMultipleProcessesTriggerDiffered() {
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("changeStateForSimpleIntermediateEvent");
+
+        List<Execution> allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        Map<String, List<Execution>> executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkInitialStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Move one execution to the event catch
+        String executionId = executionsByProcessInstance.get(processInstance1.getId()).stream()
+                .filter(e -> "beforeCatchEvent".equals(e.getActivityId()))
+                .findFirst()
+                .map(Execution::getId)
+                .get();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
+                .changeState();
+
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        //ProcessInstance1 waiting for event
+        String processId = processInstance1.getId();
+        List<Execution> executions = executionsByProcessInstance.get(processId);
+        Map<String, List<Execution>> classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        List<Task> tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        assertThat(tasks).isEmpty();
+
+
+        //processInstance2 Execution still on initial state
+        processId = processInstance2.getId();
+        executions = executionsByProcessInstance.get(processId);
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).containsOnlyKeys("beforeCatchEvent");
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        Map<String, List<Task>> classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("beforeCatchEvent")).hasSize(1);
+
+
+        //Trigger signal
+        runtimeService.signalEventReceived("someSignal");
+
+        //Move the second process to the eventCatch
+        executionId = executionsByProcessInstance.get(processInstance2.getId()).stream()
+                .filter(e -> "beforeCatchEvent".equals(e.getActivityId()))
+                .findFirst()
+                .map(Execution::getId)
+                .get();
+        runtimeService.createChangeActivityStateBuilder()
+                .moveExecutionToActivityId(executionId, "intermediateCatchEvent")
+                .changeState();
+
+        //ProcessInstance1 is on the postEvent task
+        processId = processInstance1.getId();
+        executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("afterCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        classifiedTasks = groupListContentBy(tasks, Task::getTaskDefinitionKey);
+        assertThat(classifiedTasks.get("afterCatchEvent")).hasSize(1);
+
+
+        //ProcessInstance2 is waiting for the event
+        processId = processInstance2.getId();
+        executions = runtimeService.createExecutionQuery().processInstanceId(processId).onlyChildExecutions().list();
+        classifiedExecutions = groupListContentBy(executions, Execution::getActivityId);
+        assertThat(classifiedExecutions).hasSize(1);
+        assertThat(classifiedExecutions.get("intermediateCatchEvent")).hasSize(1);
+        tasks = taskService.createTaskQuery().processInstanceId(processId).list();
+        assertThat(tasks).isEmpty();
+
+
+
+        //Fire the event once more
+        runtimeService.signalEventReceived("someSignal");
+
+        //Both process should be on the postEvent task execution
+        allExecutions = runtimeService.createExecutionQuery().onlyChildExecutions().list();
+        executionsByProcessInstance = groupListContentBy(allExecutions, Execution::getProcessInstanceId);
+        assertThat(executionsByProcessInstance).hasSize(2);
+
+        checkFinalStateForMultipleProcessesWithSimpleEventCatch(executionsByProcessInstance);
+
+        //Complete the remaining tasks for both processes
+        taskService.createTaskQuery().list().forEach(this::completeTask);
+        assertProcessEnded(processInstance1.getId());
+        assertProcessEnded(processInstance2.getId());
+    }
+
+
+    protected String getJobActivityId(Job job) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            Map<String, Object> jobConfigurationMap = objectMapper.readValue(job.getJobHandlerConfiguration(), new TypeReference<Map<String, Object>>() {
+
+            });
+            return (String) jobConfigurationMap.get("activityId");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    protected void completeTask(Task task) {
+        taskService.complete(task.getId());
+    }
+    protected static<T> Map<String, List<T>> groupListContentBy(List<T> source, Function<T, String> classifier) {
+        return source.stream().collect(Collectors.groupingBy(classifier));
+    }
+}
+

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/inclusiveGatewayForkJoin.bpmn20.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="startInclusiveGwProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="gwFork"/>
+
+        <inclusiveGateway id="gwFork"/>
+
+        <sequenceFlow id="gwFlow1" sourceRef="gwFork" targetRef="task1">
+            <conditionExpression>${true}</conditionExpression>
+        </sequenceFlow>
+        <userTask id="task1"/>
+        <sequenceFlow id="gwFlow2" sourceRef="gwFork" targetRef="task2">
+            <conditionExpression>${true}</conditionExpression>
+        </sequenceFlow>
+        <userTask id="task2"/>
+
+        <sequenceFlow id="gwFlow3" sourceRef="task1" targetRef="gwJoin"/>
+        <sequenceFlow id="gwFlow4" sourceRef="task2" targetRef="gwJoin"/>
+
+        <inclusiveGateway id="gwJoin"/>
+
+        <sequenceFlow id="flow3" sourceRef="gwJoin" targetRef="taskAfter"/>
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow4" sourceRef="taskAfter" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/inclusiveGatewayNestedInsideMultiInstanceSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/inclusiveGatewayNestedInsideMultiInstanceSubProcess.bpmn20.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="inclusiveGatewayInsideMultiInstanceSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelSubProcess"/>
+
+        <subProcess id="parallelSubProcess">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>3</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+
+            <startEvent id="theSubProcessStart"/>
+            <sequenceFlow id="subFlow1" sourceRef="theSubProcessStart" targetRef="inclusiveFork"/>
+
+            <inclusiveGateway id="inclusiveFork"/>
+
+            <sequenceFlow id="subFlow2" sourceRef="inclusiveFork" targetRef="taskInclusive1">
+                <conditionExpression>${true}</conditionExpression>
+            </sequenceFlow>
+
+            <sequenceFlow id="subFlow3" sourceRef="inclusiveFork" targetRef="taskInclusive2">
+                <conditionExpression>${true}</conditionExpression>
+            </sequenceFlow>
+
+            <sequenceFlow id="subFlow4" sourceRef="inclusiveFork" targetRef="taskInclusive3">
+                <conditionExpression>${true}</conditionExpression>
+            </sequenceFlow>
+
+            <userTask id="taskInclusive1"/>
+            <userTask id="taskInclusive2"/>
+            <userTask id="taskInclusive3"/>
+
+            <sequenceFlow id="subFlow5" sourceRef="taskInclusive1" targetRef="inclusiveJoin"/>
+            <sequenceFlow id="subFlow6" sourceRef="taskInclusive2" targetRef="inclusiveJoin"/>
+            <sequenceFlow id="subFlow7" sourceRef="taskInclusive3" targetRef="inclusiveJoin"/>
+
+            <inclusiveGateway id="inclusiveJoin"/>
+
+            <sequenceFlow id="subflow8" sourceRef="inclusiveJoin" targetRef="postForkTask"/>
+            <userTask id="postForkTask"/>
+            <sequenceFlow id="subflow3" sourceRef="postForkTask" targetRef="theSubProcessEnd"/>
+            <endEvent id="theSubProcessEnd"/>
+        </subProcess>
+
+        <sequenceFlow id="flow2" sourceRef="parallelSubProcess" targetRef="lastTask"/>
+        <userTask id="lastTask"/>
+        <sequenceFlow id="flow3" sourceRef="lastTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceNestedParallelSubProcesses.bpmn20.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="parallelNestedMultiInstanceSubProcesses">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelSubProcessOuter"/>
+
+        <subProcess id="parallelSubProcessOuter">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>3</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+
+            <startEvent id="theSubProcessStart" />
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask1" />
+            <userTask id="subTask1" />
+            <sequenceFlow id="subflow2" sourceRef="subTask1" targetRef="parallelNestedSubProcess" />
+
+            <subProcess id="parallelNestedSubProcess">
+                <multiInstanceLoopCharacteristics isSequential="false">
+                    <loopCardinality>3</loopCardinality>
+                </multiInstanceLoopCharacteristics>
+                <startEvent id="theNestedSubProcessStart" />
+                <sequenceFlow id="nestedSubflow1" sourceRef="theNestedSubProcessStart" targetRef="nestedSubTask1" />
+                <userTask id="nestedSubTask1" />
+                <sequenceFlow id="nestedSubflow2" sourceRef="nestedSubTask1" targetRef="nestedSubTask2" />
+                <userTask id="nestedSubTask2" />
+                <sequenceFlow id="nestedSubflow3" sourceRef="nestedSubTask2" targetRef="theNestedSubProcessEnd" />
+                <endEvent id="theNestedSubProcessEnd" />
+            </subProcess>
+
+            <sequenceFlow id="subflow3" sourceRef="parallelNestedSubProcess" targetRef="subTask2" />
+            <userTask id="subTask2" />
+            <sequenceFlow id="subflow4" sourceRef="subTask2" targetRef="theSubProcessEnd" />
+            <endEvent id="theSubProcessEnd" />
+        </subProcess>
+
+        <sequenceFlow id="flow2" sourceRef="parallelSubProcessOuter" targetRef="lastTask"/>
+        <userTask id="lastTask" name="last task"/>
+        <sequenceFlow id="flow3" sourceRef="lastTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceParallel.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceParallel.bpmn20.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="parallelMultiInstance">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="beforeMultiInstance"/>
+        <userTask id="beforeMultiInstance"/>
+        <sequenceFlow sourceRef="beforeMultiInstance" targetRef="parallelTasks"/>
+
+        <userTask id="parallelTasks" name="Parallel Task">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>${nrOfLoops}</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+        </userTask>
+
+        <sequenceFlow id="flow2" sourceRef="parallelTasks" targetRef="nextTask"/>
+        <userTask id="nextTask" name="next task"/>
+        <sequenceFlow id="flow3" sourceRef="nextTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceParallelSubProcess.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="parallelMultiInstanceSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelSubProcess"/>
+
+        <subProcess id="parallelSubProcess">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>${nrOfLoops}</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+            <startEvent id="theSubProcessStart" />
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask1" />
+            <userTask id="subTask1" />
+            <sequenceFlow id="subflow2" sourceRef="subTask1" targetRef="subTask2" />
+            <userTask id="subTask2" />
+            <sequenceFlow id="subflow3" sourceRef="subTask2" targetRef="theSubProcessEnd" />
+            <endEvent id="theSubProcessEnd" />
+        </subProcess>
+
+        <sequenceFlow id="flow2" sourceRef="parallelSubProcess" targetRef="lastTask"/>
+        <userTask id="lastTask" name="last task"/>
+        <sequenceFlow id="flow3" sourceRef="lastTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceSequential.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multiInstanceSequential.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="sequentialMultiInstance">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="beforeMultiInstance"/>
+
+        <userTask id="beforeMultiInstance"/>
+
+        <sequenceFlow id="flow2" sourceRef="beforeMultiInstance" targetRef="seqTasks"/>
+
+        <userTask id="seqTasks" name="Sequential Task">
+            <multiInstanceLoopCharacteristics isSequential="true">
+                <loopCardinality>${nrOfLoops}</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+        </userTask>
+
+        <sequenceFlow id="flow3" sourceRef="seqTasks" targetRef="nextTask"/>
+        <userTask id="nextTask" name="next task"/>
+        <sequenceFlow id="flow4" sourceRef="nextTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multipleParallelSubProcesses.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/multipleParallelSubProcesses.bpmn20.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:activiti="http://activiti.org/bpmn" targetNamespace="Examples">
+
+  <process id="startParallelProcess">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore" />
+
+    <userTask id="taskBefore" name="Task before sub process" />
+
+    <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="inclusiveFork" />
+
+    <inclusiveGateway id="inclusiveFork" />
+
+    <sequenceFlow id="flow3" sourceRef="inclusiveFork" targetRef="taskInclusive1">
+        <conditionExpression xsi:type="tFormalExpression">
+            <![CDATA[${var1 != 'test'}]]>
+        </conditionExpression>
+    </sequenceFlow>
+
+    <sequenceFlow id="flow4" sourceRef="inclusiveFork" targetRef="taskInclusive2">
+        <conditionExpression xsi:type="tFormalExpression">
+            <![CDATA[${var1 == 'test'}]]>
+        </conditionExpression>
+    </sequenceFlow>
+
+    <sequenceFlow id="flow5" sourceRef="inclusiveFork" targetRef="taskInclusive3">
+        <conditionExpression xsi:type="tFormalExpression">
+            <![CDATA[${var1 == 'test2'}]]>
+        </conditionExpression>
+    </sequenceFlow>
+
+    <userTask id="taskInclusive1" />
+
+    <userTask id="taskInclusive2" />
+
+    <userTask id="taskInclusive3" />
+
+    <sequenceFlow id="flow6" sourceRef="taskInclusive1" targetRef="parallelFork" />
+
+    <parallelGateway id="parallelFork" />
+
+    <sequenceFlow id="flow7" sourceRef="parallelFork" targetRef="subProcess1" />
+
+    <subProcess id="subProcess1">
+
+      <startEvent id="theSubProcessStart" />
+
+      <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subtask" />
+
+      <userTask id="subtask" />
+
+      <sequenceFlow id="subflow2" sourceRef="subtask" targetRef="subtask2" />
+
+      <userTask id="subtask2" />
+
+      <sequenceFlow id="subflow3" sourceRef="subtask2" targetRef="theSubProcessEnd" />
+
+      <endEvent id="theSubProcessEnd" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow8" sourceRef="parallelFork" targetRef="subProcess2" />
+
+    <subProcess id="subProcess2">
+
+      <startEvent id="theSubProcessStart2" />
+
+      <sequenceFlow id="subflow4" sourceRef="theSubProcessStart2" targetRef="subtask3" />
+
+      <userTask id="subtask3" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow5" sourceRef="subtask3" targetRef="theSubProcessEnd2" />
+
+      <endEvent id="theSubProcessEnd2" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow9" sourceRef="subProcess1" targetRef="parallelJoin" />
+
+    <sequenceFlow id="flow10" sourceRef="subProcess2" targetRef="parallelJoin" />
+
+    <parallelGateway id="parallelJoin" />
+
+    <sequenceFlow id="flow11" sourceRef="parallelJoin" targetRef="inclusiveJoin" />
+
+    <sequenceFlow id="flow12" sourceRef="taskInclusive2" targetRef="inclusiveJoin" />
+
+    <sequenceFlow id="flow13" sourceRef="taskInclusive3" targetRef="inclusiveJoin" />
+
+    <inclusiveGateway id="inclusiveJoin" />
+
+    <sequenceFlow id="flow14" sourceRef="inclusiveJoin" targetRef="taskAfter" />
+
+    <userTask id="taskAfter" name="Task after sub process" />
+
+    <sequenceFlow id="flow15" sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskNestedSubProcess.bpmn20.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="startNestedSubProcess">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess"/>
+
+        <subProcess id="subProcess">
+
+            <startEvent id="theSubProcessStart"/>
+
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask"/>
+
+            <userTask id="subTask" name="Task in subprocess"/>
+
+            <sequenceFlow id="subflow2" sourceRef="subTask" targetRef="nestedSubProcess"/>
+
+            <subProcess id="nestedSubProcess">
+
+                <startEvent id="theNestedSubProcessStart"/>
+
+                <sequenceFlow id="nestedSubflow1" sourceRef="theNestedSubProcessStart" targetRef="nestedSubTask"/>
+
+                <userTask id="nestedSubTask" name="Task in nested subprocess"/>
+
+                <sequenceFlow id="nestedSubflow2" sourceRef="nestedSubTask" targetRef="theNestedSubProcessEnd"/>
+
+                <endEvent id="theNestedSubProcessEnd"/>
+
+            </subProcess>
+
+            <sequenceFlow id="subflow3" sourceRef="nestedSubProcess" targetRef="subTaskAfter"/>
+
+            <userTask id="subTaskAfter" name="Task in subprocess"/>
+
+            <sequenceFlow id="subflow4" sourceRef="subTaskAfter" targetRef="theSubProcessEnd"/>
+
+            <endEvent id="theSubProcessEnd"/>
+
+        </subProcess>
+
+        <sequenceFlow id="flow3" sourceRef="subProcess" targetRef="taskAfter"/>
+
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow4" sourceRef="taskAfter" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskProcessV2.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskProcessV2.bpmn20.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="ExamplesCategory">
+
+    <process id="oneTaskProcess" name="The One Task Process V2">
+        <documentation>This is a process for testing purposes</documentation>
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTaskV2"/>
+        <userTask id="theTaskV2" name="my task"/>
+        <sequenceFlow id="flow2" sourceRef="theTaskV2" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskSubProcess.bpmn20.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="Examples">
+
+    <process id="startSimpleSubProcess">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess"/>
+
+        <subProcess id="subProcess">
+            <dataObject itemSubjectRef="xsd:string" name="name" id="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a1">
+                <extensionElements>
+                    <activiti:value>John</activiti:value>
+                </extensionElements>
+            </dataObject>
+
+            <startEvent id="theSubProcessStart"/>
+
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask"/>
+
+            <userTask id="subTask" name="Task in subProcess"/>
+
+            <sequenceFlow id="subflow2" sourceRef="subTask" targetRef="theSubProcessEnd"/>
+
+            <endEvent id="theSubProcessEnd"/>
+
+        </subProcess>
+
+        <sequenceFlow id="flow3" sourceRef="subProcess" targetRef="taskAfter"/>
+
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow4" sourceRef="taskAfter" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskSubProcessWithTimer.bpmn20.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="startSimpleSubProcess">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess"/>
+
+        <subProcess id="subProcess">
+
+            <startEvent id="theSubProcessStart"/>
+
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask"/>
+
+            <userTask id="subTask" name="Task in subprocess"/>
+
+            <sequenceFlow id="subflow2" sourceRef="subTask" targetRef="theSubProcessEnd"/>
+
+            <endEvent id="theSubProcessEnd"/>
+
+        </subProcess>
+
+        <boundaryEvent id="boundaryTimerEvent" attachedToRef="subProcess">
+            <timerEventDefinition>
+                <timeDuration>PT1H</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+
+        <sequenceFlow id="flow3" sourceRef="boundaryTimerEvent" targetRef="theEnd"/>
+
+        <sequenceFlow id="flow4" sourceRef="subProcess" targetRef="taskAfter"/>
+
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow5" sourceRef="taskAfter" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/oneTaskWithTimerInSubProcess.bpmn20.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="startSimpleSubProcess">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess"/>
+
+        <subProcess id="subProcess">
+
+            <startEvent id="theSubProcessStart"/>
+
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask"/>
+
+            <userTask id="subTask" name="Task in subProcess"/>
+
+            <boundaryEvent id="boundaryTimerEvent" attachedToRef="subTask">
+                <timerEventDefinition>
+                    <timeDuration>PT1H</timeDuration>
+                </timerEventDefinition>
+            </boundaryEvent>
+
+            <sequenceFlow id="subflow2" sourceRef="boundaryTimerEvent" targetRef="theSubProcessEnd"/>
+
+            <sequenceFlow id="subflow3" sourceRef="subTask" targetRef="subTask2"/>
+
+            <userTask id="subTask2"/>
+
+            <sequenceFlow id="subflow4" sourceRef="subTask2" targetRef="theSubProcessEnd"/>
+
+            <endEvent id="theSubProcessEnd"/>
+
+        </subProcess>
+
+        <sequenceFlow id="flow4" sourceRef="subProcess" targetRef="taskAfter"/>
+
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow5" sourceRef="taskAfter" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelGatewayInsideMultiInstanceSubProcess.bpmn20.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="parallelGatewayInsideMultiInstanceSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="parallelSubProcess"/>
+
+        <subProcess id="parallelSubProcess">
+            <multiInstanceLoopCharacteristics isSequential="false">
+                <loopCardinality>3</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+
+            <startEvent id="theSubProcessStart"/>
+            <sequenceFlow id="subFlow1" sourceRef="theSubProcessStart" targetRef="preForkTask"/>
+            <userTask id="preForkTask"/>
+            <sequenceFlow id="subFlow2" sourceRef="preForkTask" targetRef="parallelFork"/>
+
+            <parallelGateway id="parallelFork"/>
+            <sequenceFlow id="forkFlow1" sourceRef="parallelFork" targetRef="forkTask1"/>
+            <userTask id="forkTask1"/>
+            <sequenceFlow id="forkFlow2" sourceRef="parallelFork" targetRef="forkTask2"/>
+            <userTask id="forkTask2"/>
+            <sequenceFlow id="forkFlow3" sourceRef="forkTask1" targetRef="parallelJoin"/>
+            <sequenceFlow id="forkFlow4" sourceRef="forkTask2" targetRef="parallelJoin"/>
+            <parallelGateway id="parallelJoin"/>
+
+            <sequenceFlow id="subflow2" sourceRef="parallelJoin" targetRef="postForkTask"/>
+            <userTask id="postForkTask"/>
+            <sequenceFlow id="subflow3" sourceRef="postForkTask" targetRef="theSubProcessEnd"/>
+            <endEvent id="theSubProcessEnd"/>
+        </subProcess>
+
+        <sequenceFlow id="flow2" sourceRef="parallelSubProcess" targetRef="lastTask"/>
+        <userTask id="lastTask"/>
+        <sequenceFlow id="flow3" sourceRef="lastTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelSubProcesses.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelSubProcesses.bpmn20.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:activiti="http://activiti.org/bpmn" targetNamespace="Examples">
+
+  <process id="startParallelProcess">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore" />
+
+    <userTask id="taskBefore" name="Task before sub process" />
+
+    <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="parallelFork" />
+
+    <parallelGateway id="parallelFork" />
+
+    <sequenceFlow id="flow3" sourceRef="parallelFork" targetRef="subProcess1" />
+
+    <subProcess id="subProcess1">
+
+      <startEvent id="theSubProcessStart" />
+
+      <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subtask" />
+
+      <userTask id="subtask" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow2" sourceRef="subtask" targetRef="theSubProcessEnd" />
+
+      <endEvent id="theSubProcessEnd" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow4" sourceRef="parallelFork" targetRef="subProcess2" />
+
+    <subProcess id="subProcess2">
+
+      <startEvent id="theSubProcessStart2" />
+
+      <sequenceFlow id="subflow3" sourceRef="theSubProcessStart2" targetRef="subtask2" />
+
+      <userTask id="subtask2" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow4" sourceRef="subtask2" targetRef="theSubProcessEnd2" />
+
+      <endEvent id="theSubProcessEnd2" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow5" sourceRef="subProcess1" targetRef="parallelJoin" />
+
+    <sequenceFlow id="flow6" sourceRef="subProcess2" targetRef="parallelJoin" />
+
+    <parallelGateway id="parallelJoin" />
+
+    <sequenceFlow id="flow7" sourceRef="parallelJoin" targetRef="taskAfter" />
+
+    <userTask id="taskAfter" name="Task after sub process" />
+
+    <sequenceFlow id="flow8" sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelSubProcessesMultipleTasks.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelSubProcessesMultipleTasks.bpmn20.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+    xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:activiti="http://activiti.org/bpmn" targetNamespace="Examples">
+
+  <process id="startParallelProcess">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore" />
+
+    <userTask id="taskBefore" name="Task before sub process" />
+
+    <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="parallelFork" />
+
+    <parallelGateway id="parallelFork" />
+
+    <sequenceFlow id="flow3" sourceRef="parallelFork" targetRef="subProcess1" />
+
+    <subProcess id="subProcess1">
+
+      <startEvent id="theSubProcessStart" />
+
+      <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subtask" />
+
+      <userTask id="subtask" />
+
+      <sequenceFlow id="subflow2" sourceRef="subtask" targetRef="subtask2" />
+
+      <userTask id="subtask2" />
+
+      <sequenceFlow id="subflow3" sourceRef="subtask2" targetRef="theSubProcessEnd" />
+
+      <endEvent id="theSubProcessEnd" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow4" sourceRef="parallelFork" targetRef="subProcess2" />
+
+    <subProcess id="subProcess2">
+
+      <startEvent id="theSubProcessStart2" />
+
+      <sequenceFlow id="subflow4" sourceRef="theSubProcessStart2" targetRef="subtask3" />
+
+      <userTask id="subtask3" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow5" sourceRef="subtask3" targetRef="theSubProcessEnd2" />
+
+      <endEvent id="theSubProcessEnd2" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow5" sourceRef="subProcess1" targetRef="parallelJoin" />
+
+    <sequenceFlow id="flow6" sourceRef="subProcess2" targetRef="parallelJoin" />
+
+    <parallelGateway id="parallelJoin" />
+
+    <sequenceFlow id="flow7" sourceRef="parallelJoin" targetRef="taskAfter" />
+
+    <userTask id="taskAfter" name="Task after sub process" />
+
+    <sequenceFlow id="flow8" sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelTask.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/parallelTask.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="startParallelProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="parallelFork"/>
+
+        <parallelGateway id="parallelFork"/>
+
+        <sequenceFlow id="flow3" sourceRef="parallelFork" targetRef="task1"/>
+        <userTask id="task1"/>
+        <sequenceFlow id="flow4" sourceRef="parallelFork" targetRef="task2"/>
+        <userTask id="task2"/>
+
+        <sequenceFlow id="flow5" sourceRef="task1" targetRef="parallelJoin"/>
+        <sequenceFlow id="flow6" sourceRef="task2" targetRef="parallelJoin"/>
+
+        <parallelGateway id="parallelJoin"/>
+
+        <sequenceFlow id="flow7" sourceRef="parallelJoin" targetRef="taskAfter"/>
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow8" sourceRef="taskAfter" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+    <message id="message" name="myMessage"/>
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <messageEventDefinition messageRef="message"/>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="messageEventSubProcess" triggeredByEvent="true">
+                <startEvent id="messageEventSubProcessStart" isInterrupting="true">
+                    <messageEventDefinition messageRef="myMessage"/>
+                </startEvent>
+                <sequenceFlow sourceRef="messageEventSubProcessStart" targetRef="messageEventSubProcessTask"/>
+                <userTask id="messageEventSubProcessTask"/>
+                <sequenceFlow sourceRef="messageEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="messageEventSubProcess" triggeredByEvent="true">
+                <startEvent id="messageEventSubProcessStart" isInterrupting="false">
+                    <messageEventDefinition messageRef="myMessage"/>
+                </startEvent>
+                <sequenceFlow sourceRef="messageEventSubProcessStart" targetRef="messageEventSubProcessTask"/>
+                <userTask id="messageEventSubProcessTask"/>
+                <sequenceFlow sourceRef="messageEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+
+            <subProcess id="signalEventSubProcess" triggeredByEvent="true">
+                <startEvent id="signalEventSubProcessStart" isInterrupting="false">
+                    <signalEventDefinition signalRef="mySignal"/>
+                </startEvent>
+                <sequenceFlow sourceRef="signalEventSubProcessStart" targetRef="signalEventSubProcessTask"/>
+                <userTask id="signalEventSubProcessTask"/>
+                <sequenceFlow sourceRef="signalEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+        
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedNonInterruptingTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="timerEventSubProcess" triggeredByEvent="true">
+                <startEvent id="timerEventSubProcessStart" isInterrupting="false">
+                    <timerEventDefinition>
+                        <timeCycle>R/PT15M</timeCycle>
+                    </timerEventDefinition>
+                </startEvent>
+                <sequenceFlow sourceRef="timerEventSubProcessStart" targetRef="timerEventSubProcessTask"/>
+                <userTask id="timerEventSubProcessTask"/>
+                <sequenceFlow sourceRef="timerEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+
+            <subProcess id="signalEventSubProcess" triggeredByEvent="true">
+                <startEvent id="signalEventSubProcessStart" isInterrupting="true">
+                    <signalEventDefinition signalRef="mySignal"/>
+                </startEvent>
+                <sequenceFlow sourceRef="signalEventSubProcessStart" targetRef="signalEventSubProcessTask"/>
+                <userTask id="signalEventSubProcessTask"/>
+                <sequenceFlow sourceRef="signalEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+        
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNestedTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask" name="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow sourceRef="spawnParallelTask" targetRef="parallelTask"/>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow sourceRef="parallelTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="timerEventSubProcess" triggeredByEvent="true">
+                <startEvent id="timerEventSubProcessStart" isInterrupting="true">
+                    <timerEventDefinition>
+                        <timeCycle>R/PT15M</timeCycle>
+                    </timerEventDefinition>
+                </startEvent>
+                <sequenceFlow sourceRef="timerEventSubProcessStart" targetRef="timerEventSubProcessTask"/>
+                <userTask id="timerEventSubProcessTask"/>
+                <sequenceFlow sourceRef="timerEventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+    <message id="message" name="myMessage"/>
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <messageEventDefinition messageRef="message"/>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+    <signal id="signal" name="eventSignal"/>
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <signalEventDefinition signalRef="signal"/>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelNonInterruptingTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <timerEventDefinition>
+                    <timeCycle>R/PT15M</timeCycle>
+                </timerEventDefinition>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+    <signal id="signal" name="eventSignal"/>
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <signalEventDefinition signalRef="signal"/>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.TimerParallelTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="TAES" name="Timer and Event SubProcess" isExecutable="true">
+        <startEvent id="processStart"/>
+        <userTask id="processTask" name="processTask"/>
+        <boundaryEvent id="spawnParallelTask" attachedToRef="processTask" cancelActivity="false">
+            <timerEventDefinition>
+                <timeDuration>PT15M</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="sid-010924B1-4782-404F-AB7B-8961589B113B" sourceRef="spawnParallelTask" targetRef="parallelTask"></sequenceFlow>
+        <sequenceFlow id="sid-F8AF2DCF-E4A9-4165-8979-B5080DF20A7D" sourceRef="processStart" targetRef="processTask"/>
+        <endEvent id="processEnd"/>
+        <subProcess id="eventSubProcess" name="subProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <timerEventDefinition>
+                    <timeCycle>R/PT15M</timeCycle>
+                </timerEventDefinition>
+            </startEvent>
+            <userTask id="eventSubProcessTask" name="eventSubProcessTask"/>
+            <endEvent id="eventSubProcessEnd"/>
+            <sequenceFlow id="sid-7A53BFC1-8770-4940-BF44-3379C5F7B460" sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+            <sequenceFlow id="sid-9717A6A0-3729-4E23-9641-E1A97663EA1D" sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+        </subProcess>
+        <userTask id="parallelTask" name="parallelTask"/>
+        <sequenceFlow id="sid-4C32419F-EC7F-4221-922D-B5C2422AF854" sourceRef="processTask" targetRef="processEnd"/>
+        <sequenceFlow id="sid-181731D6-3B7A-49C8-898E-0E6B716EA008" sourceRef="parallelTask" targetRef="processEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.adhocSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.adhocSubProcess.bpmn20.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+             xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC"
+             xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI"
+             typeLanguage="http://www.w3.org/2001/XMLSchema"
+             expressionLanguage="http://www.w3.org/1999/XPath"
+             targetNamespace="http://www.activiti.org/processdef">
+  <process id="ADHOC" name="AdHoc SubProcess" isExecutable="true">
+    <startEvent id="startEvent1"></startEvent>
+    <adHocSubProcess id="adhocSubProcess" name="Adhoc SubProcess" cancelRemainingInstances="true" ordering="Parallel">
+      <userTask id="userTask1" name="User Task 1" activiti:assignee="$INITIATOR">
+        <extensionElements>
+          <modeler:activiti-idm-initiator xmlns:modeler="http://activiti.org/modeler"><![CDATA[true]]></modeler:activiti-idm-initiator>
+        </extensionElements>
+      </userTask>
+      <userTask id="userTask2" name="User Task 2" activiti:assignee="$INITIATOR">
+        <extensionElements>
+          <modeler:activiti-idm-initiator xmlns:modeler="http://activiti.org/modeler"><![CDATA[true]]></modeler:activiti-idm-initiator>
+        </extensionElements>
+      </userTask>
+    </adHocSubProcess>
+    <userTask id="beforeSubProcess" name="Before SubProcess" activiti:assignee="$INITIATOR">
+      <extensionElements>
+        <modeler:activiti-idm-initiator xmlns:modeler="http://activiti.org/modeler"><![CDATA[true]]></modeler:activiti-idm-initiator>
+      </extensionElements>
+    </userTask>
+    <sequenceFlow id="sid-78725DB3-A0F2-4361-99AB-B6260DD8367B" sourceRef="startEvent1" targetRef="beforeSubProcess"></sequenceFlow>
+    <sequenceFlow id="sid-D1F5CC13-9F19-41BD-AA2A-9C4F9E27F08B" sourceRef="beforeSubProcess" targetRef="adhocSubProcess"></sequenceFlow>
+    <userTask id="afterSubProcess" name="After SubProcess" activiti:assignee="$INITIATOR">
+      <extensionElements>
+        <modeler:activiti-idm-initiator xmlns:modeler="http://activiti.org/modeler"><![CDATA[true]]></modeler:activiti-idm-initiator>
+      </extensionElements>
+    </userTask>
+    <sequenceFlow id="sid-E8DB026C-66A4-4A46-8E72-DCB2F01503B2" sourceRef="adhocSubProcess" targetRef="afterSubProcess"></sequenceFlow>
+    <endEvent id="sid-0EE89BBB-8B7C-4056-A5BA-B32B0EA51B9D"></endEvent>
+    <sequenceFlow id="sid-46ADB491-4794-4B58-80AA-9AA8EC50CBD4" sourceRef="afterSubProcess" targetRef="sid-0EE89BBB-8B7C-4056-A5BA-B32B0EA51B9D"></sequenceFlow>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_ADHOC">
+    <bpmndi:BPMNPlane bpmnElement="ADHOC" id="BPMNPlane_ADHOC">
+      <bpmndi:BPMNShape bpmnElement="startEvent1" id="BPMNShape_startEvent1">
+        <omgdc:Bounds height="30.0" width="30.0" x="30.0" y="195.5"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="adhocSubProcess" id="BPMNShape_adhocSubProcess">
+        <omgdc:Bounds height="265.0" width="187.5" x="270.0" y="78.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask1" id="BPMNShape_userTask1">
+        <omgdc:Bounds height="80.0" width="100.0" x="313.75" y="118.5"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask2" id="BPMNShape_userTask2">
+        <omgdc:Bounds height="80.0" width="100.0" x="313.75" y="228.0"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="beforeSubProcess" id="BPMNShape_beforeSubProcess">
+        <omgdc:Bounds height="80.0" width="100.0" x="105.0" y="170.5"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="afterSubProcess" id="BPMNShape_afterSubProcess">
+        <omgdc:Bounds height="80.0" width="100.0" x="502.5" y="170.5"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="sid-0EE89BBB-8B7C-4056-A5BA-B32B0EA51B9D" id="BPMNShape_sid-0EE89BBB-8B7C-4056-A5BA-B32B0EA51B9D">
+        <omgdc:Bounds height="28.0" width="28.0" x="647.5" y="196.5"></omgdc:Bounds>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sid-D1F5CC13-9F19-41BD-AA2A-9C4F9E27F08B" id="BPMNEdge_sid-D1F5CC13-9F19-41BD-AA2A-9C4F9E27F08B">
+        <omgdi:waypoint x="204.94999999989614" y="210.5"></omgdi:waypoint>
+        <omgdi:waypoint x="269.99999999995384" y="210.5"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-E8DB026C-66A4-4A46-8E72-DCB2F01503B2" id="BPMNEdge_sid-E8DB026C-66A4-4A46-8E72-DCB2F01503B2">
+        <omgdi:waypoint x="457.45000000000005" y="210.5"></omgdi:waypoint>
+        <omgdi:waypoint x="502.5" y="210.5"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-78725DB3-A0F2-4361-99AB-B6260DD8367B" id="BPMNEdge_sid-78725DB3-A0F2-4361-99AB-B6260DD8367B">
+        <omgdi:waypoint x="59.9499984899576" y="210.5"></omgdi:waypoint>
+        <omgdi:waypoint x="104.9999999999917" y="210.5"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="sid-46ADB491-4794-4B58-80AA-9AA8EC50CBD4" id="BPMNEdge_sid-46ADB491-4794-4B58-80AA-9AA8EC50CBD4">
+        <omgdi:waypoint x="602.449999999996" y="210.5"></omgdi:waypoint>
+        <omgdi:waypoint x="647.5" y="210.5"></omgdi:waypoint>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="true">
+                    <messageEventDefinition messageRef="myMessage"/>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="false">
+                    <messageEventDefinition messageRef="myMessage"/>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="false">
+                    <signalEventDefinition signalRef="mySignal"/>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+        
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedNonInterruptingTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="false">
+                    <timerEventDefinition>
+                        <timeCycle>R/PT15M</timeCycle>
+                    </timerEventDefinition>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="true">
+                    <signalEventDefinition signalRef="mySignal"/>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+        
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.nestedTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="subProcess"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="subProcess">
+            <startEvent id="subProcessStart"/>
+            <sequenceFlow sourceRef="subProcessStart" targetRef="subProcessTask"/>
+            <userTask id="subProcessTask"/>
+            <sequenceFlow sourceRef="subProcessTask" targetRef="subProcessEnd"/>
+            <endEvent id="subProcessEnd"/>
+            <subProcess id="eventSubProcess" triggeredByEvent="true">
+                <startEvent id="eventSubProcessStart" isInterrupting="true">
+                    <timerEventDefinition>
+                        <timeCycle>R1/PT15M</timeCycle>
+                    </timerEventDefinition>
+                </startEvent>
+                <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask"/>
+                <userTask id="eventSubProcessTask"/>
+                <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd"/>
+                <endEvent id="eventSubProcessEnd"/>
+            </subProcess>
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.oneTaskNestedSubProcessWithObject.bpmn20.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="Examples">
+
+    <process id="startNestedSubProcess">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore"/>
+
+        <userTask id="taskBefore" name="Task before sub process"/>
+
+        <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess"/>
+
+        <subProcess id="subProcess">
+
+            <startEvent id="theSubProcessStart"/>
+
+            <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subTask"/>
+
+            <userTask id="subTask" name="Task in subprocess"/>
+
+            <sequenceFlow id="subflow2" sourceRef="subTask" targetRef="nestedSubProcess"/>
+
+            <subProcess id="nestedSubProcess">
+                <dataObject itemSubjectRef="xsd:string" name="name" id="ID_91ee51f3-481d-439c-a62d-8b382a1cf7a1">
+                    <extensionElements>
+                        <activiti:value>John</activiti:value>
+                    </extensionElements>
+                </dataObject>
+
+                <startEvent id="theNestedSubProcessStart"/>
+
+                <sequenceFlow id="nestedSubflow1" sourceRef="theNestedSubProcessStart" targetRef="nestedSubTask"/>
+
+                <userTask id="nestedSubTask" name="Task in nested subprocess"/>
+
+                <sequenceFlow id="nestedSubflow2" sourceRef="nestedSubTask" targetRef="theNestedSubProcessEnd"/>
+
+                <endEvent id="theNestedSubProcessEnd"/>
+
+            </subProcess>
+
+            <sequenceFlow id="subflow3" sourceRef="nestedSubProcess" targetRef="subTaskAfter"/>
+
+            <userTask id="subTaskAfter" name="Task in subprocess"/>
+
+            <sequenceFlow id="subflow4" sourceRef="subTaskAfter" targetRef="theSubProcessEnd"/>
+
+            <endEvent id="theSubProcessEnd"/>
+
+        </subProcess>
+
+        <sequenceFlow id="flow3" sourceRef="subProcess" targetRef="taskAfter"/>
+
+        <userTask id="taskAfter" name="Task after sub process"/>
+
+        <sequenceFlow id="flow4" sourceRef="taskAfter" targetRef="theEnd"/>
+
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateEventRegistryCatchEvent.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateEventRegistryCatchEvent.bpmn20.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="someSignal"/>
+
+    <process id="changeStateForSimpleIntermediateEvent">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="beforeCatchEvent"/>
+        <userTask id="beforeCatchEvent"/>
+
+        <sequenceFlow id="flow2" sourceRef="beforeCatchEvent" targetRef="intermediateCatchEvent"/>
+        <intermediateCatchEvent id="intermediateCatchEvent">
+            <extensionElements>
+                <activiti:eventType>myEvent</activiti:eventType>
+            </extensionElements>
+        </intermediateCatchEvent>
+
+        <sequenceFlow id="flow3" sourceRef="intermediateCatchEvent" targetRef="afterCatchEvent"/>
+        <userTask id="afterCatchEvent"/>
+
+        <sequenceFlow id="flow4" sourceRef="afterCatchEvent" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateMessageCatchEvent.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="someMessage"/>
+
+    <process id="changeStateForSimpleIntermediateEvent">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="beforeCatchEvent"/>
+        <userTask id="beforeCatchEvent"/>
+
+        <sequenceFlow id="flow2" sourceRef="beforeCatchEvent" targetRef="intermediateCatchEvent"/>
+        <intermediateCatchEvent id="intermediateCatchEvent">
+            <messageEventDefinition messageRef="myMessage"/>
+        </intermediateCatchEvent>
+
+        <sequenceFlow id="flow3" sourceRef="intermediateCatchEvent" targetRef="afterCatchEvent"/>
+        <userTask id="afterCatchEvent"/>
+
+        <sequenceFlow id="flow4" sourceRef="afterCatchEvent" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleIntermediateSignalCatchEvent.bpmn20.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="someSignal"/>
+
+    <process id="changeStateForSimpleIntermediateEvent">
+
+        <startEvent id="theStart"/>
+
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="beforeCatchEvent"/>
+        <userTask id="beforeCatchEvent"/>
+
+        <sequenceFlow id="flow2" sourceRef="beforeCatchEvent" targetRef="intermediateCatchEvent"/>
+        <intermediateCatchEvent id="intermediateCatchEvent">
+            <signalEventDefinition signalRef="mySignal"/>
+        </intermediateCatchEvent>
+
+        <sequenceFlow id="flow3" sourceRef="intermediateCatchEvent" targetRef="afterCatchEvent"/>
+        <userTask id="afterCatchEvent"/>
+
+        <sequenceFlow id="flow4" sourceRef="afterCatchEvent" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <messageEventDefinition messageRef="myMessage" />
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingMessageEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingMessageEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <message id="myMessage" name="eventMessage"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <messageEventDefinition messageRef="myMessage" />
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="false">
+                <signalEventDefinition signalRef="mySignal" />
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleNonInterruptingTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <timerEventDefinition>
+                    <timeCycle>R/PT15M</timeCycle>
+                </timerEventDefinition>
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleSignalEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleSignalEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <signal id="mySignal" name="eventSignal"/>
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <signalEventDefinition signalRef="mySignal" />
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleTimerEventSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/changestate/RuntimeServiceChangeStateTest.simpleTimerEventSubProcess.bpmn20.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             targetNamespace="Examples">
+
+    <process id="changeStateForEventSubProcess">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow sourceRef="theStart" targetRef="processTask"/>
+        <userTask id="processTask"/>
+        <sequenceFlow sourceRef="processTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+        <subProcess id="eventSubProcess" triggeredByEvent="true">
+            <startEvent id="eventSubProcessStart" isInterrupting="true">
+                <timerEventDefinition>
+                    <timeCycle>R/PT15M</timeCycle>
+                </timerEventDefinition>
+            </startEvent>
+            <sequenceFlow sourceRef="eventSubProcessStart" targetRef="eventSubProcessTask" />
+            <userTask id="eventSubProcessTask"/>
+            <sequenceFlow sourceRef="eventSubProcessTask" targetRef="eventSubProcessEnd" />
+            <endEvent id="eventSubProcessEnd" />
+        </subProcess>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/taskTwoSubProcesses.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/taskTwoSubProcesses.bpmn20.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn" targetNamespace="Examples">
+
+  <process id="twoSubProcesses">
+
+    <startEvent id="theStart" />
+
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="taskBefore" />
+    
+    <userTask id="taskBefore" name="Task before sub process" />
+    
+    <sequenceFlow id="flow2" sourceRef="taskBefore" targetRef="subProcess" />
+
+    <subProcess id="subProcess">
+
+      <startEvent id="theSubProcessStart" />
+
+      <sequenceFlow id="subflow1" sourceRef="theSubProcessStart" targetRef="subtask" />
+
+      <userTask id="subtask" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow2" sourceRef="subtask" targetRef="theSubProcessEnd" />
+
+      <endEvent id="theSubProcessEnd" />
+
+    </subProcess>
+    
+    <sequenceFlow id="flow5" sourceRef="subProcess" targetRef="subProcess2" />
+    
+    <subProcess id="subProcess2">
+
+      <startEvent id="theSubProcessStart2" />
+
+      <sequenceFlow id="subflow3" sourceRef="theSubProcessStart2" targetRef="subtask2" />
+
+      <userTask id="subtask2" name="Task in subprocess" />
+
+      <sequenceFlow id="subflow4" sourceRef="subtask2" targetRef="theSubProcessEnd2" />
+
+      <endEvent id="theSubProcessEnd2" />
+
+    </subProcess>
+
+    <sequenceFlow id="flow3" sourceRef="subProcess2" targetRef="taskAfter" />
+    
+    <userTask id="taskAfter" name="Task after sub process" />
+    
+    <sequenceFlow id="flow4" sourceRef="taskAfter" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksParentProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksParentProcess.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="twoTasksParentProcess">
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="callActivity" />
+    <callActivity id="callActivity" calledElement="oneTaskProcess" />
+    <sequenceFlow id="flow3" sourceRef="callActivity" targetRef="secondTask" />
+    <userTask id="secondTask" name="Second task" />
+    <sequenceFlow id="flow4" sourceRef="secondTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksParentProcessV2.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksParentProcessV2.bpmn20.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="twoTasksParentProcess">
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="callActivity" />
+    <callActivity id="callActivity" calledElement="twoTasksProcess" />
+    <sequenceFlow id="flow3" sourceRef="callActivity" targetRef="secondTask" />
+    <userTask id="secondTask" name="Second task" />
+    <sequenceFlow id="flow4" sourceRef="secondTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksProcessWithTimer.bpmn20.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="twoTasksProcess">
+  
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask" />
+    <userTask id="firstTask" name="First task" />
+    <boundaryEvent id="boundaryTimerEvent" attachedToRef="firstTask">
+      <timerEventDefinition>
+        <timeDuration>PT1H</timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="flow2" sourceRef="boundaryTimerEvent" targetRef="theEnd" />
+    <sequenceFlow id="flow3" sourceRef="firstTask" targetRef="secondTask" />
+    <userTask id="secondTask" name="Second task" />    
+    <sequenceFlow id="flow4" sourceRef="secondTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+    
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksProcessWithTimers.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/twoTasksProcessWithTimers.bpmn20.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="twoTasksProcessWithTimers">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask"/>
+        <userTask id="firstTask" name="First task"/>
+        <boundaryEvent id="firstTimerEvent" attachedToRef="firstTask">
+            <timerEventDefinition>
+                <timeDuration>PT1H</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="secondTask"/>
+        <sequenceFlow id="flow3" sourceRef="firstTimerEvent" targetRef="theEnd"/>
+        <userTask id="secondTask" name="Second task"/>
+        <boundaryEvent id="secondTimerEvent" attachedToRef="secondTask">
+            <timerEventDefinition>
+                <timeDuration>PT1H</timeDuration>
+            </timerEventDefinition>
+        </boundaryEvent>
+        <sequenceFlow id="flow4" sourceRef="secondTask" targetRef="theEnd"/>
+        <sequenceFlow id="flow5" sourceRef="secondTimerEvent" targetRef="thirdTask"/>
+        <userTask id="thirdTask" name="Third task"/>
+        <sequenceFlow id="flow6" sourceRef="thirdTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/variables/callActivityWithCalledElementExpression.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/variables/callActivityWithCalledElementExpression.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" targetNamespace="Examples">
+
+    <process id="calledElementExpression">
+
+        <startEvent id="theStart"/>
+        <sequenceFlow id="flow1" sourceRef="theStart" targetRef="firstTask"/>
+        <userTask id="firstTask" name="First task"/>
+        <sequenceFlow id="flow2" sourceRef="firstTask" targetRef="callActivity"/>
+        <callActivity id="callActivity" calledElement="${subProcessDefId}"/>
+        <sequenceFlow id="flow3" sourceRef="callActivity" targetRef="lastTask"/>
+        <userTask id="lastTask" name="Last task"/>
+        <sequenceFlow id="flow4" sourceRef="lastTask" targetRef="theEnd"/>
+        <endEvent id="theEnd"/>
+
+    </process>
+
+</definitions>


### PR DESCRIPTION
Hello, I submitted the function of freely modifying the process,And the relevant unit tests are carried out
This function is officially provided with relevant APIs in both the flowable and camunda versions,

In the Flowable API, this is the case:  eg:   runtimeService.createChangeActivityStateBuilder()
.processInstanceId(processInstanceId)
.moveActivityIdTo(currentActivitiId,targetNodeId)
.changeState();

In the Camunda API, this is the case:  eg:   
runtimeService.createProcessInstanceModification(processInstanceId)
  .startBeforeActivity(targetNodeId)
  .execute();

Activiti lost many users in China because it did not provide this function,
Currently, most of the code is implemented with reference to Flowable,
Of course, in some scenarios, it is different from Flowable
At present, the jump of event subprocess is not supported. 
After next month, I will write the code of relevant functions and conduct unit tests
I hope you can merge my code, thank you