### PR TITLE
MNT-25450: incorrect 'total' calculation when querying historic process instances testcontainers 8.1.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,21 +41,21 @@ jobs:
         database: [ none, mssql, mysql, postgres, mariadb, oracle ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
 
-      - name: Setup Java JDK 21
-        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # 4.2.1
+      - name: Setup Java JDK 17
+        uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # 3.12.0
         with:
-          java-version: 21
+          java-version: 17
           distribution: 'temurin'
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: []pre-commit, database-tests]
+    needs: [pre-commit, database-tests]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,14 @@ on:
       - reopened
       - synchronize
       - labeled
+
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name || github.run_id }}
   cancel-in-progress: true
+
 jobs:
   check-ext-build:
     name: Check dependabot/external build
@@ -28,9 +31,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@v3.0.2
-  build:
+
+  database-tests:
     runs-on: ubuntu-latest
     needs: pre-commit
+    strategy:
+      fail-fast: false
+      matrix:
+        database: [ none, mssql, mysql, postgres, mariadb, oracle ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Setup Java JDK 21
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # 4.2.1
+        with:
+          java-version: 21
+          distribution: 'temurin'
+
+      - name: Test
+        shell: bash
+        run: mvn test -Dlicense.skipAddThirdParty=true -Ddb=${{ matrix.database }} ${{ env.MAVEN_CLI_OPTS}}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: []pre-commit, database-tests]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -15,6 +15,8 @@
 
   <properties>
     <activiti-engine.unpack.version>7.2.0</activiti-engine.unpack.version>
+    <postgresql.version>42.7.2</postgresql.version>
+    <testcontainers.version>1.19.8</testcontainers.version>
   </properties>
 
   <dependencies>
@@ -194,15 +196,61 @@
       <artifactId>hibernate-core</artifactId>
       <optional>true</optional>
     </dependency>
