### PR TITLE
Correcting the oracle adding column script

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.engine.sql
@@ -1,1 +1,1 @@
-alter table ACT_RU_IDENTITYLINK add column DETAILS_ BLOB;
+alter table ACT_RU_IDENTITYLINK add DETAILS_ BLOB;

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.history.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.history.sql
@@ -1,1 +1,1 @@
-alter table ACT_HI_IDENTITYLINK add column DETAILS_ BLOB;
+alter table ACT_HI_IDENTITYLINK add DETAILS_ BLOB;


### PR DESCRIPTION
In oracle upgrade script we have a "column" keyword which is not required in Oracle.
Earlier it was
alter table ACT_RU_IDENTITYLINK add column DETAILS_ BLOB;
now it is
alter table ACT_RU_IDENTITYLINK add DETAILS_ BLOB;