### PR TITLE
AAE-49074 Eliminate PostgreSQL cached plan errors in rolling deployments via explicit Task columns

### DIFF
--- a/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
+++ b/activiti-core/activiti-engine/src/main/resources/org/activiti/db/mapping/entity/Task.xml
@@ -183,6 +183,14 @@
     </foreach>
   </delete>
 
+   <sql id="taskColumns">
+     ${aliasPrefix}ID_, ${aliasPrefix}REV_, ${aliasPrefix}NAME_, ${aliasPrefix}BUSINESS_KEY_, ${aliasPrefix}PARENT_TASK_ID_,
+     ${aliasPrefix}DESCRIPTION_, ${aliasPrefix}PRIORITY_, ${aliasPrefix}CREATE_TIME_, ${aliasPrefix}OWNER_, ${aliasPrefix}ASSIGNEE_,
+     ${aliasPrefix}DELEGATION_, ${aliasPrefix}EXECUTION_ID_, ${aliasPrefix}PROC_INST_ID_, ${aliasPrefix}PROC_DEF_ID_,
+     ${aliasPrefix}TASK_DEF_KEY_, ${aliasPrefix}DUE_DATE_, ${aliasPrefix}CATEGORY_, ${aliasPrefix}SUSPENSION_STATE_,
+     ${aliasPrefix}TENANT_ID_, ${aliasPrefix}FORM_KEY_, ${aliasPrefix}CLAIM_TIME_, ${aliasPrefix}APP_VERSION_
+   </sql>
+
   <!-- TASK RESULTMAP -->
 
   <resultMap id="taskResultMap" type="org.activiti.engine.impl.persistence.entity.TaskEntityImpl">
@@ -252,24 +260,26 @@
   <!-- TASK SELECT -->
 
   <select id="selectTask" parameterType="string" resultMap="taskResultMap">
-    select * from ${prefix}ACT_RU_TASK where ID_ = #{id, jdbcType=VARCHAR}
+    select <include refid="taskColumns"><property name="aliasPrefix" value=""/></include>
+    from ${prefix}ACT_RU_TASK where ID_ = #{id, jdbcType=VARCHAR}
   </select>
 
   <select id="selectTasksByParentTaskId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="taskResultMap">
-    select * from ${prefix}ACT_RU_TASK where PARENT_TASK_ID_ = #{parameter}
+    select <include refid="taskColumns"><property name="aliasPrefix" value=""/></include>
+    from ${prefix}ACT_RU_TASK where PARENT_TASK_ID_ = #{parameter}
   </select>
 
   <select id="selectTasksByExecutionId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="taskResultMap">
-    select distinct T.*
+    select distinct <include refid="taskColumns"><property name="aliasPrefix" value=""/></include>
     from ${prefix}ACT_RU_TASK T
     where T.EXECUTION_ID_ = #{parameter}
   </select>
 
-  <select id="selectTasksByProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="taskResultMap">
-    select T.*
-    from ${prefix}ACT_RU_TASK T
-    where T.PROC_INST_ID_ = #{parameter}
-  </select>
+   <select id="selectTasksByProcessInstanceId" parameterType="org.activiti.engine.impl.db.ListQueryParameterObject" resultMap="taskResultMap">
+      select <include refid="taskColumns"><property name="aliasPrefix" value=""/></include>
+     from ${prefix}ACT_RU_TASK T
+     where T.PROC_INST_ID_ = #{parameter}
+   </select>
 
   <select id="selectTaskByQueryCriteria" parameterType="org.activiti.engine.impl.TaskQueryImpl" resultMap="taskResultMap">
     <include refid="selectTaskByQueryCriteria"/>
@@ -360,12 +370,26 @@
     VAR.TEXT_ as VAR_TEXT_,
     VAR.TEXT2_ as VAR_TEXT2_,
     VAR.LONG_ as VAR_LONG_'"/>
