### PR TITLE
Expressions should be evaluated once a variable is created

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/conf/ProcessRuntimeAutoConfiguration.java
@@ -255,11 +255,13 @@ public class ProcessRuntimeAutoConfiguration {
     public ProcessVariablesInitiator processVariablesInitiator(ProcessExtensionService processExtensionService,
                                                                VariableParsingService variableParsingService,
                                                                VariableValidationService variableValidationService,
-                                                               ExtensionsVariablesMappingProvider mappingProvider) {
+                                                               ExtensionsVariablesMappingProvider mappingProvider,
+                                                               ExpressionResolver expressionResolver) {
         return new ProcessVariablesInitiator(processExtensionService,
                                              variableParsingService,
                                              variableValidationService,
-                                             mappingProvider);
+                                             mappingProvider,
+                                             expressionResolver);
     }
 
     @Bean

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/CompositeVariableExpressionEvaluator.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/CompositeVariableExpressionEvaluator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.runtime.api.impl;
+
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.delegate.Expression;
+import org.activiti.engine.impl.el.ExpressionManager;
+import org.activiti.engine.impl.interceptor.DelegateInterceptor;
+
+public class CompositeVariableExpressionEvaluator implements ExpressionEvaluator {
+
+    private SimpleMapExpressionEvaluator simpleMapExpressionEvaluator;
+    private VariableScopeExpressionEvaluator variableScopeExpressionEvaluator;
+
+    public CompositeVariableExpressionEvaluator(SimpleMapExpressionEvaluator simpleMapExpressionEvaluator,
+                                                VariableScopeExpressionEvaluator variableScopeExpressionEvaluator) {
+        this.simpleMapExpressionEvaluator = simpleMapExpressionEvaluator;
+        this.variableScopeExpressionEvaluator = variableScopeExpressionEvaluator;
+    }
+
+    @Override
+    public Object evaluate(Expression expression,
+        ExpressionManager expressionManager,
+        DelegateInterceptor delegateInterceptor) {
+        try {
+            return simpleMapExpressionEvaluator.evaluate(expression, expressionManager, delegateInterceptor);
+        } catch (ActivitiException activitiException) {
+            return variableScopeExpressionEvaluator.evaluate(expression, expressionManager, delegateInterceptor);
+        }
+    }
+
+}

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExpressionResolver.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExpressionResolver.java
@@ -114,9 +114,8 @@ public class ExpressionResolver {
             return expressionEvaluator.evaluate(expressionManager.createExpression(sourceString), expressionManager,
                 delegateInterceptor);
         } catch (final Exception e) {
-            logger.warn("Unable to resolve expression in variables, keeping original value",
-                        e);
-            return sourceString;
+            logger.warn("Unable to resolve expression in variables", e);
+            return null;
         }
     }
 
@@ -133,8 +132,8 @@ public class ExpressionResolver {
                 matcher.appendReplacement(sb,
                                           Objects.toString(value));
             } catch (final Exception e) {
-                logger.warn("Unable to resolve expression in variables, keeping original value",
-                            e);
+                logger.warn("Unable to resolve expression in variables", e);
+                matcher.appendReplacement(sb, "");
             }
         }
         matcher.appendTail(sb);

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -173,19 +173,25 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
                                                    Map<String, Object> availableVariables,
                                                    Map<String, Object> outboundVariables) {
         if (mappingExecutionContext.hasExecution()) {
-            if (availableVariables != null && !availableVariables.isEmpty()) {
-                return expressionResolver.resolveExpressionsMap(
-                    new CompositeVariableExpressionEvaluator(
-                        new SimpleMapExpressionEvaluator(availableVariables),
-                        new VariableScopeExpressionEvaluator(mappingExecutionContext.getExecution())),
-                        outboundVariables);
-            }
-            return expressionResolver.resolveExpressionsMap(
-                new VariableScopeExpressionEvaluator(mappingExecutionContext.getExecution()), outboundVariables);
+            return resolveExecutionExpressions(mappingExecutionContext, availableVariables, outboundVariables);
         } else {
             return expressionResolver.resolveExpressionsMap(
                 new SimpleMapExpressionEvaluator(availableVariables), outboundVariables);
         }
+    }
+
+    private Map<String, Object> resolveExecutionExpressions(MappingExecutionContext mappingExecutionContext,
+                                                            Map<String, Object> availableVariables,
+                                                            Map<String, Object> outboundVariables) {
+        if (availableVariables != null && !availableVariables.isEmpty()) {
+            return expressionResolver.resolveExpressionsMap(
+                new CompositeVariableExpressionEvaluator(
+                    new SimpleMapExpressionEvaluator(availableVariables),
+                    new VariableScopeExpressionEvaluator(mappingExecutionContext.getExecution())),
+                outboundVariables);
+        }
+        return expressionResolver.resolveExpressionsMap(
+            new VariableScopeExpressionEvaluator(mappingExecutionContext.getExecution()), outboundVariables);
     }
 
     private boolean isTargetProcessVariableDefined(Extension extensions,

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -73,7 +73,9 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         }
 
         if (extensions.shouldMapAllInputs(execution.getCurrentActivityId())) {
-            return execution.getVariables();
+            Map<String, Object> variables = new HashMap<>(constants);
+            variables.putAll(execution.getVariables());
+            return variables;
         }
 
         Map<String, Object> inboundVariables = calculateInputVariables(execution, extensions);

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ExpressionResolverTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ExpressionResolverTest.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.activiti.engine.ActivitiException;
@@ -215,7 +216,7 @@ public class ExpressionResolverTest {
     }
 
     @Test
