### PR TITLE
AAE-38661 Fix deletion process instances with duplicate variables

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImpl.java
@@ -759,29 +759,7 @@ public class ExecutionEntityManagerImpl
             }
         }
 
-        // Get variables related to execution and delete them
-        if (
-            !enableExecutionRelationshipCounts ||
-                (enableExecutionRelationshipCounts && ((CountingExecutionEntity) executionEntity).getVariableCount() > 0)
-        ) {
-            Collection<VariableInstance> executionVariables = executionEntity.getVariableInstancesLocal().values();
-            for (VariableInstance variableInstance : executionVariables) {
-                if (variableInstance instanceof VariableInstanceEntity) {
-                    VariableInstanceEntity variableInstanceEntity = (VariableInstanceEntity) variableInstance;
-
-                    VariableInstanceEntityManager variableInstanceEntityManager = getVariableInstanceEntityManager();
-                    variableInstanceEntityManager.delete(variableInstanceEntity);
-                    if (
-                        variableInstanceEntity.getByteArrayRef() != null &&
-                            variableInstanceEntity.getByteArrayRef().getId() != null
-                    ) {
-                        getByteArrayEntityManager().deleteByteArrayById(
-                            variableInstanceEntity.getByteArrayRef().getId()
-                        );
-                    }
-                }
-            }
-        }
+        deleteVariables(executionEntity, enableExecutionRelationshipCounts);
 
         // Delete jobs
 
@@ -868,6 +846,29 @@ public class ExecutionEntityManagerImpl
             for (EventSubscriptionEntity eventSubscription : eventSubscriptions) {
                 eventSubscriptionEntityManager.delete(eventSubscription);
             }
