### PR TITLE
AAE-46705 Activiti build job cannot be rerun in some cases

### DIFF
--- a/.github/actions/maven-build-and-analyze/action.yml
+++ b/.github/actions/maven-build-and-analyze/action.yml
@@ -1,0 +1,53 @@
+name: Maven build and analyze
+description: >-
+  Builds and tests the project with Maven, aggregates JaCoCo coverage and runs
+  the SonarCloud analysis. Java must be set up before calling this action.
+
+inputs:
+  nexus-username:
+    description: Nexus username for Maven.
+    required: true
+  nexus-password:
+    description: Nexus password for Maven.
+    required: true
+  sonar-token:
+    description: SonarCloud token. When empty, the analysis is skipped.
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Build and Test with Maven
+      shell: bash
+      run: mvn install ${{ env.MAVEN_CLI_OPTS }}
+      env:
+        MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
+        MAVEN_USERNAME: ${{ inputs.nexus-username }}
+        MAVEN_PASSWORD: ${{ inputs.nexus-password }}
+
+    - name: Merge JaCoCo execution files
+      shell: bash
+      run: mvn jacoco:merge@merge -N
+
+    - name: Generate aggregate coverage report
+      shell: bash
+      run: mvn jacoco:report -Djacoco.dataFile=${{ github.workspace }}/target/jacoco.exec
+
+    - name: Set SONAR_SCANNER_OPTS
+      shell: bash
+      run: |
+        echo "SONAR_SCANNER_OPTS=sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=activiti -Dsonar.projectKey=Activiti_Activiti -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco*/jacoco.xml" >> $GITHUB_ENV
+
+    - name: Run SonarCloud analysis
+      if: ${{ inputs.sonar-token != '' }}
+      shell: bash
+      run: mvn ${{ env.SONAR_SCANNER_OPTS }} ${{ env.MAVEN_CLI_OPTS }}
+      env:
+        MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
+        MAVEN_USERNAME: ${{ inputs.nexus-username }}
+        MAVEN_PASSWORD: ${{ inputs.nexus-password }}
+        SONAR_TOKEN: ${{ inputs.sonar-token }}
+
+    - name: Echo Longest Test Run
+      uses: ./.github/actions/echo-longest-run

--- a/.github/actions/setup-java-maven/action.yml
+++ b/.github/actions/setup-java-maven/action.yml
@@ -1,0 +1,28 @@
+name: Setup Java and Maven cache
+description: Restores the Maven ~/.m2 cache and sets up the JDK.
+
+inputs:
+  java-version:
+    description: The Java version to set up.
+    required: false
+    default: "25"
+  java-distribution:
+    description: The Java distribution to set up.
+    required: false
+    default: "corretto"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+
+    - name: Setup Java JDK ${{ inputs.java-version }}
+      uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # 5.4.0
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.java-distribution }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
     directories:
     - "/"
     - "/.github/actions/echo-longest-run"
+    - "/.github/actions/setup-java-maven"
+    - "/.github/actions/maven-build-and-analyze"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.github/workflows/main_pull.yml
+++ b/.github/workflows/main_pull.yml
@@ -34,6 +34,11 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/pre-commit@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
       - name: Ensure SHA pinned actions
         uses: hyland/github-actions-ensure-sha-pinned-actions@7957efb76aba0eec7580a9c0392d3e5bec381359 # v2.0.1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Ensure all actions are covered by Dependabot
+        uses: Alfresco/alfresco-build-tools/.github/actions/dependabot-missing-actions-check@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
       - name: Check PR preview
         id: check_pr_preview
         shell: bash
@@ -49,6 +54,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-java-maven
 
@@ -87,6 +94,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-java-maven
 

--- a/.github/workflows/main_pull.yml
+++ b/.github/workflows/main_pull.yml
@@ -1,7 +1,5 @@
 name: PR - Validate and Build
 
-permissions: read-all
-
 on:
   pull_request:
     branches:
@@ -21,6 +19,8 @@ concurrency:
 jobs:
   pre-checks:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       preview: ${{ steps.check_pr_preview.outputs.preview }}
     steps:
