### PR TITLE
DeployCmd.java  orderby qa

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/DeployCmd.java
@@ -63,7 +63,7 @@ public class DeployCmd<T> implements Command<Deployment>, Serializable {
         }
       } else {
         List<Deployment> deploymentList = commandContext.getProcessEngineConfiguration().getRepositoryService().createDeploymentQuery().deploymentName(deployment.getName())
-            .deploymentTenantId(deployment.getTenantId()).orderByDeploymentId().desc().list();
+            .deploymentTenantId(deployment.getTenantId()).orderByDeploymenTime().desc().list();
 
         if (!deploymentList.isEmpty()) {
           existingDeployments.addAll(deploymentList);


### PR DESCRIPTION
When I use StrongUuidGenerator to generate uuid,orderByDeploymentId() may be wrong.
You used orderByDeploymenTime() in [if] at line 60,but used orderByDeploymentId() in [else] at line 66.