+        }
+
+    }
+
+    private void deleteVariables(ExecutionEntity executionEntity, boolean enableExecutionRelationshipCounts) {
+        if (
+            !enableExecutionRelationshipCounts || ((CountingExecutionEntity) executionEntity).getVariableCount() > 0
+        ) {
+            List<VariableInstanceEntity> executionVariables =
+                getVariableInstanceEntityManager().findVariableInstancesByExecutionId(executionEntity.getId());
+            for (VariableInstanceEntity variableInstanceEntity : executionVariables) {
+                VariableInstanceEntityManager variableInstanceEntityManager = getVariableInstanceEntityManager();
+                variableInstanceEntityManager.delete(variableInstanceEntity);
+                if (
+                    variableInstanceEntity.getByteArrayRef() != null &&
+                        variableInstanceEntity.getByteArrayRef().getId() != null
+                ) {
+                    getByteArrayEntityManager().deleteByteArrayById(
+                        variableInstanceEntity.getByteArrayRef().getId()
+                    );
+                }
+            }
+
         }
     }
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
@@ -101,6 +101,9 @@ public class ExecutionEntityManagerImplTest {
     private EventSubscriptionEntityManager eventSubscriptionEntityManager;
 
     @Mock
+    private VariableInstanceEntityManager variableInstanceEntityManager;
+
+    @Mock
     private HistoricProcessInstanceEntityManager historicProcessInstanceEntityManager;
 
     @Before
@@ -120,6 +123,7 @@ public class ExecutionEntityManagerImplTest {
         given(processEngineConfiguration.getEventSubscriptionEntityManager()).willReturn(
             eventSubscriptionEntityManager
         );
+        given(processEngineConfiguration.getVariableInstanceEntityManager()).willReturn(variableInstanceEntityManager);
         given(processEngineConfiguration.getHistoricProcessInstanceEntityManager()).willReturn(
             historicProcessInstanceEntityManager
         );
@@ -485,7 +489,7 @@ public class ExecutionEntityManagerImplTest {
         ));
 
         given(executionEntityManager.findById("validProcessInstanceId")).willReturn(processInstanceEntity);
-        given(commandContext.getVariableInstanceEntityManager()).willReturn(mock(VariableInstanceEntityManager.class));
+
         executionEntityManager.deleteProcessInstanceExecutionEntity(
             "validProcessInstanceId",
             "currentFlowElementId",
@@ -533,7 +537,7 @@ public class ExecutionEntityManagerImplTest {
         ));
 
         given(executionEntityManager.findById("validProcessInstanceId")).willReturn(processInstanceEntity);
-        given(commandContext.getVariableInstanceEntityManager()).willReturn(mock(VariableInstanceEntityManager.class));
+
         executionEntityManager.deleteProcessInstanceExecutionEntity(
             "validProcessInstanceId",
             "currentFlowElementId",

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/VariableEventsTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/VariableEventsTest.java
@@ -229,13 +229,19 @@ public class VariableEventsTest extends PluggableActivitiTestCase {
             .collect(Collectors.toList());
         assertThat(variableEvents)
             .extracting(ActivitiVariableEvent::getType, ActivitiVariableEvent::getVariableName)
-            .containsExactly(
+            .startsWith(
                 tuple(ActivitiEventType.VARIABLE_CREATED, "parentVar1"),
                 tuple(ActivitiEventType.VARIABLE_CREATED, "subVar1"),
                 tuple(ActivitiEventType.VARIABLE_CREATED, "parentVar2"),
-                tuple(ActivitiEventType.VARIABLE_DELETED, "subVar1"),
-                tuple(ActivitiEventType.VARIABLE_DELETED, "parentVar2"),
-                tuple(ActivitiEventType.VARIABLE_DELETED, "parentVar1")
+                tuple(ActivitiEventType.VARIABLE_DELETED, "subVar1")
+            );
+        // The deletion order of parentVar1 and parentVar2 is not guaranteed
+        // because they belong to the same execution and the DB query has no ORDER BY
+        assertThat(variableEvents.subList(4, 6))
+            .extracting(ActivitiVariableEvent::getType, ActivitiVariableEvent::getVariableName)
+            .containsExactlyInAnyOrder(
+                tuple(ActivitiEventType.VARIABLE_DELETED, "parentVar1"),
+                tuple(ActivitiEventType.VARIABLE_DELETED, "parentVar2")
             );
     }
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/executioncount/VerifyDatabaseOperationsTest.java
@@ -145,7 +145,7 @@ public class VerifyDatabaseOperationsTest extends PluggableActivitiTestCase {
             "process-variables-servicetask01"
         );
 
-        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L);
+        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L, "selectVariablesByExecutionId", 1L);
         assertDatabaseInserts(
             "StartProcessInstanceCmd",
             "HistoricVariableInstanceEntityImpl-bulk-with-4",
@@ -167,7 +167,7 @@ public class VerifyDatabaseOperationsTest extends PluggableActivitiTestCase {
             "process-variables-servicetask02"
         );
 
-        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L);
+        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L, "selectVariablesByExecutionId", 1L);
         assertDatabaseInserts(
             "StartProcessInstanceCmd",
             "HistoricVariableInstanceEntityImpl-bulk-with-50",
@@ -237,7 +237,7 @@ public class VerifyDatabaseOperationsTest extends PluggableActivitiTestCase {
     public void testExlusiveGateway() {
         deployStartProcessInstanceAndProfile("process05.bpmn20.xml", "process05");
 
-        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L);
+        assertDatabaseSelects("StartProcessInstanceCmd", "selectLatestProcessDefinitionByKey", 1L, "selectIdentityLinksByProcessInstance", 1L, "selectVariablesByExecutionId", 1L);
         assertDatabaseInserts(
             "StartProcessInstanceCmd",
             "HistoricActivityInstanceEntityImpl-bulk-with-5",

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/db/DuplicateVariableInsertViaPropagatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/db/DuplicateVariableInsertViaPropagatorTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.db;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BrokenBarrierException;
+import java.util.concurrent.CyclicBarrier;
+import org.activiti.engine.impl.bpmn.behavior.MappingExecutionContext;
+import org.activiti.engine.impl.bpmn.behavior.VariablesCalculator;
+import org.activiti.engine.impl.bpmn.behavior.VariablesPropagator;
+import org.activiti.engine.impl.interceptor.Command;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.impl.persistence.entity.VariableInstance;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.task.Task;
+import org.assertj.core.groups.Tuple;
+
+/**
+ * Test demonstrating that concurrent variable propagation via {@link VariablesPropagator}
+ * can produce duplicate-named variables in the database
+ *
+ * This simulates what happens when multiple concurrent connector results
+ * (e.g. from parallel multi-instance service tasks) each propagate output variables
+ * with the same name to the root process instance via separate REQUIRES_NEW transactions.
+ */
+public class DuplicateVariableInsertViaPropagatorTest extends PluggableActivitiTestCase {
+
+    /**
+     * Two threads concurrently propagate the same variable name via {@link VariablesPropagator}.
+     * Under READ COMMITTED isolation, both threads see no existing variable and each inserts a new row,
+     * resulting in duplicate-named variables in the database.
+     */
+    public void testBeAbleToDeleteProcessWithDuplicateVariableInsertViaVariablesPropagator() throws Exception {
+        String processDefinitionId = deployOneTaskTestProcess();
+        final ProcessInstance processInstance = runtimeService.startProcessInstanceById(processDefinitionId);
+
+        final Task task = taskService.createTaskQuery().processInstanceId(processInstance.getId()).singleResult();
+        final String childExecutionId = task.getExecutionId();
+
+        final CyclicBarrier startBarrier = new CyclicBarrier(2);
+        final CyclicBarrier endBarrier = new CyclicBarrier(2);
+
+        final List<Exception> exceptions = new ArrayList<Exception>();
+
+        Thread firstThread = new Thread(
+            new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        managementService.executeCommand(
+                            new PropagateVariablesWithBarriersCommand(
+                                startBarrier,
+                                endBarrier,
+                                childExecutionId
+                            )
+                        );
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+            }
+        );
+
+        Thread secondThread = new Thread(
+            new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        managementService.executeCommand(
+                            new PropagateVariablesWithBarriersCommand(
+                                startBarrier,
+                                endBarrier,
+                                childExecutionId
+                            )
+                        );
+                    } catch (Exception e) {
+                        exceptions.add(e);
+                    }
+                }
+            }
+        );
+
+        firstThread.start();
+        secondThread.start();
+
+        firstThread.join();
+        secondThread.join();
+
+        // Use getVariableInstancesByExecutionIds to load all variable instances (including duplicates)
+        Set<String> executionIds = new HashSet<String>();
+        executionIds.add(processInstance.getId());
+        List<VariableInstance> variableInstances = runtimeService.getVariableInstancesByExecutionIds(executionIds);
+
+        // Only one variable instance should exist (no duplicates)
+        assertThat(variableInstances)
+            .extracting(VariableInstance::getName, VariableInstance::getValue)
+            .containsExactly(
+                Tuple.tuple("var", "12345"),
+                Tuple.tuple("var", "12345"));
+
+        assertThat(exceptions).isEmpty();
+
+        runtimeService.deleteProcessInstance(processInstance.getId(), "ShouldNotFail");
+    }
+
+    /**
+     * Command that wraps {@link VariablesPropagator#propagate} with barrier synchronization
+     * to guarantee concurrent execution of variable propagation from two threads.
+     *
+     * Uses a pass-through {@link VariablesCalculator} that returns variables as-is,
+     * simulating the behavior of connector output variable propagation.
+     */
+    private class PropagateVariablesWithBarriersCommand implements Command<Void> {
+
+        private final CyclicBarrier startBarrier;
+        private final CyclicBarrier endBarrier;
+        private final String executionId;
+
+        public PropagateVariablesWithBarriersCommand(
+            CyclicBarrier startBarrier,
+            CyclicBarrier endBarrier,
+            String executionId
+        ) {
+            this.startBarrier = startBarrier;
+            this.endBarrier = endBarrier;
+            this.executionId = executionId;
+        }
+
+        @Override
+        public Void execute(CommandContext commandContext) {
+            try {
+                startBarrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            }
+
+            ExecutionEntity execution = commandContext.getExecutionEntityManager().findById(executionId);
+
+            // Use a pass-through calculator that returns available variables as-is,
+            // simulating what happens with connector output variables
+            VariablesPropagator propagator = getVariablesPropagator();
+            propagator.propagate(execution, singletonMap("var", "12345"));
+
+            try {
+                endBarrier.await();
+            } catch (InterruptedException | BrokenBarrierException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        }
+
+        private VariablesPropagator getVariablesPropagator() {
+            VariablesCalculator passThroughCalculator = new VariablesCalculator() {
+                @Override
+                public Map<String, Object> calculateOutPutVariables(
+                    MappingExecutionContext mappingExecutionContext,
+                    Map<String, Object> availableVariables
+                ) {
+                    return availableVariables;
+                }
+
+                @Override
+                public Map<String, Object> calculateInputVariables(
+                    org.activiti.engine.delegate.DelegateExecution execution
+                ) {
+                    return null;
+                }
+            };
+
+            return new VariablesPropagator(passThroughCalculator);
+        }
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
@@ -41,10 +41,11 @@ class DeleteProcessInstanceFKViolationTest {
 
     @BeforeEach
     void setUp() {
+        String processEngineName = "activiti-fk-test-" + UUID.randomUUID();
         processEngine =
             ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration()
-                .setProcessEngineName("activiti-fk-test-" + UUID.randomUUID())
-                .setJdbcUrl("jdbc:h2:mem:activiti-fk-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=1000")
+                .setProcessEngineName(processEngineName)
+                .setJdbcUrl("jdbc:h2:mem:" + processEngineName + ";DB_CLOSE_DELAY=1000")
                 .setJdbcUsername("sa")
                 .setJdbcPassword("")
                 .setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP)

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
@@ -16,7 +16,6 @@
 package org.activiti.engine.test.regression;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -103,16 +102,16 @@ class DeleteProcessInstanceFKViolationTest {
         runtimeService.deleteProcessInstance(processInstance.getId(), "test");
 
         assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count())
-            .isEqualTo(0);
+            .isZero();
 
         try (Connection conn = getConnection()) {
             assertThat(countVariablesByProcessInstance(conn, executionId))
                 .as("No variables should remain after deletion")
-                .isEqualTo(0);
+                .isZero();
 
             assertThat(countByteArraysByName(conn, "var:duplicateVar"))
                 .as("No byte arrays should remain after deletion")
-                .isEqualTo(0);
+                .isZero();
         }
     }
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
@@ -44,6 +44,7 @@ class DeleteProcessInstanceFKViolationTest {
     void setUp() {
         processEngine =
             ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration()
+                .setProcessEngineName("activiti-fk-test-" + UUID.randomUUID())
                 .setJdbcUrl("jdbc:h2:mem:activiti-fk-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=1000")
                 .setJdbcUsername("sa")
                 .setJdbcPassword("")

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/regression/DeleteProcessInstanceFKViolationTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.regression;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+import org.activiti.engine.ProcessEngine;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.RepositoryService;
+import org.activiti.engine.RuntimeService;
+import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class DeleteProcessInstanceFKViolationTest {
+
+    private ProcessEngine processEngine;
+    private ProcessEngineConfigurationImpl processEngineConfiguration;
+    private RepositoryService repositoryService;
+    private RuntimeService runtimeService;
+
+    @BeforeEach
+    void setUp() {
+        processEngine =
+            ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration()
+                .setJdbcUrl("jdbc:h2:mem:activiti-fk-test-" + UUID.randomUUID() + ";DB_CLOSE_DELAY=1000")
+                .setJdbcUsername("sa")
+                .setJdbcPassword("")
+                .setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_CREATE_DROP)
+                .buildProcessEngine();
+
+        processEngineConfiguration = (ProcessEngineConfigurationImpl) processEngine.getProcessEngineConfiguration();
+        repositoryService = processEngine.getRepositoryService();
+        runtimeService = processEngine.getRuntimeService();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (processEngine != null) {
+            processEngine.close();
+        }
+    }
+
+    /**
+     * Reproduces the FK violation caused by duplicate-named variables on the same execution.
+     *
+     * <p>In production, this happens when parallel multi-instance subprocess instances have
+     * connector service tasks whose results arrive concurrently. Each result is processed in a
+     * separate {@code REQUIRES_NEW} transaction via {@code ServiceTaskIntegrationResultEventHandler}.
+     * {@code VariablesPropagator.propagate()} sets output variables on the root process instance.
+     * When two concurrent transactions both create a variable with the same name (e.g., "csvFileName"),
+     * neither sees the other's uncommitted INSERT, so both create a new row. Result: two DB rows
+     * with the same name on the same execution.
+     *
+     * <p>When the process later completes, {@code deleteExecutionEntity()} previously loaded variables
+     * into a {@code HashMap} keyed by name — the duplicate was overwritten. Only one was deleted.
+     * The other blocked the execution DELETE with: {@code violates foreign key constraint "act_fk_var_exe"}.
+     */
+    @Test
+    void should_deleteProcessInstance_whenDuplicateNamedVariablesExist() throws Exception {
+        repositoryService
+            .createDeployment()
+            .addClasspathResource(
+                "org/activiti/engine/test/regression/deleteProcessFKTest-simpleUserTask.bpmn20.xml"
+            )
+            .deploy();
+
+        ProcessInstance processInstance = runtimeService.startProcessInstanceByKey("simpleUserTaskProcess");
+        String executionId = processInstance.getId();
+
+        try (Connection conn = getConnection()) {
+            String byteArrayId = insertByteArray(conn, "var:duplicateVar");
+            insertVariable(conn, "duplicateVar", executionId, "value-from-mi-instance-1");
+            insertVariable(conn, "duplicateVar", executionId, "longString", byteArrayId);
+
+            assertThat(countVariables(conn, executionId, "duplicateVar"))
+                .as("Both duplicate-named variables should exist in DB")
+                .isEqualTo(2);
+        }
+
+        runtimeService.deleteProcessInstance(processInstance.getId(), "test");
+
+        assertThat(runtimeService.createProcessInstanceQuery().processInstanceId(processInstance.getId()).count())
+            .isEqualTo(0);
+
+        try (Connection conn = getConnection()) {
+            assertThat(countVariablesByProcessInstance(conn, executionId))
+                .as("No variables should remain after deletion")
+                .isEqualTo(0);
+
+            assertThat(countByteArraysByName(conn, "var:duplicateVar"))
+                .as("No byte arrays should remain after deletion")
+                .isEqualTo(0);
+        }
+    }
+
+    private Connection getConnection() throws SQLException {
+        return processEngineConfiguration.getDataSource().getConnection();
+    }
+
+    private void insertVariable(
+        Connection conn,
+        String name,
+        String executionId,
+        String textValue
+    ) throws SQLException {
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO ACT_RU_VARIABLE (ID_, REV_, TYPE_, NAME_, EXECUTION_ID_, PROC_INST_ID_, TEXT_) " +
+                "VALUES (?, 1, 'string', ?, ?, ?, ?)"
+            )
+        ) {
+            ps.setString(1, UUID.randomUUID().toString());
+            ps.setString(2, name);
+            ps.setString(3, executionId);
+            ps.setString(4, executionId);
+            ps.setString(5, textValue);
+            ps.executeUpdate();
+        }
+    }
+
+    private void insertVariable(
+        Connection conn,
+        String name,
+        String executionId,
+        String type,
+        String byteArrayId
+    ) throws SQLException {
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO ACT_RU_VARIABLE (ID_, REV_, TYPE_, NAME_, EXECUTION_ID_, PROC_INST_ID_, BYTEARRAY_ID_) " +
+                "VALUES (?, 1, ?, ?, ?, ?, ?)"
+            )
+        ) {
+            ps.setString(1, UUID.randomUUID().toString());
+            ps.setString(2, type);
+            ps.setString(3, name);
+            ps.setString(4, executionId);
+            ps.setString(5, executionId);
+            ps.setString(6, byteArrayId);
+            ps.executeUpdate();
+        }
+    }
+
+    private String insertByteArray(Connection conn, String name) throws SQLException {
+        String id = UUID.randomUUID().toString();
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO ACT_GE_BYTEARRAY (ID_, REV_, NAME_, BYTES_) VALUES (?, 1, ?, ?)"
+            )
+        ) {
+            ps.setString(1, id);
+            ps.setString(2, name);
+            ps.setBytes(3, "test-byte-content".getBytes());
+            ps.executeUpdate();
+        }
+        return id;
+    }
+
+    private int countVariables(Connection conn, String executionId, String name) throws SQLException {
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM ACT_RU_VARIABLE WHERE EXECUTION_ID_ = ? AND NAME_ = ?"
+            )
+        ) {
+            ps.setString(1, executionId);
+            ps.setString(2, name);
+            return executeCount(ps);
+        }
+    }
+
+    private int countVariablesByProcessInstance(Connection conn, String processInstanceId) throws SQLException {
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM ACT_RU_VARIABLE WHERE PROC_INST_ID_ = ?"
+            )
+        ) {
+            ps.setString(1, processInstanceId);
+            return executeCount(ps);
+        }
+    }
+
+    private int countByteArraysByName(Connection conn, String name) throws SQLException {
+        try (
+            PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*) FROM ACT_GE_BYTEARRAY WHERE NAME_ = ?"
+            )
+        ) {
+            ps.setString(1, name);
+            return executeCount(ps);
+        }
+    }
+
+    private int executeCount(PreparedStatement ps) throws SQLException {
+        try (ResultSet rs = ps.executeQuery()) {
+            rs.next();
+            return rs.getInt(1);
+        }
+    }
+}

