### PR TITLE
[MNT-24779] Terminate sub processes

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -414,6 +414,12 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
         for (ExecutionEntity miExecutionEntity : subExecutionEntity.getExecutions()) {
           if (miExecutionEntity.getSubProcessInstance() != null) {
             deleteProcessInstanceCascade(miExecutionEntity.getSubProcessInstance(), deleteReason, deleteHistory);
+          } else {
+            for (ExecutionEntity miSubExecutionEntity : miExecutionEntity.getExecutions()) {
+              if (miSubExecutionEntity.getSubProcessInstance() != null) {
+                deleteProcessInstanceCascade(miSubExecutionEntity.getSubProcessInstance(), deleteReason, deleteHistory);
+              }
+            }
           }
         }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -442,7 +442,7 @@ public class ExecutionEntityManagerImpl extends AbstractEntityManager<ExecutionE
 
       // Execute execution listeners for process end.
       Process process = ProcessDefinitionUtil.getProcess(processInstanceExecutionEntity.getProcessDefinitionId());
-      if (CollectionUtil.isNotEmpty(process.getExecutionListeners())) {
+      if (process != null && CollectionUtil.isNotEmpty(process.getExecutionListeners())) {
           executeExecutionListeners(process,
               processInstanceExecutionEntity,
               ExecutionListener.EVENTNAME_END);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
@@ -29,8 +29,13 @@ import org.activiti.engine.delegate.event.ActivitiEventDispatcher;
 import org.activiti.engine.impl.cfg.PerformanceSettings;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.history.HistoryManager;
 import org.activiti.engine.impl.identity.Authentication;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.deploy.DeploymentManager;
+import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
 import org.activiti.engine.impl.persistence.entity.data.ExecutionDataManager;
+import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.Clock;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,11 +65,57 @@ public class ExecutionEntityManagerImplTest {
     @Mock
     private IdentityLinkEntityManager identityLinkEntityManager;
 
+    @Mock
+    CommandContext commandContext;
+
+    @Mock
+    private TaskEntityManager taskEntityManager;
+
+    @Mock
+    private DeploymentManager deploymentManager;
+
+    @Mock
+    private HistoryManager historyManager;
+
+    @Mock
+    private PerformanceSettings performanceSettings;
+
+    @Mock
+    private TimerJobEntityManager timerJobEntityManager;
+
+    @Mock
+    private JobEntityManager jobEntityManager;
+
+    @Mock
+    private SuspendedJobEntityManager suspendedJobEntityManager;
+
+    @Mock
+    private DeadLetterJobEntityManager deadLetterJobEntityManager;
+
+    @Mock
+    private EventSubscriptionEntityManager eventSubscriptionEntityManager;
+
+    @Mock
+    private HistoricProcessInstanceEntityManager historicProcessInstanceEntityManager;
+
     @Before
     public void setUp() throws Exception {
         given(processEngineConfiguration.getClock()).willReturn(clock);
         given(processEngineConfiguration.getEventDispatcher()).willReturn(eventDispatcher);
         given(processEngineConfiguration.getIdentityLinkEntityManager()).willReturn(identityLinkEntityManager);
+        given(processEngineConfiguration.getTaskEntityManager()).willReturn(taskEntityManager);
+        given(processEngineConfiguration.getDeploymentManager()).willReturn(deploymentManager);
+        given(processEngineConfiguration.getHistoryManager()).willReturn(historyManager);
+        given(processEngineConfiguration.getPerformanceSettings()).willReturn(performanceSettings);
+        given(processEngineConfiguration.getIdentityLinkEntityManager()).willReturn(identityLinkEntityManager);
+        given(processEngineConfiguration.getTimerJobEntityManager()).willReturn(timerJobEntityManager);
+        given(processEngineConfiguration.getJobEntityManager()).willReturn(jobEntityManager);
+        given(processEngineConfiguration.getSuspendedJobEntityManager()).willReturn(suspendedJobEntityManager);
+        given(processEngineConfiguration.getDeadLetterJobEntityManager()).willReturn(deadLetterJobEntityManager);
+        given(processEngineConfiguration.getEventSubscriptionEntityManager()).willReturn(eventSubscriptionEntityManager);
+        given(processEngineConfiguration.getHistoricProcessInstanceEntityManager()).willReturn(historicProcessInstanceEntityManager);
+        given(commandContext.getExecutionEntityManager()).willReturn(executionEntityManager);
+        Context.setCommandContext(commandContext);
         Context.setProcessEngineConfiguration(processEngineConfiguration);
     }
 
@@ -283,5 +334,93 @@ public class ExecutionEntityManagerImplTest {
         } finally {
            Authentication.setAuthenticatedUserId(null);
         }
+    }
+
+    /**
+     * Execution Tree:
+     *
+     * |- exec1 (execution)
+     * |--- exec2 (subExecution)
+     * |----- exec3_1 (miExecution)
+     * |------- exec4_1 (miSubExecution)
+     * |--------- subProcessInstance4_1 (subProcessInstance)
+     * |----- exec3_2 (miExecution)
+     * |------- exec4_2 (miSubExecution)
+     * |--------- subProcessInstance4_2 (subProcessInstance)
+     *
+     */
+    @Test
+    public void should_deleteProcessInstanceAndSubProcessInstances() {
+
+        final String businessKey = "businessKey";
+        final String processInstanceId = "processInstanceId";
+
+        // Process instance
+        ExecutionEntity pocessInstance = new ExecutionEntityImpl();
+        pocessInstance.setId(processInstanceId);
+
+        // Level 1
+        ExecutionEntity exec1 = createChildExecution(pocessInstance);
+        exec1.setId("exec1");
+        exec1.setProcessInstance(pocessInstance);
+
+        given(executionEntityManager.findById(processInstanceId)).willReturn(exec1);
+
+        ProcessDefinition processDefinition = mock(ProcessDefinition.class);
+        given(deploymentManager.findDeployedProcessDefinitionById(any())).willReturn(processDefinition);
+
+        ProcessDefinitionCacheEntry cacheEntry = mock(ProcessDefinitionCacheEntry.class);
+        given(deploymentManager.resolveProcessDefinition(processDefinition)).willReturn(cacheEntry);
+
+        org.activiti.bpmn.model.Process process = mock(org.activiti.bpmn.model.Process.class);
+        given(process.getExecutionListeners()).willReturn(new ArrayList<>());
+
+        // Level 2
+        ExecutionEntity exec2 = createChildExecution(exec1);
+        exec2.setId("exec2");
+        exec2.setMultiInstanceRoot(true);
+
+        // Level 3 - 1
+        ExecutionEntity exec3_1 = createChildExecution(exec2);
+        exec3_1.setId("exec3_1");
+
+        // Level 3 - 2
+        ExecutionEntity exec3_2 = createChildExecution(exec2);
+        exec3_2.setId("exec3_2");
+
+        // Level 4 - 1
+        ExecutionEntity exec4_1 = createChildExecution(exec3_1);
+        exec4_1.setId("exec4_1");
+        ExecutionEntity subProcessExec4_1 = createSubProcessInstance(processDefinition, businessKey, exec4_1, "subProcessInstanceId4_1");
+        exec4_1.setSubProcessInstance(subProcessExec4_1);
+
+        // Level 4 - 2
+        ExecutionEntity exec4_2 = createChildExecution(exec3_2);
+        exec4_2.setId("exec4_2");
+        ExecutionEntity subProcessExec4_2 = createSubProcessInstance(processDefinition, businessKey, exec4_2, "subProcessInstanceId4_2");
+        exec4_2.setSubProcessInstance(subProcessExec4_2);
+
+        executionEntityManager.deleteProcessInstance(processInstanceId, "deleted by test", true);
+
+        // Assert
+        assertThat(exec1.getProcessInstance().isDeleted()).isTrue();
+        assertThat(subProcessExec4_1.getProcessInstance().isDeleted()).isTrue();
+        assertThat(subProcessExec4_2.getProcessInstance().isDeleted()).isTrue();
+    }
+
+    private ExecutionEntity createChildExecution(ExecutionEntity parentExecution) {
+        ExecutionEntityImpl childExecution = ExecutionEntityImpl.createWithEmptyRelationshipCollections();
+        given(executionDataManager.create()).willReturn(childExecution);
+        return executionEntityManager.createChildExecution(parentExecution);
+    }
+
+    private ExecutionEntity createSubProcessInstance(ProcessDefinition processDefinition, String businessKey, ExecutionEntity superExecution, String subProcessInstanceId) {
+        ExecutionEntity processInstance = ExecutionEntityImpl.createWithEmptyRelationshipCollections();
+        processInstance.setId("processInstance_" + subProcessInstanceId);
+        ExecutionEntity subProcessInstance = ExecutionEntityImpl.createWithEmptyRelationshipCollections();
+        subProcessInstance.setId(subProcessInstanceId);
+        subProcessInstance.setProcessInstance(processInstance);
+        given(executionDataManager.create()).willReturn(subProcessInstance);
+        return executionEntityManager.createSubprocessInstance(processDefinition, superExecution, businessKey);
     }
 }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
@@ -114,8 +114,6 @@ public class ExecutionEntityManagerImplTest {
         given(processEngineConfiguration.getDeadLetterJobEntityManager()).willReturn(deadLetterJobEntityManager);
         given(processEngineConfiguration.getEventSubscriptionEntityManager()).willReturn(eventSubscriptionEntityManager);
         given(processEngineConfiguration.getHistoricProcessInstanceEntityManager()).willReturn(historicProcessInstanceEntityManager);
-        given(commandContext.getExecutionEntityManager()).willReturn(executionEntityManager);
-        Context.setCommandContext(commandContext);
         Context.setProcessEngineConfiguration(processEngineConfiguration);
     }
 
@@ -337,7 +335,7 @@ public class ExecutionEntityManagerImplTest {
     }
 
     /**
-     * Execution Tree:
+     * Test sub-process instances deletion from execution tree below:
      *
      * |- exec1 (execution)
      * |--- exec2 (subExecution)
@@ -355,6 +353,14 @@ public class ExecutionEntityManagerImplTest {
         final String businessKey = "businessKey";
         final String processInstanceId = "processInstanceId";
 
+        boolean isContextInitialized = false;
+
+        if (Context.getCommandContext() == null) {
+            given(commandContext.getExecutionEntityManager()).willReturn(executionEntityManager);
+            Context.setCommandContext(commandContext);
+            isContextInitialized = true;
+        }
+
         // Process instance
         ExecutionEntity pocessInstance = new ExecutionEntityImpl();
         pocessInstance.setId(processInstanceId);
@@ -371,9 +377,6 @@ public class ExecutionEntityManagerImplTest {
 
         ProcessDefinitionCacheEntry cacheEntry = mock(ProcessDefinitionCacheEntry.class);
         given(deploymentManager.resolveProcessDefinition(processDefinition)).willReturn(cacheEntry);
-
-        org.activiti.bpmn.model.Process process = mock(org.activiti.bpmn.model.Process.class);
-        given(process.getExecutionListeners()).willReturn(new ArrayList<>());
 
         // Level 2
         ExecutionEntity exec2 = createChildExecution(exec1);
@@ -406,6 +409,10 @@ public class ExecutionEntityManagerImplTest {
         assertThat(exec1.getProcessInstance().isDeleted()).isTrue();
         assertThat(subProcessExec4_1.getProcessInstance().isDeleted()).isTrue();
         assertThat(subProcessExec4_2.getProcessInstance().isDeleted()).isTrue();
+
+        if (isContextInitialized) {
+            Context.setCommandContext(null);
+        }
     }
 
     private ExecutionEntity createChildExecution(ExecutionEntity parentExecution) {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
@@ -129,8 +129,6 @@ public class ExecutionEntityManagerImplTest {
         String businessKey = "businessKey";
         String tenantId = "tenantId";
 
-        PerformanceSettings performanceSettings = mock(PerformanceSettings.class);
-        given(processEngineConfiguration.getPerformanceSettings()).willReturn(performanceSettings);
         ExecutionEntity execution = new ExecutionEntityImpl();
         execution.setId("processInstanceId");
         given(executionDataManager.create()).willReturn(execution);
@@ -311,8 +309,6 @@ public class ExecutionEntityManagerImplTest {
         String tenantId = "tenantId";
         Date startTime = new Date();
         given(clock.getCurrentTime()).willReturn(startTime);
-        PerformanceSettings performanceSettings = mock(PerformanceSettings.class);
-        given(processEngineConfiguration.getPerformanceSettings()).willReturn(performanceSettings);
         ExecutionEntity execution = new ExecutionEntityImpl();
         execution.setId("processInstanceId");
         given(executionDataManager.create()).willReturn(execution);
@@ -339,12 +335,12 @@ public class ExecutionEntityManagerImplTest {
      *
      * |- exec1 (execution)
      * |--- exec2 (subExecution)
-     * |----- exec3_1 (miExecution)
-     * |------- exec4_1 (miSubExecution)
-     * |--------- subProcessInstance4_1 (subProcessInstance)
-     * |----- exec3_2 (miExecution)
-     * |------- exec4_2 (miSubExecution)
-     * |--------- subProcessInstance4_2 (subProcessInstance)
+     * |----- exec31 (miExecution)
+     * |------- exec41 (miSubExecution)
+     * |--------- subProcessInstance41 (subProcessInstance)
+     * |----- exec32 (miExecution)
+     * |------- exec42 (miSubExecution)
+     * |--------- subProcessInstance42 (subProcessInstance)
      *
      */
     @Test
@@ -353,12 +349,12 @@ public class ExecutionEntityManagerImplTest {
         final String businessKey = "businessKey";
         final String processInstanceId = "processInstanceId";
 
-        boolean isContextInitialized = false;
+        boolean isCmdCtxInitialized = false;
 
         if (Context.getCommandContext() == null) {
             given(commandContext.getExecutionEntityManager()).willReturn(executionEntityManager);
             Context.setCommandContext(commandContext);
-            isContextInitialized = true;
+            isCmdCtxInitialized = true;
         }
 
         // Process instance
@@ -384,33 +380,33 @@ public class ExecutionEntityManagerImplTest {
         exec2.setMultiInstanceRoot(true);
 
         // Level 3 - 1
-        ExecutionEntity exec3_1 = createChildExecution(exec2);
-        exec3_1.setId("exec3_1");
+        ExecutionEntity exec31 = createChildExecution(exec2);
+        exec31.setId("exec31");
 
         // Level 3 - 2
-        ExecutionEntity exec3_2 = createChildExecution(exec2);
-        exec3_2.setId("exec3_2");
+        ExecutionEntity exec32 = createChildExecution(exec2);
+        exec32.setId("exec32");
 
         // Level 4 - 1
-        ExecutionEntity exec4_1 = createChildExecution(exec3_1);
-        exec4_1.setId("exec4_1");
-        ExecutionEntity subProcessExec4_1 = createSubProcessInstance(processDefinition, businessKey, exec4_1, "subProcessInstanceId4_1");
-        exec4_1.setSubProcessInstance(subProcessExec4_1);
+        ExecutionEntity exec41 = createChildExecution(exec31);
+        exec41.setId("exec41");
+        ExecutionEntity subProcessExec41 = createSubProcessInstance(processDefinition, businessKey, exec41, "subProcessInstanceId41");
+        exec41.setSubProcessInstance(subProcessExec41);
 
         // Level 4 - 2
-        ExecutionEntity exec4_2 = createChildExecution(exec3_2);
-        exec4_2.setId("exec4_2");
-        ExecutionEntity subProcessExec4_2 = createSubProcessInstance(processDefinition, businessKey, exec4_2, "subProcessInstanceId4_2");
-        exec4_2.setSubProcessInstance(subProcessExec4_2);
+        ExecutionEntity exec42 = createChildExecution(exec32);
+        exec42.setId("exec42");
+        ExecutionEntity subProcessExec42 = createSubProcessInstance(processDefinition, businessKey, exec42, "subProcessInstanceId42");
+        exec42.setSubProcessInstance(subProcessExec42);
 
         executionEntityManager.deleteProcessInstance(processInstanceId, "deleted by test", true);
 
         // Assert
         assertThat(exec1.getProcessInstance().isDeleted()).isTrue();
-        assertThat(subProcessExec4_1.getProcessInstance().isDeleted()).isTrue();
-        assertThat(subProcessExec4_2.getProcessInstance().isDeleted()).isTrue();
+        assertThat(subProcessExec41.getProcessInstance().isDeleted()).isTrue();
+        assertThat(subProcessExec42.getProcessInstance().isDeleted()).isTrue();
 
-        if (isContextInitialized) {
+        if (isCmdCtxInitialized) {
             Context.setCommandContext(null);
         }
     }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

- Problem
  - When a process is terminated, the sub-processes are not being terminated. 

- Fix
  - Add a for-loop that goes one additional level in the execution tree in order to terminate the sub-process instances as well. This way the code will behave the same way as in Activiti 5.

- Issue Link
  - [MNT-24779](https://hyland.atlassian.net/browse/MNT-24779)

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No


[MNT-24779]: https://hyland.atlassian.net/browse/MNT-24779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