### PR TITLE
#4134 - publish candidate starters events only when enabled

### DIFF
--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -61,6 +61,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
@@ -219,6 +220,7 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
 
     @Bean
     @ConditionalOnMissingBean
+    @ConditionalOnProperty("activiti.candidateStarters.enabled")
     public ProcessCandidateStartersEventProducer processCandidateStartersEventProducer(RepositoryService repositoryService,
                                                                                        @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessCandidateStarterUserAddedEvent>> candidateStarterUserListeners,
                                                                                        @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessCandidateStarterGroupAddedEvent>> candidateStarterGroupListeners) {

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessCandidateStarterEventIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessCandidateStarterEventIT.java
@@ -25,6 +25,7 @@ import org.activiti.spring.boot.process.listener.ProcessCandidateStarterUserRemo
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.List;
 
@@ -33,6 +34,7 @@ import static org.assertj.core.groups.Tuple.tuple;
 
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@TestPropertySource(properties = "activiti.candidateStarters.enabled=true")
 public class ProcessCandidateStarterEventIT {
 
     @Autowired


### PR DESCRIPTION
#4134 
Don't publish events if `activiti.candidateStarters.enabled` is `false`