--- a/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/regression/deleteProcessFKTest-simpleUserTask.bpmn20.xml
+++ b/activiti-core/activiti-engine/src/test/resources/org/activiti/engine/test/regression/deleteProcessFKTest-simpleUserTask.bpmn20.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+             xmlns:activiti="http://activiti.org/bpmn"
+             targetNamespace="http://activiti.org/test">
+
+  <process id="simpleUserTaskProcess" name="Simple User Task Process" isExecutable="true">
+    <startEvent id="start"/>
+    <sequenceFlow id="flow1" sourceRef="start" targetRef="userTask"/>
+    <userTask id="userTask" name="User Task"/>
+    <sequenceFlow id="flow2" sourceRef="userTask" targetRef="end"/>
+    <endEvent id="end"/>
+  </process>
+
+</definitions>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
  When parallel multi-instance subprocess instances have connector service tasks,  each connector result is processed in a separate `REQUIRES_NEW` transaction.  `VariablesPropagator.propagate()` sets output variables on the root process instance. Under `READ COMMITTED` isolation, concurrent transactions both see no existing  variable with the target name, so both INSERT a new row. Result: two DB rows  with the same variable name on the same execution.

  During deletion, `VariableScopeImpl.ensureVariableInstancesInitialized()` loads variables into a `HashMap<String, VariableInstanceEntity>` keyed by name. Duplicate-named rows overwrite each other — only one survives in the map. `deleteExecutionEntity()` iterates the map and deletes only the visible entry. The invisible duplicate still references the execution via `EXECUTION_ID_`, causing the FK violation on the subsequent execution `DELETE`.

  **Fix:** replace the HashMap-based variable loading in `ExecutionEntityManagerImpl.deleteExecutionEntity()` with a direct DB query via `findVariableInstancesByExecutionId()`, which returns a List preserving all duplicates. Each variable is individually deleted, including its associated byte array references.

<!--
You can also link to an open issue here
-->

- Issue Link: AAE-38661

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No
