### PR TITLE
AAE-24226 Reduced the logging level from error to warn in CommandCont…

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -29,6 +29,7 @@ import org.activiti.engine.ActivitiOptimisticLockingException;
 import org.activiti.engine.ActivitiTaskAlreadyClaimedException;
 import org.activiti.engine.ApplicationStatusHolder;
 import org.activiti.engine.JobNotFoundException;
+import org.activiti.engine.delegate.BpmnError;
 import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
 import org.activiti.engine.impl.asyncexecutor.JobManager;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
@@ -149,11 +150,15 @@ public class CommandContext {
         } else if (exception instanceof ActivitiOptimisticLockingException) {
             // reduce log level, as normally we're not interested in logging this exception
             log.debug("Optimistic locking exception : " + exception);
-        } else if(ApplicationStatusHolder.isShutdownInProgress()) {
+        }
+       else if(ApplicationStatusHolder.isShutdownInProgress()) {
             //reduce log level, because this may have been caused by the application termination
             log.warn("Error while closing command context", exception);
-        } else {
-            log.warn("Error while closing command context",
+        } else if(exception instanceof BpmnError){
+            log.warn("Bpmn error : " + exception);
+        }
+        else {
+            log.error("Error while closing command context",
                       exception);
         }
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -155,7 +155,7 @@ public class CommandContext {
             //reduce log level, because this may have been caused by the application termination
             log.warn("Error while closing command context", exception);
         } else if(exception instanceof BpmnError){
-            log.warn("Bpmn error : " + exception);
+            log.warn("Error while closing command context", exception);
         }
         else {
             log.error("Error while closing command context",

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -153,7 +153,8 @@ public class CommandContext {
             //reduce log level, because this may have been caused by the application termination
             log.warn("Error while closing command context", exception);
         } else {
-            log.error("Error while closing command context", exception);
+            log.warn("Error while closing command context",
+                      exception);
         }
     }
 


### PR DESCRIPTION
…ext for BpmnError

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-24226

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
