### PR TITLE
AAE-46367 Implement Category-based Automatic Multi-Instance Call Activity Variable Mapping

### DIFF
--- a/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
+++ b/activiti-core-common/activiti-connector-model/src/main/java/org/activiti/core/common/model/connector/VariableDefinition.java
@@ -35,6 +35,8 @@ public class VariableDefinition {
 
     private boolean ephemeral;
 
+    private String category;
+
     public String getId() {
         return id;
     }
@@ -105,5 +107,13 @@ public class VariableDefinition {
 
     public boolean isEphemeral() {
         return ephemeral;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
     }
 }

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -390,10 +390,11 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         Map<String, Object> availableVariables
     ) {
         Map<String, Object> outboundVariables = new HashMap<>();
-        ProcessVariablesMapping processVariablesMapping = extensions.getMappingForFlowElement(
-            mappingExecutionContext.getActivityId()
-        );
-        Map<String, Mapping> outputMappings = new LinkedHashMap<>(processVariablesMapping.getOutputs());
+        Map<String, Mapping> outputMappings = Optional
+            .of(extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()))
+            .map(ProcessVariablesMapping::getOutputs)
+            .map(LinkedHashMap::new)
+            .get();
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
         if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -22,6 +22,7 @@ import com.flipkart.zjsonpatch.Jackson3JsonPatch;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -67,6 +68,8 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
     private static final Pattern VARIABLE_PATTERN = Pattern.compile("/\\$\\{(\\w+)}");
 
     public static final String JSON_PATCH_MAPPING_ERROR = "Invalid jsonPatch variable mapping";
