### PR TITLE
AAE-38377 Add IntelliJ import rules to .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,9 @@ indent_size = 2
 
 [*.java]
 indent_size = 4
+ij_java_imports_layout = $*,|,@*,*
+ij_java_class_count_to_use_import_on_demand = 999999
+ij_java_names_count_to_use_import_on_demand = 999999
 
 [*.md]
 max_line_length = off

--- a/ide-configuration/.editorconfig
+++ b/ide-configuration/.editorconfig
@@ -11,6 +11,9 @@ indent_size = 2
 
 [*.java]
 indent_size = 4
+ij_java_imports_layout = $*,|,@*,*
+ij_java_class_count_to_use_import_on_demand = 999999
+ij_java_names_count_to_use_import_on_demand = 999999
 
 [*.md]
 max_line_length = off


### PR DESCRIPTION
## Summary
This PR adds IntelliJ IDEA import rules to the .editorconfig files to ensure consistent import formatting across all contributors using IntelliJ IDE.

## Changes
- Added IntelliJ Java import rules to  files
- Import layout configured as: static imports, blank line, other imports (`ij_java_imports_layout = $*,|,@*,*`)
- Disabled wildcard imports by setting thresholds to 999999

## Benefits
- Reduces code review time by preventing import-related review comments
- Ensures all IntelliJ users follow the same import standards automatically
- Improves code consistency across the project

## Ticket
AAE-38377