@@ -43,22 +43,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: pre-checks
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-
-      - name: Setup Java JDK 25
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # 5.4.0
-        with:
-          java-version: 25
-          distribution: "corretto"
+      - uses: ./.github/actions/setup-java-maven
 
       - name: Set preview version
         if: ${{ needs.pre-checks.outputs.preview == 'true' }}
@@ -77,50 +69,45 @@ jobs:
         if: ${{ needs.pre-checks.outputs.preview == 'true' }}
         run: mvn -B versions:set -DnewVersion=$VERSION -DprocessAllModules=true -DgenerateBackupPoms=false
 
-      - name: Define Maven Command
-        id: define_maven_command
-        shell: bash
-        run: |
-          if [[ $DO_PUSH == 'true' && $SECRET_SOURCE != 'None' ]]
-          then
-            echo "command=deploy" >> $GITHUB_OUTPUT
-          else
-            echo "command=install" >> $GITHUB_OUTPUT
-          fi
-        env:
-          DO_PUSH: ${{ needs.pre-checks.outputs.preview }}
-          SECRET_SOURCE: ${{ github.secret_source }}
+      - uses: ./.github/actions/maven-build-and-analyze
+        with:
+          nexus-username: ${{ secrets.NEXUS_USERNAME }}
+          nexus-password: ${{ secrets.NEXUS_PASSWORD }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Build and Test with Maven (and maybe deploy)
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - pre-checks
+      - build
+    if: ${{ needs.pre-checks.outputs.preview == 'true' && github.secret_source != 'None' && success() }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: ./.github/actions/setup-java-maven
+
+      - name: Set preview version
+        run: |
+          GITHUB_PR_NUMBER=PR-${{ github.event.pull_request.number }}
+          echo 0.0.1-${GITHUB_PR_NUMBER}-${GITHUB_RUN_NUMBER}-SNAPSHOT > VERSION
+
+      - name: Set VERSION env variable
+        run: |
+          VERSION=$(cat VERSION)
+          echo set VERSION=$VERSION
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Update pom files to the new version
+        run: mvn -B versions:set -DnewVersion=$VERSION -DprocessAllModules=true -DgenerateBackupPoms=false
+
+      - name: Deploy preview with Maven
         shell: bash
-        run: mvn ${{ steps.define_maven_command.outputs.command }} ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn deploy -DskipTests ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-
-      - name: Merge JaCoCo execution files
-        shell: bash
-        run: mvn jacoco:merge@merge -N
-
-      - name: Generate aggregate coverage report
-        shell: bash
-        run: mvn jacoco:report -Djacoco.dataFile=${{ github.workspace }}/target/jacoco.exec
-
-      - name: Set SONAR_SCANNER_OPTS
-        shell: bash
-        run: |
-          echo "SONAR_SCANNER_OPTS=sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=activiti -Dsonar.projectKey=Activiti_Activiti -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco*/jacoco.xml" >> $GITHUB_ENV
-
-      - name: Run SonarCloud analysis
-        if: ${{ env.SONAR_TOKEN != '' }}
-        shell: bash
-        run: mvn ${{ env.SONAR_SCANNER_OPTS }} ${{ env.MAVEN_CLI_OPTS}}
-        env:
-          MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Echo Longest Test Run
-        uses: ./.github/actions/echo-longest-run

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: dependabot check
         id: dependabot
+        if: ${{ github.event_name == 'push' }}
         uses: Alfresco/alfresco-build-tools/.github/actions/github-pr-check-metadata@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
         with:
           gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -90,7 +91,7 @@ jobs:
     needs:
       - create-tag
       - build
-    if: ${{ success() }}
+    if: ${{ github.event_name == 'push' && success() }}
     permissions:
       actions: write
       contents: read
@@ -128,7 +129,6 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
 
       - name: Configure propagation git author
-        if: ${{ env.BRANCH_NAME == 'develop' }}
         uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
         with:
           username: ${{ vars.HXPS_GIT_USERNAME }}
@@ -137,7 +137,6 @@ jobs:
 
       - name: Propagate
         uses: Alfresco/alfresco-build-tools/.github/actions/jx-updatebot-pr@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
-        if: ${{ env.BRANCH_NAME == 'develop' }}
         env:
           DEVELOPMENT_BRANCH: ${{ github.ref_name }}
         with:
@@ -159,7 +158,7 @@ jobs:
       - build
       - publish
       - propagate
-    if: always() && failure()
+    if: always() && failure() && github.event_name == 'push'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: dependabot check
         id: dependabot
-        if: ${{ github.event_name == 'push' }}
         uses: Alfresco/alfresco-build-tools/.github/actions/github-pr-check-metadata@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
         with:
           gh-token: ${{ secrets.BOT_GITHUB_TOKEN }}
@@ -91,7 +90,7 @@ jobs:
     needs:
       - create-tag
       - build
-    if: ${{ github.event_name == 'push' && success() }}
+    if: ${{ success() }}
     permissions:
       actions: write
       contents: read
@@ -129,6 +128,7 @@ jobs:
         uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
 
       - name: Configure propagation git author
+        if: ${{ env.BRANCH_NAME == 'develop' }}
         uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
         with:
           username: ${{ vars.HXPS_GIT_USERNAME }}
@@ -137,6 +137,7 @@ jobs:
 
       - name: Propagate
         uses: Alfresco/alfresco-build-tools/.github/actions/jx-updatebot-pr@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
+        if: ${{ env.BRANCH_NAME == 'develop' }}
         env:
           DEVELOPMENT_BRANCH: ${{ github.ref_name }}
         with:
@@ -158,7 +159,7 @@ jobs:
       - build
       - publish
       - propagate
-    if: always() && failure() && github.event_name == 'push'
+    if: always() && failure()
     permissions:
       contents: read
     steps:

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -36,6 +36,8 @@ jobs:
           skip_checkout: true
       - name: Ensure SHA pinned actions
         uses: hyland/github-actions-ensure-sha-pinned-actions@7957efb76aba0eec7580a9c0392d3e5bec381359 # v2.0.1
+      - name: Ensure all actions are covered by Dependabot
+        uses: Alfresco/alfresco-build-tools/.github/actions/dependabot-missing-actions-check@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
 
   create-tag:
     runs-on: ubuntu-latest
@@ -76,6 +78,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.create-tag.outputs.version }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-java-maven
 
@@ -99,6 +102,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ needs.create-tag.outputs.version }}
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-java-maven
 

