### PR TITLE
Fix querying the latest version of the model under multi-tenant env

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Model.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Model.xml
@@ -159,7 +159,12 @@
         and RES.DEPLOYMENT_ID_ is not null
       </if>
       <if test="latest">
-        and RES.VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_MODEL where KEY_ = RES.KEY_)
+        and RES.VERSION_ = (select max(VERSION_) from ${prefix}ACT_RE_MODEL where KEY_ = RES.KEY_ and (
+            (TENANT_ID_ is null and RES.TENANT_ID_ is null) or
+            (TENANT_ID_ is null and RES.TENANT_ID_ = '') or
+            (TENANT_ID_ = '' and RES.TENANT_ID_ is null) or
+            (TENANT_ID_ = RES.TENANT_ID_)
+         ))
       </if>
       <if test="tenantId != null">
         and RES.TENANT_ID_ = #{tenantId}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/tenant/ModelLatestVersionWithTenantIdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/tenant/ModelLatestVersionWithTenantIdTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2010-2020 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.tenant;
+
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.repository.Model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModelLatestVersionWithTenantIdTest extends PluggableActivitiTestCase {
+    private static final String FIRST_TENANT_ID = "firstTenantId";
+    private static final String SECOND_TENANT_ID = "secondTenantId";
+    private static final String THIRD_TENANT_ID = null;
+    private static final String FOURTH_TENANT_ID = ProcessEngineConfiguration.NO_TENANT_ID;
+
+    private static final String TEST_MODEL_KEY = "theModelKey";
+
+    @Override
+    protected void setUp() throws Exception {
+        // same key version 1
+        Model model = repositoryService.newModel();
+        model.setKey(TEST_MODEL_KEY);
+        model.setTenantId(FIRST_TENANT_ID);
+        model.setVersion(1); // version 1
+        repositoryService.saveModel(model);
+
+        // same key  version 2
+        model = repositoryService.newModel();
+        model.setKey(TEST_MODEL_KEY);
+        model.setTenantId(SECOND_TENANT_ID);
+        model.setVersion(2); // version 2
+        repositoryService.saveModel(model);
+
+        // same key  version 3
+        model = repositoryService.newModel();
+        model.setKey(TEST_MODEL_KEY);
+        model.setTenantId(THIRD_TENANT_ID);
+        model.setVersion(3); // version 3
+        repositoryService.saveModel(model);
+
+        // same key  version 4
+        model = repositoryService.newModel();
+        model.setKey(TEST_MODEL_KEY);
+        model.setTenantId(FOURTH_TENANT_ID);
+        model.setVersion(4); // version 4
+        repositoryService.saveModel(model);
+
+        super.setUp();
+    }
+
+    public void testModelVersionTenancy() {
+
+        // Check query
+        assertThat(repositoryService.createModelQuery().modelKey(TEST_MODEL_KEY).latestVersion().modelTenantId(FIRST_TENANT_ID).singleResult().getVersion()).isEqualTo(1);
+        assertThat(repositoryService.createModelQuery().modelKey(TEST_MODEL_KEY).latestVersion().modelTenantId(SECOND_TENANT_ID).singleResult().getVersion()).isEqualTo(2);
+        assertThat(repositoryService.createModelQuery().modelKey(TEST_MODEL_KEY).latestVersion().modelWithoutTenantId().singleResult().getVersion()).isEqualTo(4);
+        assertThat(repositoryService.createModelQuery().modelKey(TEST_MODEL_KEY).latestVersion().list().size()).isEqualTo(3);
+        assertThat(repositoryService.createModelQuery().latestVersion().modelTenantIdLike("first%").list().size()).isEqualTo(1);
+        assertThat(repositoryService.createModelQuery().latestVersion().modelTenantId("a%").list().size()).isEqualTo(0);
+
+        // Clean up
+        for (Model item : repositoryService.createModelQuery().list()) {
+            repositoryService.deleteModel(item.getId());
+        }
+    }
+}


### PR DESCRIPTION
…onments.

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
When using the multi-tenant feature, the latest model version record information cannot be queried correctly.

Example: 

| key         | tenant_id      | version |
| ----------- | -------------- | ------- |
| theModelKey | firstTenantId  | 1       |
| theModelKey | secondTenantId | 2       |
| theModelKey | null           | 3       |
| theModelKey | ""             | 4       |

```java

// java
repositoryService.createModelQuery().modelKey("theModelKey").latestVersion().modelTenantId("firstTenantId").singleResult();
//  sql
select distinct RES.* from ACT_RE_MODEL RES WHERE RES.KEY_ = 'theModelKey' and RES.VERSION_ = (select max(VERSION_) from ACT_RE_MODEL where KEY_ = RES.KEY_  ) and RES.TENANT_ID_ = 'firstTenantId' order by RES.ID_ asc

//expect: version=1, actual: null
```


<!--
You can also link to an open issue here
-->

- Issue Link:

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