+
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mssqlserver</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.microsoft.sqlserver</groupId>
+      <artifactId>mssql-jdbc</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>oracle-xe</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.database.jdbc</groupId>
+      <artifactId>ojdbc8</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mariadb</artifactId>
+      <version>${testcontainers.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.mariadb.jdbc</groupId>
+      <artifactId>mariadb-java-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <scope>test</scope>
+      <version>${testcontainers.version}</version>
     </dependency>
     <dependency>
       <groupId>org.postgresql</groupId>

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/AbstractNativeQuery.java
@@ -122,11 +122,8 @@ public abstract class AbstractNativeQuery<T extends NativeQuery<?, ?>, U> implem
       parameterMap.put("resultType", "LIST_PAGE");
       parameterMap.put("firstResult", firstResult);
       parameterMap.put("maxResults", maxResults);
-      if (StringUtils.isNotBlank(Objects.toString(parameterMap.get("orderBy")))) {
-        parameterMap.put("orderByColumns", "RES." + parameterMap.get("orderBy"));
-      } else {
-        parameterMap.put("orderByColumns", "RES.ID_ asc");
-      }
+      Object orderBy = parameterMap.getOrDefault("orderBy", "ID_ asc");
+      parameterMap.put("orderByColumns", "RES." + orderBy);
 
       int firstRow = firstResult + 1;
       parameterMap.put("firstRow", firstRow);

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/test/PluggableActivitiTestCase.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/test/PluggableActivitiTestCase.java
@@ -28,8 +28,15 @@ import org.activiti.engine.impl.interceptor.CommandInvoker;
 import org.activiti.engine.impl.interceptor.DebugCommandInvoker;
 import org.activiti.engine.impl.interceptor.RetryInterceptor;
 import org.activiti.engine.test.EnableVerboseExecutionTreeLogging;
+import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MSSQLServerContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
 
 /**
  * Base class for the activiti test cases.
@@ -44,6 +51,42 @@ import org.slf4j.LoggerFactory;
 public abstract class PluggableActivitiTestCase extends AbstractActivitiTestCase {
 
   private static Logger pluggableActivitiTestCaseLogger = LoggerFactory.getLogger(PluggableActivitiTestCase.class);
+
+
+    @Rule
+    public static JdbcDatabaseContainer databaseContainer = Database.getInstance().startNewJdbcDatabaseContainer();
+
+    public static class JDBCProperties {
+
+        private JDBCProperties() {
+        }
+
+        public static String getUrl() {
+            if (databaseContainer == null) return "jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1";
+            return databaseContainer.getJdbcUrl();
+        }
+
+        public static String getUsername() {
+            if (databaseContainer == null) return "sa";
+            return databaseContainer.getUsername();
+        }
+
+        public static String getPassword() {
+            if (databaseContainer == null) return "";
+            return databaseContainer.getPassword();
+        }
+
+        public static String getDriver() {
+            if (databaseContainer == null) return "org.h2.Driver";
+            return databaseContainer.getDriverClassName();
+        }
+
+        public static JDBCProperties getInstance() {
+            return new JDBCProperties();
+        }
+
+    }
+
 
   protected static ProcessEngine cachedProcessEngine;
 
@@ -129,5 +172,80 @@ public abstract class PluggableActivitiTestCase extends AbstractActivitiTestCase
         commandExecutor.setFirst(original);
     }
   }
+
+    public enum Database {
+        POSTGRES {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                PostgreSQLContainer postgreSQLContainer = new PostgreSQLContainer("postgres:13.7");
+                postgreSQLContainer.start();
+                return postgreSQLContainer;
+            }
+        },
+        ORACLE {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                OracleContainer oracleContainer = new OracleContainer(
+                    "gvenzl/oracle-xe:21-slim-faststart")
+                    .withDatabaseName("testDB")
+                    .withUsername("testUser")
+                    .withPassword("testPassword");
+
+                oracleContainer.start();
+                return oracleContainer;
+            }
+
+        },
+        MYSQL {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                MySQLContainer mySQLContainer = new MySQLContainer("mysql:8");
+                mySQLContainer.start();
+                return mySQLContainer;
+            }
+        },
+        MARIADB {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                MariaDBContainer mariaDBContainer = new MariaDBContainer("mariadb:10.6.16");
+                mariaDBContainer.start();
+                return mariaDBContainer;
+            }
+        },
+        MSSQL {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                MSSQLServerContainer mssqlserver = new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU9-ubuntu-16.04")
+                    .acceptLicense();
+                mssqlserver.addEnv("MSSQL_COLLATION", "LATIN1_GENERAL_100_CS_AS_SC_UTF8");
+                mssqlserver.start();
+                return mssqlserver;
+            }
+
+        },
+        NONE {
+            @Override
+            protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+                return null;
+            }
+        };
+
+        protected JdbcDatabaseContainer startNewJdbcDatabaseContainer() {
+            throw new UnsupportedOperationException(
+                String.format(
+                    "The [%s] database was not configured to use Testcontainers!",
+                    name()
+                )
+            );
+        }
+
+        public static Database getInstance() {
+            String database = System.getProperty("db");
+            database = database == null ? "NONE" : database.toUpperCase();
+            pluggableActivitiTestCaseLogger.info("Initiating " + database + " container");
+            return valueOf(database);
+        }
+
+    }
 
 }

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -709,12 +709,15 @@
   </sql>
 
   <sql id="orderBy">
-    <if test="'${v3_limitAfter}' != null">
-      ${v3_limitAfter}
-      <if test="${isCount} != true">
+    <choose>
+      <when test="${isCount}">
+        ${v3_limitAfter_withoutRank}
+      </when>
+      <otherwise>
+        ${v3_limitAfter}
         ORDER BY rnk
-      </if>
-    </if>
+      </otherwise>
+    </choose>
   </sql>
 
   <sql id="selectHistoricProcessInstancesByQueryCriteria">

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/HistoricProcessInstance.xml
@@ -711,10 +711,10 @@
   <sql id="orderBy">
     <choose>
       <when test="${isCount}">
-        ${v3_limitAfter_withoutRank}
+        ${v3_after_withoutLimit}
       </when>
       <otherwise>
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
         ORDER BY rnk
       </otherwise>
     </choose>

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -280,12 +280,12 @@
       <property name="isCount" value="false"/>
     </include>
     <choose>
-      <when test="'${v3_limitAfter}' != null and _databaseId != 'mssql' and _databaseId != 'oracle'">
+      <when test="'${v3_after_withLimit}' != null and _databaseId != 'mssql' and _databaseId != 'oracle'">
         ${orderBy}
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
       </when>
       <otherwise>
-        ${v3_limitAfter}
+        ${v3_after_withLimit}
         ORDER BY rnk
       </otherwise>
     </choose>

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
@@ -2,4 +2,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/h2.properties
@@ -1,3 +1,5 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
@@ -2,4 +2,7 @@
 
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mariadb.properties
@@ -4,5 +4,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
@@ -8,4 +8,3 @@ boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mssql.properties
@@ -6,4 +6,6 @@ limitBeforeNativeQuery=SELECT SUB.* FROM ( select RES.* , row_number() over (ORD
 orderBy=
 boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
@@ -2,4 +2,3 @@ limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/mysql.properties
@@ -1,3 +1,5 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
@@ -2,4 +2,6 @@ limitBefore=select * from ( select a.*, ROWNUM rnum from (
 limitAfter= ) a where ROWNUM < #{lastRow}) where rnum  >= #{firstRow}
 boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) RES ) ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/oracle.properties
@@ -4,4 +4,3 @@ boolValue=1
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) RES ) ranked WHERE rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) RES ) ranked
-

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
@@ -1,4 +1,6 @@
 limitAfter=LIMIT #{maxResults} OFFSET #{firstResult}
 blobType=BINARY
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
-v3_limitAfter=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withLimit=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
+v3_after_withoutLimit=) as RES ) as ranked
+

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/properties/postgres.properties
@@ -3,4 +3,3 @@ blobType=BINARY
 v3_limitBetween=, row_number() over (ORDER BY ${orderByColumns}) rnk
 v3_after_withLimit=) as RES ) as ranked where rnk >= #{firstRow} AND rnk < #{lastRow}
 v3_after_withoutLimit=) as RES ) as ranked
-

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -1261,16 +1261,10 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
             processInstancesId.add(processInstance.getId());
         }
 
+        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        final List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn(processInstancesId).listPage(0, 3);
-        assertThat(tasks).hasSize(3);
-        assertThat(taskService.createTaskQuery().processInstanceIdIn(processInstancesId).count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
-        ((TaskQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0, 3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/task/TaskQueryTest.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import org.activiti.api.runtime.shared.identity.UserGroupManager;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiIllegalArgumentException;
+import org.activiti.engine.impl.TaskQueryImpl;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;
@@ -1250,6 +1251,29 @@ public class TaskQueryTest extends PluggableActivitiTestCase {
     Long count = taskService.createTaskQuery().or().taskId("invalid").taskDefinitionKeyLike("%unexistingKey%").count();
     assertThat(count.longValue()).isEqualTo(0L);
   }
+
+    @Deployment(resources = {"org/activiti/engine/test/api/task/TaskQueryTest.testTaskVariableValueEquals.bpmn20.xml"})
+    public void testQueryByMaxResults() {
+        // GIVEN: 5 running process instances
+        List<String> processInstancesId = new ArrayList<>();
+        for( int i=0; i<5; i++) {
+            final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("oneTaskProcess");
+            processInstancesId.add(processInstance.getId());
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        final List<Task> tasks = taskService.createTaskQuery().processInstanceIdIn(processInstancesId).listPage(0, 3);
+        assertThat(tasks).hasSize(3);
+        assertThat(taskService.createTaskQuery().processInstanceIdIn(processInstancesId).count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final TaskQuery query = taskService.createTaskQuery().processInstanceIdIn(processInstancesId);
+        ((TaskQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+    }
 
   @Deployment
   public void testTaskVariableValueEquals() throws Exception {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -49,15 +49,10 @@ public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
             runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
         }
 
+        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery();
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        assertThat(historyService.createHistoricProcessInstanceQuery().listPage(0, 3)).hasSize(3);
-        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().desc();
-        ((HistoricProcessInstanceQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0, 3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/history/HistoricProcessInstanceTest.java
@@ -31,6 +31,8 @@ import java.util.Map;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.history.HistoricIdentityLink;
 import org.activiti.engine.history.HistoricProcessInstance;
+import org.activiti.engine.history.HistoricProcessInstanceQuery;
+import org.activiti.engine.impl.HistoricProcessInstanceQueryImpl;
 import org.activiti.engine.impl.history.HistoryLevel;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
 import org.activiti.engine.runtime.ProcessInstance;
@@ -39,6 +41,27 @@ import org.activiti.engine.task.Task;
 import org.activiti.engine.test.Deployment;
 
 public class HistoricProcessInstanceTest extends PluggableActivitiTestCase {
+
+    @Deployment(resources = {"org/activiti/engine/test/history/oneTaskProcess.bpmn20.xml"})
+    public void testHistoricProcessInstanceMaxResults() {
+        // GIVEN: 5 running process instances
+        for (int i=0; i<5; i++) {
+            runtimeService.startProcessInstanceByKey("oneTaskProcess", "myBusinessKey");
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        assertThat(historyService.createHistoricProcessInstanceQuery().listPage(0, 3)).hasSize(3);
+        assertThat(historyService.createHistoricProcessInstanceQuery().count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final HistoricProcessInstanceQuery query = historyService.createHistoricProcessInstanceQuery().orderByProcessInstanceStartTime().desc();
+        ((HistoricProcessInstanceQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+    }
+
 
     @Deployment(resources = {"org/activiti/engine/test/history/oneTaskProcess.bpmn20.xml"})
     public void testHistoricDataCreatedForProcessExecution() {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/examples/mgmt/ManagementServiceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/examples/mgmt/ManagementServiceTest.java
@@ -57,7 +57,7 @@ public class ManagementServiceTest extends PluggableActivitiTestCase {
     assertThat(assigneeIndex).isGreaterThanOrEqualTo(0);
     assertThat(createTimeIndex).isGreaterThanOrEqualTo(0);
 
-    assertThat(tableMetaData.getColumnTypes().get(assigneeIndex)).isIn("CHARACTER VARYING");
+    assertThat(tableMetaData.getColumnTypes().get(assigneeIndex)).isIn("VARCHAR", "NVARCHAR2", "nvarchar", "NVARCHAR","CHARACTER VARYING");
     assertThat(tableMetaData.getColumnTypes().get(createTimeIndex)).isIn("TIMESTAMP", "TIMESTAMP(6)", "datetime", "DATETIME");
   }
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
@@ -36,9 +37,11 @@ import org.activiti.engine.history.HistoricActivityInstance;
 import org.activiti.engine.history.HistoricDetail;
 import org.activiti.engine.history.HistoricProcessInstance;
 import org.activiti.engine.history.HistoricTaskInstance;
+import org.activiti.engine.history.HistoricTaskInstanceQuery;
 import org.activiti.engine.history.HistoricVariableInstance;
 import org.activiti.engine.history.HistoricVariableInstanceQuery;
 import org.activiti.engine.history.HistoricVariableUpdate;
+import org.activiti.engine.impl.HistoricTaskInstanceQueryImpl;
 import org.activiti.engine.impl.test.ResourceActivitiTestCase;
 import org.activiti.engine.impl.variable.EntityManagerSession;
 import org.activiti.engine.impl.variable.EntityManagerSessionFactory;
@@ -592,6 +595,30 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
 
         assertThatExceptionOfType(ActivitiIllegalArgumentException.class)
             .isThrownBy(() -> historyService.createHistoricDetailQuery().orderByVariableType().list());
+    }
+
+    @Deployment(resources = {"org/activiti/standalone/history/FullHistoryTest.testHistoricTaskInstanceVariableUpdates.bpmn20.xml"})
+    public void testHistoricTaskInstanceWithMaxResults() {
+        // GIVEN: 5 running process
+        List<String> processInstanceIds = new ArrayList<>();
+        for (int i=0;i<5;i++) {
+            final ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("HistoricTaskInstanceTest");
+            processInstanceIds.add(processInstance.getId());
+        }
+
+        // WHEN: listing, at most, 3 running process instances
+        // THEN: the result must have 3 results
+        // THEN: total number of process instances is 5
+        final List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().listPage(0, 3);
+        assertThat(tasks).hasSize(3);
+        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(5);
+
+        // WHEN: listing, at most, 3 running process instances
+        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
+        ((HistoricTaskInstanceQueryImpl)query).setMaxResults(3);
+        // THEN: total number of process instances is 5
+        assertThat(query.count()).isEqualTo(5);
+
     }
 
     @Deployment

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/history/FullHistoryTest.java
@@ -606,19 +606,12 @@ public class FullHistoryTest extends ResourceActivitiTestCase {
             processInstanceIds.add(processInstance.getId());
         }
 
+        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
         // WHEN: listing, at most, 3 running process instances
         // THEN: the result must have 3 results
-        // THEN: total number of process instances is 5
-        final List<HistoricTaskInstance> tasks = historyService.createHistoricTaskInstanceQuery().listPage(0, 3);
-        assertThat(tasks).hasSize(3);
-        assertThat(historyService.createHistoricTaskInstanceQuery().count()).isEqualTo(5);
-
-        // WHEN: listing, at most, 3 running process instances
-        final HistoricTaskInstanceQuery query = historyService.createHistoricTaskInstanceQuery();
-        ((HistoricTaskInstanceQueryImpl)query).setMaxResults(3);
+        assertThat(query.listPage(0,3)).hasSize(3);
         // THEN: total number of process instances is 5
         assertThat(query.count()).isEqualTo(5);
-
     }
 
     @Deployment

--- a/activiti-core/activiti-engine/src/test/resources/activiti.cfg.xml
+++ b/activiti-core/activiti-engine/src/test/resources/activiti.cfg.xml
@@ -5,11 +5,18 @@
   xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
 
   <bean id="processEngineConfiguration" class="org.activiti.engine.impl.cfg.StandaloneProcessEngineConfiguration">
-
-    <property name="jdbcUrl" value="jdbc:h2:mem:activiti;DB_CLOSE_DELAY=-1" />
-    <property name="jdbcDriver" value="org.h2.Driver" />
-    <property name="jdbcUsername" value="sa" />
-    <property name="jdbcPassword" value="" />
+    <property name="jdbcUrl">
+      <bean factory-method="getUrl" class="org.activiti.engine.impl.test.PluggableActivitiTestCase.JDBCProperties" />
+    </property>
+    <property name="jdbcDriver">
+      <bean factory-method="getDriver" class="org.activiti.engine.impl.test.PluggableActivitiTestCase.JDBCProperties" />
+    </property>
+    <property name="jdbcUsername">
+      <bean factory-method="getUsername" class="org.activiti.engine.impl.test.PluggableActivitiTestCase.JDBCProperties" />
+    </property>
+    <property name="jdbcPassword">
+      <bean factory-method="getPassword" class="org.activiti.engine.impl.test.PluggableActivitiTestCase.JDBCProperties" />
+    </property>
 
     <!-- Database configurations -->
     <property name="databaseSchemaUpdate" value="drop-create" />


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [X] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/MNT-25450

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [X] No
