### PR TITLE
Activiti 4935 upgrade apache commons mail in 8.1.x

### DIFF
--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -44,8 +44,14 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-email</artifactId>
-    </dependency>
+      <artifactId>commons-email2-jakarta</artifactId>
+      <version>2.0.0-M1-SNAPSHOT</version>
+      </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-email2-core</artifactId>
+      <version>2.0.0-M1-SNAPSHOT</version>
+     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -52,6 +52,13 @@
       <artifactId>commons-email2-core</artifactId>
       <version>2.0.0-M1-SNAPSHOT</version>
      </dependency>
+<!-- jakarta.mail is transitive dependency commons-email2-jakarta,
+      Hence jakarta.mail dependency can be removed from here, when commons-email2-jakarta is available in maven central -->
+    <dependency>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>jakarta.mail</artifactId>
+      <version>2.0.1</version>
+    </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>

--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -45,12 +45,12 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-email2-jakarta</artifactId>
-      <version>2.0.0-M1-SNAPSHOT</version>
+      <version>2.0.0-M1-20240118.130716-5</version>
       </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-email2-core</artifactId>
-      <version>2.0.0-M1-SNAPSHOT</version>
+      <version>2.0.0-M1-20240118.130716-4</version>
      </dependency>
 <!-- jakarta.mail is transitive dependency commons-email2-jakarta,
       Hence jakarta.mail dependency can be removed from here, when commons-email2-jakarta is available in maven central -->

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MailActivityBehavior.java
@@ -24,7 +24,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.activation.DataSource;
+import jakarta.activation.DataSource;
 import javax.naming.NamingException;
 
 import org.activiti.engine.ActivitiException;
@@ -34,11 +34,11 @@ import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
-import org.apache.commons.mail.Email;
-import org.apache.commons.mail.EmailException;
-import org.apache.commons.mail.HtmlEmail;
-import org.apache.commons.mail.MultiPartEmail;
-import org.apache.commons.mail.SimpleEmail;
+import org.apache.commons.mail2.jakarta.Email;
+import org.apache.commons.mail2.core.EmailException;
+import org.apache.commons.mail2.jakarta.HtmlEmail;
+import org.apache.commons.mail2.jakarta.MultiPartEmail;
+import org.apache.commons.mail2.jakarta.SimpleEmail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -945,6 +945,17 @@ limitations under the License.
         <enabled>false</enabled>
       </snapshots>
     </repository>
+<!--    Added below repository as a temporary measure,
+        It can be removed once commons-email2-* dependencies are added to our repo-->
+    <repository>
+      <id>apache central</id>
+      <name>Central Repository</name>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <url>https://repository.apache.org/content/repositories/snapshots/</url>
+    </repository>
     <repository>
       <id>activiti-releases</id>
       <url>https://artifacts.alfresco.com/nexus/content/repositories/activiti-releases</url>

--- a/pom.xml
+++ b/pom.xml
@@ -948,12 +948,15 @@ limitations under the License.
 <!--    Added below repository as a temporary measure,
         It can be removed once commons-email2-* dependencies are added to our repo-->
     <repository>
-      <id>apache central</id>
-      <name>Central Repository</name>
+      <id>apache central snapshots</id>
+      <name>Central Repository Snapshots</name>
       <layout>default</layout>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
       <url>https://repository.apache.org/content/repositories/snapshots/</url>
     </repository>
     <repository>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: Technical Upgrade

## Description
It includes an upgrade towards jakarta mail
<!--
You can also link to an open issue here
-->

- Issue Link: https://alfresco.atlassian.net/browse/ACTIVITI-4935

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