+    <bind name="OUTER_VARIABLES_COLUMNS" value="',RES.VAR_ID_ as VAR_ID_,
+    RES.VAR_NAME_ as VAR_NAME_,
+    RES.VAR_TYPE_ as VAR_TYPE_,
+    RES.VAR_REV_ as VAR_REV_,
+    RES.VAR_PROC_INST_ID_ as VAR_PROC_INST_ID_,
+    RES.VAR_EXECUTION_ID_ as VAR_EXECUTION_ID_,
+    RES.VAR_TASK_ID_ as VAR_TASK_ID_,
+    RES.VAR_BYTEARRAY_ID_ as VAR_BYTEARRAY_ID_,
+    RES.VAR_DOUBLE_ as VAR_DOUBLE_,
+    RES.VAR_TEXT_ as VAR_TEXT_,
+    RES.VAR_TEXT2_ as VAR_TEXT2_,
+    RES.VAR_LONG_ as VAR_LONG_'"/>
     <choose>
       <when test="includeTaskLocalVariables || includeProcessVariables">
         <bind name="variablesColumns" value="VARIABLES_COLUMNS"/>
+        <bind name="outerVariablesColumns" value="OUTER_VARIABLES_COLUMNS"/>
       </when>
       <otherwise>
         <bind name="variablesColumns" value="''"/>
+        <bind name="outerVariablesColumns" value="''"/>
       </otherwise>
     </choose>
 
@@ -398,15 +422,15 @@
         <choose>
           <!-- if it's not a count and there's a distinct, we need to remove duplicated based on RES.ID_ -->
           <when test="distinctMode == 'distinct'">
