### PR TITLE
AAE-12101 publish only one event for the latest version

### DIFF
--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/ApplicationDeployedEventProducerTest.java
@@ -92,6 +92,7 @@ public class ApplicationDeployedEventProducerTest {
                                                      mock(Deployment.class));
 
         given(deploymentQuery.deploymentName(APPLICATION_DEPLOYMENT_NAME)).willReturn(deploymentQuery);
+        given(deploymentQuery.latestVersion()).willReturn(deploymentQuery);
         given(deploymentQuery.list()).willReturn(internalDeployment);
 
         List<org.activiti.api.process.model.Deployment> apiDeployments= asList(


### PR DESCRIPTION
In the previous version the RB was producing 1 event for each deployed version, while we need to produce only one for the latest version.

Ref: https://github.com/Activiti/Activiti/issues/4209