### PR TITLE
AAE-24227 Reduced the Log level of ActivitiException from Error to warn

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -154,7 +154,7 @@ public class CommandContext {
        else if(ApplicationStatusHolder.isShutdownInProgress()) {
             //reduce log level, because this may have been caused by the application termination
             log.warn("Error while closing command context", exception);
-        } else if(exception instanceof BpmnError){
+        } else if(exception instanceof BpmnError || exception instanceof ActivitiException) {
             log.warn("Error while closing command context", exception);
         }
         else {


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link:  https://hyland.atlassian.net/browse/AAE-24227

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
