### PR TITLE
MNT-25450: incorrect 'total' calculation when querying historic process instances

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -709,12 +709,15 @@
   </sql>
 
   <sql id="orderBy">
-    <if test="'${v3_limitAfter}' != null">
-      ${v3_limitAfter}
-      <if test="${isCount} != true">
+    <choose>
+      <when test="${isCount}">
+        ${v3_limitAfter_withoutRank}
+      </when>
+      <otherwise>
+        ${v3_limitAfter}
         ORDER BY rnk
-      </if>
-    </if>
+      </otherwise>
+    </choose>
   </sql>
 
   <sql id="selectHistoricProcessInstancesByQueryCriteria">

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -711,10 +711,10 @@
   <sql id="orderBy">
     <choose>
       <when test="${isCount}">
-        ${v3_limitAfter_withoutRank}
+        ${v3_after_withoutLimit}
       </when>
       <otherwise>
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
         ORDER BY rnk
       </otherwise>
     </choose>

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -280,12 +280,12 @@
       <property name="isCount" value="false"/>
     </include>
     <choose>
-      <when test="'${v3_limitAfter}' != null and _databaseId != 'mssql' and _databaseId != 'oracle'">
+      <when test="'${v3_after_withLimit}' != null and _databaseId != 'mssql' and _databaseId != 'oracle'">
         ${orderBy}
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
       </when>
       <otherwise>
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
         ORDER BY rnk
       </otherwise>
     </choose>

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
@@ -2,4 +2,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
@@ -1,3 +1,5 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
@@ -2,4 +2,7 @@
 
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
@@ -4,5 +4,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
@@ -8,4 +8,3 @@ boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
@@ -6,4 +6,6 @@ limitBeforeNativeQuery=SELECT SUB.* FROM ( select RES.* , row_number() over (ORD
 orderBy=
 boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
@@ -2,4 +2,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
@@ -1,3 +1,5 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
@@ -2,4 +2,6 @@ limitBefore=select * from ( select a.*, ROWNUM rnum from (
 limitAfter= ) a where ROWNUM < #{lastRow}) where rnum  >= #{firstRow}
 boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) RES ) ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
@@ -4,4 +4,3 @@ boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) RES ) ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
@@ -1,4 +1,6 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 blobType=BINARY
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
@@ -3,4 +3,3 @@ blobType=BINARY
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
-import org.activiti.engine.impl.TaskQueryImpl;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -1261,16 +1261,10 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
             processInstancesId.add(processInstance.getId());
         }
 
+        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        final List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn(processInstancesId).listPage(0, 3);
-        assertThat(tasks).hasSize(3);
-        assertThat(taskService.createTaskQuery().processInstanceIdIn(processInstancesId).count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
-        ((TaskQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0, 3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.impl.TaskQueryImpl;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;
@@ -1250,6 +1251,29 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
     Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("%unexistingKey%").count();
     assertThat(count.longValue()).isEqualTo(0L);
   }
+
+    @Deployment(resources = {"org/activiti/engine/test/api/task/TaskQueryTest.testTaskVariableValueEquals.bpmn20.xml"})
+    public void testQueryByMaxResults() {
+        // GIVEN: 5 running process instances
+        List<String> processInstancesId = new ArrayList<>();
+        for( int i=0; i<5; i++) {
+            final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+            processInstancesId.add(processInstance.getId());
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        final List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn(processInstancesId).listPage(0, 3);
+        assertThat(tasks).hasSize(3);
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(processInstancesId).count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
+        ((TaskQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+    }
 
   @Deployment
   public void testTaskVariableValueEquals() throws Exception {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -49,15 +49,10 @@ public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
         }
 
+        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        assertThat(historyService.createHistoricProcessInstanceQuery().listPage(0, 3)).hasSize(3);
-        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().desc();
-        ((HistoricProcessInstanceQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0, 3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.history.HistoricIdentityLink;
 import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.history.HistoricProcessInstanceQuery;
+import org.activiti.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -39,6 +41,27 @@ import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
 
 public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
+
+    @Deployment(resources = {"org/activiti/engine/test/history/oneTaskProcess.bpmn20.xml"})
+    public void testHistoricProcessInstanceMaxResults() {
+        // GIVEN: 5 running process instances
+        for (int i=0; i<5; i++) {
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        assertThat(historyService.createHistoricProcessInstanceQuery().listPage(0, 3)).hasSize(3);
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().desc();
+        ((HistoricProcessInstanceQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+    }
+
 
     @Deployment(resources = {"org/activiti/engine/test/history/oneTaskProcess.bpmn20.xml"})
     public void testHistoricDataCreatedForProcessExecution() {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -32,7 +32,6 @@ import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.history.HistoricIdentityLink;
 import org.activiti.engine.history.HistoricProcessInstance;
 import org.activiti.engine.history.HistoricProcessInstanceQuery;
-import org.activiti.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -36,9 +37,11 @@ import org.activiti.engine.history.HistoricActivityInstance;
 import org.activiti.engine.history.HistoricDetail;
 import org.activiti.engine.history.HistoricProcessInstance;
 import org.activiti.engine.history.HistoricTaskInstance;
+import org.activiti.engine.history.HistoricTaskInstanceQuery;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.history.HistoricVariableUpdate;
+import org.activiti.engine.impl.HistoricTaskInstanceQueryImpl;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
 import org.activiti.engine.impl.variable.EntityManagerSession;
 import org.activiti.engine.impl.variable.EntityManagerSessionFactory;
@@ -592,6 +595,30 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
 
         assertThatExceptionOfType(ActivitiIllegalArgumentException.class)
             .isThrownBy(() -> historyService.createHistoricDetailQuery().orderByVariableType().list());
+    }
+
+    @Deployment(resources = {"org/activiti/standalone/history/FullHistoryTest.testHistoricTaskInstanceVariableUpdates.bpmn20.xml"})
+    public void testHistoricTaskInstanceWithMaxResults() {
+        // GIVEN: 5 running process
+        List<String> processInstanceIds = new ArrayList<>();
+        for (int i=0;i<5;i++) {
+            final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
+            processInstanceIds.add(processInstance.getId());
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        final List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().listPage(0, 3);
+        assertThat(tasks).hasSize(3);
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
+        ((HistoricTaskInstanceQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+
     }
 
     @Deployment

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -606,19 +606,12 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
             processInstanceIds.add(processInstance.getId());
         }
 
+        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        final List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().listPage(0, 3);
-        assertThat(tasks).hasSize(3);
-        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
-        ((HistoricTaskInstanceQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0,3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
-
     }
 
     @Deployment

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -41,7 +41,6 @@ import org.activiti.engine.history.HistoricTaskInstanceQuery;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.history.HistoricVariableUpdate;
-import org.activiti.engine.impl.HistoricTaskInstanceQueryImpl;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
 import org.activiti.engine.impl.variable.EntityManagerSession;
 import org.activiti.engine.impl.variable.EntityManagerSessionFactory;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/MNT-25450

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
