### PR TITLE
AAE-50661 Bump spring-boot to 4.0.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
     <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
-    <spring-boot.version>4.0.7</spring-boot.version>
+    <spring-boot.version>4.0.8</spring-boot.version>
     <!-- AAE-46198 temporary Tomcat version override. Remove when upgrading to Spring Boot 4.1.x -->
     <tomcat.version>11.0.24</tomcat.version>
     <jakarta.el-api.version>6.0.1</jakarta.el-api.version>


### PR DESCRIPTION
This will resolve to version 2.25.5 of log4j-api, which should fix the security vulnerability "improper encoding of non-finite floating-point values during MapMessage JSON serialization."

https://hyland.atlassian.net/browse/AAE-50661