### PR TITLE
Added SQL queries for https://hyland.atlassian.net/browse/ACTIVITI-5196

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.6001.to.6002.engine.sql
@@ -214,3 +214,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.6001.to.6002.engine.sql
@@ -197,3 +197,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.hsql.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.hsql.upgradestep.6001.to.6002.engine.sql
@@ -197,3 +197,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mariadb.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mariadb.upgradestep.6001.to.6002.engine.sql
@@ -198,3 +198,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.6001.to.6002.engine.sql
@@ -219,3 +219,15 @@ INNER JOIN
 (
      select START_USER_ID_, PROC_INST_ID_ from ACT_HI_PROCINST
 ) innerTable ON outerTable.PROC_INST_ID_ = innerTable.PROC_INST_ID_;
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.6001.to.6002.engine.sql
@@ -198,3 +198,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql5.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql5.upgradestep.6001.to.6002.engine.sql
@@ -198,3 +198,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.6001.to.6002.engine.sql
@@ -212,3 +212,15 @@ alter table ACT_RU_EXECUTION add ID_LINK_COUNT_ INTEGER;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=ACT_RU_EXECUTION.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = 0
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.6001.to.6002.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.6001.to.6002.engine.sql
@@ -212,3 +212,15 @@ alter table ACT_RU_EXECUTION add column ID_LINK_COUNT_ integer;
 update ACT_GE_PROPERTY set VALUE_ = '6.0.0.2' where NAME_ = 'schema.version';
 
 update ACT_RU_EXECUTION as exe set START_USER_ID_ = (select START_USER_ID_ from ACT_HI_PROCINST where PROC_INST_ID_=exe.PROC_INST_ID_);
+
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = false
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_TIMER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = false
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_SUSPENDED_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+UPDATE ACT_RU_EXECUTION SET IS_SCOPE_ = false
+WHERE ID_ = ( SELECT EXECUTION_ID_ FROM ACT_RU_DEADLETTER_JOB WHERE EXECUTION_ID_ = ACT_RU_EXECUTION.ID_ AND HANDLER_TYPE_ = 'timer-intermediate-transition');
+
+
+update ACT_RU_TIMER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_SUSPENDED_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';
+update ACT_RU_DEADLETTER_JOB set HANDLER_TYPE_ = 'trigger-timer' where HANDLER_TYPE_ = 'timer-intermediate-transition';


### PR DESCRIPTION
This PR contains changes required for 
https://hyland.atlassian.net/browse/ACTIVITI-5169

 I incorporated the change for Handler type Timer-intermediate-transition:
 For this timer job I changed handler_type from **timer-intermediate-transition** with **trigger-timer** in relevant act_ru_timer_job or act_ru_deadletter_job or act_ru_suspended_job. 
 Also, I changed **is_scope** to false for the entries in act_ru_execution table whose execution_id is there in the act_ru_timer_job or act_ru_deadletter_job or act_ru_suspended_job.

 