### PR TITLE
AAE-11508 produce the application rollback event when the application has been rolled back

### DIFF
--- a/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/events/ApplicationEvent.java
+++ b/activiti-api/activiti-api-process-model/src/main/java/org/activiti/api/process/model/events/ApplicationEvent.java
@@ -23,6 +23,7 @@ public interface ApplicationEvent extends
         RuntimeEvent<Deployment, ApplicationEvents> {
 
     enum ApplicationEvents {
-        APPLICATION_DEPLOYED
+        APPLICATION_DEPLOYED,
+        APPLICATION_ROLLBACK
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ApplicationDeployedEventImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-model-impl/src/main/java/org/activiti/api/runtime/event/impl/ApplicationDeployedEventImpl.java
@@ -22,12 +22,19 @@ import org.activiti.api.process.model.events.ApplicationEvent;
 public class ApplicationDeployedEventImpl extends RuntimeEventImpl<Deployment, ApplicationEvent.ApplicationEvents>
         implements ApplicationDeployedEvent {
 
+    private final ApplicationEvents eventType;
+
     public ApplicationDeployedEventImpl(Deployment entity) {
+        this(entity, ApplicationEvents.APPLICATION_DEPLOYED);
+    }
+
+    public ApplicationDeployedEventImpl(Deployment entity, ApplicationEvents eventType) {
         super(entity);
+        this.eventType = eventType;
     }
 
     @Override
     public ApplicationEvents getEventType() {
-        return ApplicationEvents.APPLICATION_DEPLOYED;
+        return eventType;
     }
 }


### PR DESCRIPTION
When runtime bundle starts, if the property activiti.deploy.after-rollback (or the the env var ACTIVITI_CLOUD_APPLICATION_NAME) has been set to true, it produce an APPLICATION_ROLLBACK event in place of an APPLICATION_DEPLOYED event.

Ref. https://github.com/Activiti/Activiti/issues/4195