### PR TITLE
AAE-42489 Start process by id with specific version

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -221,13 +221,13 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
         if (getProcessInstancesPayload != null) {
             if (
                 getProcessInstancesPayload.getProcessDefinitionKeys() != null &&
-                    !getProcessInstancesPayload.getProcessDefinitionKeys().isEmpty()
+                !getProcessInstancesPayload.getProcessDefinitionKeys().isEmpty()
             ) {
                 internalQuery.processDefinitionKeys(getProcessInstancesPayload.getProcessDefinitionKeys());
             }
             if (
                 getProcessInstancesPayload.getBusinessKey() != null &&
-                    !getProcessInstancesPayload.getBusinessKey().isEmpty()
+                !getProcessInstancesPayload.getBusinessKey().isEmpty()
             ) {
                 internalQuery.processInstanceBusinessKey(getProcessInstancesPayload.getBusinessKey());
             }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -90,18 +90,28 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
 
     @Override
     public ProcessDefinition processDefinition(String processDefinitionId) {
-        org.activiti.engine.repository.ProcessDefinition processDefinition = repositoryService
+        org.activiti.engine.repository.ProcessDefinition processDefinition;
+        processDefinition = repositoryService
             .createProcessDefinitionQuery()
-            .processDefinitionIdOrKey(processDefinitionId)
-            .deploymentIds(latestDeploymentIds())
+            .processDefinitionId(processDefinitionId)
             .orderByProcessDefinitionVersion()
             .asc()
             .list()
             .stream()
             .findFirst()
-            .orElseThrow(() ->
-                new ActivitiObjectNotFoundException(
-                    "Unable to find process definition for the given id or key:'" + processDefinitionId + "'"
+            .orElseGet(() -> repositoryService
+                .createProcessDefinitionQuery()
+                .processDefinitionIdOrKey(processDefinitionId)
+                .deploymentIds(latestDeploymentIds())
+                .orderByProcessDefinitionVersion()
+                .asc()
+                .list()
+                .stream()
+                .findFirst()
+                .orElseThrow(() ->
+                    new ActivitiObjectNotFoundException(
+                        "Unable to find process definition for the given id or key:'" + processDefinitionId + "'"
+                    )
                 )
             );
 
@@ -211,13 +221,13 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
         if (getProcessInstancesPayload != null) {
             if (
                 getProcessInstancesPayload.getProcessDefinitionKeys() != null &&
-                !getProcessInstancesPayload.getProcessDefinitionKeys().isEmpty()
+                    !getProcessInstancesPayload.getProcessDefinitionKeys().isEmpty()
             ) {
                 internalQuery.processDefinitionKeys(getProcessInstancesPayload.getProcessDefinitionKeys());
             }
             if (
                 getProcessInstancesPayload.getBusinessKey() != null &&
-                !getProcessInstancesPayload.getBusinessKey().isEmpty()
+                    !getProcessInstancesPayload.getBusinessKey().isEmpty()
             ) {
                 internalQuery.processInstanceBusinessKey(getProcessInstancesPayload.getBusinessKey());
             }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImpl.java
@@ -17,6 +17,7 @@ package org.activiti.runtime.api.impl;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.activiti.api.model.shared.model.VariableInstance;
@@ -91,14 +92,10 @@ public class ProcessAdminRuntimeImpl implements ProcessAdminRuntime {
     @Override
     public ProcessDefinition processDefinition(String processDefinitionId) {
         org.activiti.engine.repository.ProcessDefinition processDefinition;
-        processDefinition = repositoryService
-            .createProcessDefinitionQuery()
-            .processDefinitionId(processDefinitionId)
-            .orderByProcessDefinitionVersion()
-            .asc()
-            .list()
-            .stream()
-            .findFirst()
+        processDefinition = Optional.ofNullable(repositoryService
+                .createProcessDefinitionQuery()
+                .processDefinitionId(processDefinitionId)
+                .singleResult())
             .orElseGet(() -> repositoryService
                 .createProcessDefinitionQuery()
                 .processDefinitionIdOrKey(processDefinitionId)

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
@@ -205,7 +205,7 @@ class ProcessAdminRuntimeImplTest {
         given(deploymentQuery.list()).willReturn(List.of(deployment));
         given(deployment.getId()).willReturn("deployId");
         given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
-        given(processDefinitionQuery.list()).willReturn(List.of()).willReturn(List.of(internalProcessDef));
+        given(processDefinitionQuery.list()).willReturn(List.of(internalProcessDef));
         given(processDefinitionConverter.from(internalProcessDef)).willReturn(apiProcessDef);
 
         var result = processAdminRuntime.processDefinition("procDefKey");
@@ -220,7 +220,7 @@ class ProcessAdminRuntimeImplTest {
         var apiProcessDef = new ProcessDefinitionImpl();
 
         given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
-        given(processDefinitionQuery.list()).willReturn(List.of(internalProcessDef));
+        given(processDefinitionQuery.singleResult()).willReturn(internalProcessDef);
         given(processDefinitionConverter.from(internalProcessDef)).willReturn(apiProcessDef);
 
         var result = processAdminRuntime.processDefinition("procDefId");
@@ -240,7 +240,8 @@ class ProcessAdminRuntimeImplTest {
 
         assertThatThrownBy(() -> processAdminRuntime.processDefinition("unknownId"))
             .isInstanceOf(ActivitiObjectNotFoundException.class);
-        verify(processDefinitionQuery, times(2)).list();
+        verify(processDefinitionQuery).singleResult();
+        verify(processDefinitionQuery).list();
     }
 
     @Test

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessAdminRuntimeImplTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
@@ -193,7 +194,7 @@ class ProcessAdminRuntimeImplTest {
     }
 
     @Test
-    void should_returnProcessDefinition_whenFoundByIdWithLatestDeployment() {
+    void should_returnProcessDefinition_whenFoundByKeyWithLatestDeployment() {
         var processDefinitionQuery = mock(ProcessDefinitionQuery.class, Answers.RETURNS_SELF);
         var deploymentQuery = mock(org.activiti.engine.repository.DeploymentQuery.class, Answers.RETURNS_SELF);
         var internalProcessDef = mock(org.activiti.engine.repository.ProcessDefinition.class);
@@ -203,6 +204,21 @@ class ProcessAdminRuntimeImplTest {
         given(repositoryService.createDeploymentQuery()).willReturn(deploymentQuery);
         given(deploymentQuery.list()).willReturn(List.of(deployment));
         given(deployment.getId()).willReturn("deployId");
+        given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
+        given(processDefinitionQuery.list()).willReturn(List.of()).willReturn(List.of(internalProcessDef));
+        given(processDefinitionConverter.from(internalProcessDef)).willReturn(apiProcessDef);
+
+        var result = processAdminRuntime.processDefinition("procDefKey");
+
+        assertThat(result).isEqualTo(apiProcessDef);
+    }
+
+    @Test
+    void should_returnProcessDefinition_whenFoundByIdForSpecificVersion() {
+        var processDefinitionQuery = mock(ProcessDefinitionQuery.class, Answers.RETURNS_SELF);
+        var internalProcessDef = mock(org.activiti.engine.repository.ProcessDefinition.class);
+        var apiProcessDef = new ProcessDefinitionImpl();
+
         given(repositoryService.createProcessDefinitionQuery()).willReturn(processDefinitionQuery);
         given(processDefinitionQuery.list()).willReturn(List.of(internalProcessDef));
         given(processDefinitionConverter.from(internalProcessDef)).willReturn(apiProcessDef);
@@ -224,6 +240,7 @@ class ProcessAdminRuntimeImplTest {
 
         assertThatThrownBy(() -> processAdminRuntime.processDefinition("unknownId"))
             .isInstanceOf(ActivitiObjectNotFoundException.class);
+        verify(processDefinitionQuery, times(2)).list();
     }
 
     @Test

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ApplicationUpgradeIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/ApplicationUpgradeIT.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.activiti.api.process.model.ProcessDefinition;
 import org.activiti.api.process.model.payloads.GetProcessDefinitionsPayload;
 import org.activiti.api.process.runtime.ProcessAdminRuntime;
@@ -44,7 +45,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-public class ApplicationUpgradeIT {
+class ApplicationUpgradeIT {
 
     private static final String SINGLE_TASK_PROCESS_DEFINITION_KEY = "SingleTaskProcess";
     private static final String PROCESS_NAME = "single-task";
@@ -82,19 +83,19 @@ public class ApplicationUpgradeIT {
     private List<String> deploymentIds;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         deploymentIds = new ArrayList<>();
         securityUtil.logInAs("user");
         eventSubscriptionQuery = new EventSubscriptionQueryImpl(processEngineConfigurationImpl.getCommandExecutor());
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         deploymentIds.forEach(deploymentId -> repositoryService.deleteDeployment(deploymentId, true));
     }
 
     @Test
-    public void should_updateDeploymentVersion_when_manifestIsPresent() {
+    void should_updateDeploymentVersion_when_manifestIsPresent() {
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("7");
 
@@ -124,7 +125,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_getLatestProcessDefinitionByKey_when_multipleVersions() {
+    void should_getLatestProcessDefinitionByKey_when_multipleVersions() {
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("12");
         deployProcesses(projectManifest, SINGLE_TASK_PROCESS_DEFINITION_PATH);
@@ -141,7 +142,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_adminApiGetLatestProcessDefinitionByKey_when_multipleVersions() {
+    void should_adminApiGetLatestProcessDefinitionByKey_when_multipleVersions() {
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("12");
         deployProcesses(projectManifest, SINGLE_TASK_PROCESS_DEFINITION_PATH);
@@ -160,7 +161,39 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void processDefinitions_should_returnOnlyTheLatestVersion_when_multipleVersions() {
+    void should_adminApiGetSpecificVersionProcessDefinitionById_when_multipleVersions() {
+        ProjectManifest projectManifest = new ProjectManifest();
+        projectManifest.setVersion("12");
+        Deployment firstDeployment = deployProcesses(projectManifest, SINGLE_TASK_PROCESS_DEFINITION_PATH);
+
+        projectManifest.setVersion("34");
+        Deployment latestDeployment = deployProcesses(projectManifest, SINGLE_TASK_PROCESS_DEFINITION_PATH);
+
+        securityUtil.logInAs("admin");
+
+        GetProcessDefinitionsPayload getProcessDefinitionsPayload = new GetProcessDefinitionsPayload();
+        getProcessDefinitionsPayload.setProcessDefinitionKeys(Set.of(SINGLE_TASK_PROCESS_DEFINITION_KEY));
+
+        ProcessDefinition firstProcessDefinition = processAdminRuntime.processDefinitions(
+                Pageable.of(0, 100),
+                getProcessDefinitionsPayload
+            ).getContent()
+            .stream()
+            .filter(processDefinition -> processDefinition.getAppVersion().equals(String.valueOf(firstDeployment.getVersion())))
+            .findFirst()
+            .orElseThrow();
+
+        ProcessDefinition result = processAdminRuntime.processDefinition(firstProcessDefinition.getId());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getName()).isEqualTo(PROCESS_NAME);
+        assertThat(result.getId()).contains(SINGLE_TASK_PROCESS_DEFINITION_KEY);
+        assertThat(result.getAppVersion()).isEqualTo(String.valueOf(firstDeployment.getVersion()));
+        assertThat(firstDeployment.getVersion()).isLessThan(latestDeployment.getVersion());
+    }
+
+    @Test
+    void processDefinitions_should_returnOnlyTheLatestVersion_when_multipleVersions() {
         //given
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("12");
@@ -190,7 +223,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void processDefinitions_should_returnProcesses_when_deploymentIsCreatedWithoutProjectManifest() {
+    void processDefinitions_should_returnProcesses_when_deploymentIsCreatedWithoutProjectManifest() {
         //given
         deployProcessesWithoutProjectManifest(
             "customDeployment",
@@ -208,7 +241,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void processDefinitions_should_returnOnlyTheLatestVersion_when_deploymentIsCreatedWithoutManifestAndIsUpdatedWithManifest() {
+    void processDefinitions_should_returnOnlyTheLatestVersion_when_deploymentIsCreatedWithoutManifestAndIsUpdatedWithManifest() {
         //given
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("12");
@@ -245,7 +278,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_updateDeploymentVersion_when_onlyEnforcedAppVersionIsSet() {
+    void should_updateDeploymentVersion_when_onlyEnforcedAppVersionIsSet() {
         Deployment deployment1 = repositoryService
             .createDeployment()
             .setEnforcedAppVersion(1)
@@ -266,7 +299,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_updateDeploymentVersion_when_onlyProjectManifestVersionIsSet() {
+    void should_updateDeploymentVersion_when_onlyProjectManifestVersionIsSet() {
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("2");
 
@@ -296,7 +329,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_enforcedAppVersionTakePriorityOverProjectManifestVersion() {
+    void should_enforcedAppVersionTakePriorityOverProjectManifestVersion() {
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("2");
 
@@ -327,7 +360,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_noUpgradeTakePlace_when_enforcedAppVersionAndProjectManifestVersionAreNotSet() {
+    void should_noUpgradeTakePlace_when_enforcedAppVersionAndProjectManifestVersionAreNotSet() {
         Deployment deployment1 = repositoryService
             .createDeployment()
             .enableDuplicateFiltering()
@@ -370,12 +403,12 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void disableAllPreviousStartEvents_shouldBeFalse_when_notSet() {
+    void disableAllPreviousStartEvents_shouldBeFalse_when_notSet() {
         assertThat(activitiProperties.shouldDisableExistingStartEventSubscriptions()).isFalse();
     }
 
     @Test
-    public void should_notDeletePreviousTimerStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
+    void should_notDeletePreviousTimerStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
         String deploymentName = "startEventDeployment";
 
         String deploymentId = deployProcess(deploymentName, "processes/ProcessWithTimerStartEvent.bpmn20.xml");
@@ -395,7 +428,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_notDeletePreviousMessageStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
+    void should_notDeletePreviousMessageStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
         String deploymentName = "testDeployment";
         deployProcess(deploymentName, "processes/ProcessWithMessageStartEvent.bpmn20.xml");
 
@@ -412,7 +445,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_notDeletePreviousSignalStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
+    void should_notDeletePreviousSignalStartEvents_when_projectIsUpgraded_and_disableStartEventsIsFalse() {
         String deploymentName = "signalDeployment";
 
         deployProcess(deploymentName, "processes/ProcessWithSignalStartEvent.bpmn20.xml");
@@ -430,7 +463,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_returnOnlyTheLatestVersions_when_multipleVersions_andRequestForLatestVersions() {
+    void should_returnOnlyTheLatestVersions_when_multipleVersions_andRequestForLatestVersions() {
         //given
         ProjectManifest projectManifest = new ProjectManifest();
         projectManifest.setVersion("12");
@@ -458,7 +491,7 @@ public class ApplicationUpgradeIT {
             .filteredOn(
                 processDefinition ->
                     processDefinition.getKey().equals(SINGLE_TASK_PROCESS_DEFINITION_KEY) ||
-                    processDefinition.getKey().equals(MULTI_INSTANCE_PROCESS_DEFINITION_KEY)
+                        processDefinition.getKey().equals(MULTI_INSTANCE_PROCESS_DEFINITION_KEY)
             )
             .extracting(ProcessDefinition::getKey, ProcessDefinition::getVersion, ProcessDefinition::getAppVersion)
             .containsExactlyInAnyOrder(
@@ -476,7 +509,7 @@ public class ApplicationUpgradeIT {
     }
 
     @Test
-    public void should_returnAllVersions_when_multipleVersions_andRequestForAllVersions() {
+    void should_returnAllVersions_when_multipleVersions_andRequestForAllVersions() {
         //given
         ProjectManifest projectManifest = new ProjectManifest();
         int firstVersion = 1;
@@ -506,7 +539,7 @@ public class ApplicationUpgradeIT {
             .filteredOn(
                 processDefinition ->
                     processDefinition.getKey().equals(SINGLE_TASK_PROCESS_DEFINITION_KEY) ||
-                    processDefinition.getKey().equals(MULTI_INSTANCE_PROCESS_DEFINITION_KEY)
+                        processDefinition.getKey().equals(MULTI_INSTANCE_PROCESS_DEFINITION_KEY)
             )
             .extracting(ProcessDefinition::getKey, ProcessDefinition::getVersion, ProcessDefinition::getAppVersion)
             .containsExactlyInAnyOrder(


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description
This PR updates the admin process-definition resolution logic to allow starting a process by an explicit process definition ID (enabling targeting a specific deployed/app version).
<!--
You can also link to an open issue here
-->

- Issue Link: AAE-42489

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
