### PR TITLE
AAE-46492 Add commandId to Activiti events

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEvent.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/ActivitiEvent.java
@@ -41,4 +41,16 @@ public interface ActivitiEvent {
      * @return the id of the process definition this event is associated with. Returns null, if the event was not dispatched from within an active execution.
      */
     String getProcessDefinitionId();
+
+    /**
+     * Returns a stable identifier that groups all events produced within the same engine command (i.e. a single
+     * {@code CommandContext} / transaction). All events fired during a single API call such as
+     * {@code runtimeService.startProcessInstanceByKey(...)} share the same {@code commandId}.
+     * Events fired outside a command context (e.g. during engine startup) return {@code null}.
+     *
+     * @return the command-scoped group id, or {@code null} if not available.
+     */
+    default String getCommandId() {
+        return null;
+    }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventDispatcherImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventDispatcherImpl.java
@@ -65,20 +65,30 @@ public class ActivitiEventDispatcherImpl implements ActivitiEventDispatcher {
 
     @Override
     public void dispatchEvent(ActivitiEvent event) {
+        // Stamp the commandId from the active CommandContext onto the event, unless already set
+        CommandContext commandContext = Context.getCommandContext();
+        if (
+            commandContext != null &&
+            event instanceof ActivitiEventImpl activitiEventImpl &&
+            activitiEventImpl.getCommandId() == null
+        ) {
+            activitiEventImpl.setCommandId(commandContext.getCommandId());
+        }
+
         if (enabled) {
             eventSupport.dispatchEvent(event);
         }
 
-        if (event.getType() == ActivitiEventType.ENTITY_DELETED && event instanceof ActivitiEntityEvent) {
-            ActivitiEntityEvent entityEvent = (ActivitiEntityEvent) event;
-            if (entityEvent.getEntity() instanceof ProcessDefinition) {
-                // process definition deleted event doesn't need to be dispatched to event listeners
-                return;
-            }
+        if (
+            event.getType() == ActivitiEventType.ENTITY_DELETED &&
+            event instanceof ActivitiEntityEvent entityEvent &&
+            entityEvent.getEntity() instanceof ProcessDefinition
+        ) {
+            // process definition deleted event doesn't need to be dispatched to event listeners
+            return;
         }
 
         // Try getting hold of the Process definition, based on the process definition key, if a context is active
-        CommandContext commandContext = Context.getCommandContext();
         if (commandContext != null) {
             BpmnModel bpmnModel = extractBpmnModelFromEvent(event);
             if (bpmnModel != null) {
@@ -100,16 +110,18 @@ public class ActivitiEventDispatcherImpl implements ActivitiEventDispatcher {
     protected BpmnModel extractBpmnModelFromEvent(ActivitiEvent event) {
         BpmnModel result = null;
 
-        if (result == null && event.getProcessDefinitionId() != null) {
+        if (event.getProcessDefinitionId() != null) {
             ProcessDefinition processDefinition = ProcessDefinitionUtil.getProcessDefinition(
                 event.getProcessDefinitionId(),
                 true
             );
             if (processDefinition != null) {
-                result = Context.getProcessEngineConfiguration()
-                    .getDeploymentManager()
-                    .resolveProcessDefinition(processDefinition)
-                    .getBpmnModel();
+                result =
+                    Context
+                        .getProcessEngineConfiguration()
+                        .getDeploymentManager()
+                        .resolveProcessDefinition(processDefinition)
+                        .getBpmnModel();
             }
         }
 

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/delegate/event/impl/ActivitiEventImpl.java
@@ -32,6 +32,7 @@ public class ActivitiEventImpl implements ActivitiEvent {
     protected String processDefinitionId;
     private String reason;
     private String actor;
+    protected String commandId;
 
     /**
      * Creates a new event implementation, not part of an execution context.
@@ -109,5 +110,14 @@ public class ActivitiEventImpl implements ActivitiEvent {
 
     public void setActor(String actor) {
         this.actor = actor;
+    }
+
+    @Override
+    public String getCommandId() {
+        return commandId;
+    }
+
+    public void setCommandId(String commandId) {
+        this.commandId = commandId;
     }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/interceptor/CommandContext.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.activiti.engine.ActivitiEngineAgenda;
 import org.activiti.engine.ActivitiException;
 import org.activiti.engine.ActivitiOptimisticLockingException;
@@ -79,6 +80,7 @@ public class CommandContext {
     protected List<CommandContextCloseListener> closeListeners;
     protected Map<String, Object> attributes; // General-purpose storing of anything during the lifetime of a command context
     protected boolean reused;
+    private final String commandId = UUID.randomUUID().toString();
 
     protected ActivitiEngineAgenda agenda;
     protected Map<String, ExecutionEntity> involvedExecutions = new HashMap<>(1); // The executions involved with the command
@@ -491,5 +493,14 @@ public class CommandContext {
 
     public void setReused(boolean reused) {
         this.reused = reused;
+    }
+
+    /**
+     * Returns a stable identifier for this command execution. All {@link org.activiti.engine.delegate.event.ActivitiEvent}s
+     * produced within the same {@link CommandContext} share the same {@code commandId}, allowing consumers to
+     * correlate them as a single, atomic unit of work.
+     */
+    public String getCommandId() {
+        return commandId;
     }
 }

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandIdStampingTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandIdStampingTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.activiti.engine.delegate.event.ActivitiEventType;
+import org.activiti.engine.delegate.event.impl.ActivitiEventDispatcherImpl;
+import org.activiti.engine.delegate.event.impl.ActivitiEventImpl;
+import org.activiti.engine.impl.context.Context;
+import org.activiti.engine.impl.interceptor.CommandContext;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+
+/**
+ * Unit-style tests that verify the commandId stamping logic in {@link ActivitiEventDispatcherImpl}.
+ */
+public class CommandIdStampingTest extends PluggableActivitiTestCase {
+
+    private ActivitiEventDispatcherImpl dispatcher;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        dispatcher = new ActivitiEventDispatcherImpl();
+        var listener = new TestActivitiEventListener();
+        dispatcher.addEventListener(listener);
+    }
+
+    /**
+     * When a CommandContext is active, the dispatcher stamps its commandId onto events that do not yet have one.
+     */
+    public void testCommandIdIsStampedFromActiveCommandContext() {
+        CommandContext commandContext = new CommandContext(null, processEngineConfiguration);
+        Context.setCommandContext(commandContext);
+        Context.setProcessEngineConfiguration(processEngineConfiguration);
+        try {
+            ActivitiEventImpl event = new ActivitiEventImpl(ActivitiEventType.ENTITY_CREATED);
+
+            dispatcher.dispatchEvent(event);
+
+            assertThat(event.getCommandId())
+                .as("commandId should be stamped from the active CommandContext")
+                .isNotNull()
+                .isEqualTo(commandContext.getCommandId());
+        } finally {
+            Context.removeCommandContext();
+            Context.removeProcessEngineConfiguration();
+        }
+    }
+
+    /**
+     * If the event already carries a commandId, the dispatcher must not overwrite it (propagated upstream ids).
+     */
+    public void testCommandIdIsNotOverwrittenIfAlreadySet() {
+        CommandContext commandContext = new CommandContext(null, processEngineConfiguration);
+        Context.setCommandContext(commandContext);
+        Context.setProcessEngineConfiguration(processEngineConfiguration);
+        try {
+            ActivitiEventImpl event = new ActivitiEventImpl(ActivitiEventType.ENTITY_CREATED);
+            String preSetId = "upstream-correlation-id";
+            event.setCommandId(preSetId);
+
+            dispatcher.dispatchEvent(event);
+
+            assertThat(event.getCommandId())
+                .as("pre-set commandId must not be overwritten by the dispatcher")
+                .isEqualTo(preSetId);
+        } finally {
+            Context.removeCommandContext();
+            Context.removeProcessEngineConfiguration();
+        }
+    }
+
+    /**
+     * Events fired outside a command context (e.g. during engine startup) must keep commandId as null.
+     */
+    public void testCommandIdIsNullWhenNoCommandContextIsActive() {
+        assertThat(Context.getCommandContext()).as("no CommandContext should be active").isNull();
+
+        ActivitiEventImpl event = new ActivitiEventImpl(ActivitiEventType.ENTITY_CREATED);
+
+        dispatcher.dispatchEvent(event);
+
+        assertThat(event.getCommandId())
+            .as("commandId should remain null when no CommandContext is active")
+            .isNull();
+    }
+}

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandScopedEventGroupIdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandScopedEventGroupIdTest.java
@@ -21,11 +21,9 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.activiti.engine.delegate.event.ActivitiEvent;
 import org.activiti.engine.delegate.event.impl.ActivitiEventImpl;
 import org.activiti.engine.impl.test.PluggableActivitiTestCase;
-import org.activiti.engine.runtime.ProcessInstance;
 import org.activiti.engine.test.Deployment;
 
 /**

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandScopedEventGroupIdTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/event/CommandScopedEventGroupIdTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.engine.test.api.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.activiti.engine.delegate.event.ActivitiEvent;
+import org.activiti.engine.delegate.event.impl.ActivitiEventImpl;
+import org.activiti.engine.impl.test.PluggableActivitiTestCase;
+import org.activiti.engine.runtime.ProcessInstance;
+import org.activiti.engine.test.Deployment;
+
+/**
+ * Integration tests verifying that all {@link ActivitiEvent}s produced within the same engine command share
+ * the same {@code commandId}, and that separate API calls produce distinct ids.
+ */
+public class CommandScopedEventGroupIdTest extends PluggableActivitiTestCase {
+
+    private TestActivitiEventListener listener;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        listener = new TestActivitiEventListener();
+        processEngineConfiguration.getEventDispatcher().addEventListener(listener);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (listener != null) {
+            processEngineConfiguration.getEventDispatcher().removeEventListener(listener);
+            listener.clearEventsReceived();
+        }
+        super.tearDown();
+    }
+
+    /**
+     * All events emitted by a single {@code startProcessInstanceByKey} call must share one commandId.
+     */
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    public void testAllEventsFromSingleStartCommandShareCommandId() {
+        runtimeService.startProcessInstanceByKey("oneTaskProcess");
+
+        List<String> commandIds = collectCommandIds(listener.getEventsReceived());
+
+        assertThat(commandIds)
+            .as("events must carry a non-null commandId when dispatched inside a CommandContext")
+            .isNotEmpty()
+            .doesNotContainNull();
+
+        Set<String> uniqueCommandIds = new HashSet<>(commandIds);
+        assertThat(uniqueCommandIds)
+            .as("all events from the same start command must share one commandId")
+            .hasSize(1);
+    }
+
+    /**
+     * Two separate API calls must produce two different commandIds.
+     */
+    @Deployment(resources = { "org/activiti/engine/test/api/runtime/oneTaskProcess.bpmn20.xml" })
+    public void testTwoSeparateStartCommandsProduceDifferentCommandIds() {
+        runtimeService.startProcessInstanceByKey("oneTaskProcess");
+        List<String> firstBatchIds = collectCommandIds(listener.getEventsReceived());
+        listener.clearEventsReceived();
+
+        runtimeService.startProcessInstanceByKey("oneTaskProcess");
+        List<String> secondBatchIds = collectCommandIds(listener.getEventsReceived());
+
+        assertThat(firstBatchIds).as("first batch must have commandIds").isNotEmpty().doesNotContainNull();
+        assertThat(secondBatchIds).as("second batch must have commandIds").isNotEmpty().doesNotContainNull();
+
+        String firstCommandId = firstBatchIds.getFirst();
+        String secondCommandId = secondBatchIds.getFirst();
+        assertThat(firstCommandId)
+            .as("separate API calls must produce distinct commandIds")
+            .isNotEqualTo(secondCommandId);
+    }
+
+    // -----------------------------------------------------------------------
+
+    private List<String> collectCommandIds(List<ActivitiEvent> events) {
+        List<String> ids = new ArrayList<>();
+        for (ActivitiEvent event : events) {
+            if (event instanceof ActivitiEventImpl) {
+                ids.add(event.getCommandId());
+            }
+        }
+        return ids;
+    }
+}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [x] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

This PR introduces a **command-scoped correlation identifier** (`commandId`) on `ActivitiEvent`s so consumers can reliably group all events emitted within the same engine command / `CommandContext` (typically one transaction).

**Changes:**
- Add a generated `commandId` to `CommandContext` and expose it via `getCommandId()`.
- Extend the public `ActivitiEvent` API with `getCommandId()` (default method) and implement it in `ActivitiEventImpl`.
- Stamp `commandId` onto events in `ActivitiEventDispatcherImpl` when a `CommandContext` is active, plus add unit/integration tests.

<!--
You can also link to an open issue here
-->

- Issue Link: AAE-46492

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
