### PR TITLE
Methods to check for error boundary events

### DIFF
--- a/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/BoundaryEvent.java
+++ b/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/BoundaryEvent.java
@@ -48,6 +48,15 @@ public class BoundaryEvent extends Event {
     this.cancelActivity = cancelActivity;
   }
 
+  public boolean hasErrorEventDefinition() {
+    if(this.eventDefinitions != null && !this.eventDefinitions.isEmpty()){
+      return this.eventDefinitions.stream().anyMatch(eventDefinition ->
+        ErrorEventDefinition.class.isInstance(eventDefinition)
+      );
+    }
+    return false;
+  }
+
   public BoundaryEvent clone() {
     BoundaryEvent clone = new BoundaryEvent();
     clone.setValues(this);

--- a/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ServiceTask.java
+++ b/activiti-core/activiti-bpmn-model/src/main/java/org/activiti/bpmn/model/ServiceTask.java
@@ -100,6 +100,15 @@ public class ServiceTask extends TaskWithFieldExtensions {
     this.skipExpression = skipExpression;
   }
 
+  public boolean hasBoundaryErrorEvents() {
+    if (this.boundaryEvents != null && !this.boundaryEvents.isEmpty()) {
+      return this.boundaryEvents.stream().anyMatch(boundaryEvent ->
+        boundaryEvent.hasErrorEventDefinition()
+      );
+    }
+    return false;
+  }
+
   public ServiceTask clone() {
     ServiceTask clone = new ServiceTask();
     clone.setValues(this);

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.bpmn.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
@@ -1,0 +1,38 @@
+package org.activiti.bpmn.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+public class BoundaryEventTest {
+
+    @Test
+    public void hasErrorEventDefinition_should_returnTrue_when_hasAnErrorEvent() {
+        // given
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new ErrorEventDefinition()));
+
+        // then
+        assertThat(boundaryEvent.hasErrorEventDefinition()).isTrue();
+    }
+
+    @Test
+    public void hasErrorEventDefinition_should_returnFalse_when_empty() {
+        // given
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+
+        // then
+        assertThat(boundaryEvent.hasErrorEventDefinition()).isFalse();
+    }
+
+    @Test
+    public void hasErrorEventDefinition_should_returnFalse_when_doesNotContainErrorEvent() {
+        // given
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new MessageEventDefinition()));
+
+        // then
+        assertThat(boundaryEvent.hasErrorEventDefinition()).isFalse();
+    }
+}

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.activiti.bpmn.model;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
@@ -1,0 +1,53 @@
+package org.activiti.bpmn.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class ServiceTaskTest {
+
+    @Test
+    public void hasBoundaryErrorEvents_should_returnTrue_when_hasAnErrorBoundaryEvent() {
+        // given
+        ServiceTask serviceTask = new ServiceTask();
+        serviceTask.setBoundaryEvents(createErrorBoundaryEvents());
+
+        // then
+        assertThat(serviceTask.hasBoundaryErrorEvents()).isTrue();
+    }
+
+    @Test
+    public void hasErrorEventDefinition_should_returnFalse_when_hasNoBoundaryEvent() {
+        // given
+        ServiceTask serviceTask = new ServiceTask();
+
+        // then
+        assertThat(serviceTask.hasBoundaryErrorEvents()).isFalse();
+    }
+
+    @Test
+    public void hasErrorEventDefinition_should_returnFalse_when_doesNotHaveAnErrorBoundaryEvent() {
+        // given
+        ServiceTask serviceTask = new ServiceTask();
+        serviceTask.setBoundaryEvents(createNoErrorBoundaryEvents());
+
+        // then
+        assertThat(serviceTask.hasBoundaryErrorEvents()).isFalse();
+    }
+
+    private List<BoundaryEvent> createErrorBoundaryEvents() {
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new ErrorEventDefinition()));
+
+        return Arrays.asList(boundaryEvent);
+    }
+
+    private List<BoundaryEvent> createNoErrorBoundaryEvents() {
+        BoundaryEvent boundaryEvent = new BoundaryEvent();
+        boundaryEvent.setEventDefinitions(Arrays.asList(new MessageEventDefinition()));
+
+        return Arrays.asList(boundaryEvent);
+    }
+}


### PR DESCRIPTION
This PR introduces two new methods:

- `BoundaryEvent.hasErrorEventDefinition()`: checks if the boundary event contains an `ErrorEventDefinition`
- `ServiceTask.hasBoundaryErrorEvents()`: checks if the service task contains a boundary error event

It is part of the solution for Activiti/Activiti#4184.