### PR TITLE
AAE-16060 avoid triggering  Create Pre-release workflow on rc tag [skip ci]

### DIFF
--- a/.github/workflows/create-github-prerelease.yaml
+++ b/.github/workflows/create-github-prerelease.yaml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 jobs:
   create-prerelease:


### PR DESCRIPTION
This is to prevent creating Github pre-release on matching `rc` tag regex