-            select RES.* ${v3_limitBetween}
+            select <include refid="taskColumns"><property name="aliasPrefix" value="RES."/></include> ${outerVariablesColumns} ${v3_limitBetween}
             from (
-            select ${distinctMode} RES.ID_ as uniqueId, RES.* ${variablesColumns}
+            select ${distinctMode} RES.ID_ as uniqueId, <include refid="taskColumns"><property name="aliasPrefix" value="RES."/></include> ${variablesColumns}
           </when>
-          <!-- if it's not a count nor distinct, we don't need explicit RES.ID_ -->
-          <otherwise>
-            select RES.* ${v3_limitBetween}
-            from (
-            select RES.* ${variablesColumns}
+           <!-- if it's not a count nor distinct, we don't need explicit RES.ID_ -->
+           <otherwise>
+             select <include refid="taskColumns"><property name="aliasPrefix" value="RES."/></include> ${outerVariablesColumns} ${v3_limitBetween}
+             from (
+             select <include refid="taskColumns"><property name="aliasPrefix" value="RES."/></include> ${variablesColumns}
           </otherwise>
         </choose>
       </otherwise>

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/db/TaskQueryPostgresCachedPlanTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/db/TaskQueryPostgresCachedPlanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.activiti.engine.impl.db;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/db/TaskQueryPostgresCachedPlanTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/impl/db/TaskQueryPostgresCachedPlanTest.java
@@ -1,0 +1,135 @@
+package org.activiti.engine.impl.db;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import org.activiti.engine.ProcessEngine;
+import org.activiti.engine.ProcessEngineConfiguration;
+import org.activiti.engine.TaskService;
+import org.activiti.engine.task.Task;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.postgresql.PostgreSQLContainer;
+
+class TaskQueryPostgresCachedPlanTest {
+
+    private static final String ENGINE_NAME = "cachedPlanTestEngine";
+    private static final String TASK_NAME = "cached plan task";
+    private static final String SUB_TASK_NAME = "cached plan sub task";
+    private static final String VARIABLE_NAME = "cachedPlanVariable";
+    private static final String VARIABLE_VALUE = "someValue";
+    private static final String ASSIGNEE = "kermit";
+    private static final int PRIORITY = 42;
+
+    private static final PostgreSQLContainer postgres = new PostgreSQLContainer("postgres:15-alpine");
+
+    private ProcessEngine processEngine;
+    private TaskService taskService;
+
+    @BeforeAll
+    static void startDatabase() {
+        postgres.start();
+    }
+
+    @AfterAll
+    static void stopDatabase() {
+        postgres.stop();
+    }
+
+    @BeforeEach
+    void setUp() {
+        processEngine = ProcessEngineConfiguration.createStandaloneProcessEngineConfiguration()
+            .setProcessEngineName(ENGINE_NAME)
+            .setJdbcUrl(jdbcUrlWithImmediateServerSidePrepare())
+            .setJdbcUsername(postgres.getUsername())
+            .setJdbcPassword(postgres.getPassword())
+            .setJdbcMaxActiveConnections(1)
+            .setDatabaseSchemaUpdate(ProcessEngineConfiguration.DB_SCHEMA_UPDATE_TRUE)
+            .buildProcessEngine();
+        taskService = processEngine.getTaskService();
+    }
+
+    @AfterEach
+    void tearDown() {
+        processEngine.close();
+    }
+
+    @Test
+    void should_keepQueryingTasks_when_taskTableGainsColumnAfterStatementsWerePrepared() throws SQLException {
+        String taskId = createTask(TASK_NAME, null);
+        String subTaskId = createTask(SUB_TASK_NAME, taskId);
+        taskService.setVariableLocal(taskId, VARIABLE_NAME, VARIABLE_VALUE);
+        prepareStatementsOnServer(taskId);
+
+        addColumnToTaskTable();
+
+        assertThat(queryTasks()).extracting(Task::getId).containsExactlyInAnyOrder(taskId, subTaskId);
+        assertThat(taskService.getSubTasks(taskId)).extracting(Task::getId).containsExactly(subTaskId);
+        assertThat(queryTaskWithLocalVariables(taskId).getTaskLocalVariables()).containsEntry(
+            VARIABLE_NAME,
+            VARIABLE_VALUE
+        );
+
+        taskService.setAssignee(taskId, ASSIGNEE);
+        assertThat(queryTasks())
+            .filteredOn(task -> task.getId().equals(taskId))
+            .singleElement()
+            .satisfies(task -> {
+                assertThat(task.getName()).isEqualTo(TASK_NAME);
+                assertThat(task.getAssignee()).isEqualTo(ASSIGNEE);
+                assertThat(task.getPriority()).isEqualTo(PRIORITY);
+            });
+    }
+
+    /*
+     * prepareThreshold=1 makes the driver switch to a server side prepared statement
+     * right after the first execution, which is when PostgreSQL starts caching the plan.
+     */
+    private void prepareStatementsOnServer(String taskId) {
+        queryTasks();
+        queryTaskWithLocalVariables(taskId);
+        taskService.getSubTasks(taskId);
+        taskService.setPriority(taskId, PRIORITY);
+    }
+
+    private void addColumnToTaskTable() throws SQLException {
+        try (
+            Connection connection = DriverManager.getConnection(
+                postgres.getJdbcUrl(),
+                postgres.getUsername(),
+                postgres.getPassword()
+            );
+            Statement statement = connection.createStatement()
+        ) {
+            statement.execute("alter table ACT_RU_TASK add column NEW_COL_ varchar(64)");
+        }
+    }
+
+    private String createTask(String name, String parentTaskId) {
+        Task task = taskService.newTask();
+        task.setName(name);
+        task.setParentTaskId(parentTaskId);
+        taskService.saveTask(task);
+        return task.getId();
+    }
+
+    private List<Task> queryTasks() {
+        return taskService.createTaskQuery().orderByTaskName().asc().list();
+    }
+
+    private Task queryTaskWithLocalVariables(String taskId) {
+        return taskService.createTaskQuery().taskId(taskId).includeTaskLocalVariables().singleResult();
+    }
+
+    private static String jdbcUrlWithImmediateServerSidePrepare() {
+        String jdbcUrl = postgres.getJdbcUrl();
+        return jdbcUrl + (jdbcUrl.contains("?") ? "&" : "?") + "prepareThreshold=1";
+    }
+}


### PR DESCRIPTION
AAE-49074


This PR refactors `Task.xml` task queries to avoid wildcard column selection by introducing reusable SQL fragments for task columns, aiming to improve maintainability and reduce PostgreSQL cached-plan issues during rolling deployments.

**Changes:**
- Added reusable SQL fragments for task column lists (unaliased and `RES.`-aliased).
- Updated multiple task `SELECT` queries to use the explicit column fragments instead of `select *` / `RES.*`.
- Refactored parts of the query-criteria selection logic to select explicit `RES` columns rather than `RES.*`.
