### PR TITLE
Change varbinary(max) to LONGBLOB for IdentityLink table

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.history.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.history.sql
@@ -132,7 +132,7 @@ create table ACT_HI_IDENTITYLINK (
     USER_ID_ varchar(255),
     TASK_ID_ varchar(64),
     PROC_INST_ID_ varchar(64),
-    DETAILS_ varbinary(max),
+    DETAILS_ LONGBLOB,
     primary key (ID_)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
It fixes syntax error in a MySQL query for ACT_HI_IDENTITYLINK table creation
<!--
You can also link to an open issue here
-->

- Issue Link:
https://alfresco.atlassian.net/browse/ACTIVITI-5007
https://github.com/Activiti/Activiti/issues/4491
<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
