### PR TITLE
MNT-23915: errors thrown in called activities get caught by parent pr…

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/helper/ErrorPropagation.java
@@ -60,7 +60,7 @@ public class ErrorPropagation {
             isCatchExecutedForProcess = executeCatch(eventMap, execution, errorRef);
         }
 
-        if (isCallActivity(execution)) {
+        if (!isCatchExecutedForProcess && isCallActivity(execution)) {
             isCatchExecutedForCallActivity = findCatchingEventsAndExecuteCatchForCallActivity(errorRef, execution);
         }
     } finally {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.java
@@ -214,9 +214,31 @@ public class BoundaryErrorEventTest extends PluggableActivitiTestCase {
 
     @Deployment(resources = { "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parent.bpmn20.xml",
         "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml" })
-    public void testCatchErrorOnCallActivityWithSubprocess() {
+    public void testCatchSpecificErrorOnCallActivityWithSubprocess() {
         String procId = runtimeService.startProcessInstanceByKey("catchErrorOnCallActivity").getId();
+
         Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("Child Error Task");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("Escalated Task");
+
+        // Completing the task will end the process instance
+        taskService.complete(task.getId());
+        assertProcessEnded(procId);
+    }
+
+    @Deployment(resources = { "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parentWithGenericErrorRef.bpmn20.xml",
+        "org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml" })
+    public void testCatchGenericErrorOnCallActivityWithSubprocess() {
+        String procId = runtimeService.startProcessInstanceByKey("catchErrorOnCallActivity").getId();
+
+        Task task = taskService.createTaskQuery().singleResult();
+        assertThat(task.getName()).isEqualTo("Child Error Task");
+        taskService.complete(task.getId());
+
+        task = taskService.createTaskQuery().singleResult();
         assertThat(task.getName()).isEqualTo("Escalated Task");
 
         // Completing the task will end the process instance

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.subprocess2ndLevelThrowsError.bpmn20.xml
@@ -22,7 +22,11 @@
     <boundaryEvent id="catchEvent" attachedToRef="subprocessThrowsError">
       <errorEventDefinition errorRef="myError" />
     </boundaryEvent>
-    <sequenceFlow id="flow3" sourceRef="catchEvent" targetRef="theErrorEnd"/>
+
+    <!-- with userTask after catchEvent -->
+    <userTask id="childErrorUserTask" name="Child Error Task"/>
+    <sequenceFlow id="flow3" sourceRef="catchEvent" targetRef="childErrorUserTask"/>
+    <sequenceFlow id="flow4" sourceRef="childErrorUserTask" targetRef="theErrorEnd"/>
 
     <endEvent id="theErrorEnd">
       <errorEventDefinition errorRef="myError" />

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parentWithGenericErrorRef.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/event/error/BoundaryErrorEventTest.testCatchErrorOnCallActivity-parentWithGenericErrorRef.bpmn20.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definitions"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns:activiti="http://activiti.org/bpmn"
+  targetNamespace="Examples">
+
+  <process id="catchErrorOnCallActivity">
+
+    <startEvent id="theStart" />
+    <sequenceFlow id="flow1" sourceRef="theStart" targetRef="callSubProcess" />
+
+    <callActivity id="callSubProcess" calledElement="simpleSubProcess" />
+
+    <boundaryEvent id="catchError" attachedToRef="callSubProcess">
+      <errorEventDefinition/>
+    </boundaryEvent>
+    <sequenceFlow id="flow3" sourceRef="catchError" targetRef="escalatedTask" />
+
+    <userTask id="escalatedTask" name="Escalated Task" />
+    <sequenceFlow id="flow4" sourceRef="callSubProcess" targetRef="theEnd" />
+
+    <endEvent id="theEnd" />
+
+  </process>
+
+</definitions>


### PR DESCRIPTION
…ocess (#4474)

* Only checks if it's a called activity if there's no catch been executed

Co-authored-by: Bassam Al-Sarori <2126270+balsarori@users.noreply.github.com>
(cherry picked from commit 3c2e714f96e8949599835c703a4fd5d92b8bc3b7)

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://alfresco.atlassian.net/browse/MNT-23915

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
