### PR TITLE
Activiti-5746-Fixed Oracle SQL syntax: removed invalid 'column' keyword

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.engine.sql
@@ -1,1 +1,1 @@
-alter table ACT_RU_IDENTITYLINK add column DETAILS_ BLOB;
+alter table ACT_RU_IDENTITYLINK add DETAILS_ BLOB;

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.history.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.800.to.810.history.sql
@@ -1,1 +1,1 @@
-alter table ACT_HI_IDENTITYLINK add column DETAILS_ BLOB;
+alter table ACT_HI_IDENTITYLINK add DETAILS_ BLOB;


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/ACTIVITI-5746

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No
