### PR TITLE
ACTIVITI-4981: field "engineVersion" is synced between memory and DB …

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -279,6 +279,7 @@ public class BpmnDeployer implements Deployer {
                 processDefinition.setVersion(persistedProcessDefinition.getVersion());
                 processDefinition.setAppVersion(persistedProcessDefinition.getAppVersion());
                 processDefinition.setSuspensionState(persistedProcessDefinition.getSuspensionState());
+                processDefinition.setEngineVersion(persistedProcessDefinition.getEngineVersion());
             }
         }
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
@@ -48,6 +48,7 @@ public class BpmnDeployerTest {
         persistedProcessDefinition.setId("procId");
         persistedProcessDefinition.setVersion(1);
         persistedProcessDefinition.setAppVersion(2);
+        persistedProcessDefinition.setEngineVersion("activiti-5");
         given(bpmnDeploymentHelper.getPersistedInstanceOfProcessDefinition(parsedProcessDefinition))
             .willReturn(persistedProcessDefinition);
 
@@ -60,7 +61,7 @@ public class BpmnDeployerTest {
         assertThat(parsedProcessDefinition.getVersion()).isEqualTo(persistedProcessDefinition.getVersion());
         assertThat(parsedProcessDefinition.getAppVersion()).isEqualTo(persistedProcessDefinition.getAppVersion());
         assertThat(parsedProcessDefinition.getSuspensionState()).isEqualTo(persistedProcessDefinition.getSuspensionState());
-
+        assertThat(parsedProcessDefinition.getEngineVersion()).isEqualTo(persistedProcessDefinition.getEngineVersion());
     }
 
 }


### PR DESCRIPTION
…(#4497)

(cherry picked from commit 02d7e2db72e7b4cda814740f825ee44446589305)