### PR TITLE
Backporting changes of ACTIVITI-1291 added involvedGroupsIn() query capability for ProcessQuery (both HistoricProcessInstanceQuery & ProcessInstanceQuery in develop branch

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstanceQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/history/HistoricProcessInstanceQuery.java
@@ -333,4 +333,9 @@ public interface HistoricProcessInstanceQuery extends Query<HistoricProcessInsta
    * Instruct localization to fallback to more general locales including the default locale of the JVM if the specified locale is not found.
    */
   HistoricProcessInstanceQuery withLocalizationFallback();
+
+    /**
+     * Only select the historic process instances with which the given groups are involved.
+     */
+  HistoricProcessInstanceQuery involvedGroupsIn(List<String> involvedGroups);
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ExecutionQueryImpl.java
@@ -79,6 +79,7 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
   protected String involvedUser;
   protected Set<String> processDefinitionKeys;
   protected Set<String> processDefinitionIds;
+  protected List<String> involvedGroups;
 
   // Not exposed in API, but here for the ProcessInstanceQuery support, since
   // the name lives on the
@@ -604,5 +605,12 @@ public class ExecutionQueryImpl extends AbstractVariableQueryImpl<ExecutionQuery
 
   public void setStartedBy(String startedBy) {
     this.startedBy = startedBy;
+  }
+
+  public List<String> getInvolvedGroups() {
+    return involvedGroups;
+  }
+  public void setInvolvedGroups(List<String> involvedGroups) {
+    this.involvedGroups = involvedGroups;
   }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/HistoricProcessInstanceQueryImpl.java
@@ -84,6 +84,7 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   protected List<HistoricProcessInstanceQueryImpl> orQueryObjects = new ArrayList<HistoricProcessInstanceQueryImpl>();
   protected HistoricProcessInstanceQueryImpl currentOrQueryObject = null;
   protected boolean inOrStatement = false;
+  protected List<String> involvedGroups;
 
   public HistoricProcessInstanceQueryImpl() {
   }
@@ -791,4 +792,23 @@ public class HistoricProcessInstanceQueryImpl extends AbstractVariableQueryImpl<
   public List<HistoricProcessInstanceQueryImpl> getOrQueryObjects() {
     return orQueryObjects;
   }
+
+  public List<String> getInvolvedGroups() {
+    return involvedGroups;
+  }
+
+  public HistoricProcessInstanceQuery involvedGroupsIn(List<String> involvedGroups) {
+    if (involvedGroups == null || involvedGroups.isEmpty()) {
+      throw new ActivitiIllegalArgumentException("Involved groups list is null or empty.");
+    }
+
+    if (inOrStatement) {
+      this.currentOrQueryObject.involvedGroups = involvedGroups;
+    } else {
+      this.involvedGroups = involvedGroups;
+    }
+    return this;
+  }
+
+
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/ProcessInstanceQueryImpl.java
@@ -95,6 +95,7 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
   protected boolean onlyProcessInstanceExecutions;
   protected boolean onlySubProcessExecutions;
   protected String rootProcessInstanceId;
+  protected List<String> involvedGroups;
 
   public ProcessInstanceQueryImpl() {
   }
@@ -865,5 +866,22 @@ public class ProcessInstanceQueryImpl extends AbstractVariableQueryImpl<ProcessI
 
   public void setStartedBy(String startedBy) {
     this.startedBy = startedBy;
+  }
+
+  public List<String> getInvolvedGroups() {
+    return involvedGroups;
+  }
+
+  public ProcessInstanceQuery involvedGroupsIn(List<String> involvedGroups) {
+    if (involvedGroups == null || involvedGroups.isEmpty()) {
+      throw new ActivitiIllegalArgumentException("Involved groups list is null or empty.");
+    }
+
+    if (inOrStatement) {
+      this.currentOrQueryObject.involvedGroups = involvedGroups;
+    } else {
+      this.involvedGroups = involvedGroups;
+    }
+    return this;
   }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstanceQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/runtime/ProcessInstanceQuery.java
@@ -338,4 +338,9 @@ public interface ProcessInstanceQuery extends Query<ProcessInstanceQuery, Proces
    * Order by tenant id (needs to be followed by {@link #asc()} or {@link #desc()}).
    */
   ProcessInstanceQuery orderByTenantId();
+
+    /**
+     * Select the process instances with which the given groups are involved.
+     */
+  ProcessInstanceQuery involvedGroupsIn(List<String> involvedGroups);
 }

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Execution.xml
@@ -584,6 +584,9 @@
   </sql>
 
   <sql id="commonSelectExecutionsByQueryCriteriaSql">
+    <if test="involvedGroups != null">
+      inner join ${prefix}ACT_RU_IDENTITYLINK I on I.PROC_INST_ID_ = RES.ID_
+    </if>
     <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
       <choose>
         <when test="queryVariableValue.local">
@@ -595,6 +598,9 @@
       </choose>
     </foreach>
     <foreach collection="orQueryObjects" index="orIndex" item="orQueryObject">
+      <if test="orQueryObject.involvedGroups != null">
+        left join ${prefix}ACT_RU_IDENTITYLINK I_OR${orIndex} on I_OR${orIndex}.PROC_INST_ID_ = RES.ID_
+      </if>
       <if test="orQueryObject.processDefinitionId != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionVersion != null || orQueryObject.processDefinitionCategory != null || orQueryObject.processDefinitionName != null || (orQueryObject.processDefinitionIds != null &amp;&amp; !orQueryObject.processDefinitionIds.isEmpty()) || (orQueryObject.processDefinitionKeys != null &amp;&amp; !orQueryObject.processDefinitionKeys.isEmpty())">
         inner join ${prefix}ACT_RE_PROCDEF P_OR${orIndex} on RES.PROC_DEF_ID_ = P_OR${orIndex}.ID_
       </if>
@@ -735,6 +741,17 @@
       </if>
       <if test="involvedUser != null">
         and EXISTS(select ID_ from ${prefix}ACT_RU_IDENTITYLINK I where I.PROC_INST_ID_ = RES.ID_ and I.USER_ID_ = #{involvedUser})
+      </if>
+      <if test="involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+        and
+        (
+        I.TYPE_ = 'participant'
+        and
+        I.GROUP_ID_ IN
+        <foreach item="group" index="index" collection="involvedGroups" open="(" separator="," close=")">
+          #{group}
+        </foreach>
+        )
       </if>
       <!-- PLEASE NOTE: If you change anything have a look into the HistoricVariableInstance & HistoricProcessInstance, the same query object is used there! -->
       <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
@@ -907,6 +924,16 @@
           </if>
           <if test="orQueryObject.involvedUser != null">
             or EXISTS(select ID_ from ${prefix}ACT_RU_IDENTITYLINK I where I.PROC_INST_ID_ = RES.ID_ and I.USER_ID_ = #{orQueryObject.involvedUser})
+          </if>
+          <if test="orQueryObject.involvedGroups != null &amp;&amp; orQueryObject.involvedGroups.size() &gt; 0">
+            or (
+            I_OR${orIndex}.TYPE_ = 'participant'
+            and
+            I_OR${orIndex}.GROUP_ID_ IN
+            <foreach item="group" index="index" collection="orQueryObject.involvedGroups" open="(" separator="," close=")">
+              #{group}
+            </foreach>
+            )
           </if>
           <if test="orQueryObject.startedBy != null">
             or RES.START_USER_ID_ = #{orQueryObject.startedBy}

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -352,10 +352,16 @@
   </sql>
 
   <sql id="commonSelectHistoricProcessInstancesByQueryCriteriaSql">
+    <if test="involvedGroups != null">
+      inner join ${prefix}ACT_HI_IDENTITYLINK I on I.PROC_INST_ID_ = RES.ID_
+    </if>
     <foreach collection="queryVariableValues" index="index" item="queryVariableValue">
       inner join ${prefix}ACT_HI_VARINST  A${index} on RES.PROC_INST_ID_ = A${index}.PROC_INST_ID_
     </foreach>
     <foreach collection="orQueryObjects" index="orIndex" item="orQueryObject">
+      <if test="orQueryObject.involvedGroups != null">
+        left join ${prefix}ACT_HI_IDENTITYLINK I_OR${orIndex} on I_OR${orIndex}.PROC_INST_ID_ = RES.ID_
+      </if>
       <if test="orQueryObject.processKeyNotIn != null || orQueryObject.processDefinitionKey != null || orQueryObject.processDefinitionCategory != null || orQueryObject.processDefinitionName != null || orQueryObject.processDefinitionVersion != null || (orQueryObject.processDefinitionKeyIn != null &amp;&amp; orQueryObject.processDefinitionKeyIn.size() &gt; 0)">
         inner join ${prefix}ACT_RE_PROCDEF DEF_OR${orIndex} on RES.PROC_DEF_ID_ = DEF_OR${orIndex}.ID_
       </if>
@@ -449,6 +455,17 @@
       <if test="involvedUser != null">
         and (
           exists(select LINK.USER_ID_ from ${prefix}ACT_HI_IDENTITYLINK LINK where USER_ID_ = #{involvedUser} and LINK.PROC_INST_ID_ = RES.ID_)
+        )
+      </if>
+      <if test="involvedGroups != null &amp;&amp; involvedGroups.size() &gt; 0">
+        and
+        (
+        I.TYPE_ = 'participant'
+        and
+        I.GROUP_ID_ IN
+        <foreach item="group" index="index" collection="involvedGroups" open="(" separator="," close=")">
+          #{group}
+        </foreach>
         )
       </if>
       <if test="startedBy != null">
@@ -620,6 +637,16 @@
           <if test="orQueryObject.involvedUser != null">
             or (
               exists(select LINK.USER_ID_ from ${prefix}ACT_HI_IDENTITYLINK LINK where USER_ID_ = #{orQueryObject.involvedUser} and LINK.PROC_INST_ID_ = RES.ID_)
+            )
+          </if>
+          <if test="orQueryObject.involvedGroups != null &amp;&amp; orQueryObject.involvedGroups.size() &gt; 0">
+            or (
+            I_OR${orIndex}.TYPE_ = 'participant'
+            and
+            I_OR${orIndex}.GROUP_ID_ IN
+            <foreach item="group" index="index" collection="orQueryObject.involvedGroups" open="(" separator="," close=")">
+              #{group}
+            </foreach>
             )
           </if>
           <if test="orQueryObject.startedBy != null">

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryGroupInvolvementTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryGroupInvolvementTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.history;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+public class HistoricProcessInstanceQueryGroupInvolvementTest extends PluggableActivitiTestCase {
+
+    protected void setUp() throws Exception {
+        super.setUp();
+        repositoryService.createDeployment().addClasspathResource("org/activiti/engine/test/api/history/HistoricProcessInstanceQueryGroupInvolvementTest.bpmn20.xml").deploy();
+
+        ProcessInstance processInstance0 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+        runtimeService.addParticipantGroup(processInstance0.getId(), "group1");
+
+        ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+        runtimeService.addParticipantGroup(processInstance1.getId(), "group1");
+        runtimeService.addParticipantGroup(processInstance1.getId(), "group2");
+
+        ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+        runtimeService.addParticipantUser(processInstance2.getId(), "kermit");
+        List<Task> taskList = taskService.createTaskQuery().list();
+        for (Task task : taskList) {
+            taskService.complete(task.getId());
+        }
+    }
+
+    protected void tearDown() throws Exception {
+        for (org.activiti.engine.repository.Deployment deployment : repositoryService.createDeploymentQuery().list()) {
+            repositoryService.deleteDeployment(deployment.getId(), true);
+        }
+        super.tearDown();
+    }
+
+    public void testGroupInvolvementWithProcessInstance() {
+        List<String> groupList = new ArrayList<String>();
+        groupList.add("group1");
+        groupList.add("group2");
+        //Assert group and user involvement query is working
+        assertThat(historyService.createHistoricProcessInstanceQuery().or().involvedUser("kermit").involvedGroupsIn(groupList).endOr().count()).isEqualTo(3L);
+        //Assert group only involvement query working
+        assertThat( historyService.createHistoricProcessInstanceQuery().involvedGroupsIn(groupList).count()).isEqualTo(2L);
+        //Assert user only involvement query working
+        assertThat( historyService.createHistoricProcessInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+    }
+
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/InstanceInvolvementTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/InstanceInvolvementTest.java
@@ -27,7 +27,7 @@ import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.task.IdentityLink;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
-
+import java.util.ArrayList;
 /**
 
  */
@@ -152,5 +152,61 @@ public class InstanceInvolvementTest extends PluggableActivitiTestCase {
     }
     return false;
   }
+    /**
+     * Group Involvement Tests Start
+     */
 
+  @Deployment(resources={ "org/activiti/engine/test/api/runtime/groupInvolvementProcess.bpmn20.xml" })
+  public void testGroupInvolvementWithProcessInstance() {
+    ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+
+    // Add 2 links of a different type for the same user
+    runtimeService.addParticipantGroup(processInstance.getId(), "group1");
+    List<String> groupList = new ArrayList<String>();
+    groupList.add("group1");
+    groupList.add("group2");
+    groupList.add("group3");
+    assertThat( runtimeService.createProcessInstanceQuery().involvedGroupsIn(groupList).count()).isEqualTo(1L);
+  }
+
+  @Deployment(resources={ "org/activiti/engine/test/api/runtime/groupInvolvementProcess.bpmn20.xml" })
+  public void testMultipleGroupInvolvementWithProcessInstance() {
+    ProcessInstance processInstance0 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+    // Add 2 links of a different type for the same user
+    runtimeService.addParticipantGroup(processInstance0.getId(), "group1");
+    ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+    runtimeService.addParticipantGroup(processInstance1.getId(), "group1");
+    runtimeService.addParticipantGroup(processInstance1.getId(), "group2");
+
+    ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+    runtimeService.addParticipantGroup(processInstance2.getId(), "group3");
+    List<String> groupList = new ArrayList<String>();
+    groupList.add("group1");
+    groupList.add("group2");
+    groupList.add("group3");
+    assertThat( runtimeService.createProcessInstanceQuery().involvedGroupsIn(groupList).count()).isEqualTo(3L);
+  }
+
+  @Deployment(resources={ "org/activiti/engine/test/api/runtime/groupInvolvementProcess.bpmn20.xml" })
+  public void testMultipleGroupAndUserInvolvementWithProcessInstance() {
+  ProcessInstance processInstance0 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+  runtimeService.addParticipantGroup(processInstance0.getId(), "group1");
+
+  ProcessInstance processInstance1 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+  runtimeService.addParticipantGroup(processInstance1.getId(), "group1");
+  runtimeService.addParticipantGroup(processInstance1.getId(), "group2");
+
+  ProcessInstance processInstance2 = runtimeService.startProcessInstanceByKey("groupInvolvementProcess");
+  runtimeService.addParticipantUser(processInstance2.getId(), "kermit");
+  List<String> groupList = new ArrayList<String>();
+  groupList.add("group1");
+  groupList.add("group2");
+  assertThat( runtimeService.createProcessInstanceQuery().or().involvedUser("kermit").involvedGroupsIn(groupList).endOr().count()).isEqualTo(3L);
+  assertThat( runtimeService.createProcessInstanceQuery().involvedGroupsIn(groupList).count()).isEqualTo(2L);
+  assertThat( runtimeService.createProcessInstanceQuery().involvedUser("kermit").count()).isEqualTo(1L);
+  }
+
+    /**
+     * Group Involvement Tests End
+     */
 }

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryGroupInvolvementTest.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/history/HistoricProcessInstanceQueryGroupInvolvementTest.bpmn20.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="groupInvolvementProcess" name="groupInvolvementProcess">
+    <documentation>Historic Process Description</documentation>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theProcessTask" />
+    <userTask id="theProcessTask" name="my process task" />
+    <sequenceFlow id="flow2" sourceRef="theProcessTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/groupInvolvementProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/api/runtime/groupInvolvementProcess.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="org.activiti.enginge.test.api.runtime.Category">
+
+  <process id="groupInvolvementProcess" name="groupInvolvementProcess">
+    <extensionElements>
+      <activiti:localization locale="es" name="Nombre del proceso">
+        <activiti:documentation>Descripción del proceso</activiti:documentation>
+      </activiti:localization>
+    </extensionElements>
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="theTask" />
+    <userTask id="theTask" name="my task" />
+    <sequenceFlow id="flow2" sourceRef="theTask" targetRef="theEnd" />
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
Porting the changes from 5.x for the ACTIVITI ticket https://alfresco.atlassian.net/browse/ACTIVITI-1291
and pointing to the Original merged PR https://github.com/Activiti/Activiti/pull/1386/files