### PR TITLE
AAE-44048 Migrate standalone JUnit 4 tests to JUnit 5 (Phase 1)

### DIFF
--- a/activiti-core/activiti-bpmn-model/pom.xml
+++ b/activiti-core/activiti-bpmn-model/pom.xml
@@ -31,8 +31,8 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BaseElementTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BaseElementTest.java
@@ -22,14 +22,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BaseElementTest {
 
     private BaseElement baseElement;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         this.baseElement = new BaseElement() {
             @Override

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BoundaryEventTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BoundaryEventTest {
 

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BpmnModelTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/BpmnModelTest.java
@@ -17,14 +17,14 @@ package org.activiti.bpmn.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class BpmnModelTest {
 
     private BpmnModel bpmnModel;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         bpmnModel = new BpmnModel();
     }

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/FlowNodeTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/FlowNodeTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class FlowNodeTest {
 

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/LinkThrowEventFlowNodeHelperTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/LinkThrowEventFlowNodeHelperTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.reflect.InvocationTargetException;
 import org.activiti.bpmn.model.helper.LinkThrowEventFlowNodeHelper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class LinkThrowEventFlowNodeHelperTest {
 

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/ServiceTaskTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ServiceTaskTest {
 

--- a/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/StartEventTest.java
+++ b/activiti-core/activiti-bpmn-model/src/test/java/org/activiti/bpmn/model/StartEventTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class StartEventTest {
 

--- a/activiti-core/activiti-engine/pom.xml
+++ b/activiti-core/activiti-engine/pom.xml
@@ -141,6 +141,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.subethamail</groupId>
       <artifactId>subethasmtp-wiser</artifactId>
       <scope>test</scope>

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/delegate/event/impl/ActivitiVariableEventImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/delegate/event/impl/ActivitiVariableEventImplTest.java
@@ -18,7 +18,7 @@ package org.activiti.engine.delegate.event.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.engine.delegate.event.ActivitiEventType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ActivitiVariableEventImplTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/NoneVariablesCalculatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/NoneVariablesCalculatorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import java.util.Collections;
 import java.util.Map;
 import org.activiti.engine.delegate.DelegateExecution;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class NoneVariablesCalculatorTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehaviorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/ParallelMultiInstanceBehaviorTest.java
@@ -31,9 +31,9 @@ import org.activiti.bpmn.model.Activity;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.impl.cmd.CompleteTaskCmd;
 import org.activiti.engine.impl.interceptor.CommandContext;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -55,13 +55,13 @@ public class ParallelMultiInstanceBehaviorTest {
 
     private AutoCloseable autoCloseable;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         autoCloseable = openMocks(this);
         doReturn(commandContext).when(multiInstanceBehavior).getCommandContext();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         autoCloseable.close();
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagatorTest.java
@@ -28,9 +28,9 @@ import java.util.UUID;
 import org.activiti.engine.delegate.DelegateExecution;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntityManager;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -49,13 +49,13 @@ public class VariablesPropagatorTest {
 
     private AutoCloseable autoCloseable;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         autoCloseable = openMocks(this);
         doReturn(executionEntityManager).when(variablesPropagator).getExecutionEntityManager();
     }
 
-    @After
+    @AfterEach
     public void tearDown() throws Exception {
         autoCloseable.close();
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/deployer/BpmnDeployerTest.java
@@ -21,13 +21,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import org.activiti.engine.impl.persistence.entity.ProcessDefinitionEntityImpl;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class BpmnDeployerTest {
 
     @InjectMocks

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotterTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/SubProcessVariableSnapshotterTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/task/TaskComparatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/helper/task/TaskComparatorTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.activiti.engine.impl.persistence.entity.TaskEntityImpl;
 import org.activiti.engine.task.TaskInfo;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TaskComparatorTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/IntermediateThrowEventParserHandlerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/IntermediateThrowEventParserHandlerTest.java
@@ -25,14 +25,14 @@ import org.activiti.bpmn.model.ThrowEvent;
 import org.activiti.engine.impl.bpmn.behavior.IntermediateThrowLinkEventActivityBehavior;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.bpmn.parser.factory.ActivityBehaviorFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IntermediateThrowEventParserHandlerTest {
 
     @InjectMocks
@@ -44,7 +44,7 @@ public class IntermediateThrowEventParserHandlerTest {
     @Mock
     private ActivityBehaviorFactory activityBehaviorFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(bpmnParse.getActivityBehaviorFactory()).willReturn(activityBehaviorFactory);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/LinkEventDefinitionParserHandlerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/LinkEventDefinitionParserHandlerTest.java
@@ -25,14 +25,14 @@ import org.activiti.bpmn.model.LinkEventDefinition;
 import org.activiti.engine.impl.bpmn.behavior.IntermediateCatchLinkEventActivityBehavior;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.bpmn.parser.factory.ActivityBehaviorFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class LinkEventDefinitionParserHandlerTest {
 
     @InjectMocks
@@ -44,7 +44,7 @@ public class LinkEventDefinitionParserHandlerTest {
     @Mock
     private ActivityBehaviorFactory activityBehaviorFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(bpmnParse.getActivityBehaviorFactory()).willReturn(activityBehaviorFactory);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/ServiceTaskParseHandlerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/bpmn/parser/handler/ServiceTaskParseHandlerTest.java
@@ -23,14 +23,14 @@ import org.activiti.bpmn.model.ServiceTask;
 import org.activiti.engine.impl.bpmn.behavior.ServiceTaskDelegateExpressionActivityBehavior;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.bpmn.parser.factory.ActivityBehaviorFactory;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ServiceTaskParseHandlerTest {
 
     @InjectMocks
@@ -42,7 +42,7 @@ public class ServiceTaskParseHandlerTest {
     @Mock
     private ActivityBehaviorFactory activityBehaviorFactory;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(bpmnParse.getActivityBehaviorFactory()).willReturn(activityBehaviorFactory);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/DeployCmdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/DeployCmdTest.java
@@ -33,14 +33,17 @@ import org.activiti.engine.impl.persistence.entity.DeploymentEntityManager;
 import org.activiti.engine.impl.repository.DeploymentBuilderImpl;
 import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.runtime.Clock;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class DeployCmdTest {
 
     private static final int ENFORCED_DEPLOYMENT_VERSION = 7;
@@ -69,7 +72,7 @@ public class DeployCmdTest {
     @InjectMocks
     private DeployCmd deployCmd;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(commandContext.getProcessEngineConfiguration()).willReturn(processEngineConfiguration);
         given(commandContext.getDeploymentEntityManager()).willReturn(deploymentEntityManager);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/DeleteIntegrationContextCmdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/DeleteIntegrationContextCmdTest.java
@@ -23,13 +23,13 @@ import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DeleteIntegrationContextCmdTest {
 
     @Mock
@@ -41,7 +41,7 @@ public class DeleteIntegrationContextCmdTest {
     @Mock
     private IntegrationContextManager integrationContextManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(commandContext.getProcessEngineConfiguration()).willReturn(processEngineConfiguration);
         given(processEngineConfiguration.getIntegrationContextManager()).willReturn(integrationContextManager);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextCmdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/cmd/integration/RetrieveIntegrationContextCmdTest.java
@@ -23,13 +23,13 @@ import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextManager;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class RetrieveIntegrationContextCmdTest {
 
     @Mock
@@ -41,7 +41,7 @@ public class RetrieveIntegrationContextCmdTest {
     @Mock
     private IntegrationContextManager integrationContextManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(commandContext.getProcessEngineConfiguration()).willReturn(processEngineConfiguration);
         given(processEngineConfiguration.getIntegrationContextManager()).willReturn(integrationContextManager);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/ELResolverReflectionBlockerDecoratorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/ELResolverReflectionBlockerDecoratorTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.delegate.Expression;
 import org.activiti.engine.impl.delegate.invocation.DefaultDelegateInterceptor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ELResolverReflectionBlockerDecoratorTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/VariableScopeElResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/VariableScopeElResolverTest.java
@@ -36,15 +36,18 @@ import org.activiti.engine.impl.el.variable.ProcessInitiatorELResolver;
 import org.activiti.engine.impl.el.variable.TaskElResolver;
 import org.activiti.engine.impl.el.variable.VariableElResolver;
 import org.activiti.engine.impl.el.variable.VariableScopeItemELResolver;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class VariableScopeElResolverTest {
 
     @Spy
@@ -63,7 +66,7 @@ public class VariableScopeElResolverTest {
     @Mock
     private VariableScopeItemELResolver thirdItemResolver;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         doReturn(Arrays.asList(firstItemResolver, secondItemResolver, thirdItemResolver))
             .when(variableScopeElResolver)

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/AuthenticatedUserELResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/AuthenticatedUserELResolverTest.java
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.mock;
 
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.identity.Authentication;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 public class AuthenticatedUserELResolverTest {
 
@@ -29,7 +29,7 @@ public class AuthenticatedUserELResolverTest {
 
     private AuthenticatedUserELResolver resolver = new AuthenticatedUserELResolver();
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         Authentication.setAuthenticatedUserId(null);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/ExecutionElResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/ExecutionElResolverTest.java
@@ -22,7 +22,7 @@ import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl;
 import org.activiti.engine.impl.persistence.entity.TaskEntityImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionElResolverTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/ProcessInitiatorELResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/ProcessInitiatorELResolverTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntity;
 import org.activiti.engine.impl.persistence.entity.ExecutionEntityImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ProcessInitiatorELResolverTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/TaskElResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/TaskElResolverTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.mock;
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.persistence.entity.TaskEntity;
 import org.activiti.engine.impl.persistence.entity.TaskEntityImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TaskElResolverTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/VariableElResolverTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/el/variable/VariableElResolverTest.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Arrays;
 import org.activiti.engine.delegate.VariableScope;
 import org.activiti.engine.impl.persistence.entity.VariableInstance;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class VariableElResolverTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/interceptor/CommandContextTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/interceptor/CommandContextTest.java
@@ -25,13 +25,13 @@ import org.activiti.engine.impl.agenda.DefaultActivitiEngineAgenda;
 import org.activiti.engine.impl.cfg.ProcessEngineConfigurationImpl;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 public class CommandContextTest {
 
-    @Before
+    @BeforeEach
     public void resetStatusToRunning() throws Exception {
         setStaticValue(ApplicationStatusHolder.class.getDeclaredField("running"), true);
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityImplTest.java
@@ -17,7 +17,7 @@ package org.activiti.engine.impl.persistence.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class ExecutionEntityImplTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/ExecutionEntityManagerImplTest.java
@@ -41,15 +41,18 @@ import org.activiti.engine.impl.persistence.deploy.ProcessDefinitionCacheEntry;
 import org.activiti.engine.impl.persistence.entity.data.ExecutionDataManager;
 import org.activiti.engine.repository.ProcessDefinition;
 import org.activiti.engine.runtime.Clock;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class ExecutionEntityManagerImplTest {
 
     @InjectMocks
@@ -106,7 +109,7 @@ public class ExecutionEntityManagerImplTest {
     @Mock
     private HistoricProcessInstanceEntityManager historicProcessInstanceEntityManager;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         given(processEngineConfiguration.getClock()).willReturn(clock);
         given(processEngineConfiguration.getEventDispatcher()).willReturn(eventDispatcher);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/data/MybatisIntegrationContextDataManagerTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/data/MybatisIntegrationContextDataManagerTest.java
@@ -20,12 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.activiti.engine.impl.persistence.entity.data.integration.MybatisIntegrationContextDataManager;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntityImpl;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class MybatisIntegrationContextDataManagerTest {
 
     @InjectMocks

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/persistence/entity/integration/IntegrationContextManagerImplTest.java
@@ -21,13 +21,13 @@ import static org.mockito.Mockito.mock;
 
 import org.activiti.engine.impl.persistence.entity.data.DataManager;
 import org.activiti.engine.impl.persistence.entity.data.integration.IntegrationContextDataManager;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IntegrationContextManagerImplTest {
 
     @InjectMocks

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/repository/DeploymentBuilderImplTest.java
@@ -26,16 +26,16 @@ import static org.mockito.Mockito.verify;
 import java.io.IOException;
 import java.io.InputStream;
 import org.activiti.engine.ActivitiException;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.Resource;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class DeploymentBuilderImplTest {
 
     @Spy

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/runtime/ProcessInstanceBuilderImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/runtime/ProcessInstanceBuilderImplTest.java
@@ -21,13 +21,13 @@ import static org.mockito.Mockito.mock;
 
 import org.activiti.engine.impl.RuntimeServiceImpl;
 import org.activiti.engine.runtime.ProcessInstance;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class ProcessInstanceBuilderImplTest {
 
     @InjectMocks

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/variable/BigDecimalTypeTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/variable/BigDecimalTypeTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import org.activiti.engine.impl.persistence.entity.VariableInstanceEntityImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class BigDecimalTypeTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/variable/JsonTypeConverterTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/variable/JsonTypeConverterTest.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class JsonTypeConverterTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/integration/IntegrationContextServiceImplTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/integration/IntegrationContextServiceImplTest.java
@@ -25,13 +25,13 @@ import org.activiti.engine.impl.cmd.integration.DeleteIntegrationContextCmd;
 import org.activiti.engine.impl.cmd.integration.RetrieveIntegrationContextsCmd;
 import org.activiti.engine.impl.interceptor.CommandExecutor;
 import org.activiti.engine.impl.persistence.entity.integration.IntegrationContextEntity;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class IntegrationContextServiceImplTest {
 
     @InjectMocks

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/bpmn/event/MessageEventDefinitionWithExtensionElementsTest.java
@@ -23,7 +23,7 @@ import org.activiti.bpmn.model.Message;
 import org.activiti.bpmn.model.MessageEventDefinition;
 import org.activiti.engine.impl.bpmn.parser.BpmnParse;
 import org.activiti.engine.impl.bpmn.parser.handler.MessageEventDefinitionParseHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 public class MessageEventDefinitionWithExtensionElementsTest {

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/RetryInterceptorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/RetryInterceptorTest.java
@@ -30,9 +30,9 @@ import org.activiti.engine.impl.interceptor.Command;
 import org.activiti.engine.impl.interceptor.CommandContext;
 import org.activiti.engine.impl.interceptor.CommandInterceptor;
 import org.activiti.engine.impl.interceptor.RetryInterceptor;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  */
@@ -42,7 +42,7 @@ public class RetryInterceptorTest {
 
     protected RetryInterceptor retryInterceptor;
 
-    @Before
+    @BeforeEach
     public void setupProcessEngine() {
         ProcessEngineConfigurationImpl processEngineConfiguration =
             (ProcessEngineConfigurationImpl) new StandaloneInMemProcessEngineConfiguration();
@@ -54,7 +54,7 @@ public class RetryInterceptorTest {
         processEngine = processEngineConfiguration.buildProcessEngine();
     }
 
-    @After
+    @AfterEach
     public void shutdownProcessEngine() {
         processEngine.close();
         counter.set(0);

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/cfg/multitenant/MultiTenantProcessEngineTest.java
@@ -31,9 +31,9 @@ import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.task.Task;
 import org.activiti.engine.task.TaskQuery;
 import org.h2.jdbcx.JdbcDataSource;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
 
@@ -44,12 +44,12 @@ public class MultiTenantProcessEngineTest {
     private MultiSchemaMultiTenantProcessEngineConfiguration config;
     private ProcessEngine processEngine;
 
-    @Before
+    @BeforeEach
     public void setup() {
         setupTenantInfoHolder();
     }
 
-    @After
+    @AfterEach
     public void close() {
         processEngine.close();
     }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/AsyncExecutorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/jobexecutor/AsyncExecutorTest.java
@@ -30,8 +30,8 @@ import org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.activiti.engine.impl.test.JobTestHelper;
 import org.activiti.engine.runtime.Job;
 import org.activiti.engine.runtime.ProcessInstance;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,7 +168,7 @@ public class AsyncExecutorTest {
     }
 
     //TODO enable this test again: temporary disabled because it's randomly failing
-    @Ignore
+    @Disabled
     @Test
     public void testAsyncScriptExecutionOnTwoEngines() {
         ProcessEngine firstProcessEngine = null;

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/calendar/DurationHelperTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/calendar/DurationHelperTest.java
@@ -26,7 +26,7 @@ import org.activiti.engine.impl.calendar.DurationHelper;
 import org.activiti.engine.impl.util.DefaultClockImpl;
 import org.activiti.engine.runtime.Clock;
 import org.apache.commons.lang3.time.DateUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class DurationHelperTest {
 

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DefaultProcessValidatorTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DefaultProcessValidatorTest.java
@@ -35,8 +35,8 @@ import org.activiti.validation.ProcessValidatorFactory;
 import org.activiti.validation.ValidationError;
 import org.activiti.validation.validator.Problems;
 import org.activiti.validation.validator.ValidatorSetNames;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
 
@@ -45,7 +45,7 @@ public class DefaultProcessValidatorTest {
 
     private ProcessValidator processValidator;
 
-    @Before
+    @BeforeEach
     public void setupProcessValidator() {
         ProcessValidatorFactory processValidatorFactory = new ProcessValidatorFactory();
         this.processValidator = processValidatorFactory.createDefaultProcessValidator();

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DisabledSchemaValidationTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/standalone/validation/DisabledSchemaValidationTest.java
@@ -24,9 +24,9 @@ import org.activiti.engine.ProcessEngines;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.impl.cfg.StandaloneInMemProcessEngineConfiguration;
 import org.activiti.engine.repository.Deployment;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
 
@@ -37,7 +37,7 @@ public class DisabledSchemaValidationTest {
 
     protected RepositoryService repositoryService;
 
-    @Before
+    @BeforeEach
     public void setup() {
         this.processEngine = new StandaloneInMemProcessEngineConfiguration()
             .setProcessEngineName(this.getClass().getName())
@@ -46,7 +46,7 @@ public class DisabledSchemaValidationTest {
         this.repositoryService = processEngine.getRepositoryService();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {
             repositoryService.deleteDeployment(deployment.getId());

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/AbstractAutoDeploymentStrategyTest.java
@@ -24,15 +24,18 @@ import org.activiti.core.common.spring.project.ApplicationUpgradeContextService;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.repository.Deployment;
 import org.activiti.engine.repository.DeploymentBuilder;
-import org.junit.Before;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.ContextResource;
 import org.springframework.core.io.Resource;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public abstract class AbstractAutoDeploymentStrategyTest {
 
     @Mock
@@ -85,7 +88,7 @@ public abstract class AbstractAutoDeploymentStrategyTest {
     protected final String resourceName4 = "/opt/processes/resourceName4.zip";
     protected final String resourceName5 = "/opt/processes/resourceName5.jar";
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         when(resourceMock1.getPathWithinContext()).thenReturn(resourceName1);
         when(resourceMock2.getDescription()).thenReturn(resourceName2);

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/DefaultAutoDeploymentStrategyTest.java
@@ -27,15 +27,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 import org.activiti.spring.autodeployment.DefaultAutoDeploymentStrategy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
 
 public class DefaultAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private DefaultAutoDeploymentStrategy deploymentStrategy;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         super.before();
         deploymentStrategy = new DefaultAutoDeploymentStrategy(applicationUpgradeContextServiceMock);

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/NoneAutoDeploymentStrategyTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/NoneAutoDeploymentStrategyTest.java
@@ -21,15 +21,15 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import org.activiti.engine.RepositoryService;
 import org.activiti.spring.autodeployment.NoneAutoDeploymentStrategy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
 
 public class NoneAutoDeploymentStrategyTest {
 
     private NoneAutoDeploymentStrategy deploymentStrategy;
 
-    @Before
+    @BeforeEach
     public void before() {
         deploymentStrategy = new NoneAutoDeploymentStrategy(mock());
     }

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/ResourceParentFolderAutoDeploymentStrategyTest.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 import org.activiti.spring.autodeployment.ResourceParentFolderAutoDeploymentStrategy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.core.io.Resource;
 
@@ -47,7 +47,7 @@ public class ResourceParentFolderAutoDeploymentStrategyTest extends AbstractAuto
     private final String parentFilename1 = "parentFilename1";
     private final String parentFilename2 = "parentFilename2";
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         super.before();
         deploymentStrategy = new ResourceParentFolderAutoDeploymentStrategy(applicationUpgradeContextServiceMock);

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/autodeployment/SingleResourceAutoDeploymentStrategyTest.java
@@ -25,15 +25,15 @@ import static org.mockito.Mockito.verify;
 import java.io.InputStream;
 import java.util.zip.ZipInputStream;
 import org.activiti.spring.autodeployment.SingleResourceAutoDeploymentStrategy;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.io.Resource;
 
 public class SingleResourceAutoDeploymentStrategyTest extends AbstractAutoDeploymentStrategyTest {
 
     private SingleResourceAutoDeploymentStrategy deploymentStrategy;
 
-    @Before
+    @BeforeEach
     public void before() throws Exception {
         super.before();
         deploymentStrategy = new SingleResourceAutoDeploymentStrategy(applicationUpgradeContextServiceMock);

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/XmlNamespaceProcessScopeTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/components/scope/XmlNamespaceProcessScopeTest.java
@@ -18,23 +18,23 @@ package org.activiti.spring.test.components.scope;
 import org.activiti.engine.ProcessEngine;
 import org.activiti.engine.RepositoryService;
 import org.activiti.engine.repository.Deployment;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * tests the scoped beans
  *
 
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:org/activiti/spring/test/components/ScopingTests-context.xml")
-@Ignore
+@Disabled
 // Ignored for the moment. Josh is working on this.
 public class XmlNamespaceProcessScopeTest {
 
@@ -43,7 +43,7 @@ public class XmlNamespaceProcessScopeTest {
     @Autowired
     private ProcessEngine processEngine;
 
-    @Before
+    @BeforeEach
     public void before() throws Throwable {
         this.processEngine.getRepositoryService()
             .createDeployment()
@@ -53,7 +53,7 @@ public class XmlNamespaceProcessScopeTest {
         processScopeTestEngine = new ProcessScopeTestEngine(this.processEngine);
     }
 
-    @After
+    @AfterEach
     public void after() {
         RepositoryService repositoryService = this.processEngine.getRepositoryService();
         for (Deployment deployment : repositoryService.createDeploymentQuery().list()) {

--- a/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/engine/SpringProcessEngineTest.java
+++ b/activiti-core/activiti-spring/src/test/java/org/activiti/spring/test/engine/SpringProcessEngineTest.java
@@ -18,17 +18,17 @@ package org.activiti.spring.test.engine;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.activiti.engine.ProcessEngines;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 /**
  * Spring process engine base test
  *
 
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @ContextConfiguration("classpath:org/activiti/spring/test/engine/springProcessEngine-context.xml")
 public class SpringProcessEngineTest {
 


### PR DESCRIPTION
Migrate 50 standalone test files that don't extend any Activiti base class from JUnit 4 to JUnit 5 annotations, plus update 2 pom.xml dependencies and 1 abstract test base class.

Changes:
- @RunWith(MockitoJUnitRunner.class) -> @ExtendWith(MockitoExtension.class)
- @RunWith(SpringJUnit4ClassRunner.class) -> @ExtendWith(SpringExtension.class)
- @Test (org.junit) -> @Test (org.junit.jupiter.api)
- @Before -> @BeforeEach, @After -> @AfterEach
- @BeforeClass -> @BeforeAll, @AfterClass -> @AfterAll
- @Ignore -> @Disabled
- Add @MockitoSettings(strictness = LENIENT) where MockitoJUnitRunner was lenient by default but MockitoExtension is strict
- Add junit-jupiter test dependency to activiti-bpmn-model
- Add mockito-junit-jupiter test dependency to activiti-engine

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [x] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-44048

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
