### PR TITLE
MNT-24081: executionListeners executed when process instance is deleted

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -425,9 +425,8 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
       return;
     }
 
-      Process process = ProcessDefinitionUtil.getProcess(processInstanceExecutionEntity.getProcessDefinitionId());
-
       // Execute execution listeners for process end.
+      Process process = ProcessDefinitionUtil.getProcess(processInstanceExecutionEntity.getProcessDefinitionId());
       if (CollectionUtil.isNotEmpty(process.getExecutionListeners())) {
           executeExecutionListeners(process,
               processInstanceExecutionEntity,

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/examples/bpmn/executionlistener/ExecutionListenerTest.java
@@ -179,4 +179,23 @@ public class ExecutionListenerTest extends PluggableActivitiTestCase {
     assertThat(recordedEvents.get(1).getParameter()).isEqualTo("Subprocess End");
     assertThat(recordedEvents.get(2).getParameter()).isEqualTo("Process End");
   }
+
+  @Deployment(resources = { "org/activiti/examples/bpmn/executionlistener/ExecutionListenersOnProcessEndWhenProcessIsDeleted.bpmn20.xml" })
+  public void testExecutionListenerOnProcessEndWhenProcessIsDeleted() {
+      RecorderExecutionListener.clear();
+
+      // GIVEN: a process with an executionListener to be executed at the end of the process
+      ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("executionListenersProcess");
+
+      // WHEN: we delete the process
+      runtimeService.deleteProcessInstance(processInstance.getProcessInstanceId(), null);
+
+      // THEN: the process should end and
+      assertProcessEnded(processInstance.getId());
+
+      // THEN: and the executionListener should have run
+      List<RecordedEvent> recordedEvents = RecorderExecutionListener.getRecordedEvents();
+      assertThat(recordedEvents).hasSize(1);
+      assertThat(recordedEvents.get(0).getParameter()).isEqualTo("Process has ended");
+  }
 }

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersOnProcessEndWhenProcessIsDeleted.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/examples/bpmn/executionlistener/ExecutionListenersOnProcessEndWhenProcessIsDeleted.bpmn20.xml
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20240205183454397" modeler:modelId="1" modeler:modelVersion="2" modeler:modelLastUpdated="1706900616725">
+  <process id="executionListenersProcess" isExecutable="true">
+
+    <extensionElements>
+      <activiti:executionListener event="end" class="org.activiti.examples.bpmn.executionlistener.RecorderExecutionListener">
+        <activiti:field name="parameter" stringValue="Process has ended" />
+      </activiti:executionListener>
+    </extensionElements>
+
+    <startEvent id="startEvent"/>
+    <sequenceFlow id="startEvent_userTask" sourceRef="startEvent" targetRef="userTask"/>
+
+    <userTask id="userTask" name="UserTask"/>
+    <sequenceFlow id="userTask_endEvent" sourceRef="userTask" targetRef="endEvent"/>
+
+    <endEvent id="endEvent"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_executionListenersProcess">
+    <bpmndi:BPMNPlane bpmnElement="executionListenersProcess" id="BPMNPlane_executionListenersProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="30.0" y="200.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent" id="BPMNShape_endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="300.0" y="206.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask" id="BPMNShape_userTask">
+        <omgdc:Bounds height="80.0" width="100.0" x="135.0" y="180.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="userTask_endEvent" id="BPMNEdge_userTask_endEvent">
+        <omgdi:waypoint x="235.0" y="220.0"/>
+        <omgdi:waypoint x="300.0" y="220.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="startEvent_userTask" id="BPMNEdge_startEvent_userTask">
+        <omgdi:waypoint x="60.0" y="215.0"/>
+        <omgdi:waypoint x="80.875" y="215.0"/>
+        <omgdi:waypoint x="135.0" y="217.59903961584632"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://alfresco.atlassian.net/browse/MNT-24081

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
