### PR TITLE
AAE-23532 Fix race condition for service tasks using connectors

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/DefaultServiceTaskBehavior.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/connector/DefaultServiceTaskBehavior.java
@@ -20,11 +20,12 @@ import org.activiti.api.process.model.IntegrationContext;
 import org.activiti.api.process.runtime.connector.Connector;
 import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.engine.delegate.DelegateExecution;
-import org.activiti.engine.impl.bpmn.behavior.AbstractBpmnActivityBehavior;
+import org.activiti.engine.impl.bpmn.behavior.DelegateExecutionFunction;
+import org.activiti.engine.impl.bpmn.behavior.DelegateExecutionOutcome;
 import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
 import org.springframework.context.ApplicationContext;
 
-public class DefaultServiceTaskBehavior extends AbstractBpmnActivityBehavior {
+public class DefaultServiceTaskBehavior implements DelegateExecutionFunction {
 
     private final ApplicationContext applicationContext;
     private final IntegrationContextBuilder integrationContextBuilder;
@@ -42,12 +43,12 @@ public class DefaultServiceTaskBehavior extends AbstractBpmnActivityBehavior {
      * in according if we have a connector action definition match or not.
      **/
     @Override
-    public void execute(DelegateExecution execution) {
+    public DelegateExecutionOutcome apply(DelegateExecution execution) {
         Connector connector = getConnector(getImplementation(execution));
         IntegrationContext integrationContext = connector.apply(integrationContextBuilder.from(execution));
 
         variablesPropagator.propagate(execution, integrationContext.getOutBoundVariables());
-        leave(execution);
+        return DelegateExecutionOutcome.LEAVE_EXECUTION;
     }
 
     private String getImplementation(DelegateExecution execution) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionFunction.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.bpmn.behavior;
+
+import java.util.function.Function;
+import org.activiti.engine.delegate.DelegateExecution;
+
+public interface DelegateExecutionFunction extends Function<DelegateExecution, DelegateExecutionOutcome> {
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionOutcome.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionOutcome.java
@@ -20,6 +20,6 @@ public enum DelegateExecutionOutcome {
 
     LEAVE_EXECUTION,
 
-    DO_NOTHING
+    WAIT_FOR_TRIGGER
 
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionOutcome.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/DelegateExecutionOutcome.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.activiti.engine.impl.bpmn.behavior;
+
+public enum DelegateExecutionOutcome {
+
+    LEAVE_EXECUTION,
+
+    DO_NOTHING
+
+}

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -61,8 +61,10 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
   @Override
   public void trigger(DelegateExecution execution, String signalName, Object signalData) {
     Object delegate = DelegateExpressionUtil.resolveDelegateExpression(expression, execution, fieldDeclarations);
-    if (delegate instanceof TriggerableActivityBehavior) {
-      ((TriggerableActivityBehavior) delegate).trigger(execution, signalName, signalData);
+    if (delegate instanceof DelegateExecutionFunction) {
+        leave(execution);
+    } else if (delegate instanceof TriggerableActivityBehavior behavior) {
+      behavior.trigger(execution, signalName, signalData);
     }
   }
 
@@ -83,16 +85,21 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
         }
 
         Object delegate = DelegateExpressionUtil.resolveDelegateExpression(expression, execution, fieldDeclarations);
-        if (delegate instanceof ActivityBehavior) {
+        if (delegate instanceof DelegateExecutionFunction function) {
+            DelegateExecutionOutcome outcome = function.apply(execution);
+            if (outcome == DelegateExecutionOutcome.LEAVE_EXECUTION) {
+                leave(execution);
+            }
+        } else if (delegate instanceof ActivityBehavior) {
 
-          if (delegate instanceof AbstractBpmnActivityBehavior) {
-            ((AbstractBpmnActivityBehavior) delegate).setMultiInstanceActivityBehavior(getMultiInstanceActivityBehavior());
+          if (delegate instanceof AbstractBpmnActivityBehavior behavior) {
+            behavior.setMultiInstanceActivityBehavior(getMultiInstanceActivityBehavior());
           }
 
           Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new ActivityBehaviorInvocation((ActivityBehavior) delegate, execution));
 
-        } else if (delegate instanceof JavaDelegate) {
-          Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new JavaDelegateInvocation((JavaDelegate) delegate, execution));
+        } else if (delegate instanceof JavaDelegate javaDelegate) {
+          Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new JavaDelegateInvocation(javaDelegate, execution));
           leave(execution);
 
         } else {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/ServiceTaskDelegateExpressionActivityBehavior.java
@@ -85,26 +85,26 @@ public class ServiceTaskDelegateExpressionActivityBehavior extends TaskActivityB
         }
 
         Object delegate = DelegateExpressionUtil.resolveDelegateExpression(expression, execution, fieldDeclarations);
-          switch (delegate) {
-              case DelegateExecutionFunction function -> {
-                  DelegateExecutionOutcome outcome = function.apply(execution);
-                  if (outcome == DelegateExecutionOutcome.LEAVE_EXECUTION) {
-                      leave(execution);
-                  }
-              }
-              case ActivityBehavior activityBehavior -> {
-                  if (delegate instanceof AbstractBpmnActivityBehavior behavior) {
-                      behavior.setMultiInstanceActivityBehavior(getMultiInstanceActivityBehavior());
-                  }
-                  Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new ActivityBehaviorInvocation(activityBehavior, execution));
-              }
-              case JavaDelegate javaDelegate -> {
-                  Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new JavaDelegateInvocation(javaDelegate, execution));
-                  leave(execution);
-              }
-              case null, default ->
-                  throw new ActivitiIllegalArgumentException("Delegate expression " + expression + " did neither resolve to an implementation of " + ActivityBehavior.class + " nor " + JavaDelegate.class);
-          }
+        switch (delegate) {
+            case DelegateExecutionFunction function -> {
+                DelegateExecutionOutcome outcome = function.apply(execution);
+                if (outcome == DelegateExecutionOutcome.LEAVE_EXECUTION) {
+                    leave(execution);
+                }
+            }
+            case ActivityBehavior activityBehavior -> {
+                if (delegate instanceof AbstractBpmnActivityBehavior behavior) {
+                    behavior.setMultiInstanceActivityBehavior(getMultiInstanceActivityBehavior());
+                }
+                Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new ActivityBehaviorInvocation(activityBehavior, execution));
+            }
+            case JavaDelegate javaDelegate -> {
+                Context.getProcessEngineConfiguration().getDelegateInterceptor().handleInvocation(new JavaDelegateInvocation(javaDelegate, execution));
+                leave(execution);
+            }
+            case null, default ->
+                throw new ActivitiIllegalArgumentException("The resolved delegate expression " + expression + " should be an implementation of one of " + ActivityBehavior.class + ", " + JavaDelegate.class + " or " + DelegateExecutionFunction.class);
+        }
       } else {
         leave(execution);
       }

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-sequence-servicetask-racecondition.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-sequence-servicetask-racecondition.bpmn20.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="miSequentialServiceTaskRaceCondition">
+        <startEvent id="startevent1" name="Start"></startEvent>
+        <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="miServiceTask"></sequenceFlow>
+
+        <serviceTask id="miServiceTask" name="miServiceTask ${loopCounter}" implementation="testRaceConditionMultipleInstances">
+            <multiInstanceLoopCharacteristics isSequential="true">
+                <loopCardinality>${2}</loopCardinality>
+            </multiInstanceLoopCharacteristics>
+        </serviceTask>
+
+        <sequenceFlow id="flow3" name="" sourceRef="miServiceTask" targetRef="theEnd"></sequenceFlow>
+        <endEvent id="theEnd"></endEvent>
+    </process>
+
+</definitions>

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/service-task-single-racecondition-with-multi-instance.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/service-task-single-racecondition-with-multi-instance.bpmn20.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="definition"
+             xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="Examples">
+
+    <process id="serviceTaskSingleInstanceRaceConditionWithOtherProcessWithMultiInstance">
+        <startEvent id="startevent1" name="Start"></startEvent>
+        <sequenceFlow id="flow1" name="" sourceRef="startevent1" targetRef="serviceTask"></sequenceFlow>
+
+        <serviceTask id="serviceTask" name="ServiceTask for race condition" implementation="testRaceConditionSingleInstance">
+        </serviceTask>
+
+        <sequenceFlow id="flow3" name="" sourceRef="serviceTask" targetRef="theEnd"></sequenceFlow>
+        <endEvent id="theEnd"></endEvent>
+    </process>
+
+</definitions>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
Having `DefaultServiceTaskBehavior` as an `ActivityBehavior` was causing racing conditions because it's instantiated as a singleton. Given the fact that `DefaultServiceTaskBehavior` is always wrapped inside a `ServiceTaskDelegateExpressionActivityBehavior` that is already an `ActivityBehavior`, there is no reason to have `DefaultServiceTaskBehavior` also implementing `ActivityBehavior`. This PR is simplifying the layers and extracting new interface to be used by `DefaultServiceTaskBehavior`.

<!--
You can also link to an open issue here
-->

- Issue Link: AAE-23532

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
