### PR TITLE
MNT-25578: changed "serial" to "bigserial" column on postgresql database (#5398)

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ProcessEngine.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/ProcessEngine.java
@@ -41,7 +41,7 @@ import org.activiti.engine.api.internal.Internal;
 public interface ProcessEngine {
 
   /** the version of the activiti library */
-  public static String VERSION = "8.1.4"; // Note the extra -x at the end. To cater for snapshot releases with different database changes
+  public static String VERSION = "8.1.5"; // Note the extra -x at the end. To cater for snapshot releases with different database changes
 
     /**
      * The name as specified in 'process-engine-name' in the activiti.cfg.xml configuration file. The default name for a process engine is 'default

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/db/DbSqlSession.java
@@ -144,6 +144,7 @@ public class DbSqlSession implements Session {
         ACTIVITI_VERSIONS.add(new ActivitiVersion("8.0.0"));
         ACTIVITI_VERSIONS.add(new ActivitiVersion("8.1.0"));
         ACTIVITI_VERSIONS.add(new ActivitiVersion("8.1.3"));
+        ACTIVITI_VERSIONS.add(new ActivitiVersion("8.1.4"));
         ACTIVITI_VERSIONS.add(new ActivitiVersion(ProcessEngine.VERSION));
     }
 

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.db2.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.h2.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.h2.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.hsql.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.hsql.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mariadb.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mariadb.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mssql.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mssql.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.mysql.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_bin;
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.oracle.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.oracle.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.postgres.create.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/create/activiti.postgres.create.engine.sql
@@ -6,10 +6,10 @@ create table ACT_GE_PROPERTY (
 );
 
 insert into ACT_GE_PROPERTY
-values ('schema.version', '8.1.4', 1);
+values ('schema.version', '8.1.5', 1);
 
 insert into ACT_GE_PROPERTY
-values ('schema.history', 'create(8.1.4)', 1);
+values ('schema.history', 'create(8.1.5)', 1);
 
 insert into ACT_GE_PROPERTY
 values ('next.dbid', '1', 1);
@@ -259,7 +259,7 @@ create table ACT_RU_EVENT_SUBSCR (
 );
 
 create table ACT_EVT_LOG (
-    LOG_NR_ SERIAL PRIMARY KEY,
+    LOG_NR_ BIGSERIAL PRIMARY KEY,
     TYPE_ varchar(64),
     PROC_DEF_ID_ varchar(64),
     PROC_INST_ID_ varchar(64),

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.db2.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.h2.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mariadb.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mariadb.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mssql.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.mysql.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.oracle.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,1 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';

--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.814.to.815.engine.sql
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/upgrade/activiti.postgres.upgradestep.814.to.815.engine.sql
@@ -1,0 +1,5 @@
+update ACT_GE_PROPERTY set VALUE_ = '8.1.5' where NAME_ = 'schema.version';
+
+ALTER TABLE act_evt_log ALTER COLUMN log_nr_ TYPE bigint;
+ALTER SEQUENCE act_evt_log_log_nr__seq AS bigint;
+ALTER SEQUENCE act_evt_log_log_nr__seq NO MAXVALUE;


### PR DESCRIPTION
fixed upgrade script for MariaDB; updated DB version schema for new DBs; changed "serial" to "bigserial" column on postgresql database

<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/MNT-25578

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
