### PR TITLE
MNT-23965: added .getEngineServices() to execution to allow Activiti5…

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/DelegateExecution.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/DelegateExecution.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 import org.activiti.bpmn.model.ActivitiListener;
 import org.activiti.bpmn.model.FlowElement;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.impl.context.Context;
 
 /**
  * Execution used in {@link JavaDelegate}s and {@link ExecutionListener}s.
@@ -115,7 +117,7 @@ public interface DelegateExecution extends VariableScope {
   /* Execution management */
 
   /**
-   * returns the parent of this execution, or null if there no parent.
+   * returns the parent of this execution, or null if there's no parent.
    */
   DelegateExecution getParent();
 
@@ -181,5 +183,9 @@ public interface DelegateExecution extends VariableScope {
    * @param isMultiInstanceRoot
    */
   void setMultiInstanceRoot(boolean isMultiInstanceRoot);
+
+  default ProcessEngineConfiguration getEngineServices() {
+      return Context.getProcessEngineConfiguration();
+  }
 
 }


### PR DESCRIPTION
…… (#4434)

* MNT-23965: added .getEngineServices() to execution to allow Activiti5 inflight cases

(cherry picked from commit 25542eb1279d562f84c1ee9c934df05932f3ebc1)

**NOTES:**
* This PR is to start discussion about if this change (regarding Activiti-5) should be implemented on Activiti-8