### PR TITLE
ReceiveTask.java typo bug

### DIFF
--- a/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ReceiveTask.java
+++ b/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ReceiveTask.java
@@ -23,7 +23,7 @@ public class ReceiveTask extends Task {
     return clone;
   }
 
-  public void setValues(ManualTask otherElement) {
+  public void setValues(ReceiveTask otherElement) {
     super.setValues(otherElement);
   }
 }


### PR DESCRIPTION
Here is a typing error
This is different from common typing errors. The setValues () here will result in calling the methods of the parent class

Although it is intended to call the method of the parent class

eg: In the ManualTask, it calls setValues() of this class first, then uses setValues of this class to call setValues() of the parent class