### PR TITLE
AAE-31361 Handle standalone tasks while checking for ephemeral variables

### DIFF
--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/ProcessExtensionService.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/ProcessExtensionService.java
@@ -49,8 +49,11 @@ public class ProcessExtensionService {
     public Extension getExtensionsForId(@NonNull String processDefinitionId) {
         return processExtensionRepository.getExtensionsForId(processDefinitionId).orElse(EMPTY_EXTENSION);
     }
-    public boolean hasEphemeralVariable(@NonNull String processDefinitionId,
+    public boolean hasEphemeralVariable(String processDefinitionId,
                                         @NonNull String variableName) {
+        if(processDefinitionId == null) {
+            return false;
+        }
         Extension extension = this.getExtensionsForId(processDefinitionId);
         return Optional.ofNullable(extension)
             .map(ext -> ext.getPropertyByName(variableName))

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionServiceTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/ProcessExtensionServiceTest.java
@@ -90,4 +90,11 @@ class ProcessExtensionServiceTest {
         assertThat(result).isFalse();
     }
 
+    @Test
+    void should_returnFalse_when_processDefinitionId_isNull() {
+        String variableName = "variableName";
+        boolean result = processExtensionService.hasEphemeralVariable(null, variableName);
+        assertThat(result).isFalse();
+    }
+
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
Standalone tasks don't have process definition attached, so we need to be table to handle the case where the process definition id is not set

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-31361

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
