### PR TITLE
Removed alias table name from the Oracle DB script

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.6001.to.6002.engine.sql
@@ -211,4 +211,4 @@ alter table ACT_RU_EXECUTION add ID_LINK_COUNT_ INTEGER;
 
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
-update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+update ACT_RU_EXECUTION set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=ACT_RU_EXECUTION.PROC_INST_ID_);


### PR DESCRIPTION
I created this PR to remove Alias table name from the Oracle DB script as it was creating problem. So did changes in Oracle DB script. It solves https://github.com/Activiti/Activiti/issues/4328