--- a/.github/workflows/main_push.yml
+++ b/.github/workflows/main_push.yml
@@ -1,10 +1,5 @@
 name: Push - Validate, Build and Release
 
-permissions:
-  actions: write
-  checks: write
-  contents: write
-
 on:
   push:
     branches:
@@ -20,6 +15,10 @@ concurrency:
 jobs:
   pre-checks:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: write
+      contents: read
     outputs:
       skip: ${{ steps.dependabot.outputs.result }}
     steps:
@@ -38,87 +37,92 @@ jobs:
       - name: Ensure SHA pinned actions
         uses: hyland/github-actions-ensure-sha-pinned-actions@7957efb76aba0eec7580a9c0392d3e5bec381359 # v2.0.1
 
-  build:
+  create-tag:
     runs-on: ubuntu-latest
     needs: pre-checks
     if: ${{ needs.pre-checks.outputs.skip != 'true' }}
+    permissions:
+      actions: write
+      contents: write
+    outputs:
+      version: ${{ steps.tag.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      - uses: Alfresco/alfresco-build-tools/.github/actions/maven-tag@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
+        id: tag
         with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          java-version: "25"
+          maven-version: "3.9.9"
+          maven-username: ${{ secrets.NEXUS_USERNAME }}
+          maven-password: ${{ secrets.NEXUS_PASSWORD }}
+          git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          m2-cache-exclusion-pattern: org/activiti
 
-      - name: Setup Java JDK 25
-        uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # 5.4.0
+  build:
+    runs-on: ubuntu-latest
+    needs:
+      - pre-checks
+      - create-tag
+    if: ${{ needs.pre-checks.outputs.skip != 'true' }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          java-version: 25
-          distribution: "corretto"
+          ref: ${{ needs.create-tag.outputs.version }}
 
-      - uses: Alfresco/alfresco-build-tools/.github/actions/update-pom-to-next-pre-release@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
-        id: update-pom-to-next-version
+      - uses: ./.github/actions/setup-java-maven
 
-      - name: Update VERSION file
-        run: |
-          echo ${{steps.update-pom-to-next-version.outputs.next-prerelease}} > VERSION
+      - uses: ./.github/actions/maven-build-and-analyze
+        with:
+          nexus-username: ${{ secrets.NEXUS_USERNAME }}
+          nexus-password: ${{ secrets.NEXUS_PASSWORD }}
+          sonar-token: ${{ secrets.SONAR_TOKEN }}
 
-      - name: Set VERSION env variable
-        run: |
-          VERSION=$(cat VERSION)
-          echo set VERSION=$VERSION
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+  publish:
+    runs-on: ubuntu-latest
+    needs:
+      - create-tag
+      - build
+    if: ${{ success() }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ needs.create-tag.outputs.version }}
 
-      - name: Build and Test with Maven (and maybe Deploy)
+      - uses: ./.github/actions/setup-java-maven
+
+      - name: Deploy with Maven
         shell: bash
-        run: mvn deploy ${{ env.MAVEN_CLI_OPTS}}
+        run: mvn deploy -DskipTests ${{ env.MAVEN_CLI_OPTS}}
         env:
           MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
           MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
 
-      - name: Merge JaCoCo execution files
-        shell: bash
-        run: mvn jacoco:merge@merge -N
-
-      - name: Generate aggregate coverage report
-        shell: bash
-        run: mvn jacoco:report -Djacoco.dataFile=${{ github.workspace }}/target/jacoco.exec
-
-      - name: Set SONAR_SCANNER_OPTS
-        shell: bash
-        run: |
-          echo "SONAR_SCANNER_OPTS=sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.organization=activiti -Dsonar.projectKey=Activiti_Activiti -Dsonar.coverage.jacoco.xmlReportPaths=**/target/site/jacoco*/jacoco.xml" >> $GITHUB_ENV
-
-      - name: Run SonarCloud analysis
-        if: ${{ env.SONAR_TOKEN != '' }}
-        shell: bash
-        run: mvn ${{ env.SONAR_SCANNER_OPTS }} ${{ env.MAVEN_CLI_OPTS}}
-        env:
-          MAVEN_CLI_OPTS: --show-version --no-transfer-progress --settings settings.xml
-          MAVEN_USERNAME: ${{ secrets.NEXUS_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Echo Longest Test Run
-        uses: ./.github/actions/echo-longest-run
-
-      - name: Configure git user
-        uses: Alfresco/alfresco-build-tools/.github/actions/configure-git-author@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
+  propagate:
+    runs-on: ubuntu-latest
+    needs:
+      - create-tag
+      - publish
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          username: ${{ secrets.BOT_GITHUB_USERNAME }}
-          email: ${{ secrets.BOT_GITHUB_USERNAME }}@users.noreply.github.com
-
-      - name: Create release tag
-        run: |
-          git commit -am "Release $VERSION" --allow-empty
-          git tag -fa $VERSION -m "Release version $VERSION"
-          git push -f -q origin $VERSION
+          ref: ${{ needs.create-tag.outputs.version }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Get branch name
         uses: Alfresco/alfresco-build-tools/.github/actions/get-branch-name@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0
@@ -137,7 +141,7 @@ jobs:
         env:
           DEVELOPMENT_BRANCH: ${{ github.ref_name }}
         with:
-          version: ${{ env.VERSION }}
+          version: ${{ needs.create-tag.outputs.version }}
           auto-merge: "true"
           labels: ${{ env.DEVELOPMENT_BRANCH }}
           base-branch-name: ${{ env.DEVELOPMENT_BRANCH }}
@@ -150,8 +154,14 @@ jobs:
 
   notify:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - create-tag
+      - build
+      - publish
+      - propagate
     if: always() && failure()
+    permissions:
+      contents: read
     steps:
       - name: Teams Notification
         uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@10cea6c0b390c4f8af21d9dc1670d581bd10319f # v18.13.0


### PR DESCRIPTION
**What kind of change does this PR introduce?**

> - [ ] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [x] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

- Issue Link: https://hyland.atlassian.net/browse/AAE-46705

Splits the monolithic build job into `create-tag`, `build`, `publish` and `propagate` jobs so a re-run of failed jobs never re-executes a successful immutable deploy. Aligns the pipeline with activiti-cloud (build-tools `maven-tag`) and extracts shared setup and build+analyze steps into local composite actions reused by the push and pull workflows.

**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [x] No