### PR TITLE
AAE-12742 update batik from 1.14 to 1.16

### DIFF
--- a/activiti-core/pom.xml
+++ b/activiti-core/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <name>Activiti :: Core :: Parent</name>
   <properties>
-    <batik.version>1.14</batik.version>
+    <batik.version>1.16</batik.version>
     <commons-email.version>1.5</commons-email.version>
     <commons-io.version>2.11.0</commons-io.version>
     <jakarta-enterprise-concurrent.version>1.1.2</jakarta-enterprise-concurrent.version>


### PR DESCRIPTION
https://github.com/Activiti/Activiti/issues/4253

We should update batik to 1.16 in order to fix known vulnerabilities: CVE-2022-41704, CVE-2022-40146, CVE-2022-38648, CVE-2022-38398.