### PR TITLE
AAE-46386 Set DependaBot cooldown for all ecosystems as 3d

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       maven-plugins:
         patterns:
@@ -26,6 +28,8 @@ updates:
     - "/.github/actions/echo-longest-run"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Configure DependaBot cooldown period for all package ecosystems.

## Changes
- Added `cooldown` with `default-days: 3` as a sibling to `schedule` in `.github/dependabot.yml`

## Rationale
Setting a 3-day cooldown period helps prevent DependaBot from proposing dependencies which would be vectors for supply chain attacks as soon as they are released.
