### PR TITLE
AAE-24223 Log CommandContext exceptions as warning if app is in shutdown

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ApplicationStatusHolder.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ApplicationStatusHolder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine;
+
+/**
+ * Associates a given application status with the current application execution.
+ * The purpose of the class is to provide a convenient way to mark the application in shutdown in order to apply
+ * different strategies depending on it.
+ * This status is not set automatically by Activiti, it must be set by the user application depending on other
+ * frameworks in use. For instance if we are using Spring Boot we can catch the
+ * org.springframework.context.event.ContextClosedEvent and mark the application as in shutdown.
+ */
+public class ApplicationStatusHolder {
+
+    private static boolean running = true;
+
+    public static void shutdown(){
+        ApplicationStatusHolder.running = false;
+    }
+
+    public static boolean isShutdownInProgress() {
+        return !running;
+    }
+
+    public static boolean isRunning() {
+        return running;
+    }
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -27,6 +27,7 @@ import org.activiti.engine.ActivitiEngineAgenda;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiOptimisticLockingException;
 import org.activiti.engine.ActivitiTaskAlreadyClaimedException;
+import org.activiti.engine.ApplicationStatusHolder;
 import org.activiti.engine.JobNotFoundException;
 import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
 import org.activiti.engine.impl.asyncexecutor.JobManager;
@@ -144,14 +145,15 @@ public class CommandContext {
     protected void logException() {
         if (exception instanceof JobNotFoundException || exception instanceof ActivitiTaskAlreadyClaimedException) {
             // reduce log level, because this may have been caused because of job deletion due to cancelActiviti="true"
-            log.info("Error while closing command context",
-                     exception);
+            log.info("Error while closing command context", exception);
         } else if (exception instanceof ActivitiOptimisticLockingException) {
             // reduce log level, as normally we're not interested in logging this exception
             log.debug("Optimistic locking exception : " + exception);
+        } else if(ApplicationStatusHolder.isShutdownInProgress()) {
+            //reduce log level, because this may have been caused by the application termination
+            log.warn("Error while closing command context", exception);
         } else {
-            log.error("Error while closing command context",
-                      exception);
+            log.error("Error while closing command context", exception);
         }
     }
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/interceptor/CommandContextTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/interceptor/CommandContextTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.impl.interceptor;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.activiti.engine.ApplicationStatusHolder;
+import org.activiti.engine.impl.agenda.DefaultActivitiEngineAgenda;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+
+public class CommandContextTest {
+
+
+    @Before
+    public void resetStatusToRunning() throws Exception {
+        setStaticValue(ApplicationStatusHolder.class.getDeclaredField("running"), true);
+    }
+
+    @Test
+    public void should_LogExceptionAtErrorLevel_when_closing() {
+        ListAppender<ILoggingEvent> appender = startLogger();
+        startAndCloseCommandContext(new RuntimeException());
+        assertLogLevel(appender, Level.ERROR);
+    }
+
+    @Test
+    public void should_LogExceptionAtWarningLevel_when_closing() {
+        ListAppender<ILoggingEvent> appender = startLogger();
+        ApplicationStatusHolder.shutdown();
+        startAndCloseCommandContext(new RuntimeException());
+        assertLogLevel(appender, Level.WARN);
+    }
+
+    @Test
+    public void should_NotLogException_when_closing() {
+        ListAppender<ILoggingEvent> appender = startLogger();
+        startAndCloseCommandContext(null);
+        Assertions.assertThat(appender.list).isEmpty();
+    }
+
+    private void startAndCloseCommandContext(Exception exception) {
+        Command<?> command = (Command<Object>) commandContext -> "Hello world!";
+        ProcessEngineConfigurationImpl processEngineConfiguration = new ProcessEngineConfigurationImpl() {
+            @Override
+            public CommandInterceptor createTransactionInterceptor() {
+                return new CommandContextInterceptor();
+            }
+        };
+        processEngineConfiguration.setEngineAgendaFactory(DefaultActivitiEngineAgenda::new);
+        CommandContext commandContext = new CommandContext(command, processEngineConfiguration);
+        commandContext.exception = exception;
+        try {
+            commandContext.close();
+        } catch (Exception e) {
+            //suppress exception
+        }
+    }
+
+    private void assertLogLevel(ListAppender<ILoggingEvent> appender, Level level) {
+        Assertions
+            .assertThat(appender.list)
+            .extracting(ILoggingEvent::getFormattedMessage, ILoggingEvent::getLevel)
+            .contains(
+                Tuple.tuple(
+                    "Error while closing command context",
+                    level
+                )
+            );
+    }
+
+    private ListAppender<ILoggingEvent> startLogger() {
+        Logger fooLogger = (Logger) LoggerFactory.getLogger(CommandContext.class);
+
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        fooLogger.addAppender(appender);
+        appender.start();
+        return appender;
+    }
+
+    private void setStaticValue(Field field, Object value) throws Exception {
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ProcessEngineAutoConfiguration.java
@@ -85,6 +85,11 @@ public class ProcessEngineAutoConfiguration extends AbstractProcessEngineAutoCon
     }
 
     @Bean
+    public ShutdownListener shutdownListener() {
+        return new ShutdownListener();
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     @DependsOnDatabaseInitialization
     public SpringProcessEngineConfiguration springProcessEngineConfiguration(

--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
@@ -20,16 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextClosedEvent;
-import org.springframework.stereotype.Component;
 
-@Component
 public class ShutdownListener implements ApplicationListener<ContextClosedEvent> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ShutdownListener.class);
-
-    ShutdownListener() {
-        System.out.println("Shutdown listener");
-    }
 
     @Override
     public void onApplicationEvent(ContextClosedEvent event) {

--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
@@ -1,8 +1,17 @@
 /*
- * Copyright 2005-2020 Alfresco Software, Ltd. All rights reserved.
- * License rights for this program may be obtained from Alfresco Software, Ltd.
- * pursuant to a written agreement and any use of this program without such an
- * agreement is prohibited.
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.activiti.spring.boot;
 

--- a/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
+++ b/activiti-core/activiti-spring-boot-starter/src/main/java/org/activiti/spring/boot/ShutdownListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2005-2020 Alfresco Software, Ltd. All rights reserved.
+ * License rights for this program may be obtained from Alfresco Software, Ltd.
+ * pursuant to a written agreement and any use of this program without such an
+ * agreement is prohibited.
+ */
+package org.activiti.spring.boot;
+
+import org.activiti.engine.ApplicationStatusHolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextClosedEvent;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ShutdownListener implements ApplicationListener<ContextClosedEvent> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShutdownListener.class);
+
+    ShutdownListener() {
+        System.out.println("Shutdown listener");
+    }
+
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        if (event.getApplicationContext().getParent() == null) {
+            LOGGER.info("Starting application shutdown...");
+            ApplicationStatusHolder.shutdown();
+        }
+    }
+}

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ShutdownListenerTest.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ShutdownListenerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.spring.boot;
+
+import org.activiti.engine.ApplicationStatusHolder;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ShutdownListenerTest {
+
+    @Test
+    void should_MarkAsShutdown_when_CloseApplicationContext() {
+        ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+            .withUserConfiguration(Application.class);
+        contextRunner.run((context) -> {
+            assertThat(ApplicationStatusHolder.isRunning()).isTrue();
+            assertThat(ApplicationStatusHolder.isShutdownInProgress()).isFalse();
+            context.close();
+            assertThat(ApplicationStatusHolder.isRunning()).isFalse();
+            assertThat(ApplicationStatusHolder.isShutdownInProgress()).isTrue();
+        });
+    }
+
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

Log the exception as warning if it happens during a shutdown.

- Issue Link:

https://hyland.atlassian.net/browse/AAE-24223

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
