### PR TITLE
AAE-46367 Prevent leaking collection element variable into multi-instance call activity result collection with variable mapping extensions

### DIFF
--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/bpmn/behavior/VariablesPropagator.java
@@ -16,6 +16,7 @@
 package org.activiti.engine.impl.bpmn.behavior;
 
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Predicate;
 import org.activiti.bpmn.model.CallActivity;
 import org.activiti.engine.delegate.DelegateExecution;
@@ -54,7 +55,23 @@ public class VariablesPropagator {
             .filter(Predicate.not(outputVariables::containsKey))
             .forEach(execution::removeVariableLocal);
 
+        removeOutputCollectionElementVariableIfNotPresentInOutputs(execution, outputVariables);
+
         return outputVariables;
+    }
+
+    private void removeOutputCollectionElementVariableIfNotPresentInOutputs(
+        DelegateExecution execution,
+        Map<String, Object> outputVariables
+    ) {
+        if (execution.getCurrentFlowElement() instanceof CallActivity callActivity) {
+            if (callActivity.getBehavior() instanceof MultiInstanceActivityBehavior multiInstanceActivityBehavior) {
+                Optional
+                    .ofNullable(multiInstanceActivityBehavior.getCollectionElementVariable())
+                    .filter(Predicate.not(outputVariables::containsKey))
+                    .ifPresent(execution::removeVariableLocal);
+            }
+        }
     }
 
     public void propagate(DelegateExecution execution, DelegateExecution subProcessInstance) {

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCallActivityMappingIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeCallActivityMappingIT.java
@@ -415,6 +415,44 @@ public class ProcessRuntimeCallActivityMappingIT {
     }
 
     @Test
+    void shouldMapOutputVariablesFromMultiInstanceParallelCallActivityResultCollectionForEmptyOutputsWithElementVariable() {
+        securityUtil.logInAs("user");
+
+        ProcessInstance processInstance = processRuntime.start(
+            ProcessPayloadBuilder
+                .start()
+                .withProcessDefinitionKey(
+                    "multi-instance-parallel-call-activity-result-collection-empty-outputs-with-element-variable"
+                )
+                .build()
+        );
+        assertThat(processInstance).isNotNull();
+
+        List<VariableInstance> procVariables = processRuntime.variables(
+            ProcessPayloadBuilder.variables().withProcessInstanceId(processInstance.getId()).build()
+        );
+
+        assertThat(procVariables)
+            .isNotNull()
+            .singleElement(InstanceOfAssertFactories.type(VariableInstance.class))
+            .satisfies(variable -> assertThat(variable.getName()).isEqualTo("miResult"))
+            .extracting(VariableInstance::getValue)
+            .asInstanceOf(InstanceOfAssertFactories.list(Map.class))
+            .containsExactlyInAnyOrder(
+                Map.of("result", "Result 1", "resultIndex", 1),
+                Map.of("result", "Result 0", "resultIndex", 0)
+            );
+
+        final Task task = getTask(processInstance);
+
+        taskRuntime.claim(TaskPayloadBuilder.claim().withTaskId(task.getId()).withAssignee("user").build());
+
+        taskRuntime.complete(TaskPayloadBuilder.complete().withTaskId(task.getId()).build());
+
+        assertProcessCompleted(processInstance);
+    }
+
+    @Test
     void shouldMapOutputVariablesFromMultiInstanceCallActivityResultCollectionWithLoopVariables() {
         securityUtil.logInAs("user");
 

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping-extensions.json
@@ -74,6 +74,18 @@
         }
       }
     },
+    "multi-instance-parallel-call-activity-result-collection-empty-outputs-with-element-variable": {
+      "mappings": {
+        "empty-outputs-element-variable-callActivity": {
+          "inputs": {
+            "resultIndex": {
+              "type": "variable",
+              "value": "loopCounter"
+            }
+          }
+        }
+      }
+    },
     "multi-instance-parallel-call-activity-result-collection-loop-variables": {
       "mappings": {
         "loop-variables-callActivity": {

--- a/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping.bpmn20.xml
+++ b/activiti-core/activiti-spring-boot-starter/src/test/resources/processes/multi-instance-call-activity-result-collection-variable-mapping.bpmn20.xml
@@ -49,6 +49,21 @@
     <endEvent id="empty-outputs-end"/>
   </process>
 
+  <process id="multi-instance-parallel-call-activity-result-collection-empty-outputs-with-element-variable">
+    <startEvent id="empty-outputs-element-variable-start"/>
+    <sequenceFlow id="empty-outputs-element-variable-flow1" sourceRef="empty-outputs-element-variable-start" targetRef="empty-outputs-element-variable-callActivity"/>
+    <callActivity id="empty-outputs-element-variable-callActivity" calledElement="multi-instance-call-activity-result-sub-process" >
+      <multiInstanceLoopCharacteristics isSequential="false" activiti:collection="${list(0,1)}" activiti:elementVariable="item">
+        <loopCardinality>2</loopCardinality>
+        <loopDataOutputRef>miResult</loopDataOutputRef>
+      </multiInstanceLoopCharacteristics>
+    </callActivity>
+    <sequenceFlow id="empty-outputs-element-variable-flow2" sourceRef="empty-outputs-element-variable-callActivity" targetRef="empty-outputs-element-variable-userTask"/>
+    <userTask id="empty-outputs-element-variable-userTask" name="My user task" activiti:candidateUsers="user"/>
+    <sequenceFlow id="empty-outputs-element-variable-flow3" sourceRef="empty-outputs-element-variable-userTask" targetRef="empty-outputs-element-variable-end"/>
+    <endEvent id="empty-outputs-element-variable-end"/>
+  </process>
+
   <process id="multi-instance-parallel-call-activity-result-collection-loop-variables">
     <startEvent id="loop-variables-start"/>
     <sequenceFlow id="loop-variables-flow1" sourceRef="loop-variables-start" targetRef="loop-variables-callActivity"/>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

This PR addresses AAE-46367 by preventing the multi-instance *collection element variable* (e.g., `activiti:elementVariable="item"`) from leaking into the aggregated result collection (`loopDataOutputRef`) when a call activity uses variable-mapping extensions.

**Changes:**
- Add a new BPMN test process that uses a parallel multi-instance call activity with an `elementVariable`.
- Add the corresponding extensions JSON mapping entry for the new process.
- Add an integration test that asserts the multi-instance result collection contains only the intended mapped outputs.
- Update `VariablesPropagator` to remove the collection element variable from local scope when it is not part of the computed output variables.

<!--
You can also link to an open issue here
-->

- Issue Link: https://hyland.atlassian.net/browse/AAE-46367

<!--
If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
-->

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No
