### PR TITLE
ACTIVITI-4981: field "engineVersion" is synced between memory and DB …

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployer.java
@@ -279,6 +279,7 @@ public class BpmnDeployer implements Deployer {
                 processDefinition.setVersion(persistedProcessDefinition.getVersion());
                 processDefinition.setAppVersion(persistedProcessDefinition.getAppVersion());
                 processDefinition.setSuspensionState(persistedProcessDefinition.getSuspensionState());
+                processDefinition.setEngineVersion(persistedProcessDefinition.getEngineVersion());
             }
         }
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
@@ -48,6 +48,7 @@ public class BpmnDeployerTest {
         persistedProcessDefinition.setId("procId");
         persistedProcessDefinition.setVersion(1);
         persistedProcessDefinition.setAppVersion(2);
+        persistedProcessDefinition.setEngineVersion("activiti-5");
         given(bpmnDeploymentHelper.getPersistedInstanceOfProcessDefinition(parsedProcessDefinition))
             .willReturn(persistedProcessDefinition);
 
@@ -60,7 +61,7 @@ public class BpmnDeployerTest {
         assertThat(parsedProcessDefinition.getVersion()).isEqualTo(persistedProcessDefinition.getVersion());
         assertThat(parsedProcessDefinition.getAppVersion()).isEqualTo(persistedProcessDefinition.getAppVersion());
         assertThat(parsedProcessDefinition.getSuspensionState()).isEqualTo(persistedProcessDefinition.getSuspensionState());
-
+        assertThat(parsedProcessDefinition.getEngineVersion()).isEqualTo(persistedProcessDefinition.getEngineVersion());
     }
 
 }


### PR DESCRIPTION
…(#4497)

(cherry picked from commit 02d7e2db72e7b4cda814740f825ee44446589305)

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://alfresco.atlassian.net/browse/ACTIVITI-4981

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
