### PR TITLE
AAE-49428 Fix null variable validation

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessVariablesPayloadValidatorTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessVariablesPayloadValidatorTest.java
@@ -34,6 +34,7 @@ import org.activiti.spring.process.ProcessExtensionService;
 import org.activiti.spring.process.model.Extension;
 import org.activiti.spring.process.model.VariableDefinition;
 import org.activiti.spring.process.variable.VariableValidationService;
+import org.activiti.spring.process.variable.types.BigDecimalVariableType;
 import org.activiti.spring.process.variable.types.DateVariableType;
 import org.activiti.spring.process.variable.types.JavaObjectVariableType;
 import org.activiti.spring.process.variable.types.JsonObjectVariableType;
@@ -88,6 +89,14 @@ public class ProcessVariablesPayloadValidatorTest {
         variableDefinitionDatetime.setName("mydatetime");
         variableDefinitionDatetime.setType("datetime");
 
+        VariableDefinition variableDefinitionBigdecimal = new VariableDefinition();
+        variableDefinitionBigdecimal.setName("amount");
+        variableDefinitionBigdecimal.setType("bigdecimal");
+
+        VariableDefinition variableDefinitionJson = new VariableDefinition();
+        variableDefinitionJson.setName("metadata");
+        variableDefinitionJson.setType("json");
+
         variableValidationService = new VariableValidationService(
             mapOfClass(
                 VariableType.class,
@@ -97,6 +106,8 @@ public class ProcessVariablesPayloadValidatorTest {
                 new JavaObjectVariableType(String.class),
                 "integer",
                 new JavaObjectVariableType(Integer.class),
+                "bigdecimal",
+                new BigDecimalVariableType(),
                 "json",
                 new JsonObjectVariableType(jsonMapper),
                 "file",
@@ -128,7 +139,11 @@ public class ProcessVariablesPayloadValidatorTest {
                 "mydate",
                 variableDefinitionDate,
                 "mydatetime",
-                variableDefinitionDatetime
+                variableDefinitionDatetime,
+                "amount",
+                variableDefinitionBigdecimal,
+                "metadata",
+                variableDefinitionJson
             )
         );
         given(processExtensionService.getExtensionsForId(any())).willReturn(extension);
@@ -301,6 +316,35 @@ public class ProcessVariablesPayloadValidatorTest {
             processVariablesValidator.checkPayloadVariables(
                 ProcessPayloadBuilder.setVariables()
                     .withVariables(map("name", null, "age", null, "subscribe", null))
+                    .build(),
+                "10"
+            )
+        );
+    }
+
+    @Test
+    public void should_success_when_startProcessPayloadHasNullValuesForAllTypes() {
+        assertDoesNotThrow(() ->
+            processVariablesValidator.checkStartProcessPayloadVariables(
+                ProcessPayloadBuilder.start()
+                    .withVariables(
+                        map(
+                            "name",
+                            null,
+                            "age",
+                            null,
+                            "subscribe",
+                            null,
+                            "mydate",
+                            null,
+                            "mydatetime",
+                            null,
+                            "amount",
+                            null,
+                            "metadata",
+                            null
+                        )
+                    )
                     .build(),
                 "10"
             )

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/spring/process/ProcessVariablesInitiatorIT.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/spring/process/ProcessVariablesInitiatorIT.java
@@ -17,6 +17,7 @@ package org.activiti.spring.process;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.activiti.engine.impl.util.CollectionUtil.map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.entry;
@@ -226,6 +227,35 @@ public class ProcessVariablesInitiatorIT {
                 entry("process_variable_json_type_1", mappedJson),
                 entry("process_variable_json_type_2", mappedJson)
             );
+        }
+    }
+
+    @Test
+    public void calculateVariablesFromExtensionFileShouldAcceptNullValuesForBigdecimalAndJson() throws Exception {
+        try (
+            InputStream inputStream = Thread.currentThread()
+                .getContextClassLoader()
+                .getResourceAsStream("processes/default-vars-extensions.json")
+        ) {
+            ProcessExtensionModel extension = reader.read(inputStream);
+
+            ProcessDefinition processDefinition = mock(ProcessDefinition.class);
+            given(processExtensionService.getExtensionsFor(processDefinition)).willReturn(
+                extension.getExtensions("Process_DefaultVarsProcess")
+            );
+            given(processExtensionService.hasExtensionsFor(processDefinition)).willReturn(true);
+            given(processDefinition.getKey()).willReturn("Process_DefaultVarsProcess");
+
+            Map<String, Object> variables = processVariablesInitiator.calculateVariablesFromExtensionFile(
+                processDefinition,
+                map("name", "Peter", "height-meters", null, "jsonvar", null)
+            );
+
+            assertThat(variables)
+                .containsEntry("name", "Peter")
+                .containsEntry("height-meters", null)
+                .containsEntry("jsonvar", null)
+                .containsEntry("positionInTheQueue", 10);
         }
     }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/VariableValidationService.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/VariableValidationService.java
@@ -42,6 +42,9 @@ public class VariableValidationService {
         List<ActivitiException> errors = new ArrayList<>();
 
         if (variableDefinition.getType() != null) {
+            if (var == null) {
+                return errors;
+            }
             VariableType type = variableTypeMap.get(variableDefinition.getType());
 
             //if type is not in the map then assume to be json

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/BigDecimalVariableType.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/BigDecimalVariableType.java
@@ -29,6 +29,9 @@ public class BigDecimalVariableType extends VariableType {
 
     @Override
     public Object parseFromValue(Object value) throws ActivitiException {
+        if (value == null) {
+            return null;
+        }
         if (value instanceof BigDecimal) {
             return value;
         }
@@ -44,6 +47,9 @@ public class BigDecimalVariableType extends VariableType {
 
     @Override
     public void validate(Object var, List<ActivitiException> errors) {
+        if (var == null) {
+            return;
+        }
         if (!Number.class.isAssignableFrom(var.getClass())) {
             String message = String.format(VALIDATION_ERROR_FORMAT, var.getClass());
             errors.add(new ActivitiException(message));

--- a/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/JsonObjectVariableType.java
+++ b/activiti-core/activiti-spring-process-extensions/src/main/java/org/activiti/spring/process/variable/types/JsonObjectVariableType.java
@@ -42,6 +42,9 @@ public class JsonObjectVariableType extends VariableType {
 
     @Override
     public void validate(Object var, List<ActivitiException> errors) {
+        if (var == null) {
+            return;
+        }
         //we can consider var json so long as it can be stored as json
         //this doesn't guarantee a string body to be valid json as jackson will wrap a string to make it valid
         //also doesn't guarantee it will be persisted as json

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2010-2026 Hyland Software, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.activiti.spring.process.variable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.activiti.common.util.DateFormatterProvider;
+import org.activiti.engine.ActivitiException;
+import org.activiti.engine.RepositoryService;
+import org.activiti.spring.process.model.VariableDefinition;
+import org.activiti.spring.process.variable.types.BigDecimalVariableType;
+import org.activiti.spring.process.variable.types.DateVariableType;
+import org.activiti.spring.process.variable.types.JavaObjectVariableType;
+import org.activiti.spring.process.variable.types.JsonObjectVariableType;
+import org.activiti.spring.process.variable.types.VariableType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import tools.jackson.databind.json.JsonMapper;
+
+@SpringBootTest
+public class VariableValidationServiceTest {
+
+    @Autowired
+    private Map<String, VariableType> variableTypeMap;
+
+    @Autowired
+    private VariableValidationService variableValidationService;
+
+    @MockitoBean
+    private RepositoryService repositoryService;
+
+    @Test
+    void should_returnEmptyErrors_when_validatingNullValueDirectlyForEveryRegisteredType() {
+        assertThat(variableTypeMap).hasSizeGreaterThanOrEqualTo(11);
+
+        variableTypeMap.forEach((typeKey, variableType) -> {
+            List<ActivitiException> errors = new ArrayList<>();
+            variableType.validate(null, errors);
+            assertThat(errors).as("null validation for type '%s'", typeKey).isEmpty();
+        });
+    }
+
+    @Test
+    void should_returnEmptyErrors_when_validatingNullValueThroughServiceForEveryRegisteredType() {
+        assertThat(variableTypeMap).hasSizeGreaterThanOrEqualTo(11);
+
+        variableTypeMap
+            .keySet()
+            .forEach(typeKey -> {
+                VariableDefinition definition = definitionOfType("var-" + typeKey, typeKey);
+                assertThat(variableValidationService.validateWithErrors(null, definition))
+                    .as("null validation through service for type '%s'", typeKey)
+                    .isEmpty();
+            });
+    }
+
+    @Test
+    void should_returnEmptyErrors_when_validatingNullValueThroughServiceForUnknownType() {
+        VariableDefinition definition = definitionOfType("customVar", "unknown-custom-type");
+
+        assertThat(variableValidationService.validateWithErrors(null, definition)).isEmpty();
+    }
+
+    @Test
+    void should_returnHasNoTypeError_when_definitionHasNoType() {
+        VariableDefinition definition = new VariableDefinition();
+        definition.setName("untypedVar");
+
+        List<ActivitiException> errors = variableValidationService.validateWithErrors(null, definition);
+
+        assertThat(errors).hasSize(1);
+        assertThat(errors.get(0).getMessage()).isEqualTo("untypedVar has no type");
+    }
+
+    @Test
+    void should_notInvokeTypeValidator_when_nullValueShortCircuitsInService() {
+        ThrowingVariableType throwingType = new ThrowingVariableType();
+        Map<String, VariableType> mapWithStub = new HashMap<>(variableTypeMap);
+        mapWithStub.put("throwing-type", throwingType);
+
+        VariableValidationService service = new VariableValidationService(mapWithStub);
+        VariableDefinition definition = definitionOfType("stubVar", "throwing-type");
+
+        assertThat(service.validateWithErrors(null, definition)).isEmpty();
+    }
+
+    @Test
+    void should_returnEmptyErrors_when_unknownTypeHasNullValueAndJsonFallbackIsUnavailable() {
+        JsonMapper jsonMapper = new JsonMapper();
+        DateFormatterProvider dateFormatterProvider = new DateFormatterProvider("yyyy-MM-dd[['T']HH:mm:ss[.SSS'Z']]");
+        Map<String, VariableType> mapWithoutJson = Map.of(
+            "boolean",
+            new JavaObjectVariableType(Boolean.class),
+            "string",
+            new JavaObjectVariableType(String.class),
+            "integer",
+            new JavaObjectVariableType(Integer.class),
+            "bigdecimal",
+            new BigDecimalVariableType(),
+            "date",
+            new DateVariableType(java.util.Date.class, dateFormatterProvider),
+            "datetime",
+            new DateVariableType(java.util.Date.class, dateFormatterProvider)
+        );
+
+        VariableValidationService service = new VariableValidationService(mapWithoutJson);
+        VariableDefinition definition = definitionOfType("unknownVar", "unknown-custom-type");
+
+        assertThat(service.validateWithErrors(null, definition)).isEmpty();
+    }
+
+    private static VariableDefinition definitionOfType(String name, String type) {
+        VariableDefinition definition = new VariableDefinition();
+        definition.setName(name);
+        definition.setType(type);
+        return definition;
+    }
+
+    private static class ThrowingVariableType extends VariableType {
+
+        @Override
+        public void validate(Object var, List<ActivitiException> errors) {
+            throw new RuntimeException("validate should not be called for null");
+        }
+    }
+}

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import tools.jackson.databind.json.JsonMapper;
 
 @SpringBootTest
 class VariableValidationServiceTest {

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/VariableValidationServiceTest.java
@@ -28,7 +28,6 @@ import org.activiti.spring.process.model.VariableDefinition;
 import org.activiti.spring.process.variable.types.BigDecimalVariableType;
 import org.activiti.spring.process.variable.types.DateVariableType;
 import org.activiti.spring.process.variable.types.JavaObjectVariableType;
-import org.activiti.spring.process.variable.types.JsonObjectVariableType;
 import org.activiti.spring.process.variable.types.VariableType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +36,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import tools.jackson.databind.json.JsonMapper;
 
 @SpringBootTest
-public class VariableValidationServiceTest {
+class VariableValidationServiceTest {
 
     @Autowired
     private Map<String, VariableType> variableTypeMap;
@@ -105,7 +104,6 @@ public class VariableValidationServiceTest {
 
     @Test
     void should_returnEmptyErrors_when_unknownTypeHasNullValueAndJsonFallbackIsUnavailable() {
-        JsonMapper jsonMapper = new JsonMapper();
         DateFormatterProvider dateFormatterProvider = new DateFormatterProvider("yyyy-MM-dd[['T']HH:mm:ss[.SSS'Z']]");
         Map<String, VariableType> mapWithoutJson = Map.of(
             "boolean",
@@ -138,7 +136,7 @@ public class VariableValidationServiceTest {
     private static class ThrowingVariableType extends VariableType {
 
         @Override
-        public void validate(Object var, List<ActivitiException> errors) {
+        public void validate(Object value, List<ActivitiException> errors) {
             throw new RuntimeException("validate should not be called for null");
         }
     }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/BigDecimalVariableTypeTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/BigDecimalVariableTypeTest.java
@@ -61,4 +61,21 @@ public class BigDecimalVariableTypeTest {
 
         assertThat(parsedValue1.add(parsedValue2)).isEqualTo(new BigDecimal("0.3"));
     }
+
+    @Test
+    public void should_returnEmptyExceptionList_when_validatingNullValue() {
+        BigDecimalVariableType bigDecimalVariableType = new BigDecimalVariableType();
+        List<ActivitiException> exceptionList = new ArrayList<>();
+
+        bigDecimalVariableType.validate(null, exceptionList);
+
+        assertThat(exceptionList).isEmpty();
+    }
+
+    @Test
+    public void should_returnNull_when_parsingNullValue() {
+        BigDecimalVariableType bigDecimalVariableType = new BigDecimalVariableType();
+
+        assertThat(bigDecimalVariableType.parseFromValue(null)).isNull();
+    }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/DateVariableTypeTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/DateVariableTypeTest.java
@@ -62,4 +62,11 @@ class DateVariableTypeTest {
 
         assertTrue(result.equals(expression));
     }
+
+    @Test
+    public void should_returnEmptyErrorList_when_validatingNullValue() {
+        dateVariableType.validate(null, exceptionList);
+
+        assertTrue(exceptionList.isEmpty());
+    }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/JavaObjectVariableTypeTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/JavaObjectVariableTypeTest.java
@@ -82,4 +82,13 @@ class JavaObjectVariableTypeTest {
                 )
         );
     }
+
+    @Test
+    public void should_returnEmptyErrorList_when_validatingNullValue() {
+        new JavaObjectVariableType(Boolean.class).validate(null, exceptionList);
+        new JavaObjectVariableType(Integer.class).validate(null, exceptionList);
+        new JavaObjectVariableType(String.class).validate(null, exceptionList);
+
+        assertTrue(exceptionList.isEmpty());
+    }
 }

--- a/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/JsonObjectVariableTypeTest.java
+++ b/activiti-core/activiti-spring-process-extensions/src/test/java/org/activiti/spring/process/variable/types/JsonObjectVariableTypeTest.java
@@ -41,4 +41,11 @@ class JsonObjectVariableTypeTest {
 
         assertTrue(exceptionList.isEmpty());
     }
+
+    @Test
+    public void should_returnEmptyErrorList_when_validatingNullValue() {
+        jsonObjectVariableType.validate(null, exceptionList);
+
+        assertTrue(exceptionList.isEmpty());
+    }
 }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     Before submitting a Pull Request, please ensure you've done the following:
     - 📖 The commit message follows our guidelines
     - 👷‍♂️ Tests for the changes have been added (for bug fixes / features)
     - 👷‍♀️ Create small PRs. In most cases this will be possible.
     - ✅ Provide tests for your changes.
     - 📝 Use descriptive commit messages.
     - 📗 Update any related documentation and include any relevant screenshots.
-->

<!--
(check one with "x") one of the following
-->

**What kind of change does this PR introduce?**

> - [ x] Bugfix
> - [ ] Feature
> - [ ] Code style update (formatting, local variables)
> - [ ] Refactoring (no functional changes, no api changes)
> - [ ] Build related changes
> - [ ] Documentation
> - [ ] Other... Please describe:

## Description

https://hyland.atlassian.net/browse/AAE-49428

Fixes an HTTP 500 when starting a process with explicitly null mapped variables (e.g. bigdecimal, json).

Problem: VariableValidationService.validateWithErrors always called type.validate(var, errors). BigDecimalVariableType and JsonObjectVariableType dereferenced var without a null check, causing Cannot invoke "Object.getClass()" because "var" is null.

Fix:
- Primary: Short-circuit in VariableValidationService when var == null — null carries no type info, so type validation is skipped (requiredness is handled separately, consistent with string/integer/boolean/date).
Defense in depth: Null guards added to BigDecimalVariableType.validate / parseFromValue and JsonObjectVariableType.validate.
- Tests: New VariableValidationServiceTest (registry sweep + discriminating stub test), null-validation cases in all four VariableType test classes, extended ProcessVariablesPayloadValidatorTest for process-start with null values across all types, and ProcessVariablesInitiatorIT coverage for null bigdecimal/json.



**Does this PR introduce a breaking change?** (check one with "x")

> - [ ] Yes
> - [ x] No
