### PR TITLE
AAE-23229 Support more datetime formats

### DIFF
--- a/activiti-core-common/activiti-common-util/src/main/java/org/activiti/common/util/DateFormatterProvider.java
+++ b/activiti-core-common/activiti-common-util/src/main/java/org/activiti/common/util/DateFormatterProvider.java
@@ -50,9 +50,9 @@ public class DateFormatterProvider  {
                                                       .withZone(getZoneId());
 
         try {
-            LocalDateTime localDateTime = dateTimeFormatter.parse(value,
-                                                                  LocalDateTime::from);
-            return Date.from(localDateTime.atZone(getZoneId()).toInstant());
+            ZonedDateTime zonedDateTime = dateTimeFormatter.parse(value,
+                                                                  ZonedDateTime::from);
+            return Date.from(zonedDateTime.toInstant());
         } catch (DateTimeException e) {
             LocalDate localDate = dateTimeFormatter.parse(String.valueOf(value),
                                                           LocalDate::from);
@@ -79,6 +79,10 @@ public class DateFormatterProvider  {
 
         if (value instanceof LocalDateTime) {
             return Date.from(((LocalDateTime)value).atZone(getZoneId()).toInstant());
+        }
+
+        if (value instanceof ZonedDateTime) {
+            return Date.from(((ZonedDateTime)value).toInstant());
         }
 
         throw new DateTimeException(MessageFormat.format("Error while parsing date. Type: {0}, value: {1}", value.getClass().getName(), value));

--- a/activiti-core-common/activiti-common-util/src/main/java/org/activiti/common/util/conf/ActivitiCoreCommonUtilAutoConfiguration.java
+++ b/activiti-core-common/activiti-common-util/src/main/java/org/activiti/common/util/conf/ActivitiCoreCommonUtilAutoConfiguration.java
@@ -26,7 +26,7 @@ public class ActivitiCoreCommonUtilAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public DateFormatterProvider dateFormatterProvider(@Value("${spring.activiti.date-format-pattern:yyyy-MM-dd[['T']HH:mm:ss[.SSS'Z']]}")
+    public DateFormatterProvider dateFormatterProvider(@Value("${spring.activiti.date-format-pattern:yyyy-MM-dd[['T']HH:mm:ss[.SSS][XXX]]}")
                                                        String dateFormatPattern) {
         return new DateFormatterProvider(dateFormatPattern);
     }

--- a/activiti-core-common/activiti-common-util/src/test/java/org/activiti/common/util/DateFormatterProviderTest.java
+++ b/activiti-core-common/activiti-common-util/src/test/java/org/activiti/common/util/DateFormatterProviderTest.java
@@ -22,6 +22,7 @@ import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Date;
 
@@ -29,7 +30,7 @@ import org.junit.jupiter.api.Test;
 
 public class DateFormatterProviderTest {
 
-    private DateFormatterProvider provider = new DateFormatterProvider("yyyy-MM-dd[['T']HH:mm:ss[.SSS'Z']]");
+    private final DateFormatterProvider provider = new DateFormatterProvider("yyyy-MM-dd[['T']HH:mm:ss[.SSS][XXX]]");
 
     @Test
     public void should_returnDate_when_stringRepresentsADate() {
@@ -44,12 +45,50 @@ public class DateFormatterProviderTest {
     @Test
     public void should_returnDate_when_stringRepresentsADateWithTimeInformation() {
 
-        String dateStr = "1970-01-01T01:01:01.001Z";
-        //calculate number of milliseconds after 1970-01-01T00:00:00.000Z
-        long time = Duration.ofHours(1).toMillis() + Duration.ofMinutes(1).toMillis() + Duration.ofSeconds(1).toMillis() + 1;
+        // Formats without milliseconds
+        long time = Duration.ofHours(1).toMillis() + Duration.ofMinutes(1).toMillis() + Duration.ofSeconds(1).toMillis() ;
 
+        String dateStr = "1970-01-01T01:01:01";
         Date date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
 
+        dateStr = "1970-01-01T01:01:01Z";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1970-01-01T01:01:01+00:00";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1970-01-01T02:01:01+01:00";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1969-12-31T23:01:01-02:00";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        // Formats including milliseconds
+        time = time +1;
+
+        dateStr = "1970-01-01T01:01:01.001";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1970-01-01T01:01:01.001Z";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1970-01-01T01:01:01.001+00:00";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1970-01-01T02:01:01.001+01:00";
+        date = provider.toDate(dateStr);
+        assertThat(date).hasTime(time);
+
+        dateStr = "1969-12-31T23:01:01.001-02:00";
+        date = provider.toDate(dateStr);
         assertThat(date).hasTime(time);
     }
 
@@ -100,6 +139,16 @@ public class DateFormatterProviderTest {
         Date date = provider.toDate(localDateTime);
 
         assertThat(date).isEqualTo(Date.from(localDateTime.atZone(provider.getZoneId()).toInstant()));
+    }
+
+    @Test
+    public void should_returnDate_when_zonedDateTimeIsProvided() {
+
+        ZonedDateTime zonedDateTime = ZonedDateTime.now();
+
+        Date date = provider.toDate(zonedDateTime);
+
+        assertThat(date).isEqualTo(Date.from(zonedDateTime.toInstant()));
     }
 
     @Test


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [X] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: AAE-23229
With this PR now we allow datetime variables to have the following formats:

- `2024-01-10T11:32:48Z`
- `2024-01-10T11:32:48.123Z`
- `2024-01-10T11:32:48.123+01:00`
- `2024-01-10T11:32:48.123-02:00`
- `2024-01-10T11:32:48`
- `2024-01-10T11:32:48+01:00`
- `2024-01-10T11:32:48-02:00`

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
