### PR TITLE
AAE-38145: add support for including non-user-startable processes in process definition query

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -160,6 +160,11 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             .startableByGroups(getCurrentUserGroupsIncludingEveryOneGroup());
     }
 
+    private ProcessDefinitionQuery createProcessDefinitionQueryIncludingNoUserStartableProcesses() {
+        return repositoryService
+            .createProcessDefinitionQuery();
+    }
+
     private Optional<org.activiti.engine.repository.ProcessDefinition> findLatestProcessDefinition(
         ProcessDefinitionQuery processDefinitionQuery
     ) {
@@ -233,9 +238,19 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             getProcessDefinitionsPayload.setProcessDefinitionKeys(securityKeysInPayload.getProcessDefinitionKeys());
         }
 
-        ProcessDefinitionQuery processDefinitionQuery = createProcessDefinitionQueryWithAccessCheck()
-            .latestVersion()
-            .deploymentIds(latestDeploymentIds());
+        ProcessDefinitionQuery processDefinitionQuery;
+
+
+        if (include.contains("noUserStartableProcesses")){
+            processDefinitionQuery = createProcessDefinitionQueryIncludingNoUserStartableProcesses()
+                .latestVersion()
+                .deploymentIds(latestDeploymentIds());
+        } else {
+            processDefinitionQuery = createProcessDefinitionQueryWithAccessCheck()
+                .latestVersion()
+                .deploymentIds(latestDeploymentIds());
+        }
+
 
         if (getProcessDefinitionsPayload.hasDefinitionKeys()) {
             processDefinitionQuery.processDefinitionKeys(getProcessDefinitionsPayload.getProcessDefinitionKeys());

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -76,6 +76,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProcessRuntimeImpl implements ProcessRuntime {
 
     private static final String EVERYONE_GROUP = "*";
+    private static final String NO_USER_STARTABLE_PROCESSES = "noUserStartableProcesses";
 
     private final RepositoryService repositoryService;
 
@@ -241,7 +242,7 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
         ProcessDefinitionQuery processDefinitionQuery;
 
 
-        if (include.contains("noUserStartableProcesses")){
+        if (include.contains(NO_USER_STARTABLE_PROCESSES)){
             processDefinitionQuery = createProcessDefinitionQueryIncludingNoUserStartableProcesses()
                 .latestVersion()
                 .deploymentIds(latestDeploymentIds());

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -357,6 +358,8 @@ public class ProcessRuntimeImplTest {
 
         processRuntime.processDefinitions(Pageable.of(0, 2), List.of());
 
+        verify(processDefinitionQuery).startableByUser(any());
+        verify(processDefinitionQuery).startableByGroups(any());
         verify(processDefinitionQuery).listPage(0, 2);
     }
 
@@ -387,6 +390,30 @@ public class ProcessRuntimeImplTest {
 
         processRuntime.processDefinitions(pageable, payload);
 
+        verify(processDefinitionQuery).startableByUser(any());
+        verify(processDefinitionQuery).startableByGroups(any());
         verify(processDefinitionQuery).processDefinitionCategoryNotEquals(processCategory);
+    }
+
+    @Test
+    void should_includeNoUserStartableProcess_whenSearchingProcessDefinitions() {
+        given(securityPoliciesManager.restrictProcessDefQuery(any())).willReturn(
+            ProcessPayloadBuilder.processDefinitions().build()
+        );
+
+        ProcessDefinitionQuery processDefinitionQuery = mock(ProcessDefinitionQuery.class, Answers.RETURNS_SELF);
+        given(processDefinitionQuery.deploymentIds(any())).willReturn(processDefinitionQuery);
+        given(repositoryService.createDeploymentQuery()).willReturn(mock(DeploymentQuery.class, Answers.RETURNS_SELF));
+        given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
+        given(processDefinitionQuery.listPage(0, 2)).willReturn(Collections.emptyList());
+
+        processRuntime.processDefinitions(Pageable.of(0, 2), List.of("noUserStartableProcesses"));
+
+        verify(securityManager, never()).getAuthenticatedUserId();
+        verify(repositoryService).createProcessDefinitionQuery();
+        verify(processDefinitionQuery, never()).startableByUser(any());
+        verify(processDefinitionQuery, never()).startableByGroups(any());
+        verify(processDefinitionQuery).listPage(0, 2);
+
     }
 }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -1089,10 +1089,6 @@ public class ProcessRuntimeIT {
 
         assertThat(
             processDefinitionPage
-                .getContent()).hasSize(113);
-
-        assertThat(
-            processDefinitionPage
                 .getContent()
                 .stream()
                 .filter(c -> c.getKey().equals(UNSTARTABLE_PROCESS))

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeIT.java
@@ -32,7 +32,9 @@ import org.activiti.api.model.shared.model.VariableInstance;
 import org.activiti.api.process.model.Deployment;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.ProcessInstance;
+import org.activiti.api.process.model.builders.GetProcessDefinitionsPayloadBuilder;
 import org.activiti.api.process.model.builders.ProcessPayloadBuilder;
+import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
 import org.activiti.api.process.model.payloads.SignalPayload;
 import org.activiti.api.process.model.payloads.StartProcessPayload;
 import org.activiti.api.process.model.payloads.UpdateProcessPayload;
@@ -85,6 +87,7 @@ public class ProcessRuntimeIT {
     private static final String TWO_TASKS_PROCESS = "twoTaskProcess";
     private static final Pageable PAGEABLE = Pageable.of(0, 200);
     public static final String CATEGORIZE_HUMAN_PROCESS_CATEGORY = "test-category";
+    public static final String UNSTARTABLE_PROCESS = "UnstartableProcess";
 
     @Autowired
     private ProcessRuntime processRuntime;
@@ -1077,5 +1080,23 @@ public class ProcessRuntimeIT {
         Page<ProcessInstance> processInstancePage = processAdminRuntime.processInstances(Pageable.of(0, 200));
 
         assertThat(processInstancePage).isNotNull();
+    }
+
+    @Test
+    public void should_ReturnProcessDefinitionsFromLatestVersionAndNotStartable() {
+
+        Page<ProcessDefinition> processDefinitionPage = processRuntime.processDefinitions(PAGEABLE,  List.of("noUserStartableProcesses"));
+
+        assertThat(
+            processDefinitionPage
+                .getContent()).hasSize(113);
+
+        assertThat(
+            processDefinitionPage
+                .getContent()
+                .stream()
+                .filter(c -> c.getKey().equals(UNSTARTABLE_PROCESS))
+        )
+            .isNotEmpty();
     }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link:
https://hyland.atlassian.net/browse/AAE-38145
<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
