### PR TITLE
AAE-48044 Sign jx-updatebot propagation commits in Activiti and activiti-cloud to unblock version-propagation PRs

### DIFF
--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -109,11 +109,10 @@ jobs:
         uses: ./.github/actions/echo-longest-run
 
       - name: Configure git user
-        run: |
-          git config --global user.name $GITHUB_USERNAME
-          git config --global user.email $GITHUB_USERNAME@users.noreply.github.com
-        env:
-          GITHUB_USERNAME: ${{ secrets.BOT_GITHUB_USERNAME }}
+        uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
+        with:
+          username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          email: ${{ secrets.BOT_GITHUB_USERNAME }}@users.noreply.github.com
 
       - name: Create release tag
         run: |


### PR DESCRIPTION
**What kind of change does this PR introduce?**

> - [x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

Follow-up to the initial GPG-signing change: the release-tag git identity was configured with `--global`, which leaked into the `jx-updatebot` downstream clone and overrode the propagation commit's committer to the bot user, so GitHub reported the commit as unverified (`unknown_key`). Configuring the identity with local scope (via the shared `configure-git-author` action) keeps it on the release tag only; propagation then commits as the GPG key owner and is verified.

- Issue Link: https://hyland.atlassian.net/browse/AAE-48044

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No