### PR TITLE
AAE-31361 Set Previous Value To Null While Sending UpdateEvent If Variable Is Ephemeral

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverter.java
@@ -39,10 +39,8 @@ public class ToVariableUpdatedConverter implements EventConverter<VariableUpdate
 
         VariableInstanceImpl<Object> variableInstance = createVariableInstance(internalEvent, isEphemeral);
 
-        if(isEphemeral) {
-            ((ActivitiVariableUpdatedEventImpl) internalEvent).setVariablePreviousValue(null);
-        }
+        Object previousValue = isEphemeral? null : internalEvent.getVariablePreviousValue();
 
-        return Optional.of(new VariableUpdatedEventImpl<>(variableInstance, internalEvent.getVariablePreviousValue()));
+        return Optional.of(new VariableUpdatedEventImpl<>(variableInstance, previousValue));
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverter.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/main/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverter.java
@@ -19,6 +19,7 @@ import org.activiti.api.model.shared.event.VariableUpdatedEvent;
 import org.activiti.api.runtime.event.impl.VariableUpdatedEventImpl;
 import org.activiti.api.runtime.model.impl.VariableInstanceImpl;
 import org.activiti.engine.delegate.event.ActivitiVariableUpdatedEvent;
+import org.activiti.engine.delegate.event.impl.ActivitiVariableUpdatedEventImpl;
 import org.activiti.spring.process.ProcessExtensionService;
 
 import java.util.Optional;
@@ -37,6 +38,10 @@ public class ToVariableUpdatedConverter implements EventConverter<VariableUpdate
             internalEvent.getVariableName());
 
         VariableInstanceImpl<Object> variableInstance = createVariableInstance(internalEvent, isEphemeral);
+
+        if(isEphemeral) {
+            ((ActivitiVariableUpdatedEventImpl) internalEvent).setVariablePreviousValue(null);
+        }
 
         return Optional.of(new VariableUpdatedEventImpl<>(variableInstance, internalEvent.getVariablePreviousValue()));
     }

--- a/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverterTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-runtime-shared-impl/src/test/java/org/activiti/runtime/api/event/impl/ToVariableUpdatedConverterTest.java
@@ -68,7 +68,7 @@ class ToVariableUpdatedConverterTest {
 
         Object actualValue = actualEntity.getValue();
         Object actualPreviousValue = actualEvent.getPreviousValue();
-        assertThat(actualPreviousValue).isEqualTo(100);
+        assertThat(actualPreviousValue).isNull();
         assertThat(actualValue).isNull();
     }
 


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-31361

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
