### PR TITLE
fix/MNT-23416_boundary_event_sub_subprocess

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/DelegateExecution.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/DelegateExecution.java
@@ -44,6 +44,12 @@ public interface DelegateExecution extends VariableScope {
    */
   String getRootProcessInstanceId();
 
+    /**
+     * Determines if the current execution is the root one
+     * @return true if the current execution is the root one; false otherwise
+     */
+    boolean isRootExecution();
+
   /**
    * Will contain the event name in case this execution is passed in for an {@link ExecutionListener}.
    */

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImpl.java
@@ -496,7 +496,12 @@ public class ExecutionEntityImpl extends VariableScopeImpl implements ExecutionE
     this.rootProcessInstanceId = rootProcessInstanceId;
   }
 
-  // scopes ///////////////////////////////////////////////////////////////////
+    @Override
+    public boolean isRootExecution() {
+        return id != null && id.equals(rootProcessInstanceId);
+    }
+
+    // scopes ///////////////////////////////////////////////////////////////////
 
   public boolean isScope() {
     return isScope;

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImplTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.persistence.entity;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ExecutionEntityImplTest {
+
+    public static final String ROOT_ID = "rootId";
+
+    @Test
+    public void isRootExecution_should_returnTrue_whenIdIsSameAsRoot() {
+        final ExecutionEntityImpl executionEntity = new ExecutionEntityImpl();
+        executionEntity.setId(ROOT_ID);
+        executionEntity.setRootProcessInstanceId(ROOT_ID);
+
+        assertThat(executionEntity.isRootExecution()).isTrue();
+
+    }
+
+    @Test
+    public void isRootExecution_should_returnFalse_whenIdIsNotSameAsRoot() {
+        final ExecutionEntityImpl executionEntity = new ExecutionEntityImpl();
+        executionEntity.setId("anotherId");
+        executionEntity.setRootProcessInstanceId(ROOT_ID);
+
+        assertThat(executionEntity.isRootExecution()).isFalse();
+
+    }
+
+    @Test
+    public void isRootExecution_should_returnFalse_whenIdIsNull() {
+        final ExecutionEntityImpl executionEntity = new ExecutionEntityImpl();
+        executionEntity.setId(null);
+
+        assertThat(executionEntity.isRootExecution()).isFalse();
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -212,6 +212,24 @@ public class BoundaryErrorEventTest extends PluggableActivitiTestCase {
     assertProcessEnded(procId);
   }
 
+    @Deployment(resources = { "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parent.bpmn20.xml",
+        "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml" })
+    public void testCatchErrorOnCallActivityWithSubprocess() {
+        String procId = runtimeService.startProcessInstanceByKey("catchErrorOnCallActivity").getId();
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("Task in subprocess");
+
+        // Completing the task will reach the end error event,
+        // which is caught on the call activity boundary
+        taskService.complete(task.getId());
+        task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("Escalated Task");
+
+        // Completing the task will end the process instance
+        taskService.complete(task.getId());
+        assertProcessEnded(procId);
+    }
+
   @Deployment(resources = { "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess.bpmn20.xml" })
   public void testUncaughtError() {
     runtimeService.startProcessInstanceByKey("simpleSubProcess");

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
@@ -10,7 +10,9 @@
 
     <subProcess id="subprocessThrowsError">
       <startEvent id="subprocessStart"/>
-      <sequenceFlow id="subprocessFlow1" sourceRef="subprocessStart" targetRef="subprocessErrorEnd"/>
+      <userTask id="taskInSubprocess" name="Task in subprocess" />
+      <sequenceFlow id="subprocessFlow1" sourceRef="subprocessStart" targetRef="taskInSubprocess"/>
+      <sequenceFlow id="subprocessFlow2" sourceRef="taskInSubprocess" targetRef="subprocessErrorEnd"/>
       <endEvent id="subprocessErrorEnd">
         <errorEventDefinition errorRef="myError" />
       </endEvent>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="simpleSubProcess">
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="subprocessThrowsError" />
+
+    <subProcess id="subprocessThrowsError">
+      <startEvent id="subprocessStart"/>
+      <sequenceFlow id="subprocessFlow1" sourceRef="subprocessStart" targetRef="subprocessErrorEnd"/>
+      <endEvent id="subprocessErrorEnd">
+        <errorEventDefinition errorRef="myError" />
+      </endEvent>
+    </subProcess>
+
+    <sequenceFlow id="flow2" sourceRef="subprocessThrowsError" targetRef="theEnd"/>
+    <endEvent id="theEnd"/>
+
+    <boundaryEvent id="catchEvent" attachedToRef="subprocessThrowsError">
+      <errorEventDefinition errorRef="myError" />
+    </boundaryEvent>
+    <sequenceFlow id="flow3" sourceRef="catchEvent" targetRef="theErrorEnd"/>
+
+    <endEvent id="theErrorEnd">
+      <errorEventDefinition errorRef="myError" />
+    </endEvent>
+  </process>
+
+</definitions>


### PR DESCRIPTION
…own by a subprocess within a subprocess

The end error event raised in simple subprocess is not propagating to parent call activity execution because of the same error id used in both processes. This PR fixes the edge case to try propagating the error event for call activity.

![image](https://user-images.githubusercontent.com/20428629/220362393-c6494380-78e8-455b-bda8-26148a556fdf.png)

![image](https://user-images.githubusercontent.com/20428629/220362428-1e85064b-20f0-40d2-a763-c7d4b239466d.png)

