### PR TITLE
MNT-23813: endEventListener of an userTask is triggered if attached b…

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/TakeOutgoingSequenceFlowsOperation.java
@@ -34,7 +34,6 @@ import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.delegate.event.ActivitiEventType;
 import org.activiti.engine.delegate.event.impl.ActivitiEventBuilder;
 import org.activiti.engine.impl.Condition;
-import org.activiti.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
 import org.activiti.engine.impl.bpmn.behavior.MultiInstanceActivityBehavior;
 import org.activiti.engine.impl.bpmn.helper.SkipExpressionUtil;
 import org.activiti.engine.impl.context.Context;
@@ -110,6 +109,8 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
         // hence the check for NOT being a process instance
         if (!execution.isProcessInstanceType()) {
 
+            handleBoundaryEvent(flowNode);
+
             if (CollectionUtil.isNotEmpty(flowNode.getExecutionListeners())) {
                 executeExecutionListeners(flowNode,
                                           ExecutionListener.EVENTNAME_END);
@@ -133,6 +134,7 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
                      flowNode.getClass(),
                      flowNode.getId(),
                      flowNode.getOutgoingFlows().size());
+
 
         // Get default sequence flow (if set)
         String defaultSequenceFlowId = null;
@@ -373,5 +375,15 @@ public class TakeOutgoingSequenceFlowsOperation extends AbstractOperation {
             }
         }
         return true;
+    }
+
+    private void handleBoundaryEvent(FlowNode flowNode) {
+        if (flowNode instanceof BoundaryEvent) {
+            BoundaryEvent event = (BoundaryEvent) flowNode;
+            final Activity activity = event.getAttachedToRef();
+            if (CollectionUtil.isNotEmpty(activity.getExecutionListeners())) {
+                executeExecutionListeners(activity, ExecutionListener.EVENTNAME_END);
+            }
+        }
     }
 }

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testTimerOnUserTask.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/timer/BoundaryTimerEventTest.testTimerOnUserTask.bpmn20.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:activiti="http://activiti.org/bpmn"
+	targetNamespace="Examples">
+
+	<process id="testExpressionOnTimerWithExecutionListeners">
+
+		<startEvent id="theStart" />
+		<sequenceFlow id="theStart_task" sourceRef="theStart" targetRef="task" />
+    <userTask id="task" name="Task rigged with timer">
+      <extensionElements>
+        <activiti:executionListener event="end" class="org.activiti.engine.test.bpmn.event.timer.BoundaryTimerEventTest$MyExecutionListener" />
+      </extensionElements>
+    </userTask>
+		<sequenceFlow id="task_theEnd" sourceRef="task" targetRef="theEnd" />
+
+		<boundaryEvent id="boundaryTimer" cancelActivity="true" attachedToRef="task">
+			<timerEventDefinition>
+			  <timeDuration>${duration}</timeDuration>
+			</timerEventDefinition>
+		</boundaryEvent>
+
+    <sequenceFlow id="boundaryTimer_theEnd" sourceRef="boundaryTimer" targetRef="theEnd" />
+
+		<endEvent id="theEnd" />
+
+	</process>
+
+</definitions>


### PR DESCRIPTION
…… (#4413)

* MNT-23813: endEventListener of an userTask is triggered if attached boundaryEvent is executed

* move to boundary event handling to handleActivityEnd

* minor style change

---------

Co-authored-by: Bassam Al-Sarori <2126270+balsarori@users.noreply.github.com>
(cherry picked from commit e4fd4a2470ce7bdf59ee2c10b14392eb102219d4)