### PR TITLE
Candidate starters publish events

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ProcessCandidateStarterGroupAddedEvents.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ProcessCandidateStarterGroupAddedEvents.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.event.impl;
+
+import org.activiti.api.process.runtime.events.ProcessCandidateStarterGroupAddedEvent;
+
+import java.util.List;
+
+public class ProcessCandidateStarterGroupAddedEvents {
+
+    private List<ProcessCandidateStarterGroupAddedEvent> events;
+
+    public ProcessCandidateStarterGroupAddedEvents(List<ProcessCandidateStarterGroupAddedEvent> events) {
+        this.events = events;
+    }
+
+    public List<ProcessCandidateStarterGroupAddedEvent> getEvents() {
+        return events;
+    }
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ProcessCandidateStarterUserAddedEvents.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ProcessCandidateStarterUserAddedEvents.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.api.runtime.event.impl;
+
+import org.activiti.api.process.runtime.events.ProcessCandidateStarterUserAddedEvent;
+
+import java.util.List;
+
+public class ProcessCandidateStarterUserAddedEvents {
+
+    private List<ProcessCandidateStarterUserAddedEvent> events;
+
+    public ProcessCandidateStarterUserAddedEvents(List<ProcessCandidateStarterUserAddedEvent> events) {
+        this.events = events;
+    }
+
+    public List<ProcessCandidateStarterUserAddedEvent> getEvents() {
+        return events;
+    }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -221,8 +221,12 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     @ConditionalOnMissingBean
     public ProcessCandidateStartersEventProducer processCandidateStartersEventProducer(RepositoryService repositoryService,
                                                                                        @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessCandidateStarterUserAddedEvent>> candidateStarterUserListeners,
-                                                                                       @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessCandidateStarterGroupAddedEvent>> candidateStarterGroupListeners) {
-        return new ProcessCandidateStartersEventProducer(repositoryService, candidateStarterUserListeners, candidateStarterGroupListeners);
+                                                                                       @Autowired(required = false) List<ProcessRuntimeEventListener<ProcessCandidateStarterGroupAddedEvent>> candidateStarterGroupListeners,
+                                                                                       ApplicationEventPublisher eventPublisher) {
+        return new ProcessCandidateStartersEventProducer(repositoryService,
+                                                         candidateStarterUserListeners,
+                                                         candidateStarterGroupListeners,
+                                                         eventPublisher);
     }
 
     @Bean

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/listener/ProcessCandidateStarterGroupAddedListener.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/listener/ProcessCandidateStarterGroupAddedListener.java
@@ -18,6 +18,8 @@ package org.activiti.spring.boot.process.listener;
 import org.activiti.api.process.model.ProcessCandidateStarterGroup;
 import org.activiti.api.process.runtime.events.ProcessCandidateStarterGroupAddedEvent;
 import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
+import org.activiti.api.runtime.event.impl.ProcessCandidateStarterGroupAddedEvents;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import java.util.List;
 public class ProcessCandidateStarterGroupAddedListener implements ProcessRuntimeEventListener<ProcessCandidateStarterGroupAddedEvent> {
 
     private List<ProcessCandidateStarterGroup> candidateStarterGroups = new ArrayList<>();
+    private ProcessCandidateStarterGroupAddedEvents events;
 
     @Override
     public void onEvent(ProcessCandidateStarterGroupAddedEvent event) {
@@ -35,6 +38,15 @@ public class ProcessCandidateStarterGroupAddedListener implements ProcessRuntime
 
     public List<ProcessCandidateStarterGroup> getCandidateStarterGroups() {
         return candidateStarterGroups;
+    }
+
+    @EventListener
+    public void publishedEvent(ProcessCandidateStarterGroupAddedEvents events) {
+        this.events = events;
+    }
+
+    public ProcessCandidateStarterGroupAddedEvents getPublishedEvents() {
+        return events;
     }
 
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/listener/ProcessCandidateStarterUserAddedListener.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/listener/ProcessCandidateStarterUserAddedListener.java
@@ -18,6 +18,8 @@ package org.activiti.spring.boot.process.listener;
 import org.activiti.api.process.model.ProcessCandidateStarterUser;
 import org.activiti.api.process.runtime.events.ProcessCandidateStarterUserAddedEvent;
 import org.activiti.api.process.runtime.events.listener.ProcessRuntimeEventListener;
+import org.activiti.api.runtime.event.impl.ProcessCandidateStarterUserAddedEvents;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -27,6 +29,7 @@ import java.util.List;
 public class ProcessCandidateStarterUserAddedListener implements ProcessRuntimeEventListener<ProcessCandidateStarterUserAddedEvent> {
 
     private List<ProcessCandidateStarterUser> candidateStarterUsers = new ArrayList<>();
+    private ProcessCandidateStarterUserAddedEvents events;
 
     @Override
     public void onEvent(ProcessCandidateStarterUserAddedEvent event) {
@@ -35,6 +38,15 @@ public class ProcessCandidateStarterUserAddedListener implements ProcessRuntimeE
 
     public List<ProcessCandidateStarterUser> getCandidateStarterUsers() {
         return candidateStarterUsers;
+    }
+
+    @EventListener
+    public void publishedEvents(ProcessCandidateStarterUserAddedEvents events) {
+        this.events = events;
+    }
+
+    public ProcessCandidateStarterUserAddedEvents getPublishedEvents() {
+        return events;
     }
 
 }


### PR DESCRIPTION
Add ability to publish candidate starters events as list of events. 

Will follow up with a PR on activiti-cloud to fix propagation on 
https://github.com/Activiti/activiti-cloud-application/pull/844 caused by query service not receiving candidate starters events (no process definitions will be returned if no candidate starter is linked to it)