-    public void resolveExpressionsMap_should_keepExpressionContent_when_notAbleToResolveExpressionInString() {
+    public void resolveExpressionsMap_should_removeExpressionContent_when_notAbleToResolveExpressionInString() {
         //given
         Expression expression = buildExpression("${nonResolvableExpression}");
         given(expressionEvaluator.evaluate(expression, expressionManager, delegateInterceptor)).willThrow(new ActivitiException("Invalid property"));
@@ -224,11 +225,11 @@ public class ExpressionResolverTest {
         Map<String, Object> result = expressionResolver.resolveExpressionsMap(expressionEvaluator,
                                                                               singletonMap("result", "Welcome to ${nonResolvableExpression}!"));
         //then
-        assertThat(result).containsEntry("result", "Welcome to ${nonResolvableExpression}!");
+        assertThat(result).containsEntry("result", "Welcome to !");
     }
 
     @Test
-    public void resolveExpressionsMap_should_keepExpressionContent_when_notAbleToResolveIt() {
+    public void resolveExpressionsMap_should_removeExpressionContent_when_notAbleToResolveIt() {
         //given
         Expression expression = buildExpression("${nonResolvableExpression}");
         given(expressionEvaluator.evaluate(expression, expressionManager, delegateInterceptor)).willThrow(new ActivitiException("Invalid property"));
@@ -237,8 +238,7 @@ public class ExpressionResolverTest {
         Map<String, Object> result = expressionResolver.resolveExpressionsMap(expressionEvaluator,
                                                                               singletonMap("result", "${nonResolvableExpression}"));
         //then
-        assertThat(result).containsEntry("result",
-                                         "${nonResolvableExpression}");
+        assertThat(result).containsEntry("result", null);
 
     }
 
@@ -269,7 +269,7 @@ public class ExpressionResolverTest {
 
     @Test
     public void
-           resolveExpressionsMap_should_keepExpressionContent_when_ObjecNodeContainsAnExpressionUnableToBeResolved() throws IOException {
+           resolveExpressionsMap_should_removeExpressionContent_when_ObjecNodeContainsAnExpressionUnableToBeResolved() throws IOException {
         //given
         Expression nameExpression = buildExpression("${name}");
         given(expressionEvaluator.evaluate(nameExpression, expressionManager, delegateInterceptor)).willThrow(new ActivitiException("Invalid property"));
@@ -281,7 +281,7 @@ public class ExpressionResolverTest {
                                                                               singletonMap("node", node));
         //then
         assertThat(result).containsEntry("node", map(
-            "name", "${name}",
+            "name", null,
             "age", 30
         ));
     }
@@ -305,7 +305,7 @@ public class ExpressionResolverTest {
     }
 
     @Test
-    public void resolveExpressionsMap_should_keepExpressionContent_when_ListContainsAnExpressionUnableToBeResolved() {
+    public void resolveExpressionsMap_should_removeExpressionContent_when_ListContainsAnExpressionUnableToBeResolved() {
         //given
         Expression placeExpression = buildExpression("${place}");
         given(expressionEvaluator.evaluate(placeExpression, expressionManager, delegateInterceptor)).willThrow(new ActivitiException("Invalid property"));
@@ -318,7 +318,7 @@ public class ExpressionResolverTest {
                                                                                                                      "Berlin")));
         //then
         assertThat(result).containsEntry("places",
-                                         asList("${place}",
+                                         asList(null,
                                                        "Paris",
                                                        "Berlin"));
     }
@@ -349,7 +349,7 @@ public class ExpressionResolverTest {
     }
 
     @Test
-    public void resolveExpressionsMap_should_keepExpressionContent_when_MapContainsAnExpressionUnableToBeResolved() {
+    public void resolveExpressionsMap_should_removeExpressionContent_when_MapContainsAnExpressionUnableToBeResolved() {
         //given
 
         Expression playerExpression = buildExpression("${player}");
@@ -366,8 +366,11 @@ public class ExpressionResolverTest {
         Map<String, Object> result = expressionResolver.resolveExpressionsMap(expressionEvaluator,
                                                                               singletonMap("players",players));
 
+        Map<String, Object> expectedResult = new HashMap<>(players);
+        expectedResult.put("Yellow", null);
+
         //then
-        assertThat(result).containsEntry("players", players);
+        assertThat(result).containsEntry("players", expectedResult);
     }
 
     private Expression buildExpression(String expressionContent) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/expressions/expression-in-mapping-all-output-value.json
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/resources/expressions/expression-in-mapping-all-output-value.json
@@ -1,0 +1,69 @@
+{
+  "id": "taskVarMapping",
+  "extensions": {
+    "Process_expressionMappingOutputValue": {
+      "properties": {
+        "variable-1-id": {
+          "id": "variable-1-id",
+          "name": "process_variable_1",
+          "type": "string",
+          "required": true,
+          "value": "variable_value_1"
+        },
+        "variable-2-id": {
+          "id": "variable-2-id",
+          "name": "process_variable_2",
+          "type": "string",
+          "required": true,
+          "value": "variable_value_2"
+        },
+        "variable-3-id": {
+          "id": "variable-3-id",
+          "name": "process_variable_3",
+          "type": "string",
+          "required": false
+        },
+        "variable-4-id": {
+          "id": "variable-4-id",
+          "name": "process_variable_4",
+          "type": "string",
+          "required": false
+        }
+      },
+      "mappings": {
+        "simpleTask": {
+          "inputs": {
+            "task_input_variable_name_1": {
+              "type": "VARIABLE",
+              "value": "process_variable_1"
+            },
+            "task_input_variable_name_2": {
+              "type": "VALUE",
+              "value": "static_value_1"
+            }
+          },
+          "outputs": {
+            "process_variable_3": {
+              "type": "VARIABLE",
+              "value": "task_input_variable_name_1"
+            },
+            "process_variable_4": {
+              "type": "VALUE",
+              "value": "${task_input_variable_name_2}"
+            }
+          }
+        }
+      },
+      "constants": {
+        "simpleTask": {
+          "process_constant_1": {
+            "value": "constant_1_value"
+          },
+          "process_constant_2": {
+            "value": "constant_2_value"
+          }
+        }
+      }
+    }
+  }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeVariableMappingTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeVariableMappingTest.java
@@ -24,7 +24,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.ProcessInstance;
@@ -87,15 +86,14 @@ public class ProcessRuntimeVariableMappingTest {
 
         List<VariableInstance> variables = processBaseRuntime.getProcessVariablesByProcessId(processInstance.getId());
 
-        String[] array = {"first", "${name}", "${surname}", "last"};
+        String[] array = {"first", "John", "Doe", "last"};
         List<String> list = asList(array);
 
-        Map<String, Object> dataMap = new HashMap<>();
-        dataMap.put("age-in-months", "${age * 12}");
-        dataMap.put("full-name", "${name} ${surname}");
-        dataMap.put("demoString", "expressionResolved");
-        dataMap.put("list", list);
-        JsonNode data = mapper.convertValue(dataMap, JsonNode.class);
+        Map<String, Object> data = new HashMap<>();
+        data.put("age-in-months", 240);
+        data.put("full-name", "John Doe");
+        data.put("demoString", "expressionResolved");
+        data.put("list", list);
 
         assertThat(variables).extracting(VariableInstance::getName,
                                          VariableInstance::getValue)
@@ -105,11 +103,11 @@ public class ProcessRuntimeVariableMappingTest {
                                            tuple("surname", "Doe"),
                                            tuple("data", data),
                                            tuple("user-msg",
-                                                 "Hello ${name.concat(' ').concat(surname)}, today is your ${age}th birthday! It means ${age * 365.25} days of life"),
-                                           tuple("input-unmapped-variable-with-matching-name", "${surname}"),
+                                                 "Hello John Doe, today is your 20th birthday! It means 7305.0 days of life"),
+                                           tuple("input-unmapped-variable-with-matching-name", "Doe"),
                                            tuple("input-unmapped-variable-with-non-matching-connector-input-name",
                                                  "inTestExpression"),
-                                           tuple("variableToResolve", "${name}"),
+                                           tuple("variableToResolve", "John"),
                                            tuple("out-unmapped-variable-matching-name", "defaultExpression"),
                                            tuple("output-unmapped-variable-with-non-matching-connector-output-name",
                                                  "defaultExpression"),

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/tasks/TaskRuntimeVariableMappingIT.java
@@ -58,6 +58,7 @@ public class TaskRuntimeVariableMappingIT {
     private static final String TASK_ASSIGNEE_SEQUENTIAL_MAP_ALL = "taskAssigneeSequentialMapAll";
 
     private static final String TASK_ASSIGNEE_MULTI_INSTANCE_MAPPING = "taskMultiInstanceVariableMapping";
+    private static final String TASK_EXPRESSION_MAPPING = "taskExpressionMapping";
 
     private static final String ASSIGNEE_VARIABLE_NAME = "sys_task_assignee";
 
@@ -709,6 +710,39 @@ public class TaskRuntimeVariableMappingIT {
         assertThat(tasks).isNotEmpty();
         assertThat(tasks).hasSize(size);
         return tasks;
+    }
+
+    @Test
+    public void should_evaluateToNull_when_expressionIsNotResolvable() {
+        ProcessInstance processInstance = processBaseRuntime.startProcessWithProcessDefinitionKey(TASK_EXPRESSION_MAPPING);
+
+        Task task = checkTasks(processInstance.getId());
+
+        // input mapping
+        List<VariableInstance> taskVariables = taskBaseRuntime.getTasksVariablesByTaskId(task.getId());
+        assertThat(taskVariables)
+            .isNotNull()
+            .extracting(VariableInstance::getName,
+                VariableInstance::getValue)
+            .containsOnly(
+                tuple("inValue", "varValue"),
+                tuple("inNull", null)
+            );
+
+        taskBaseRuntime.completeTask(task, Map.of("mapped", "mappedValue"));
+
+        // output mapping
+        List<VariableInstance> procVariables = processBaseRuntime.getProcessVariablesByProcessId(processInstance.getId());
+        assertThat(procVariables)
+            .isNotNull()
+            .extracting(VariableInstance::getName,
+                VariableInstance::getValue)
+            .containsOnly(
+                tuple("initVar", "varValue"),
+                tuple("outValue", "varValue"),
+                tuple("outNull", null),
+                tuple("outMapped", "mappedValue")
+            );
     }
 
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/initial-vars-expressions-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/initial-vars-expressions-extensions.json
@@ -1,0 +1,39 @@
+{
+  "id":"initialVarsExpressionModel",
+  "type":"PROCESS",
+  "name":"initialVarsExpression",
+  "extensions":{
+    "initialVarsExpression":{
+      "properties":{
+        "15932631-5073-43e6-80f6-8e30a6ba2bfa":{
+          "id":"15932631-5073-43e6-80f6-8e30a6ba2bfa",
+          "name":"initVarWithExpressionInString",
+          "type":"string",
+          "required":false,
+          "value":"start var is ${startVariable} and defined var is ${definedVar} and undefinedVar is ${undefinedVar}"
+        },
+        "15932631-5073-43e6-80f6-8e30a6ba2bfb":{
+          "id":"15932631-5073-43e6-80f6-8e30a6ba2bfb",
+          "name":"initVarWithExpression",
+          "type":"string",
+          "required":false,
+          "value":"${startVariable}"
+        },
+        "15932631-5073-43e6-80f6-8e30a6ba2bfc":{
+          "id":"15932631-5073-43e6-80f6-8e30a6ba2bfc",
+          "name":"definedVar",
+          "type":"string",
+          "required":false,
+          "value":"predefinedVarValue"
+        },
+        "15932631-5073-43e6-80f6-8e30a6ba2bfd":{
+          "id":"15932631-5073-43e6-80f6-8e30a6ba2bfd",
+          "name":"initVarWithUnresolvableExpression",
+          "type":"string",
+          "required":false,
+          "value":"${unresolvableExpression}"
+        }
+      }
+    }
+  }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/initial-vars-expressions.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/initial-vars-expressions.bpmn20.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:activiti="http://activiti.org/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-1135af1e-9be8-45ae-b245-f4e7a503c056" name="initVar" targetNamespace="" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="initialVarsExpression" name="initialVarsExpression" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_1kldzot</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1kldzot" sourceRef="Event_1" targetRef="Task_0tmjndw" />
+    <bpmn2:sequenceFlow id="SequenceFlow_176fzau" sourceRef="Task_0tmjndw" targetRef="EndEvent_0hiossh" />
+    <bpmn2:userTask id="Task_0tmjndw" activiti:assignee="${initiator}" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_1kldzot</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_176fzau</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="EndEvent_0hiossh">
+      <bpmn2:incoming>SequenceFlow_176fzau</bpmn2:incoming>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="initialVarsExpression">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kldzot_di" bpmnElement="SequenceFlow_1kldzot">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="500" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_176fzau_di" bpmnElement="SequenceFlow_176fzau">
+        <di:waypoint x="600" y="258" />
+        <di:waypoint x="682" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1pl83mi_di" bpmnElement="Task_0tmjndw">
+        <dc:Bounds x="500" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0hiossh_di" bpmnElement="EndEvent_0hiossh">
+        <dc:Bounds x="682" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-expression-mapping-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-expression-mapping-extensions.json
@@ -1,0 +1,64 @@
+{
+  "id":"taskExpressionMappingModel",
+  "type":"PROCESS",
+  "name":"Task Expression Mapping",
+  "extensions":{
+    "taskExpressionMapping":{
+      "mappings":{
+        "Task_0z87dw7":{
+          "inputs": {
+            "inNull": {
+              "type": "VALUE",
+              "value": "${notDefined}"
+            },
+            "inValue": {
+            "type": "VALUE",
+            "value": "${initVar}"
+            }
+          },
+          "outputs": {
+            "outNull": {
+              "type": "VALUE",
+              "value": "${notDefined}"
+            },
+            "outValue": {
+              "type": "VALUE",
+              "value": "${initVar}"
+            },
+            "outMapped": {
+              "type": "VALUE",
+              "value": "${mapped}"
+            }
+          }
+        }
+      },
+      "properties":{
+        "81d12b0c-a95a-4879-a36c-7d40f121cef1":{
+          "id":"81d12b0c-a95a-4879-a36c-7d40f121cef1",
+          "name":"initVar",
+          "type":"string",
+          "required":false,
+          "value": "varValue"
+        },
+        "81d12b0c-a95a-4879-a36c-7d40f121cef2":{
+          "id":"81d12b0c-a95a-4879-a36c-7d40f121cef2",
+          "name":"outValue",
+          "type":"string",
+          "required":false
+        },
+        "81d12b0c-a95a-4879-a36c-7d40f121cef3":{
+          "id":"81d12b0c-a95a-4879-a36c-7d40f121cef3",
+          "name":"outNull",
+          "type":"string",
+          "required":false
+        },
+        "81d12b0c-a95a-4879-a36c-7d40f121cef4":{
+          "id":"81d12b0c-a95a-4879-a36c-7d40f121cef4",
+          "name":"outMapped",
+          "type":"string",
+          "required":false
+        }
+      }
+    }
+  }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-expression-mapping.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-expression-mapping.bpmn20.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:activiti="http://activiti.org/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-1a45cd5c-4fd2-415c-861b-b48c2673e964" name="aprocess" targetNamespace="" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="taskExpressionMapping" name="Task Expression Mapping" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_0dtaz2b</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0dtaz2b" sourceRef="Event_1" targetRef="Task_0z87dw7" />
+    <bpmn2:userTask id="Task_0z87dw7" name="task1" activiti:assignee="${initiator}" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_0dtaz2b</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1to4xff</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="EndEvent_0c918f9">
+      <bpmn2:incoming>SequenceFlow_1e2yoks</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1to4xff" sourceRef="Task_0z87dw7" targetRef="Task_1ovvo6f" />
+    <bpmn2:sequenceFlow id="SequenceFlow_1e2yoks" sourceRef="Task_1ovvo6f" targetRef="EndEvent_0c918f9" />
+    <bpmn2:userTask id="Task_1ovvo6f" name="wait" activiti:assignee="${initiator}" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_1to4xff</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1e2yoks</bpmn2:outgoing>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="taskExpressionMapping">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dtaz2b_di" bpmnElement="SequenceFlow_0dtaz2b">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="500" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1mg3y4i_di" bpmnElement="Task_0z87dw7">
+        <dc:Bounds x="500" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0c918f9_di" bpmnElement="EndEvent_0c918f9">
+        <dc:Bounds x="812" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1to4xff_di" bpmnElement="SequenceFlow_1to4xff">
+        <di:waypoint x="600" y="258" />
+        <di:waypoint x="660" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e2yoks_di" bpmnElement="SequenceFlow_1e2yoks">
+        <di:waypoint x="760" y="258" />
+        <di:waypoint x="812" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1mdb1ku_di" bpmnElement="Task_1ovvo6f">
+        <dc:Bounds x="660" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-mapping-all-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-mapping-all-extensions.json
@@ -1,0 +1,30 @@
+{
+  "id":"taskExpressionMappingAllModel",
+  "type":"PROCESS",
+  "name":"Task Mapping All",
+  "extensions":{
+    "taskExpressionMappingAll":{
+      "mappings":{
+        "Task_0z87dw7":{
+          "mappingType": "MAP_ALL"
+        }
+      },
+      "properties":{
+        "81d12b0c-a95a-4879-a36c-7d40f121cef1":{
+          "id":"81d12b0c-a95a-4879-a36c-7d40f121cef1",
+          "name":"name",
+          "type":"string",
+          "required":false,
+          "value": "inName"
+        }
+      },
+      "constants": {
+        "Task_0z87dw7": {
+          "_constant_value_": {
+            "value": "myConstantValue"
+          }
+        }
+      }
+    }
+  }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-mapping-all.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/task-mapping-all.bpmn20.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:activiti="http://activiti.org/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="model-1a45cd5c-4fd2-415c-861b-b48c2673e964" name="aprocess" targetNamespace="" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd">
+  <bpmn2:process id="taskExpressionMappingAll" name="Task Mapping All" isExecutable="true">
+    <bpmn2:documentation />
+    <bpmn2:startEvent id="Event_1">
+      <bpmn2:outgoing>SequenceFlow_0dtaz2b</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_0dtaz2b" sourceRef="Event_1" targetRef="Task_0z87dw7" />
+    <bpmn2:userTask id="Task_0z87dw7" name="task1" activiti:assignee="${initiator}" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_0dtaz2b</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1to4xff</bpmn2:outgoing>
+    </bpmn2:userTask>
+    <bpmn2:endEvent id="EndEvent_0c918f9">
+      <bpmn2:incoming>SequenceFlow_1e2yoks</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_1to4xff" sourceRef="Task_0z87dw7" targetRef="Task_1ovvo6f" />
+    <bpmn2:sequenceFlow id="SequenceFlow_1e2yoks" sourceRef="Task_1ovvo6f" targetRef="EndEvent_0c918f9" />
+    <bpmn2:userTask id="Task_1ovvo6f" name="wait" activiti:assignee="${initiator}" activiti:priority="0">
+      <bpmn2:incoming>SequenceFlow_1to4xff</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_1e2yoks</bpmn2:outgoing>
+    </bpmn2:userTask>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="taskExpressionMapping">
+      <bpmndi:BPMNShape id="_BPMNShape_Event_2" bpmnElement="Event_1">
+        <dc:Bounds x="412" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dtaz2b_di" bpmnElement="SequenceFlow_0dtaz2b">
+        <di:waypoint x="448" y="258" />
+        <di:waypoint x="500" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1mg3y4i_di" bpmnElement="Task_0z87dw7">
+        <dc:Bounds x="500" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0c918f9_di" bpmnElement="EndEvent_0c918f9">
+        <dc:Bounds x="812" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1to4xff_di" bpmnElement="SequenceFlow_1to4xff">
+        <di:waypoint x="600" y="258" />
+        <di:waypoint x="660" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e2yoks_di" bpmnElement="SequenceFlow_1e2yoks">
+        <di:waypoint x="760" y="258" />
+        <di:waypoint x="812" y="258" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="UserTask_1mdb1ku_di" bpmnElement="Task_1ovvo6f">
+        <dc:Bounds x="660" y="218" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>


### PR DESCRIPTION
- Updated `expressionResolver` to resolve expressions and not leave expressions unresolved. Resulting to no expressions being saved in variables.
- Fixed `Expressions are not allowed as variable values in the output mapping` not being thrown when `ALL` mapping type is used.
- Process initial variables are resolved before starting the process.
- Expressions in process instance variables value are no longer resolved.

Note while I don't think we still need the exception throwing when an expression text is submitted by user i.e. start process payload or as outbound variables of tasks/connectors, I left them as they are for now. In such cases submitted text will handled as simple text and never evaluated.

refs: #4294 , AAE-11481