+
+    private static final List<String> ELIGIBLE_OUTPUT_CATEGORY = List.of("output", "input/output");
 
     public ExtensionsVariablesMappingProvider(
         ProcessExtensionService processExtensionService,
@@ -399,9 +402,9 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
             final Predicate<VariableDefinition> isEligibleOutputVariable = variableDefinition ->
                 Optional
                     .ofNullable(variableDefinition.getCategory())
-                    .or(() -> Optional.of("output"))
+                    .or(() -> Optional.of("local"))
                     .map(it -> it.toLowerCase(Locale.ROOT))
-                    .filter(category -> category.contains("output"))
+                    .filter(ELIGIBLE_OUTPUT_CATEGORY::contains)
                     .isPresent();
 
             final Function<VariableDefinition, Map.Entry<String, Mapping>> toVariableOutputMapping = variableDefinition -> {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -392,12 +392,10 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         Map<String, Object> availableVariables
     ) {
         Map<String, Object> outboundVariables = new HashMap<>();
-        Map<String, Mapping> outputMappings = Optional
-            .of(extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()))
-            .map(ProcessVariablesMapping::getOutputs)
-            .map(Map::copyOf)
-            .orElseGet(Map::of);
-
+        ProcessVariablesMapping processVariablesMapping = extensions.getMappingForFlowElement(
+            mappingExecutionContext.getActivityId()
+        );
+        Map<String, Mapping> outputMappings = processVariablesMapping.getOutputs();
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
         if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -19,7 +19,6 @@ import static java.util.Collections.emptyMap;
 import static org.activiti.spring.process.model.Mapping.SourceMappingType.VARIABLE;
 
 import com.flipkart.zjsonpatch.Jackson3JsonPatch;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -402,7 +401,6 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
             final Predicate<VariableDefinition> isEligibleOutputVariable = variableDefinition ->
                 Optional
                     .ofNullable(variableDefinition.getCategory())
-                    .or(() -> Optional.of("local"))
                     .map(it -> it.toLowerCase(Locale.ROOT))
                     .filter(ELIGIBLE_OUTPUT_CATEGORY::contains)
                     .isPresent();
@@ -420,10 +418,10 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
                 .map(DelegateExecution::getProcessDefinitionId)
                 .map(processExtensionService::getExtensionsForId)
                 .map(Extension::getProperties)
-                .map(Map::values)
-                .map(Collection::stream)
-                .ifPresent(stream ->
-                    stream
+                .ifPresent(properties ->
+                    properties
+                        .values()
+                        .stream()
                         .filter(variableDefinition ->
                             Optional
                                 .of(variableDefinition)

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -21,6 +21,8 @@ import static org.activiti.spring.process.model.Mapping.SourceMappingType.VARIAB
 import com.flipkart.zjsonpatch.Jackson3JsonPatch;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -391,7 +393,7 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         ProcessVariablesMapping processVariablesMapping = extensions.getMappingForFlowElement(
             mappingExecutionContext.getActivityId()
         );
-        Map<String, Mapping> outputMappings = processVariablesMapping.getOutputs();
+        Map<String, Mapping> outputMappings = new LinkedHashMap<>(processVariablesMapping.getOutputs());
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
         if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {
@@ -399,7 +401,7 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
                 Optional
                     .ofNullable(variableDefinition.getCategory())
                     .or(() -> Optional.of("output"))
-                    .map(String::toLowerCase)
+                    .map(it -> it.toLowerCase(Locale.ROOT))
                     .filter(category -> category.contains("output"))
                     .isPresent();
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -390,11 +390,9 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         Map<String, Object> availableVariables
     ) {
         Map<String, Object> outboundVariables = new HashMap<>();
-        Map<String, Mapping> outputMappings = Optional
-            .of(extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()))
-            .map(ProcessVariablesMapping::getOutputs)
-            .map(LinkedHashMap::new)
-            .get();
+        Map<String, Mapping> outputMappings = new LinkedHashMap<>(
+            extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()).getOutputs()
+        );
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
         if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -20,7 +20,6 @@ import static org.activiti.spring.process.model.Mapping.SourceMappingType.VARIAB
 
 import com.flipkart.zjsonpatch.Jackson3JsonPatch;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -29,6 +28,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.activiti.bpmn.model.CallActivity;
 import org.activiti.engine.ActivitiIllegalArgumentException;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -68,7 +68,7 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
 
     public static final String JSON_PATCH_MAPPING_ERROR = "Invalid jsonPatch variable mapping";
 
-    private static final List<String> ELIGIBLE_OUTPUT_CATEGORY = List.of("output", "input/output");
+    private static final List<String> OUTPUT_CATEGORY = List.of("output", "input/output");
 
     public ExtensionsVariablesMappingProvider(
         ProcessExtensionService processExtensionService,
@@ -392,17 +392,20 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         Map<String, Object> availableVariables
     ) {
         Map<String, Object> outboundVariables = new HashMap<>();
-        Map<String, Mapping> outputMappings = new LinkedHashMap<>(
-            extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()).getOutputs()
-        );
+        Map<String, Mapping> outputMappings = Optional
+            .of(extensions.getMappingForFlowElement(mappingExecutionContext.getActivityId()))
+            .map(ProcessVariablesMapping::getOutputs)
+            .map(Map::copyOf)
+            .orElseGet(Map::of);
+
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
         if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {
-            final Predicate<VariableDefinition> isEligibleOutputVariable = variableDefinition ->
+            final Predicate<VariableDefinition> isOutputVariableCategory = variableDefinition ->
                 Optional
                     .ofNullable(variableDefinition.getCategory())
                     .map(it -> it.toLowerCase(Locale.ROOT))
-                    .filter(ELIGIBLE_OUTPUT_CATEGORY::contains)
+                    .filter(OUTPUT_CATEGORY::contains)
                     .isPresent();
 
             final Function<VariableDefinition, Map.Entry<String, Mapping>> toVariableOutputMapping = variableDefinition -> {
@@ -413,26 +416,28 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
                 return Map.entry(variableDefinition.getName(), mapping);
             };
 
-            Optional
-                .ofNullable(mappingExecutionContext.getSubProcessExecution())
-                .map(DelegateExecution::getProcessDefinitionId)
-                .map(processExtensionService::getExtensionsForId)
-                .map(Extension::getProperties)
-                .ifPresent(properties ->
-                    properties
-                        .values()
-                        .stream()
-                        .filter(variableDefinition ->
-                            Optional
-                                .of(variableDefinition)
-                                .filter(Predicate.not(VariableDefinition::isEphemeral).and(isEligibleOutputVariable))
-                                .isPresent()
-                        )
-                        .map(toVariableOutputMapping)
-                        .forEach(mapping -> {
-                            outputMappings.put(mapping.getKey(), mapping.getValue());
-                        })
-                );
+            outputMappings =
+                Optional
+                    .ofNullable(mappingExecutionContext.getSubProcessExecution())
+                    .map(DelegateExecution::getProcessDefinitionId)
+                    .map(processExtensionService::getExtensionsForId)
+                    .map(Extension::getProperties)
+                    .map(properties ->
+                        properties
+                            .values()
+                            .stream()
+                            .filter(variableDefinition ->
+                                Optional
+                                    .of(variableDefinition)
+                                    .filter(
+                                        Predicate.not(VariableDefinition::isEphemeral).and(isOutputVariableCategory)
+                                    )
+                                    .isPresent()
+                            )
+                            .map(toVariableOutputMapping)
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                    )
+                    .orElseGet(Map::of);
         }
 
         for (Map.Entry<String, Mapping> mappingEntry : outputMappings.entrySet()) {

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ExtensionsVariablesMappingProvider.java
@@ -16,16 +16,14 @@
 package org.activiti.runtime.api.impl;
 
 import static java.util.Collections.emptyMap;
+import static org.activiti.spring.process.model.Mapping.SourceMappingType.VARIABLE;
 
-import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.json.JsonMapper;
-import tools.jackson.databind.node.ArrayNode;
-import tools.jackson.databind.node.NullNode;
-import tools.jackson.databind.node.ObjectNode;
 import com.flipkart.zjsonpatch.Jackson3JsonPatch;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -46,6 +44,11 @@ import org.activiti.spring.process.variable.VariableParsingService;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.node.ObjectNode;
 
 public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
 
@@ -83,7 +86,7 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
                 return Optional.of(inputMapping.getValue());
             }
 
-            if (Mapping.SourceMappingType.VARIABLE.equals(inputMapping.getType())) {
+            if (VARIABLE.equals(inputMapping.getType())) {
                 String name = inputMapping.getValue().toString();
 
                 if (isTargetProcessVariableDefined(extensions, execution, name)) {
@@ -391,6 +394,45 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
         Map<String, Mapping> outputMappings = processVariablesMapping.getOutputs();
         DelegateExecution execution = mappingExecutionContext.getExecution();
 
+        if (outputMappings.isEmpty() && isMultiInstanceCallActivity(execution)) {
+            final Predicate<VariableDefinition> isEligibleOutputVariable = variableDefinition ->
+                Optional
+                    .ofNullable(variableDefinition.getCategory())
+                    .or(() -> Optional.of("output"))
+                    .map(String::toLowerCase)
+                    .filter(category -> category.contains("output"))
+                    .isPresent();
+
+            final Function<VariableDefinition, Map.Entry<String, Mapping>> toVariableOutputMapping = variableDefinition -> {
+                final var mapping = new Mapping();
+                mapping.setType(VARIABLE);
+                mapping.setValue(variableDefinition.getName());
+
+                return Map.entry(variableDefinition.getName(), mapping);
+            };
+
+            Optional
+                .ofNullable(mappingExecutionContext.getSubProcessExecution())
+                .map(DelegateExecution::getProcessDefinitionId)
+                .map(processExtensionService::getExtensionsForId)
+                .map(Extension::getProperties)
+                .map(Map::values)
+                .map(Collection::stream)
+                .ifPresent(stream ->
+                    stream
+                        .filter(variableDefinition ->
+                            Optional
+                                .of(variableDefinition)
+                                .filter(Predicate.not(VariableDefinition::isEphemeral).and(isEligibleOutputVariable))
+                                .isPresent()
+                        )
+                        .map(toVariableOutputMapping)
+                        .forEach(mapping -> {
+                            outputMappings.put(mapping.getKey(), mapping.getValue());
+                        })
+                );
+        }
+
         for (Map.Entry<String, Mapping> mappingEntry : outputMappings.entrySet()) {
             String name = mappingEntry.getKey();
 
@@ -467,7 +509,8 @@ public class ExtensionsVariablesMappingProvider implements VariablesCalculator {
     }
 
     private boolean isMultiInstanceCallActivity(DelegateExecution execution) {
-        return Optional.ofNullable(execution)
+        return Optional
+            .ofNullable(execution)
             .filter(isMultiInstanceRootParent().and(isCallActivityFlowElement()))
             .isPresent();
     }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/CallActivityBehavior.java
@@ -182,7 +182,7 @@ public class CallActivityBehavior extends AbstractBpmnActivityBehavior implement
 
     public void completing(DelegateExecution execution, DelegateExecution subProcessInstance) throws Exception {
         copyOutParameters(execution, subProcessInstance);
-        variablesPropagator.propagate(execution, subProcessInstance.getVariables());
+        variablesPropagator.propagate(execution, subProcessInstance);
     }
 
     public void completed(DelegateExecution execution) throws Exception {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MappingExecutionContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/MappingExecutionContext.java
@@ -23,6 +23,7 @@ public class MappingExecutionContext {
     private String processDefinitionId;
     private String activityId;
     private DelegateExecution execution;
+    private DelegateExecution subProcessExecution;
 
     public MappingExecutionContext(DelegateExecution delegateExecution) {
         this.processDefinitionId = delegateExecution.getProcessDefinitionId();
@@ -33,6 +34,13 @@ public class MappingExecutionContext {
     public MappingExecutionContext(String processDefinitionId, String activityId) {
         this.processDefinitionId = processDefinitionId;
         this.activityId = activityId;
+    }
+
+    public MappingExecutionContext(DelegateExecution delegateExecution, DelegateExecution subProcessExecution) {
+        this.processDefinitionId = delegateExecution.getProcessDefinitionId();
+        this.activityId = delegateExecution.getCurrentActivityId();
+        this.execution = delegateExecution;
+        this.subProcessExecution = subProcessExecution;
     }
 
     public String getProcessDefinitionId() {
@@ -51,8 +59,19 @@ public class MappingExecutionContext {
         return execution;
     }
 
+    public DelegateExecution getSubProcessExecution() {
+        return subProcessExecution;
+    }
+
     public static MappingExecutionContext buildMappingExecutionContext(DelegateExecution delegateExecution) {
         return new MappingExecutionContext(delegateExecution);
+    }
+
+    public static MappingExecutionContext buildMappingExecutionContext(
+        DelegateExecution delegateExecution,
+        DelegateExecution subProcessExecution
+    ) {
+        return new MappingExecutionContext(delegateExecution, subProcessExecution);
     }
 
     public static MappingExecutionContext buildMappingExecutionContext(String processDefinitionId, String activityId) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
@@ -35,10 +35,12 @@ public class VariablesPropagator {
 
     protected Map<String, Object> calculateMultiInstanceCallActivityLocalVariables(
         DelegateExecution execution,
-        Map<String, Object> availableVariables
+        DelegateExecution subProcessExecution
     ) {
+        final var availableVariables = subProcessExecution.getVariables();
+
         Map<String, Object> outputVariables = variablesCalculator.calculateOutPutVariables(
-            MappingExecutionContext.buildMappingExecutionContext(execution),
+            MappingExecutionContext.buildMappingExecutionContext(execution, subProcessExecution),
             availableVariables
         );
 
@@ -55,18 +57,24 @@ public class VariablesPropagator {
         return outputVariables;
     }
 
+    public void propagate(DelegateExecution execution, DelegateExecution subProcessInstance) throws Exception {
+        if (execution.getParent().isMultiInstanceRoot()) {
+            if (execution.getCurrentFlowElement() instanceof CallActivity) {
+                execution.setVariablesLocal(
+                    calculateMultiInstanceCallActivityLocalVariables(execution, subProcessInstance)
+                );
+            }
+        } else {
+            propagate(execution, subProcessInstance.getVariables());
+        }
+    }
+
     public void propagate(DelegateExecution execution, Map<String, Object> availableVariables) {
         if (availableVariables != null && !availableVariables.isEmpty()) {
             // in the case of a multi instance we need to set the available variables in the local execution scope so that
             // MultiInstanceBehaviour will manage to aggregate the results inside the result collection. Otherwise, the mapping logic is applied.
             if (execution.getParent().isMultiInstanceRoot()) {
-                if (execution.getCurrentFlowElement() instanceof CallActivity) {
-                    execution.setVariablesLocal(
-                        calculateMultiInstanceCallActivityLocalVariables(execution, availableVariables)
-                    );
-                } else {
-                    execution.setVariablesLocal(availableVariables);
-                }
+                execution.setVariablesLocal(availableVariables);
             } else if (execution.getProcessInstanceId() != null) {
                 final ExecutionEntity processInstanceEntity = getExecutionEntityManager()
                     .findById(execution.getProcessInstanceId());

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
@@ -57,7 +57,7 @@ public class VariablesPropagator {
         return outputVariables;
     }
 
-    public void propagate(DelegateExecution execution, DelegateExecution subProcessInstance) throws Exception {
+    public void propagate(DelegateExecution execution, DelegateExecution subProcessInstance) {
         if (execution.getParent().isMultiInstanceRoot() && execution.getCurrentFlowElement() instanceof CallActivity) {
             execution.setVariablesLocal(
                 calculateMultiInstanceCallActivityLocalVariables(execution, subProcessInstance)

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
@@ -58,12 +58,10 @@ public class VariablesPropagator {
     }
 
     public void propagate(DelegateExecution execution, DelegateExecution subProcessInstance) throws Exception {
-        if (execution.getParent().isMultiInstanceRoot()) {
-            if (execution.getCurrentFlowElement() instanceof CallActivity) {
-                execution.setVariablesLocal(
-                    calculateMultiInstanceCallActivityLocalVariables(execution, subProcessInstance)
-                );
-            }
+        if (execution.getParent().isMultiInstanceRoot() && execution.getCurrentFlowElement() instanceof CallActivity) {
+            execution.setVariablesLocal(
+                calculateMultiInstanceCallActivityLocalVariables(execution, subProcessInstance)
+            );
         } else {
             propagate(execution, subProcessInstance.getVariables());
         }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCallActivityMappingIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCallActivityMappingIT.java
@@ -401,8 +401,8 @@ public class ProcessRuntimeCallActivityMappingIT {
             .extracting(VariableInstance::getValue)
             .asInstanceOf(InstanceOfAssertFactories.list(Map.class))
             .containsExactlyInAnyOrder(
-                Map.of("result", "Result 1", "resultIndex", 1, "foo", "bar"),
-                Map.of("result", "Result 0", "resultIndex", 0, "foo", "bar")
+                Map.of("result", "Result 1", "resultIndex", 1),
+                Map.of("result", "Result 0", "resultIndex", 0)
             );
 
         final Task task = getTask(processInstance);

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
@@ -70,8 +70,6 @@
               "type": "variable",
               "value": "loopCounter"
             }
-          },
-          "outputs": {
           }
         }
       }

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
@@ -119,14 +119,16 @@
           "name": "result",
           "type": "string",
           "required": false,
-          "value": "Result ${resultIndex}"
+          "value": "Result ${resultIndex}",
+          "category": "output"
         },
         "de3a01c7-e2cc-4f16-b322-d04477288a0c": {
           "id": "de3a01c7-e2cc-4f16-b322-d04477288a0c",
           "name": "resultIndex",
           "type": "integer",
           "required": false,
-          "value": "${resultIndex}"
+          "value": "${resultIndex}",
+          "category": "input/output"
         },
         "de3a01c7-e2cc-4f16-b322-d04477288a0d": {
           "id": "de3a01c7-e2cc-4f16-b322-d04477288a0d",
@@ -135,6 +137,22 @@
           "required": false,
           "value": "bar",
           "category": "local"
+        },
+        "de3a01c7-e2cc-4f16-b322-d04477288a0e": {
+          "id": "de3a01c7-e2cc-4f16-b322-d04477288a0e",
+          "name": "bar",
+          "type": "string",
+          "required": false,
+          "value": "foo",
+          "ephemeral": true
+        },
+        "de3a01c7-e2cc-4f16-b322-d04477288a0f": {
+          "id": "de3a01c7-e2cc-4f16-b322-d04477288a0f",
+          "name": "baz",
+          "type": "string",
+          "required": false,
+          "value": "bar",
+          "category": "input"
         }
       },
       "assignments": {}

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
@@ -151,6 +151,14 @@
           "required": false,
           "value": "bar",
           "category": "input"
+        },
+        "de3a01c7-e2cc-4f16-b322-d04477288a0g": {
+          "id": "de3a01c7-e2cc-4f16-b322-d04477288a0g",
+          "name": "quix",
+          "type": "string",
+          "required": false,
+          "value": "foobar",
+          "category": null
         }
       },
       "assignments": {}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

Implements automatic output variable mapping for **multi-instance call activities** when the call activity mapping has **no explicit outputs**, by deriving eligible outputs from the called/sub-process variable definitions (using a new `category` field).

**Changes:**
- Add `category` to variable definitions and extend mapping execution context to include the sub-process execution.
- Update call activity completion propagation to pass the sub-process execution and support multi-instance local variable aggregation with calculated outputs.
- Update variable-mapping provider logic and integration test/resources to validate category-based auto output selection (including filtering out `local`, `input`, and `ephemeral` variables).

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-46367

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
