### PR TITLE
MNT-24219: local variables before calling subprocess remains after en…

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ContinueProcessOperation.java
@@ -53,6 +53,8 @@ public class ContinueProcessOperation extends AbstractOperation {
 
     private static Logger logger = LoggerFactory.getLogger(ContinueProcessOperation.class);
 
+    private static ExecutionEntityCache executionEntityCache = new ExecutionEntityCacheImpl();
+
     protected boolean forceSynchronousOperation;
     protected boolean inCompensation;
 
@@ -139,6 +141,7 @@ public class ContinueProcessOperation extends AbstractOperation {
         subProcessExecution.setCurrentFlowElement(subProcess);
         subProcessExecution.setScope(true);
 
+        executionEntityCache.put(subProcess, execution);
         commandContext.getExecutionEntityManager().deleteExecutionAndRelatedData(execution, null);
         execution = subProcessExecution;
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ExecutionEntityCache.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ExecutionEntityCache.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.agenda;
+
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+
+import java.util.Map;
+
+public interface ExecutionEntityCache {
+
+    void put(SubProcess subProcess, ExecutionEntity execution);
+
+    Map<String,Object> getVariablesLocal(SubProcess subProcess);
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ExecutionEntityCacheImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/agenda/ExecutionEntityCacheImpl.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.agenda;
+
+import org.activiti.bpmn.model.SubProcess;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ExecutionEntityCacheImpl implements ExecutionEntityCache {
+
+    private static Map<String, Map<String,Object>> variablesLocalCache = new HashMap<>();
+
+
+    @Override
+    public void put(SubProcess subProcess, ExecutionEntity execution) {
+        String key = getKey(subProcess);
+        Map<String,Object> value = execution.getVariablesLocal();
+        variablesLocalCache.put(key, value);
+    }
+
+    @Override
+    public Map<String, Object> getVariablesLocal(SubProcess subProcess) {
+        final String key = getKey(subProcess);
+        return variablesLocalCache.get(key);
+    }
+
+    private String getKey(SubProcess subProcess) {
+        return subProcess.getId();
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.activiti.engine.test.bpmn.subprocess;
+
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.task.Task;
+import org.activiti.engine.task.TaskQuery;
+import org.activiti.engine.test.Deployment;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The goal of these tests is to guarantee localVars defined on parentProcess aren't lost
+ * when calling an embedded subProcess
+ */
+public class LocalVariablesWithSubProcessTest extends PluggableActivitiTestCase {
+
+  @Deployment
+  public void testLocalVariablesAreAvailableAfterSubProcess() {
+      // GIVEN a process that creates a local variable, calls a subprocess and evaluates the initial local variable
+
+      // WHEN process starts
+      runtimeService.startProcessInstanceByKey("simplerProcess");
+
+      // THEN after completing the subprocess, evaluation of the local variable is possible and flow reaches a user task
+      TaskQuery taskQuery = taskService.createTaskQuery();
+      Task taskAfterSubprocess = taskQuery.singleResult();
+      assertThat(taskAfterSubprocess.getName()).isEqualTo("user task");
+
+      // THEN local variable has value set by scriptTask before calling subprocess
+      final Map<String, Object> variablesLocal = runtimeService.getVariablesLocal(taskAfterSubprocess.getExecutionId());
+      assertThat(variablesLocal).hasSize(1);
+      assertThat(variablesLocal.get("httpStatus")).isEqualTo(500);
+  }
+
+    @Deployment
+    public void testLocalVariablesAreAvailableAfterSubProcessParallelGateway() {
+        // GIVEN a process with two parallel flows
+        // GIVEN each flow sets local variables, calls a subprocess and ends with a user task
+
+        // WHEN process starts
+        runtimeService.startProcessInstanceByKey("simplerProcess");
+
+        // THEN after completing subprocesses for each flow and reaching user tasks
+        TaskQuery taskQuery = taskService.createTaskQuery();
+        List<Task> tasks = taskQuery.list();
+        assertThat(tasks).hasSize(2);
+
+        // THEN when reaching userTaskA (flow A), we have 2 local variables
+        Task taskA = tasks.stream().filter(task1 -> task1.getName().equals("user task A")).findFirst().orElseThrow();
+        Map<String, Object> variablesLocalA = runtimeService.getVariablesLocal(taskA.getExecutionId());
+        assertThat(variablesLocalA).hasSize(2);
+        assertThat(variablesLocalA.get("commonLocalVar")).isEqualTo("A1");
+        assertThat(variablesLocalA.get("uniqueLocalVarA")).isEqualTo("A2");
+
+        // THEN when reaching userTaskB (flow B), we have 2 local variables
+        Task taskB = tasks.stream().filter(task1 -> task1.getName().equals("user task B")).findFirst().orElseThrow();
+        Map<String, Object> variablesLocalB = runtimeService.getVariablesLocal(taskB.getExecutionId());
+        assertThat(variablesLocalB).hasSize(2);
+        assertThat(variablesLocalB.get("commonLocalVar")).isEqualTo("B1");
+        assertThat(variablesLocalB.get("uniqueLocalVarB")).isEqualTo("B2");
+    }
+
+    @Deployment
+    public void testLocalVariablesAreAvailableAfterSubProcessWithUserTaskParallelGateway() {
+        // GIVEN a process with two parallel flows
+        // GIVEN each flow sets local variables, calls a subprocess (with an user task) and ends with a user task
+
+        // WHEN process starts
+        runtimeService.startProcessInstanceByKey("simplerProcess");
+
+        // WHEN and we complete the user tasks inside each subprocess
+        TaskQuery taskQuery = taskService.createTaskQuery();
+        List<Task> subProcessUserTasks = taskQuery.list();
+        assertThat(subProcessUserTasks).hasSize(2);
+
+        Task subProcessAUserTask = subProcessUserTasks.stream().filter(task1 -> task1.getName().equals("subProcessA userTask")).findFirst().orElseThrow();
+        final Map<String, Object> variablesLocal_subprocessAUsertask = runtimeService.getVariablesLocal(subProcessAUserTask.getExecutionId());
+        assertThat(variablesLocal_subprocessAUsertask).hasSize(0);
+        taskService.complete(subProcessAUserTask.getId());
+
+        Task subProcessBUserTask = subProcessUserTasks.stream().filter(task1 -> task1.getName().equals("subProcessB userTask")).findFirst().orElseThrow();
+        final Map<String, Object> variablesLocal_subprocessBUsertask = runtimeService.getVariablesLocal(subProcessBUserTask.getExecutionId());
+        assertThat(variablesLocal_subprocessBUsertask).hasSize(0);
+        taskService.complete(subProcessBUserTask.getId());
+
+        // THEN we reach the user tasks on the main process
+        taskQuery = taskService.createTaskQuery();
+        List<Task> mainProcessUserTasks = taskQuery.list();
+        assertThat(mainProcessUserTasks).hasSize(2);
+
+        // THEN when reaching userTaskA (flow A), we have 2 local variables
+        Task mainProcessAUserTask = mainProcessUserTasks.stream().filter(task -> task.getName().equals("user task A")).findFirst().orElseThrow();
+        Map<String, Object> variablesLocalA = runtimeService.getVariablesLocal(mainProcessAUserTask.getExecutionId());
+        assertThat(variablesLocalA).hasSize(2);
+        assertThat(variablesLocalA.get("commonLocalVar")).isEqualTo("A1");
+        assertThat(variablesLocalA.get("uniqueLocalVarA")).isEqualTo("A2");
+
+        // THEN when reaching userTaskB (flow B), we have 2 local variables
+        Task mainProcessBUserTask = mainProcessUserTasks.stream().filter(task -> task.getName().equals("user task B")).findFirst().orElseThrow();
+        Map<String, Object> variablesLocalB = runtimeService.getVariablesLocal(mainProcessBUserTask.getExecutionId());
+        assertThat(variablesLocalB).hasSize(2);
+        assertThat(variablesLocalB.get("commonLocalVar")).isEqualTo("B1");
+        assertThat(variablesLocalB.get("uniqueLocalVarB")).isEqualTo("B2");
+    }
+
+}

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcess.bpmn20.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20240216110429549" modeler:modelId="2" modeler:modelVersion="2" modeler:modelLastUpdated="1708081436130">
+  <process id="simplerProcess" name="simplerProcess" isExecutable="true">
+    <startEvent id="startEvent">
+      <extensionElements>
+        <modeler:editor-resource-id><![CDATA[startEvent1]]></modeler:editor-resource-id>
+      </extensionElements>
+    </startEvent>
+    <scriptTask id="script" name="script" scriptFormat="groovy" activiti:autoStoreVariables="false">
+      <script><![CDATA[execution.setVariableLocal("httpStatus",500);]]></script>
+    </scriptTask>
+    <subProcess id="subprocess" name="subProcess">
+      <startEvent id="subprocess-startEvent"/>
+      <endEvent id="subprocess-endEvent"/>
+      <sequenceFlow id="subprocess-startEvent_endEvent" sourceRef="subprocess-startEvent" targetRef="subprocess-endEvent"/>
+    </subProcess>
+    <exclusiveGateway id="gateway" default="gateway_endEvent"/>
+    <userTask id="userTask" name="user task" activiti:assignee="$INITIATOR"/>
+    <endEvent id="endEvent2"/>
+    <endEvent id="endEvent1"/>
+    <sequenceFlow id="startEvent_script" sourceRef="startEvent" targetRef="script"/>
+    <sequenceFlow id="subProcess_gateway" sourceRef="subprocess" targetRef="gateway"/>
+    <sequenceFlow id="script_subProcess" sourceRef="script" targetRef="subprocess"/>
+    <sequenceFlow id="userTask_endEvent" sourceRef="userTask" targetRef="endEvent1"/>
+    <sequenceFlow id="gateway_userTask" sourceRef="gateway" targetRef="userTask">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(httpStatus!=200)}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="gateway_endEvent" sourceRef="gateway" targetRef="endEvent2"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_simplerProcess">
+    <bpmndi:BPMNPlane bpmnElement="simplerProcess" id="BPMNPlane_simplerProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="210.0" y="157.00000221187435"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="script" id="BPMNShape_script">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess" id="BPMNShape_subprocess">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gateway" id="BPMNShape_gateway">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask" id="BPMNShape_userTask">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent2" id="BPMNShape_endEvent2">
+        <omgdc:Bounds height="28.0" width="28.0" x="809.0000186811809" y="393.00001352483696"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent1" id="BPMNShape_endEvent1">
+        <omgdc:Bounds height="28.0" width="28.0" x="1058.00001289086" y="311.0000040856278"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess-startEvent" id="BPMNShape_subprocess-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess-endEvent" id="BPMNShape_subprocess-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="script_subProcess" id="BPMNEdge_script_subProcess">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gateway_userTask" id="BPMNEdge_gateway_userTask">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gateway_endEvent" id="BPMNEdge_gateway_endEvent">
+        <omgdi:waypoint x="823.382727576" y="344.6172857234228"/>
+        <omgdi:waypoint x="823.0859050137055" y="393.00027697239125"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTask_endEvent" id="BPMNEdge_userTask_endEvent">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="startEvent_script" id="BPMNEdge_startEvent_script">
+        <omgdi:waypoint x="239.99999999999994" y="172.0000034466195"/>
+        <omgdi:waypoint x="315.00000443783705" y="172.00000962034568"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcess_gateway" id="BPMNEdge_subProcess_gateway">
+        <omgdi:waypoint x="738.0000069737439" y="325.00001130148354"/>
+        <omgdi:waypoint x="803.0000110160629" y="325.0000057188352"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subprocess-startEvent_endEvent" id="BPMNEdge_subprocess-startEvent_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcessParallelGateway.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcessParallelGateway.bpmn20.xml
@@ -1,0 +1,141 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20240216110429549" modeler:modelId="2" modeler:modelVersion="2" modeler:modelLastUpdated="1708081436130">
+  <process id="simplerProcess" name="simplerProcess" isExecutable="true">
+    <startEvent id="startEvent">
+      <extensionElements>
+        <modeler:editor-resource-id><![CDATA[startEvent1]]></modeler:editor-resource-id>
+      </extensionElements>
+    </startEvent>
+    <sequenceFlow id="startEvent_gateway" sourceRef="startEvent" targetRef="gatewayEntry"/>
+
+    <parallelGateway id="gatewayEntry"/>
+
+    <!-- branch A -->
+    <sequenceFlow id="gatewayEntry_scriptA" sourceRef="gatewayEntry" targetRef="scriptA"/>
+    <scriptTask id="scriptA" name="scriptA" scriptFormat="groovy">
+      <script><![CDATA[
+      execution.setVariableLocal("commonLocalVar","A1");
+      execution.setVariableLocal("uniqueLocalVarA","A2");
+      ]]></script>
+    </scriptTask>
+    <sequenceFlow id="scriptA_subProcessA" sourceRef="scriptA" targetRef="subProcessA"/>
+    <subProcess id="subProcessA" name="subProcessA">
+      <startEvent id="subProcessA-startEvent"/>
+      <endEvent id="subProcessA-endEvent"/>
+      <sequenceFlow id="subProcessA-startEvent_endEvent" sourceRef="subProcessA-startEvent" targetRef="subProcessA-endEvent"/>
+    </subProcess>
+    <sequenceFlow id="subProcessA_usertaskA" sourceRef="subProcessA" targetRef="userTaskA"/>
+    <userTask id="userTaskA" name="user task A"/>
+    <sequenceFlow id="userTaskA_gatewayExit" sourceRef="userTaskA" targetRef="gatewayExit"/>
+
+    <!-- branch B -->
+    <sequenceFlow id="gatewayEntry_scriptB" sourceRef="gatewayEntry" targetRef="scriptB"/>
+    <scriptTask id="scriptB" name="scriptB" scriptFormat="groovy">
+      <script><![CDATA[
+      execution.setVariableLocal("commonLocalVar","B1");
+      execution.setVariableLocal("uniqueLocalVarB","B2");
+      ]]></script>
+    </scriptTask>
+    <sequenceFlow id="scriptB_subProcessB" sourceRef="scriptB" targetRef="subProcessB"/>
+    <subProcess id="subProcessB" name="subProcessB">
+      <startEvent id="subProcessB-startEvent"/>
+      <endEvent id="subProcessB-endEvent"/>
+      <sequenceFlow id="subProcessB-startEvent_endEvent" sourceRef="subProcessB-startEvent" targetRef="subProcessB-endEvent"/>
+    </subProcess>
+    <sequenceFlow id="subProcessB_usertaskB" sourceRef="subProcessB" targetRef="userTaskB"/>
+    <userTask id="userTaskB" name="user task B"/>
+    <sequenceFlow id="userTaskB_gatewayExit" sourceRef="userTaskB" targetRef="gatewayExit"/>
+
+    <parallelGateway id="gatewayExit"/>
+
+    <sequenceFlow id="gatewayExit_endEvent" sourceRef="gatewayExit" targetRef="endEvent"/>
+    <endEvent id="endEvent"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_simplerProcess">
+    <bpmndi:BPMNPlane bpmnElement="simplerProcess" id="BPMNPlane_simplerProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="210.0" y="157.00000221187435"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="scriptA" id="BPMNShape_scriptA">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="scriptB" id="BPMNShape_scriptB">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA" id="BPMNShape_subProcessA">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB" id="BPMNShape_subProcessB">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gatewayEntry" id="BPMNShape_gatewayEntry">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gatewayExit" id="BPMNShape_gatewayExit">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTaskA" id="BPMNShape_userTaskA">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTaskB" id="BPMNShape_userTaskB">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent" id="BPMNShape_endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="809.0000186811809" y="393.00001352483696"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA-startEvent" id="BPMNShape_subProcessA-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB-startEvent" id="BPMNShape_subProcessB-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA-endEvent" id="BPMNShape_subProcessA-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB-endEvent" id="BPMNShape_subProcessB-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="scriptA_subProcessA" id="BPMNEdge_scriptA_subProcessA">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="scriptB_subProcessB" id="BPMNEdge_scriptB_subProcessB">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayEntry_scriptA" id="BPMNEdge_gatewayEntry_scriptA">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayEntry_scriptB" id="BPMNEdge_gatewayEntry_scriptB">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayExit_endEvent" id="BPMNEdge_gatewayExit_endEvent">
+        <omgdi:waypoint x="823.382727576" y="344.6172857234228"/>
+        <omgdi:waypoint x="823.0859050137055" y="393.00027697239125"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTaskA_gatewayExit" id="BPMNEdge_userTaskA_gatewayExit">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTaskB_gatewayExit" id="BPMNEdge_userTaskB_gatewayExit">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="startEvent_gateway" id="BPMNEdge_startEvent_gateway">
+        <omgdi:waypoint x="239.99999999999994" y="172.0000034466195"/>
+        <omgdi:waypoint x="315.00000443783705" y="172.00000962034568"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessA-startEvent_endEvent" id="BPMNEdge_subProcessA-startEvent_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessB-startEvent_endEvent" id="BPMNEdge_subProcessB-startEvent_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcessWithUserTaskParallelGateway.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/LocalVariablesWithSubProcessTest.testLocalVariablesAreAvailableAfterSubProcessWithUserTaskParallelGateway.bpmn20.xml
@@ -1,0 +1,152 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20240216110429549" modeler:modelId="2" modeler:modelVersion="2" modeler:modelLastUpdated="1708081436130">
+  <process id="simplerProcess" name="simplerProcess" isExecutable="true">
+    <startEvent id="startEvent">
+      <extensionElements>
+        <modeler:editor-resource-id><![CDATA[startEvent1]]></modeler:editor-resource-id>
+      </extensionElements>
+    </startEvent>
+    <sequenceFlow id="startEvent_gateway" sourceRef="startEvent" targetRef="gatewayEntry"/>
+
+    <parallelGateway id="gatewayEntry"/>
+
+    <!-- branch A -->
+    <sequenceFlow id="gatewayEntry_scriptA" sourceRef="gatewayEntry" targetRef="scriptA"/>
+    <scriptTask id="scriptA" name="scriptA" scriptFormat="groovy">
+      <script><![CDATA[
+      execution.setVariableLocal("commonLocalVar","A1");
+      execution.setVariableLocal("uniqueLocalVarA","A2");
+      ]]></script>
+    </scriptTask>
+    <sequenceFlow id="scriptA_subProcessA" sourceRef="scriptA" targetRef="subProcessA"/>
+    <subProcess id="subProcessA" name="subProcessA">
+      <startEvent id="subProcessA-startEvent"/>
+      <sequenceFlow id="subProcessA-startEvent_userTask" sourceRef="subProcessA-startEvent" targetRef="subProcessA-userTask"/>
+      <userTask id="subProcessA-userTask" name="subProcessA userTask"/>
+      <sequenceFlow id="subProcessA-userTask_endEvent" sourceRef="subProcessA-userTask" targetRef="subProcessA-endEvent"/>
+      <endEvent id="subProcessA-endEvent"/>
+    </subProcess>
+    <sequenceFlow id="subProcessA_usertaskA" sourceRef="subProcessA" targetRef="userTaskA"/>
+    <userTask id="userTaskA" name="user task A"/>
+    <sequenceFlow id="userTaskA_gatewayExit" sourceRef="userTaskA" targetRef="gatewayExit"/>
+
+    <!-- branch B -->
+    <sequenceFlow id="gatewayEntry_scriptB" sourceRef="gatewayEntry" targetRef="scriptB"/>
+    <scriptTask id="scriptB" name="scriptB" scriptFormat="groovy">
+      <script><![CDATA[
+      execution.setVariableLocal("commonLocalVar","B1");
+      execution.setVariableLocal("uniqueLocalVarB","B2");
+      ]]></script>
+    </scriptTask>
+    <sequenceFlow id="scriptB_subProcessB" sourceRef="scriptB" targetRef="subProcessB"/>
+    <subProcess id="subProcessB" name="subProcessB">
+      <startEvent id="subProcessB-startEvent"/>
+      <sequenceFlow id="subProcessB-startEvent_userTask" sourceRef="subProcessB-startEvent" targetRef="subProcessB-userTask"/>
+      <userTask id="subProcessB-userTask" name="subProcessB userTask"/>
+      <sequenceFlow id="subProcessB-userTask_endEvent" sourceRef="subProcessB-userTask" targetRef="subProcessB-endEvent"/>
+      <endEvent id="subProcessB-endEvent"/>
+    </subProcess>
+    <sequenceFlow id="subProcessB_usertaskB" sourceRef="subProcessB" targetRef="userTaskB"/>
+    <userTask id="userTaskB" name="user task B"/>
+    <sequenceFlow id="userTaskB_gatewayExit" sourceRef="userTaskB" targetRef="gatewayExit"/>
+
+    <parallelGateway id="gatewayExit"/>
+
+    <sequenceFlow id="gatewayExit_endEvent" sourceRef="gatewayExit" targetRef="endEvent"/>
+    <endEvent id="endEvent"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_simplerProcess">
+    <bpmndi:BPMNPlane bpmnElement="simplerProcess" id="BPMNPlane_simplerProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="210.0" y="157.00000221187435"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="scriptA" id="BPMNShape_scriptA">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="scriptB" id="BPMNShape_scriptB">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA" id="BPMNShape_subProcessA">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB" id="BPMNShape_subProcessB">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gatewayEntry" id="BPMNShape_gatewayEntry">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gatewayExit" id="BPMNShape_gatewayExit">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTaskA" id="BPMNShape_userTaskA">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTaskB" id="BPMNShape_userTaskB">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent" id="BPMNShape_endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="809.0000186811809" y="393.00001352483696"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA-startEvent" id="BPMNShape_subProcessA-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB-startEvent" id="BPMNShape_subProcessB-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessA-endEvent" id="BPMNShape_subProcessA-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subProcessB-endEvent" id="BPMNShape_subProcessB-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="scriptA_subProcessA" id="BPMNEdge_scriptA_subProcessA">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="scriptB_subProcessB" id="BPMNEdge_scriptB_subProcessB">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayEntry_scriptA" id="BPMNEdge_gatewayEntry_scriptA">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayEntry_scriptB" id="BPMNEdge_gatewayEntry_scriptB">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gatewayExit_endEvent" id="BPMNEdge_gatewayExit_endEvent">
+        <omgdi:waypoint x="823.382727576" y="344.6172857234228"/>
+        <omgdi:waypoint x="823.0859050137055" y="393.00027697239125"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTaskA_gatewayExit" id="BPMNEdge_userTaskA_gatewayExit">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTaskB_gatewayExit" id="BPMNEdge_userTaskB_gatewayExit">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="startEvent_gateway" id="BPMNEdge_startEvent_gateway">
+        <omgdi:waypoint x="239.99999999999994" y="172.0000034466195"/>
+        <omgdi:waypoint x="315.00000443783705" y="172.00000962034568"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessA-startEvent_userTask" id="BPMNEdge_subProcessA-startEvent_userTask">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessA-userTask_endEvent" id="BPMNEdge_subProcessA-userTask_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessB-startEvent_userTask" id="BPMNEdge_subProcessB-startEvent_userTask">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcessB-userTask_endEvent" id="BPMNEdge_subProcessB-userTask_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testLocalVariablesAreAvailableAfterSubProcess.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/bpmn/subprocess/SubProcessTest.testLocalVariablesAreAvailableAfterSubProcess.bpmn20.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:activiti="http://activiti.org/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" typeLanguage="http://www.w3.org/2001/XMLSchema" expressionLanguage="http://www.w3.org/1999/XPath" targetNamespace="http://www.activiti.org/processdef" xmlns:modeler="http://activiti.com/modeler" modeler:version="1.0en" modeler:exportDateTime="20240216110429549" modeler:modelId="2" modeler:modelVersion="2" modeler:modelLastUpdated="1708081436130">
+  <process id="simplerProcess" name="simplerProcess" isExecutable="true">
+    <startEvent id="startEvent">
+      <extensionElements>
+        <modeler:editor-resource-id><![CDATA[startEvent1]]></modeler:editor-resource-id>
+      </extensionElements>
+    </startEvent>
+    <scriptTask id="script" name="script" scriptFormat="javascript" activiti:autoStoreVariables="false">
+      <script><![CDATA[execution.setVariableLocal("httpStatus",500);]]></script>
+    </scriptTask>
+    <subProcess id="subprocess" name="subProcess">
+      <startEvent id="subprocess-startEvent"/>
+      <endEvent id="subprocess-endEvent"/>
+      <sequenceFlow id="subprocess-startEvent_endEvent" sourceRef="subprocess-startEvent" targetRef="subprocess-endEvent"/>
+    </subProcess>
+    <exclusiveGateway id="gateway" default="gateway_endEvent"/>
+    <userTask id="userTask" name="user task" activiti:assignee="$INITIATOR"/>
+    <endEvent id="endEvent2"/>
+    <endEvent id="endEvent1"/>
+    <sequenceFlow id="startEvent_script" sourceRef="startEvent" targetRef="script"/>
+    <sequenceFlow id="subProcess_gateway" sourceRef="subprocess" targetRef="gateway"/>
+    <sequenceFlow id="script_subProcess" sourceRef="script" targetRef="subprocess"/>
+    <sequenceFlow id="userTask_endEvent" sourceRef="userTask" targetRef="endEvent1"/>
+    <sequenceFlow id="gateway_userTask" sourceRef="gateway" targetRef="userTask">
+      <conditionExpression xsi:type="tFormalExpression"><![CDATA[${(httpStatus!=200)}]]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="gateway_endEvent" sourceRef="gateway" targetRef="endEvent2"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_simplerProcess">
+    <bpmndi:BPMNPlane bpmnElement="simplerProcess" id="BPMNPlane_simplerProcess">
+      <bpmndi:BPMNShape bpmnElement="startEvent" id="BPMNShape_startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="210.0" y="157.00000221187435"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="script" id="BPMNShape_script">
+        <omgdc:Bounds height="80.0" width="100.0" x="315.00000443783705" y="132.00001373616288"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess" id="BPMNShape_subprocess">
+        <omgdc:Bounds height="233.0" width="243.0" x="495.0000069737439" y="132.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="gateway" id="BPMNShape_gateway">
+        <omgdc:Bounds height="40.0" width="40.0" x="803.0000092983253" y="305.0000040010975"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="userTask" id="BPMNShape_userTask">
+        <omgdc:Bounds height="80.0" width="100.0" x="893.0000105662787" y="285.00001745549343"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent2" id="BPMNShape_endEvent2">
+        <omgdc:Bounds height="28.0" width="28.0" x="809.0000186811809" y="393.00001352483696"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="endEvent1" id="BPMNShape_endEvent1">
+        <omgdc:Bounds height="28.0" width="28.0" x="1058.00001289086" y="311.0000040856278"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess-startEvent" id="BPMNShape_subprocess-startEvent">
+        <omgdc:Bounds height="30.0" width="30.0" x="595.0000069737439" y="295.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="subprocess-endEvent" id="BPMNShape_subprocess-endEvent">
+        <omgdc:Bounds height="28.0" width="28.0" x="670.0000069737439" y="296.00001559582813"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="script_subProcess" id="BPMNEdge_script_subProcess">
+        <omgdi:waypoint x="415.00000443783705" y="172.00001425273655"/>
+        <omgdi:waypoint x="495.0000069737439" y="172.00001507925447"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gateway_userTask" id="BPMNEdge_gateway_userTask">
+        <omgdi:waypoint x="842.5798390730412" y="325.4201742263816"/>
+        <omgdi:waypoint x="893.0000105662787" y="325.2092168447399"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="gateway_endEvent" id="BPMNEdge_gateway_endEvent">
+        <omgdi:waypoint x="823.382727576" y="344.6172857234228"/>
+        <omgdi:waypoint x="823.0859050137055" y="393.00027697239125"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="userTask_endEvent" id="BPMNEdge_userTask_endEvent">
+        <omgdi:waypoint x="993.0000105662787" y="325.00001227337503"/>
+        <omgdi:waypoint x="1058.00001289086" y="325.00000553662096"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="startEvent_script" id="BPMNEdge_startEvent_script">
+        <omgdi:waypoint x="239.99999999999994" y="172.0000034466195"/>
+        <omgdi:waypoint x="315.00000443783705" y="172.00000962034568"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subProcess_gateway" id="BPMNEdge_subProcess_gateway">
+        <omgdi:waypoint x="738.0000069737439" y="325.00001130148354"/>
+        <omgdi:waypoint x="803.0000110160629" y="325.0000057188352"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge bpmnElement="subprocess-startEvent_endEvent" id="BPMNEdge_subprocess-startEvent_endEvent">
+        <omgdi:waypoint x="625.0000069737439" y="310.00001559582813"/>
+        <omgdi:waypoint x="670.0000069737439" y="310.00001559582813"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
…d of subprocess

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://alfresco.atlassian.net/browse/MNT-24219

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
