### PR TITLE
AAE-43950 Restore test execution for legacy JUnit 4 tests

### DIFF
--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
@@ -1166,23 +1166,28 @@ public class RuntimeServiceTest extends PluggableActivitiTestCase {
         builder.linkedProcessInstanceType("myLinkType");
 
         // Spy on the command executor to capture the command
+        CommandExecutor originalExecutor = runtimeService.getCommandExecutor();
         CommandExecutor commandExecutor = spy(processEngineConfiguration.getCommandExecutor());
         runtimeService.setCommandExecutor(commandExecutor);
 
-        ProcessInstance processInstance = runtimeService.startProcessInstance(builder);
+        try {
+            ProcessInstance processInstance = runtimeService.startProcessInstance(builder);
 
-        // Capture the StartProcessInstanceCmd
-        ArgumentCaptor<StartProcessInstanceCmd> commandCaptor = ArgumentCaptor.forClass(StartProcessInstanceCmd.class);
-        verify(commandExecutor).execute(commandCaptor.capture());
+            // Capture the StartProcessInstanceCmd
+            ArgumentCaptor<StartProcessInstanceCmd> commandCaptor = ArgumentCaptor.forClass(StartProcessInstanceCmd.class);
+            verify(commandExecutor).execute(commandCaptor.capture());
 
-        StartProcessInstanceCmd capturedCommand = commandCaptor.getValue();
-        assertThat(capturedCommand.getLinkedProcessInstanceId()).isEqualTo("linkedProcess123");
+            StartProcessInstanceCmd capturedCommand = commandCaptor.getValue();
+            assertThat(capturedCommand.getLinkedProcessInstanceId()).isEqualTo("linkedProcess123");
 
-        assertThat(capturedCommand.getLinkedProcessInstanceType()).isEqualTo("myLinkType");
+            assertThat(capturedCommand.getLinkedProcessInstanceType()).isEqualTo("myLinkType");
 
-        assertThat(processInstance).isNotNull();
-        assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
-        assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey456");
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
+            assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey456");
+        } finally {
+            runtimeService.setCommandExecutor(originalExecutor);
+        }
     }
 
     @Deployment(resources = { "org/activiti/engine/test/api/messageStartEvent.bpmn20.xml" })
@@ -1196,23 +1201,28 @@ public class RuntimeServiceTest extends PluggableActivitiTestCase {
         builder.linkedProcessInstanceId("linkedProcess123");
         builder.linkedProcessInstanceType("myLinkType");
 
+        CommandExecutor originalExecutor = runtimeService.getCommandExecutor();
         CommandExecutor commandExecutor = spy(processEngineConfiguration.getCommandExecutor());
         runtimeService.setCommandExecutor(commandExecutor);
 
-        ProcessInstance processInstance = runtimeService.startProcessInstance(builder);
+        try {
+            ProcessInstance processInstance = runtimeService.startProcessInstance(builder);
 
-        // Capture the StartProcessInstanceByMessageCmd
-        ArgumentCaptor<StartProcessInstanceByMessageCmd> commandCaptor = ArgumentCaptor.forClass(StartProcessInstanceByMessageCmd.class);
-        verify(commandExecutor).execute(commandCaptor.capture());
+            // Capture the StartProcessInstanceByMessageCmd
+            ArgumentCaptor<StartProcessInstanceByMessageCmd> commandCaptor = ArgumentCaptor.forClass(StartProcessInstanceByMessageCmd.class);
+            verify(commandExecutor).execute(commandCaptor.capture());
 
-        StartProcessInstanceByMessageCmd capturedCommand = commandCaptor.getValue();
-        assertThat(capturedCommand.getLinkedProcessInstanceId()).isEqualTo("linkedProcess123");
+            StartProcessInstanceByMessageCmd capturedCommand = commandCaptor.getValue();
+            assertThat(capturedCommand.getLinkedProcessInstanceId()).isEqualTo("linkedProcess123");
 
-        assertThat(capturedCommand.getLinkedProcessInstanceType()).isEqualTo("myLinkType");
+            assertThat(capturedCommand.getLinkedProcessInstanceType()).isEqualTo("myLinkType");
 
-        assertThat(processInstance).isNotNull();
-        assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
-        assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey456");
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
+            assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey456");
+        } finally {
+            runtimeService.setCommandExecutor(originalExecutor);
+        }
     }
 
 

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/email/JndiEmailTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/email/JndiEmailTest.java
@@ -20,9 +20,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.Properties;
-import javax.mail.NoSuchProviderException;
-import javax.mail.Provider;
-import javax.mail.Session;
+import jakarta.mail.NoSuchProviderException;
+import jakarta.mail.Provider;
+import jakarta.mail.Session;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 import org.activiti.engine.runtime.ProcessInstance;

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/email/MockEmailTransport.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/email/MockEmailTransport.java
@@ -16,12 +16,12 @@
 package org.activiti.spring.test.email;
 
 import java.io.IOException;
-import javax.mail.Address;
-import javax.mail.Message;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.Transport;
-import javax.mail.URLName;
+import jakarta.mail.Address;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.URLName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
     <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
+    <junit.version>5.12.2</junit.version>
     <spring-boot.version>3.5.7</spring-boot.version>
     <h2.version>2.4.240</h2.version>
     <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
@@ -759,6 +760,13 @@ limitations under the License.
           </excludes>
           <runOrder>alphabetical</runOrder>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
  
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [x] Other... Please describe: fix test execution

## Description

<!--
You can also link to an open issue here
-->

Adds junit-vintage-engine dependency to maven-surefire-plugin to enable running JUnit 4 tests alongside JUnit 5 tests.

- Issue Link: AAE-43950

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [x] Yes
> - [ ] No
