### PR TITLE
AAE-51039 Propagate linked process instance id and type when starting an already created process instance

### DIFF
--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/main/java/org/activiti/runtime/api/impl/ProcessRuntimeImpl.java
@@ -365,7 +365,12 @@ public class ProcessRuntimeImpl implements ProcessRuntime {
             internalProcessInstance.getProcessDefinitionId()
         );
         return processInstanceConverter.from(
-            runtimeService.startCreatedProcessInstance(internalProcessInstance, startProcessPayload.getVariables())
+            runtimeService.startCreatedProcessInstance(
+                internalProcessInstance,
+                startProcessPayload.getVariables(),
+                startProcessPayload.getLinkedProcessInstanceId(),
+                startProcessPayload.getLinkedProcessInstanceType()
+            )
         );
     }
 

--- a/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
+++ b/activiti-core/activiti-api-impl/activiti-api-process-runtime-impl/src/test/java/org/activiti/runtime/api/impl/ProcessRuntimeImplTest.java
@@ -306,7 +306,9 @@ public class ProcessRuntimeImplTest {
         internalProcess.setStartUserId("testuser");
         internalProcess.setAppVersion(1);
         doReturn(internalProcess).when(processQuery).singleResult();
-        when(runtimeService.startCreatedProcessInstance(internalProcess, new HashMap<>())).thenReturn(internalProcess);
+        when(runtimeService.startCreatedProcessInstance(internalProcess, new HashMap<>(), null, null)).thenReturn(
+            internalProcess
+        );
         ProcessInstanceImpl apiProcessInstance = new ProcessInstanceImpl();
         apiProcessInstance.setBusinessKey("business-result");
         apiProcessInstance.setId("999-999");
@@ -321,6 +323,48 @@ public class ProcessRuntimeImplTest {
         //then
         assertThat(createdProcessInstance.getId()).isEqualTo("999-999");
         assertThat(createdProcessInstance.getBusinessKey()).isEqualTo("business-result");
+    }
+
+    @Test
+    void should_startAnAlreadyCreatedProcessInstance_withLinkedProcessInstance_whenCalled() {
+        //given
+        String processInstanceId = "process-instance-id";
+        ProcessInstanceQuery processQuery = mock(ProcessInstanceQuery.class);
+        doReturn(processQuery).when(processQuery).processInstanceId(processInstanceId);
+        doReturn(processQuery).when(runtimeService).createProcessInstanceQuery();
+        ExecutionEntityImpl internalProcess = new ExecutionEntityImpl();
+        internalProcess.setStartUserId("testuser");
+        internalProcess.setAppVersion(1);
+        doReturn(internalProcess).when(processQuery).singleResult();
+        when(
+            runtimeService.startCreatedProcessInstance(
+                internalProcess,
+                new HashMap<>(),
+                "linkedProcessId",
+                "linkedProcessType"
+            )
+        ).thenReturn(internalProcess);
+        ProcessInstanceImpl apiProcessInstance = new ProcessInstanceImpl();
+        apiProcessInstance.setBusinessKey("business-result");
+        apiProcessInstance.setId("999-999");
+        given(processInstanceConverter.from(internalProcess)).willReturn(apiProcessInstance);
+        given(securityPoliciesManager.canWrite(any())).willReturn(true);
+        doReturn("testuser").when(securityManager).getAuthenticatedUserId();
+
+        //when
+        StartProcessPayload payload = new StartProcessPayload();
+        payload.setLinkedProcessInstanceId("linkedProcessId");
+        payload.setLinkedProcessInstanceType("linkedProcessType");
+        ProcessInstance createdProcessInstance = processRuntime.startCreatedProcess(processInstanceId, payload);
+
+        //then
+        assertThat(createdProcessInstance.getId()).isEqualTo("999-999");
+        verify(runtimeService).startCreatedProcessInstance(
+            internalProcess,
+            new HashMap<>(),
+            "linkedProcessId",
+            "linkedProcessType"
+        );
     }
 
     @Test

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -61,7 +61,12 @@ public interface RuntimeService {
     ProcessInstance startCreatedProcessInstance(ProcessInstance createdProcessInstance, Map<String, Object> variables);
 
     /**
-     * Starts a process instance previously created and adds a linked process.
+     * Starts a process instance previously created, optionally with a linked process.
+     *
+     * <p>Note: The default implementation delegates to
+     * {@link #startCreatedProcessInstance(ProcessInstance, Map)} and therefore ignores
+     * {@code linkedProcessInstanceId}/{@code linkedProcessInstanceType}. Implementations that support linking
+     * should override this method.
      *
      * @param createdProcessInstance The already created process instance.
      * @param variables the process variables map

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -72,12 +72,14 @@ public interface RuntimeService {
      * @throws NotFoundException
      *          when no process instance with the given id is found
      */
-    ProcessInstance startCreatedProcessInstance(
+    default ProcessInstance startCreatedProcessInstance(
         ProcessInstance createdProcessInstance,
         Map<String, Object> variables,
         String linkedProcessInstanceId,
         String linkedProcessInstanceType
-    );
+    ) {
+        return startCreatedProcessInstance(createdProcessInstance, variables);
+    }
 
     /**
      * Starts a new process instance in the latest version of the process definition with the given key.

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/RuntimeService.java
@@ -61,6 +61,25 @@ public interface RuntimeService {
     ProcessInstance startCreatedProcessInstance(ProcessInstance createdProcessInstance, Map<String, Object> variables);
 
     /**
+     * Starts a process instance previously created and adds a linked process.
+     *
+     * @param createdProcessInstance The already created process instance.
+     * @param variables the process variables map
+     * @param linkedProcessInstanceId the id of the linked process instance, can be null
+     * @param linkedProcessInstanceType the type of the linked process instance, can be null
+     * @throws ActivitiObjectNotFoundException
+     *          when user does not have permission to start the process instance
+     * @throws NotFoundException
+     *          when no process instance with the given id is found
+     */
+    ProcessInstance startCreatedProcessInstance(
+        ProcessInstance createdProcessInstance,
+        Map<String, Object> variables,
+        String linkedProcessInstanceId,
+        String linkedProcessInstanceType
+    );
+
+    /**
      * Starts a new process instance in the latest version of the process definition with the given key.
      *
      * @param processDefinitionKey

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -664,9 +664,7 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
         ProcessInstance createdProcessInstance,
         Map<String, Object> variables
     ) {
-        return commandExecutor.execute(
-            new StartCreatedProcessInstanceCmd<>(createdProcessInstance, variables, null, null)
-        );
+        return startCreatedProcessInstance(createdProcessInstance, variables, null, null);
     }
 
     @Override

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/RuntimeServiceImpl.java
@@ -664,7 +664,26 @@ public class RuntimeServiceImpl extends ServiceImpl implements RuntimeService {
         ProcessInstance createdProcessInstance,
         Map<String, Object> variables
     ) {
-        return commandExecutor.execute(new StartCreatedProcessInstanceCmd<>(createdProcessInstance, variables));
+        return commandExecutor.execute(
+            new StartCreatedProcessInstanceCmd<>(createdProcessInstance, variables, null, null)
+        );
+    }
+
+    @Override
+    public ProcessInstance startCreatedProcessInstance(
+        ProcessInstance createdProcessInstance,
+        Map<String, Object> variables,
+        String linkedProcessInstanceId,
+        String linkedProcessInstanceType
+    ) {
+        return commandExecutor.execute(
+            new StartCreatedProcessInstanceCmd<>(
+                createdProcessInstance,
+                variables,
+                linkedProcessInstanceId,
+                linkedProcessInstanceType
+            )
+        );
     }
 
     public ProcessInstance startProcessInstance(ProcessInstanceBuilderImpl processInstanceBuilder) {

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartCreatedProcessInstanceCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartCreatedProcessInstanceCmd.java
@@ -32,10 +32,24 @@ public class StartCreatedProcessInstanceCmd<T> implements Command<ProcessInstanc
     private static final long serialVersionUID = 1L;
     private ProcessInstance internalProcessInstance;
     private Map<String, Object> variables;
+    private String linkedProcessInstanceId;
+    private String linkedProcessInstanceType;
 
     public StartCreatedProcessInstanceCmd(ProcessInstance internalProcessInstance, Map<String, Object> variables) {
         this.internalProcessInstance = internalProcessInstance;
         this.variables = variables;
+    }
+
+    public StartCreatedProcessInstanceCmd(
+        ProcessInstance internalProcessInstance,
+        Map<String, Object> variables,
+        String linkedProcessInstanceId,
+        String linkedProcessInstanceType
+    ) {
+        this.internalProcessInstance = internalProcessInstance;
+        this.variables = variables;
+        this.linkedProcessInstanceId = linkedProcessInstanceId;
+        this.linkedProcessInstanceType = linkedProcessInstanceType;
     }
 
     @Override
@@ -57,9 +71,17 @@ public class StartCreatedProcessInstanceCmd<T> implements Command<ProcessInstanc
             variables,
             process.getInitialFlowElement(),
             Collections.emptyMap(),
-            null,
-            null
+            linkedProcessInstanceId,
+            linkedProcessInstanceType
         );
         return processExecution;
+    }
+
+    public String getLinkedProcessInstanceId() {
+        return linkedProcessInstanceId;
+    }
+
+    public String getLinkedProcessInstanceType() {
+        return linkedProcessInstanceType;
     }
 }

--- a/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartCreatedProcessInstanceCmd.java
+++ b/activiti-core/activiti-engine/src/main/java/org/activiti/engine/impl/cmd/StartCreatedProcessInstanceCmd.java
@@ -36,8 +36,7 @@ public class StartCreatedProcessInstanceCmd<T> implements Command<ProcessInstanc
     private String linkedProcessInstanceType;
 
     public StartCreatedProcessInstanceCmd(ProcessInstance internalProcessInstance, Map<String, Object> variables) {
-        this.internalProcessInstance = internalProcessInstance;
-        this.variables = variables;
+        this(internalProcessInstance, variables, null, null);
     }
 
     public StartCreatedProcessInstanceCmd(

--- a/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
+++ b/activiti-core/activiti-engine/src/test/java/org/activiti/engine/test/api/runtime/RuntimeServiceTest.java
@@ -39,6 +39,7 @@ import org.activiti.engine.history.HistoricDetail;
 import org.activiti.engine.history.HistoricProcessInstance;
 import org.activiti.engine.history.HistoricTaskInstance;
 import org.activiti.engine.impl.RuntimeServiceImpl;
+import org.activiti.engine.impl.cmd.StartCreatedProcessInstanceCmd;
 import org.activiti.engine.impl.cmd.StartProcessInstanceByMessageCmd;
 import org.activiti.engine.impl.cmd.StartProcessInstanceCmd;
 import org.activiti.engine.impl.history.HistoryLevel;
@@ -1224,6 +1225,51 @@ public class RuntimeServiceTest extends PluggableActivitiTestCase {
             assertThat(processInstance).isNotNull();
             assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
             assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey456");
+        } finally {
+            runtimeService.setCommandExecutor(originalExecutor);
+        }
+    }
+
+    @Deployment(resources = { "org/activiti/engine/test/api/oneTaskProcess.bpmn20.xml" })
+    public void testStartCreatedProcessInstanceCmdWithLinkedProcess() {
+        RuntimeServiceImpl runtimeService = (RuntimeServiceImpl) this.runtimeService;
+
+        ProcessDefinition processDefinition = repositoryService.createProcessDefinitionQuery().singleResult();
+        ProcessInstanceBuilderImpl builder = new ProcessInstanceBuilderImpl(runtimeService);
+        builder.processDefinitionId(processDefinition.getId());
+        builder.businessKey("businessKey789");
+
+        // the process instance is only created here, not started: the linked process
+        // instance is declared later, on the startCreatedProcessInstance() call
+        ProcessInstance createdProcessInstance = runtimeService.createProcessInstance(builder);
+        assertThat(createdProcessInstance.getStartTime()).isNull();
+
+        // Spy on the command executor to capture the command
+        CommandExecutor originalExecutor = runtimeService.getCommandExecutor();
+        CommandExecutor commandExecutor = spy(processEngineConfiguration.getCommandExecutor());
+        runtimeService.setCommandExecutor(commandExecutor);
+
+        try {
+            ProcessInstance processInstance = runtimeService.startCreatedProcessInstance(
+                createdProcessInstance,
+                emptyMap(),
+                "linkedProcess123",
+                "myLinkType"
+            );
+
+            // Capture the StartCreatedProcessInstanceCmd
+            ArgumentCaptor<StartCreatedProcessInstanceCmd> commandCaptor = ArgumentCaptor.forClass(
+                StartCreatedProcessInstanceCmd.class
+            );
+            verify(commandExecutor).execute(commandCaptor.capture());
+
+            StartCreatedProcessInstanceCmd capturedCommand = commandCaptor.getValue();
+            assertThat(capturedCommand.getLinkedProcessInstanceId()).isEqualTo("linkedProcess123");
+            assertThat(capturedCommand.getLinkedProcessInstanceType()).isEqualTo("myLinkType");
+
+            assertThat(processInstance).isNotNull();
+            assertThat(processInstance.getProcessDefinitionId()).isEqualTo(processDefinition.getId());
+            assertThat(processInstance.getBusinessKey()).isEqualTo("businessKey789");
         } finally {
             runtimeService.setCommandExecutor(originalExecutor);
         }

--- a/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeEventsIT.java
+++ b/activiti-core/activiti-spring-boot-starter/src/test/java/org/activiti/spring/boot/process/ProcessRuntimeEventsIT.java
@@ -262,4 +262,44 @@ public class ProcessRuntimeEventsIT {
                 )
             );
     }
+
+    @Test
+    public void startCreatedProcessEvent_should_haveNullLinkedProcessInstance_when_noLinkIsProvided() {
+        //given
+        ProcessInstance createdProcess = processRuntime.create(
+            ProcessPayloadBuilder.create().withProcessDefinitionKey(SINGLE_TASK_PROCESS).build()
+        );
+
+        //when
+        processRuntime.startCreatedProcess(createdProcess.getId(), ProcessPayloadBuilder.start().build());
+
+        //then
+        List<ProcessStartedEvent> processStartedEvents = localEventSource.getEvents(ProcessStartedEvent.class);
+        assertThat(processStartedEvents).hasSize(1);
+        assertThat(processStartedEvents.get(0).getLinkedProcessInstanceId()).isNull();
+        assertThat(processStartedEvents.get(0).getLinkedProcessInstanceType()).isNull();
+    }
+
+    @Test
+    public void startCreatedProcessEvent_should_includeLinkedProcessInstance_when_linkIsProvided() {
+        //given
+        ProcessInstance createdProcess = processRuntime.create(
+            ProcessPayloadBuilder.create().withProcessDefinitionKey(SINGLE_TASK_PROCESS).build()
+        );
+
+        //when
+        processRuntime.startCreatedProcess(
+            createdProcess.getId(),
+            ProcessPayloadBuilder.start()
+                .withLinkedProcessInstanceId("linkedProcessId")
+                .withLinkedProcessInstanceType("linkedProcessType")
+                .build()
+        );
+
+        //then
+        List<ProcessStartedEvent> processStartedEvents = localEventSource.getEvents(ProcessStartedEvent.class);
+        assertThat(processStartedEvents).hasSize(1);
+        assertThat(processStartedEvents.get(0).getLinkedProcessInstanceId()).isEqualTo("linkedProcessId");
+        assertThat(processStartedEvents.get(0).getLinkedProcessInstanceType()).isEqualTo("linkedProcessType");
+    }
 }


### PR DESCRIPTION
**Issue link:** AAE-51039

### Issue

When a process instance is started in a single call (`ProcessRuntime#start(StartProcessPayload)`), `linkedProcessInstanceId`/`linkedProcessInstanceType` are correctly propagated all the way to the `ProcessStartedEvent`.

When the same process instance is instead first **created** (`ProcessRuntime#create(CreateProcessInstancePayload)`) and only later **started** (`ProcessRuntime#startCreatedProcess(String, StartProcessPayload)`), the link declared on that second call was silently dropped:

- `ProcessRuntimeImpl#startCreatedProcess` only forwarded `startProcessPayload.getVariables()` to `RuntimeService#startCreatedProcessInstance`, ignoring `getLinkedProcessInstanceId()`/`getLinkedProcessInstanceType()`.
- `RuntimeService#startCreatedProcessInstance(ProcessInstance, Map<String,Object>)` had no parameters at all for the link.
- `StartCreatedProcessInstanceCmd` hardcoded `null, null` when calling `ProcessInstanceHelper#startProcessInstance(...)`.

### Fix

- Added a `RuntimeService#startCreatedProcessInstance` overload accepting `linkedProcessInstanceId`/`linkedProcessInstanceType` (the old 2-arg method is kept for backward compatibility and delegates with `null, null`).
- `StartCreatedProcessInstanceCmd` now carries and propagates these two fields instead of hardcoding `null`.
- `ProcessRuntimeImpl#startCreatedProcess` now reads the linked fields from the `StartProcessPayload` and passes them through.
- Added getters on `StartCreatedProcessInstanceCmd` (mirroring `StartProcessInstanceCmd`) for testability.